### PR TITLE
feat(ingestion): manual cash entry with FAB + dialog (#6)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/layout/header";
 import { Breadcrumbs } from "@/components/layout/breadcrumbs";
+import { QuickExpenseFab } from "@/components/transactions/quick-expense-fab";
+import { Toaster } from "@/components/ui/sonner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -33,6 +35,8 @@ export default function RootLayout({
         <Header />
         <Breadcrumbs />
         <div className="flex flex-1 flex-col">{children}</div>
+        <QuickExpenseFab />
+        <Toaster />
       </body>
     </html>
   );

--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
-import { transactions } from "@/lib/db/schema";
+import { accounts, categories, transactions } from "@/lib/db/schema";
 
 const updateSchema = z.object({
   txId: z.coerce.number().int().positive(),
@@ -27,5 +27,61 @@ export async function updateTransactionCategory(input: {
     })
     .where(eq(transactions.id, txId));
 
+  revalidatePath("/transactions");
+}
+
+const expenseSchema = z.object({
+  accountId: z.coerce.number().int().positive(),
+  amount: z.coerce.number().positive().finite(),
+  categorySlug: z.string().min(1).max(60).nullable(),
+  occurredOn: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  notes: z.string().max(500).nullable(),
+});
+
+export async function createManualExpense(input: {
+  accountId: number;
+  amount: number;
+  categorySlug: string | null;
+  occurredOn: string;
+  notes: string | null;
+}) {
+  const parsed = expenseSchema.parse(input);
+
+  const [account] = await db
+    .select({ id: accounts.id, currency: accounts.currency })
+    .from(accounts)
+    .where(eq(accounts.id, parsed.accountId))
+    .limit(1);
+
+  if (!account) throw new Error("Account not found");
+
+  if (parsed.categorySlug) {
+    const [cat] = await db
+      .select({ slug: categories.slug })
+      .from(categories)
+      .where(eq(categories.slug, parsed.categorySlug))
+      .limit(1);
+    if (!cat) throw new Error("Category not found");
+  }
+
+  const cents = Math.round(parsed.amount * 100);
+  const occurredAt = new Date(`${parsed.occurredOn}T12:00:00Z`);
+
+  await db.insert(transactions).values({
+    accountId: account.id,
+    occurredAt,
+    amountCents: BigInt(-cents),
+    currency: account.currency,
+    descriptionRaw: parsed.notes ?? "Manual expense",
+    descriptionClean: null,
+    merchant: null,
+    categorySlug: parsed.categorySlug,
+    classificationMethod: parsed.categorySlug ? "manual" : "unclassified",
+    classificationConfidence: parsed.categorySlug ? 100 : null,
+    source: "manual",
+    notes: parsed.notes,
+  });
+
+  revalidatePath("/");
   revalidatePath("/transactions");
 }

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Toaster } from "@/components/ui/sonner";
 import { Filters } from "@/components/transactions/filters";
 import { TransactionTable } from "@/components/transactions/transaction-table";
 import {
@@ -110,7 +109,6 @@ export default async function TransactionsPage({
         ) : null}
       </div>
 
-      <Toaster />
     </main>
   );
 }

--- a/src/components/transactions/quick-expense-dialog.tsx
+++ b/src/components/transactions/quick-expense-dialog.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { PlusIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { createManualExpense } from "@/app/transactions/actions";
+
+export type AccountOption = {
+  id: number;
+  name: string;
+  currency: "COP" | "USD";
+};
+
+export type CategoryOption = {
+  slug: string;
+  name: string;
+  parentSlug: string | null;
+};
+
+function todayLocalISO(): string {
+  const d = new Date();
+  const tz = d.getTimezoneOffset() * 60000;
+  return new Date(d.getTime() - tz).toISOString().slice(0, 10);
+}
+
+export function QuickExpenseDialog({
+  accounts,
+  categories,
+}: {
+  accounts: AccountOption[];
+  categories: CategoryOption[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const defaultAccount = accounts.find((a) => a.currency === "COP") ?? accounts[0];
+  const [accountId, setAccountId] = useState<string>(
+    defaultAccount?.id.toString() ?? "",
+  );
+  const selectedAccount = accounts.find((a) => a.id.toString() === accountId);
+  const currency = selectedAccount?.currency ?? "COP";
+  const [amount, setAmount] = useState("");
+  const [categorySlug, setCategorySlug] = useState("");
+  const [occurredOn, setOccurredOn] = useState(todayLocalISO());
+  const [notes, setNotes] = useState("");
+
+  function reset() {
+    setAmount("");
+    setCategorySlug("");
+    setNotes("");
+    setOccurredOn(todayLocalISO());
+  }
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const amtNum = Number(amount);
+    if (!Number.isFinite(amtNum) || amtNum <= 0) {
+      toast.error("Amount must be > 0");
+      return;
+    }
+    if (!accountId) {
+      toast.error("Pick an account");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        await createManualExpense({
+          accountId: Number(accountId),
+          amount: amtNum,
+          categorySlug: categorySlug || null,
+          occurredOn,
+          notes: notes.trim() || null,
+        });
+        toast.success("Expense added");
+        reset();
+        setOpen(false);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to add");
+      }
+    });
+  }
+
+  if (accounts.length === 0) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          size="lg"
+          className="fixed bottom-6 right-6 z-30 h-14 rounded-full shadow-lg"
+          aria-label="Add expense"
+        >
+          <PlusIcon className="size-5" />
+          <span className="ml-1">Expense</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Quick expense</DialogTitle>
+          <DialogDescription>
+            Add a cash expense or anything not auto-imported.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={onSubmit} className="flex flex-col gap-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="qe-amount">Amount</Label>
+              <div className="relative">
+                <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                  $
+                </span>
+                <Input
+                  id="qe-amount"
+                  type="number"
+                  inputMode="decimal"
+                  step={currency === "USD" ? "0.01" : "1"}
+                  min="0"
+                  placeholder="0"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  required
+                  autoFocus
+                  className="pl-6 pr-14 tabular-nums"
+                />
+                <span
+                  className={cn(
+                    "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 rounded px-1.5 py-0.5 text-xs font-medium",
+                    currency === "USD"
+                      ? "bg-amber-500/15 text-amber-700"
+                      : "bg-muted text-muted-foreground",
+                  )}
+                >
+                  {currency}
+                </span>
+              </div>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="qe-date">Date</Label>
+              <Input
+                id="qe-date"
+                type="date"
+                value={occurredOn}
+                onChange={(e) => setOccurredOn(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="qe-account">Account</Label>
+            <select
+              id="qe-account"
+              value={accountId}
+              onChange={(e) => setAccountId(e.target.value)}
+              className="h-9 rounded-md border bg-background px-2 text-sm"
+              required
+            >
+              {accounts.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name} ({a.currency})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="qe-cat">Category</Label>
+            <select
+              id="qe-cat"
+              value={categorySlug}
+              onChange={(e) => setCategorySlug(e.target.value)}
+              className="h-9 rounded-md border bg-background px-2 text-sm"
+            >
+              <option value="">— unclassified —</option>
+              {categories.map((c) => (
+                <option key={c.slug} value={c.slug}>
+                  {c.parentSlug ? `↳ ${c.name}` : c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="qe-notes">Notes</Label>
+            <Input
+              id="qe-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Optional"
+              maxLength={500}
+            />
+          </div>
+
+          <DialogFooter className="mt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving…" : "Add expense"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/transactions/quick-expense-fab.tsx
+++ b/src/components/transactions/quick-expense-fab.tsx
@@ -1,0 +1,24 @@
+import { asc, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, categories } from "@/lib/db/schema";
+import { QuickExpenseDialog } from "./quick-expense-dialog";
+
+export async function QuickExpenseFab() {
+  const [accs, cats] = await Promise.all([
+    db
+      .select({ id: accounts.id, name: accounts.name, currency: accounts.currency })
+      .from(accounts)
+      .where(eq(accounts.active, true))
+      .orderBy(asc(accounts.name)),
+    db
+      .select({
+        slug: categories.slug,
+        name: categories.name,
+        parentSlug: categories.parentSlug,
+      })
+      .from(categories)
+      .orderBy(asc(categories.sortOrder), asc(categories.name)),
+  ]);
+
+  return <QuickExpenseDialog accounts={accs} categories={cats} />;
+}


### PR DESCRIPTION
## Summary
- Floating action button bottom-right on every page
- shadcn Dialog with amount, date, account, category, notes
- Server action \`createManualExpense\` validates with Zod, inserts as \`source=manual\`
- Currency badge mirrors selected account; default account = first active COP
- Toaster moved to root layout (removed duplicate from \`/transactions\`)
- Revalidates \`/\` and \`/transactions\` on insert

## Follow-up
- #26 — seed cash accounts so users have a place to log COP cash expenses

## Test plan
- [x] \`bun run typecheck\` passes
- [x] \`bun run lint\` passes
- [x] Manual: dialog opens, submits, dashboard updates, top expenses reflects new entry

Closes #6