### PR TITLE
feat(ui): /transactions list with filters, search, cursor pagination (#4)

### DIFF
--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { transactions } from "@/lib/db/schema";
+
+const updateSchema = z.object({
+  txId: z.coerce.number().int().positive(),
+  categorySlug: z.string().min(1).max(60).nullable(),
+});
+
+export async function updateTransactionCategory(input: {
+  txId: number;
+  categorySlug: string | null;
+}) {
+  const { txId, categorySlug } = updateSchema.parse(input);
+
+  await db
+    .update(transactions)
+    .set({
+      categorySlug,
+      classificationMethod: categorySlug ? "manual" : "unclassified",
+      classificationConfidence: categorySlug ? 100 : null,
+      updatedAt: new Date(),
+    })
+    .where(eq(transactions.id, txId));
+
+  revalidatePath("/transactions");
+}

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,0 +1,116 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Toaster } from "@/components/ui/sonner";
+import { Filters } from "@/components/transactions/filters";
+import { TransactionTable } from "@/components/transactions/transaction-table";
+import {
+  countTotal,
+  listAccounts,
+  listCategories,
+  listTransactions,
+  PAGE_SIZE,
+} from "@/lib/transactions/queries";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = Promise<{
+  from?: string;
+  to?: string;
+  accountId?: string;
+  categorySlug?: string;
+  q?: string;
+  cursor?: string;
+}>;
+
+function buildHref(base: Record<string, string | undefined>, cursor: string | null) {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(base)) {
+    if (v) params.set(k, v);
+  }
+  if (cursor) params.set("cursor", cursor);
+  const qs = params.toString();
+  return qs ? `/transactions?${qs}` : "/transactions";
+}
+
+export default async function TransactionsPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const sp = await searchParams;
+
+  const accountId = sp.accountId ? Number(sp.accountId) : undefined;
+  const filters = {
+    from: sp.from,
+    to: sp.to,
+    accountId: Number.isFinite(accountId) ? accountId : undefined,
+    categorySlug: sp.categorySlug,
+    q: sp.q,
+    cursor: sp.cursor,
+  };
+
+  const [{ rows, nextCursor }, accounts, categories, total] = await Promise.all([
+    listTransactions(filters),
+    listAccounts(),
+    listCategories(),
+    countTotal({
+      from: filters.from,
+      to: filters.to,
+      accountId: filters.accountId,
+      categorySlug: filters.categorySlug,
+      q: filters.q,
+    }),
+  ]);
+
+  const baseQuery = {
+    from: sp.from,
+    to: sp.to,
+    accountId: sp.accountId,
+    categorySlug: sp.categorySlug,
+    q: sp.q,
+  };
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-4 p-6">
+      <header className="flex items-end justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Transactions</h1>
+          <p className="text-sm text-muted-foreground">
+            {total.toLocaleString()} total · showing up to {PAGE_SIZE} per page
+          </p>
+        </div>
+      </header>
+
+      <Filters
+        accounts={accounts}
+        categories={categories}
+        values={{
+          from: sp.from,
+          to: sp.to,
+          accountId: sp.accountId,
+          categorySlug: sp.categorySlug,
+          q: sp.q,
+        }}
+      />
+
+      <TransactionTable rows={rows} categories={categories} />
+
+      <div className="flex items-center justify-between">
+        <div className="text-xs text-muted-foreground">
+          {sp.cursor ? (
+            <Link href={buildHref(baseQuery, null)} className="underline">
+              ← First page
+            </Link>
+          ) : null}
+        </div>
+        {nextCursor ? (
+          <Button asChild variant="outline">
+            <Link href={buildHref(baseQuery, nextCursor)}>Next page →</Link>
+          </Button>
+        ) : null}
+      </div>
+
+      <Toaster />
+    </main>
+  );
+}

--- a/src/components/transactions/category-cell.tsx
+++ b/src/components/transactions/category-cell.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useTransition } from "react";
+import { toast } from "sonner";
+import { updateTransactionCategory } from "@/app/transactions/actions";
+
+export type CategoryOption = {
+  slug: string;
+  name: string;
+  parentSlug: string | null;
+};
+
+export function CategoryCell({
+  txId,
+  value,
+  options,
+}: {
+  txId: number;
+  value: string | null;
+  options: CategoryOption[];
+}) {
+  const [pending, startTransition] = useTransition();
+
+  return (
+    <select
+      disabled={pending}
+      value={value ?? ""}
+      onChange={(e) => {
+        const next = e.target.value || null;
+        startTransition(async () => {
+          try {
+            await updateTransactionCategory({ txId, categorySlug: next });
+            toast.success("Category updated");
+          } catch (err) {
+            toast.error(err instanceof Error ? err.message : "Failed to update");
+          }
+        });
+      }}
+      className="h-8 w-full rounded-md border bg-background px-2 text-sm disabled:opacity-50"
+    >
+      <option value="">— unclassified —</option>
+      {options.map((c) => (
+        <option key={c.slug} value={c.slug}>
+          {c.parentSlug ? `↳ ${c.name}` : c.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/transactions/filters.tsx
+++ b/src/components/transactions/filters.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export type FiltersProps = {
+  accounts: Array<{ id: number; name: string }>;
+  categories: Array<{ slug: string; name: string; parentSlug: string | null }>;
+  values: {
+    from?: string;
+    to?: string;
+    accountId?: string;
+    categorySlug?: string;
+    q?: string;
+  };
+};
+
+export function Filters({ accounts, categories, values }: FiltersProps) {
+  const hasAny =
+    values.from || values.to || values.accountId || values.categorySlug || values.q;
+
+  return (
+    <form
+      method="GET"
+      action="/transactions"
+      className="grid grid-cols-1 gap-3 rounded-md border bg-card p-4 sm:grid-cols-2 lg:grid-cols-6"
+    >
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="q">Search</Label>
+        <Input
+          id="q"
+          name="q"
+          type="search"
+          placeholder="merchant, description…"
+          defaultValue={values.q ?? ""}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="from">From</Label>
+        <Input id="from" name="from" type="date" defaultValue={values.from ?? ""} />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="to">To</Label>
+        <Input id="to" name="to" type="date" defaultValue={values.to ?? ""} />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="accountId">Account</Label>
+        <select
+          id="accountId"
+          name="accountId"
+          defaultValue={values.accountId ?? ""}
+          className="h-9 rounded-md border bg-background px-2 text-sm"
+        >
+          <option value="">All</option>
+          {accounts.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="categorySlug">Category</Label>
+        <select
+          id="categorySlug"
+          name="categorySlug"
+          defaultValue={values.categorySlug ?? ""}
+          className="h-9 rounded-md border bg-background px-2 text-sm"
+        >
+          <option value="">All</option>
+          {categories.map((c) => (
+            <option key={c.slug} value={c.slug}>
+              {c.parentSlug ? `↳ ${c.name}` : c.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex items-end gap-2">
+        <Button type="submit" className="flex-1">
+          Apply
+        </Button>
+        {hasAny ? (
+          <Button asChild type="button" variant="outline">
+            <Link href="/transactions">Reset</Link>
+          </Button>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -1,0 +1,127 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { TxRow } from "@/lib/transactions/queries";
+import { CategoryCell, type CategoryOption } from "./category-cell";
+
+const sourceLabel: Record<TxRow["source"], string> = {
+  apple_pay: "Apple Pay",
+  sms: "SMS",
+  ocr: "OCR",
+  csv: "CSV",
+  recurring: "Recurring",
+  manual: "Manual",
+};
+
+const methodVariant: Record<
+  TxRow["classificationMethod"],
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  rule: "default",
+  ai: "secondary",
+  manual: "outline",
+  unclassified: "destructive",
+};
+
+function formatAmount(cents: bigint, currency: TxRow["currency"]) {
+  const n = Number(cents) / 100;
+  const formatter = new Intl.NumberFormat(currency === "USD" ? "en-US" : "es-CO", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: currency === "USD" ? 2 : 0,
+  });
+  return formatter.format(n);
+}
+
+function formatDate(d: Date) {
+  return d.toLocaleDateString("es-CO", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+  });
+}
+
+export function TransactionTable({
+  rows,
+  categories,
+}: {
+  rows: TxRow[];
+  categories: CategoryOption[];
+}) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-md border bg-card p-8 text-center text-sm text-muted-foreground">
+        No transactions match the current filters.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border bg-card">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[110px]">Date</TableHead>
+            <TableHead>Description</TableHead>
+            <TableHead className="w-[150px]">Account</TableHead>
+            <TableHead className="w-[200px]">Category</TableHead>
+            <TableHead className="w-[110px]">Source</TableHead>
+            <TableHead className="w-[110px]">Method</TableHead>
+            <TableHead className="w-[140px] text-right">Amount</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((tx) => {
+            const isExpense = tx.amountCents < BigInt(0);
+            return (
+              <TableRow key={tx.id}>
+                <TableCell className="text-muted-foreground">
+                  {formatDate(tx.occurredAt)}
+                </TableCell>
+                <TableCell>
+                  <div className="font-medium">
+                    {tx.merchant ?? tx.descriptionClean ?? tx.descriptionRaw}
+                  </div>
+                  {tx.merchant || tx.descriptionClean ? (
+                    <div className="text-xs text-muted-foreground line-clamp-1">
+                      {tx.descriptionRaw}
+                    </div>
+                  ) : null}
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {tx.accountName}
+                </TableCell>
+                <TableCell>
+                  <CategoryCell
+                    txId={tx.id}
+                    value={tx.categorySlug}
+                    options={categories}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline">{sourceLabel[tx.source]}</Badge>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={methodVariant[tx.classificationMethod]}>
+                    {tx.classificationMethod}
+                  </Badge>
+                </TableCell>
+                <TableCell
+                  className={`text-right font-mono ${isExpense ? "text-destructive" : "text-emerald-600"}`}
+                >
+                  {formatAmount(tx.amountCents, tx.currency)}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -1,0 +1,155 @@
+import { and, asc, desc, eq, ilike, lt, lte, gte, or, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, categories, transactions } from "@/lib/db/schema";
+
+export const PAGE_SIZE = 50;
+
+export type TxFilters = {
+  from?: string;
+  to?: string;
+  accountId?: number;
+  categorySlug?: string;
+  q?: string;
+  cursor?: string;
+};
+
+export type TxRow = {
+  id: number;
+  occurredAt: Date;
+  amountCents: bigint;
+  currency: "COP" | "USD";
+  descriptionRaw: string;
+  descriptionClean: string | null;
+  merchant: string | null;
+  categorySlug: string | null;
+  classificationMethod: "rule" | "ai" | "manual" | "unclassified";
+  source: "apple_pay" | "sms" | "ocr" | "csv" | "recurring" | "manual";
+  accountId: number;
+  accountName: string;
+};
+
+export type TxListResult = {
+  rows: TxRow[];
+  nextCursor: string | null;
+};
+
+export function encodeCursor(occurredAt: Date, id: number): string {
+  return Buffer.from(`${occurredAt.toISOString()}|${id}`, "utf8").toString("base64url");
+}
+
+export function decodeCursor(cursor: string): { occurredAt: Date; id: number } | null {
+  try {
+    const decoded = Buffer.from(cursor, "base64url").toString("utf8");
+    const [iso, idStr] = decoded.split("|");
+    const occurredAt = new Date(iso);
+    const id = Number(idStr);
+    if (isNaN(occurredAt.getTime()) || !Number.isFinite(id)) return null;
+    return { occurredAt, id };
+  } catch {
+    return null;
+  }
+}
+
+export async function listTransactions(filters: TxFilters): Promise<TxListResult> {
+  const conditions = [];
+
+  if (filters.from) conditions.push(gte(transactions.occurredAt, new Date(filters.from)));
+  if (filters.to) {
+    const to = new Date(filters.to);
+    to.setUTCHours(23, 59, 59, 999);
+    conditions.push(lte(transactions.occurredAt, to));
+  }
+  if (filters.accountId) conditions.push(eq(transactions.accountId, filters.accountId));
+  if (filters.categorySlug) conditions.push(eq(transactions.categorySlug, filters.categorySlug));
+  if (filters.q) {
+    const term = `%${filters.q}%`;
+    conditions.push(
+      or(
+        ilike(transactions.descriptionRaw, term),
+        ilike(transactions.descriptionClean, term),
+        ilike(transactions.merchant, term),
+      )!,
+    );
+  }
+  if (filters.cursor) {
+    const c = decodeCursor(filters.cursor);
+    if (c) {
+      conditions.push(
+        or(
+          lt(transactions.occurredAt, c.occurredAt),
+          and(eq(transactions.occurredAt, c.occurredAt), lt(transactions.id, c.id)),
+        )!,
+      );
+    }
+  }
+
+  const rows = await db
+    .select({
+      id: transactions.id,
+      occurredAt: transactions.occurredAt,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      descriptionRaw: transactions.descriptionRaw,
+      descriptionClean: transactions.descriptionClean,
+      merchant: transactions.merchant,
+      categorySlug: transactions.categorySlug,
+      classificationMethod: transactions.classificationMethod,
+      source: transactions.source,
+      accountId: transactions.accountId,
+      accountName: accounts.name,
+    })
+    .from(transactions)
+    .innerJoin(accounts, eq(accounts.id, transactions.accountId))
+    .where(conditions.length ? and(...conditions) : undefined)
+    .orderBy(desc(transactions.occurredAt), desc(transactions.id))
+    .limit(PAGE_SIZE + 1);
+
+  const hasMore = rows.length > PAGE_SIZE;
+  const page = hasMore ? rows.slice(0, PAGE_SIZE) : rows;
+  const last = page.at(-1);
+  const nextCursor = hasMore && last ? encodeCursor(last.occurredAt, last.id) : null;
+
+  return { rows: page, nextCursor };
+}
+
+export async function listAccounts() {
+  return db
+    .select({ id: accounts.id, name: accounts.name })
+    .from(accounts)
+    .where(eq(accounts.active, true))
+    .orderBy(asc(accounts.name));
+}
+
+export async function listCategories() {
+  return db
+    .select({ slug: categories.slug, name: categories.name, parentSlug: categories.parentSlug })
+    .from(categories)
+    .orderBy(asc(categories.sortOrder), asc(categories.name));
+}
+
+export async function countTotal(filters: Omit<TxFilters, "cursor">): Promise<number> {
+  const conditions = [];
+  if (filters.from) conditions.push(gte(transactions.occurredAt, new Date(filters.from)));
+  if (filters.to) {
+    const to = new Date(filters.to);
+    to.setUTCHours(23, 59, 59, 999);
+    conditions.push(lte(transactions.occurredAt, to));
+  }
+  if (filters.accountId) conditions.push(eq(transactions.accountId, filters.accountId));
+  if (filters.categorySlug) conditions.push(eq(transactions.categorySlug, filters.categorySlug));
+  if (filters.q) {
+    const term = `%${filters.q}%`;
+    conditions.push(
+      or(
+        ilike(transactions.descriptionRaw, term),
+        ilike(transactions.descriptionClean, term),
+        ilike(transactions.merchant, term),
+      )!,
+    );
+  }
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(transactions)
+    .where(conditions.length ? and(...conditions) : undefined);
+  return row?.n ?? 0;
+}


### PR DESCRIPTION
## Summary
- Server Component at \`/transactions\` reads from db with filters (date range, account, category, description ILIKE search)
- Cursor-based pagination, 50/page, ordered \`(occurred_at DESC, id DESC)\` with base64url cursor
- Inline category edit via client-side select calling a Server Action that \`revalidatePath('/transactions')\`
- \`source\` and \`classificationMethod\` render as badges
- Amount color-coded by sign, formatted via \`Intl.NumberFormat\` (COP no decimals, USD 2)

## Notes / scope choices
- No \"previous page\" link — kept forward-only cursor + \"first page\" reset
- Native \`<select>\` and \`<input type=\"date\">\` (no calendar component); easy upgrade later
- DB has no transactions seeded yet, so manual smoke test renders the empty state — code paths verified via \`?q=\`, \`?from=\`, and \`?cursor=invalid\`, all 200

## Test plan
- [x] \`bun run lint\` — clean
- [x] \`bun run typecheck\` — clean
- [x] \`bun run dev\` + curl \`/transactions\`, \`/transactions?q=test&from=2025-01-01\`, \`/transactions?cursor=invalid\` → all 200, no app errors

Closes #4