### PR TITLE
fix(ui): font-sans variable + HMR over Tailscale (#22)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  allowedDevOrigins: ["ia-server.tailcabcc8.ts.net"],
 };
 
 export default nextConfig;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,9 +7,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
+  --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-sans);
+  --font-heading: var(--font-geist-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);


### PR DESCRIPTION
## Summary
- `globals.css`: replace self-referencing `--font-sans: var(--font-sans)` with `var(--font-geist-sans)` so the Geist font from `next/font` actually applies (was falling back to serif)
- `next.config.ts`: add `allowedDevOrigins: ['ia-server.tailcabcc8.ts.net']` so HMR WS works when accessing dev over Tailscale

Closes #22