### PR TITLE
feat(db): seed cash accounts (COP + USD) (#26)

### DIFF
--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -1,3 +1,4 @@
+import { inArray } from "drizzle-orm";
 import { db } from "./index";
 import {
   accounts,
@@ -19,6 +20,8 @@ const seedAccounts: Array<{
   { name: "Bancolombia e-card (suscripciones)", institution: "Bancolombia", type: "credit_card", currency: "COP" },
   { name: "Bancolombia Préstamo Consolidado", institution: "Bancolombia", type: "loan", currency: "COP" },
   { name: "ARQ Ahorros", institution: "ARQ", type: "savings", currency: "USD" },
+  { name: "Efectivo COP", institution: "Cash", type: "savings", currency: "COP" },
+  { name: "Efectivo USD", institution: "Cash", type: "savings", currency: "USD" },
 ];
 
 const seedCategories: Array<{
@@ -109,7 +112,18 @@ async function seed() {
   await db.insert(categories).values(seedCategories).onConflictDoNothing();
 
   console.log("seeding accounts...");
-  await db.insert(accounts).values(seedAccounts).onConflictDoNothing();
+  const existing = await db
+    .select({ name: accounts.name })
+    .from(accounts)
+    .where(inArray(accounts.name, seedAccounts.map((a) => a.name)));
+  const existingNames = new Set(existing.map((e) => e.name));
+  const toInsert = seedAccounts.filter((a) => !existingNames.has(a.name));
+  if (toInsert.length > 0) {
+    await db.insert(accounts).values(toInsert);
+    console.log(`  inserted ${toInsert.length} new accounts`);
+  } else {
+    console.log("  all accounts already exist");
+  }
 
   console.log("seeding classification rules...");
   await db.insert(classificationRules).values(seedRules).onConflictDoNothing();


### PR DESCRIPTION
## Summary
- Adds \`Efectivo COP\` and \`Efectivo USD\` (institution: Cash, type: savings) to seed
- Replaces \`onConflictDoNothing()\` for accounts with a name-based existence check (accounts table has no unique on \`name\`, so the prior pattern would silently insert duplicates on re-run)

## Test plan
- [x] \`bun run typecheck\` passes
- [x] \`bun run db:seed\` ran on dev DB and inserted both accounts
- [x] Re-running seed reports \"all accounts already exist\" (idempotent)
- [x] Quick expense dialog now lists Efectivo COP/USD as options

Closes #26