### PR TITLE
feat(ingestion): XLSX upload for Bancolombia (#7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 # claude code per-user config
 .claude/
 CLAUDE.md
+MovimientosTusCuentasBancolombia*.xlsx

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
+        "xlsx": "^0.18.5",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -651,6 +652,8 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
@@ -729,6 +732,8 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
 
+    "cfb": ["cfb@1.2.2", "", { "dependencies": { "adler-32": "~1.3.0", "crc-32": "~1.2.0" } }, "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA=="],
+
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -748,6 +753,8 @@
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
+
+    "codepage": ["codepage@1.15.0", "", {}, "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -770,6 +777,8 @@
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
+
+    "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -978,6 +987,8 @@
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "frac": ["frac@1.1.2", "", {}, "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
@@ -1507,6 +1518,8 @@
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
+    "ssf": ["ssf@0.11.2", "", { "dependencies": { "frac": "~1.1.2" } }, "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g=="],
+
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
@@ -1659,6 +1672,10 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "wmf": ["wmf@1.0.2", "", {}, "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="],
+
+    "word": ["word@0.3.0", "", {}, "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="],
+
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
@@ -1666,6 +1683,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
+    "xlsx": ["xlsx@0.18.5", "", { "dependencies": { "adler-32": "~1.3.0", "cfb": "~1.2.1", "codepage": "~1.15.0", "crc-32": "~1.2.1", "ssf": "~0.11.2", "wmf": "~1.0.1", "word": "~0.3.0" }, "bin": { "xlsx": "bin/xlsx.njs" } }, "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
+    "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/app/settings/import/actions.ts
+++ b/src/app/settings/import/actions.ts
@@ -1,0 +1,154 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { accounts, ingestionLogs, transactions } from "@/lib/db/schema";
+import { classifyByRule } from "@/lib/classification/rules";
+import { parseBancolombiaXlsx, type ParsedRow } from "@/lib/ingestion/xlsx-bancolombia";
+
+const previewSchema = z.object({
+  accountId: z.coerce.number().int().positive(),
+});
+
+export type PreviewRow = ParsedRow & { duplicate: boolean };
+
+export type PreviewResult = {
+  accountId: number;
+  rows: PreviewRow[];
+  skipped: { rowIndex: number; reason: string }[];
+  totals: { parsed: number; duplicates: number; new: number };
+};
+
+export async function previewBancolombiaXlsx(formData: FormData): Promise<PreviewResult> {
+  const { accountId } = previewSchema.parse({ accountId: formData.get("accountId") });
+  const file = formData.get("file");
+  if (!(file instanceof File)) throw new Error("No file uploaded");
+  if (file.size === 0) throw new Error("File is empty");
+  if (file.size > 5 * 1024 * 1024) throw new Error("File too large (>5MB)");
+
+  const [account] = await db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(eq(accounts.id, accountId))
+    .limit(1);
+  if (!account) throw new Error("Account not found");
+
+  const buf = Buffer.from(await file.arrayBuffer());
+  const { rows, skipped } = parseBancolombiaXlsx(buf, accountId);
+
+  const externalIds = rows.map((r) => r.externalId);
+  const existing = externalIds.length
+    ? await db
+        .select({ externalId: transactions.externalId })
+        .from(transactions)
+        .where(
+          and(
+            eq(transactions.accountId, accountId),
+            inArray(transactions.externalId, externalIds),
+          ),
+        )
+    : [];
+  const existingSet = new Set(existing.map((e) => e.externalId));
+
+  const previewRows: PreviewRow[] = rows.map((r) => ({
+    ...r,
+    duplicate: existingSet.has(r.externalId),
+  }));
+
+  return {
+    accountId,
+    rows: previewRows,
+    skipped,
+    totals: {
+      parsed: rows.length,
+      duplicates: previewRows.filter((r) => r.duplicate).length,
+      new: previewRows.filter((r) => !r.duplicate).length,
+    },
+  };
+}
+
+const confirmSchema = z.object({
+  accountId: z.coerce.number().int().positive(),
+  rows: z.array(
+    z.object({
+      occurredOn: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      description: z.string().min(1).max(500),
+      reference: z.string().nullable(),
+      amountCents: z.string().regex(/^-?\d+$/),
+      externalId: z.string().min(1).max(200),
+    }),
+  ),
+});
+
+export type ConfirmInput = z.infer<typeof confirmSchema>;
+export type ConfirmResult = {
+  inserted: number;
+  duplicated: number;
+};
+
+export async function confirmBancolombiaImport(input: ConfirmInput): Promise<ConfirmResult> {
+  const parsed = confirmSchema.parse(input);
+  const startedAt = new Date();
+
+  const [account] = await db
+    .select({ id: accounts.id, currency: accounts.currency })
+    .from(accounts)
+    .where(eq(accounts.id, parsed.accountId))
+    .limit(1);
+  if (!account) throw new Error("Account not found");
+
+  let inserted = 0;
+  let duplicated = 0;
+  const errors: string[] = [];
+
+  for (const r of parsed.rows) {
+    try {
+      const cls = await classifyByRule({ descriptionRaw: r.description });
+      const result = await db
+        .insert(transactions)
+        .values({
+          accountId: account.id,
+          occurredAt: new Date(`${r.occurredOn}T12:00:00Z`),
+          amountCents: BigInt(r.amountCents),
+          currency: account.currency,
+          descriptionRaw: r.description,
+          descriptionClean: null,
+          merchant: null,
+          categorySlug: cls?.categorySlug ?? null,
+          classificationMethod: cls ? "rule" : "unclassified",
+          classificationConfidence: cls?.confidence ?? null,
+          source: "csv",
+          externalId: r.externalId,
+        })
+        .onConflictDoNothing({
+          target: [transactions.accountId, transactions.externalId],
+          where: sql`${transactions.externalId} IS NOT NULL`,
+        })
+        .returning({ id: transactions.id });
+
+      if (result.length > 0) inserted++;
+      else duplicated++;
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  await db.insert(ingestionLogs).values({
+    source: "csv",
+    status: errors.length === 0 ? "ok" : "partial",
+    itemsReceived: parsed.rows.length,
+    itemsInserted: inserted,
+    itemsDuplicated: duplicated,
+    errorMessage: errors.length ? errors.slice(0, 5).join("; ") : null,
+    payload: { accountId: parsed.accountId, format: "xlsx-bancolombia" },
+    startedAt,
+    finishedAt: new Date(),
+  });
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+
+  return { inserted, duplicated };
+}

--- a/src/app/settings/import/import-form.tsx
+++ b/src/app/settings/import/import-form.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useFormStatus } from "react-dom";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { formatMoney } from "@/lib/money";
+import { cn } from "@/lib/utils";
+import {
+  confirmBancolombiaImport,
+  previewBancolombiaXlsx,
+  type PreviewResult,
+} from "./actions";
+
+type AccountOption = { id: number; name: string; currency: "COP" | "USD" };
+
+function ParseButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? "Parsing…" : "Parse file"}
+    </Button>
+  );
+}
+
+const dateFmt = new Intl.DateTimeFormat("es-CO", { day: "2-digit", month: "short" });
+
+export function ImportForm({ accounts }: { accounts: AccountOption[] }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [accountId, setAccountId] = useState<string>(
+    accounts[0]?.id.toString() ?? "",
+  );
+  const [preview, setPreview] = useState<PreviewResult | null>(null);
+  const [excluded, setExcluded] = useState<Set<string>>(new Set());
+
+  const account = accounts.find((a) => a.id.toString() === accountId);
+  const currency = account?.currency ?? "COP";
+
+  async function onUpload(formData: FormData) {
+    try {
+      const result = await previewBancolombiaXlsx(formData);
+      setPreview(result);
+      setExcluded(new Set(result.rows.filter((r) => r.duplicate).map((r) => r.externalId)));
+      toast.success(
+        `Parsed ${result.totals.parsed} rows · ${result.totals.new} new · ${result.totals.duplicates} duplicates`,
+      );
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Parse failed");
+    }
+  }
+
+  function toggleRow(externalId: string) {
+    setExcluded((prev) => {
+      const next = new Set(prev);
+      if (next.has(externalId)) next.delete(externalId);
+      else next.add(externalId);
+      return next;
+    });
+  }
+
+  function onConfirm() {
+    if (!preview) return;
+    const rows = preview.rows
+      .filter((r) => !excluded.has(r.externalId))
+      .map((r) => ({
+        occurredOn: r.occurredOn,
+        description: r.description,
+        reference: r.reference,
+        amountCents: r.amountCents.toString(),
+        externalId: r.externalId,
+      }));
+    if (rows.length === 0) {
+      toast.error("Nothing to import");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        const res = await confirmBancolombiaImport({
+          accountId: preview.accountId,
+          rows,
+        });
+        toast.success(
+          `Imported ${res.inserted} · ${res.duplicated} skipped as duplicate`,
+        );
+        setPreview(null);
+        setExcluded(new Set());
+        router.push("/transactions");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Import failed");
+      }
+    });
+  }
+
+  const includedCount = preview
+    ? preview.rows.length - excluded.size
+    : 0;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Bancolombia · XLSX upload</CardTitle>
+          <CardDescription>
+            Pick the account this file belongs to, then upload the
+            “Movimientos” .xlsx exported from Sucursal Virtual.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form action={onUpload} className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="imp-account">Account</Label>
+              <select
+                id="imp-account"
+                name="accountId"
+                value={accountId}
+                onChange={(e) => setAccountId(e.target.value)}
+                className="h-9 rounded-md border bg-background px-2 text-sm"
+                required
+              >
+                {accounts.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.name} ({a.currency})
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="imp-file">XLSX file</Label>
+              <Input
+                id="imp-file"
+                name="file"
+                type="file"
+                accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                required
+              />
+            </div>
+            <div>
+              <ParseButton />
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {preview && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Preview · {includedCount} of {preview.rows.length} selected</CardTitle>
+            <CardDescription>
+              Duplicates pre-excluded. Toggle any row to include or skip it.
+              {preview.skipped.length > 0
+                ? ` ${preview.skipped.length} row(s) skipped during parsing.`
+                : ""}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <div className="overflow-x-auto rounded-md border">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/50 text-xs uppercase text-muted-foreground">
+                  <tr>
+                    <th className="w-10 p-2"></th>
+                    <th className="p-2 text-left">Date</th>
+                    <th className="p-2 text-left">Description</th>
+                    <th className="p-2 text-left">Reference</th>
+                    <th className="p-2 text-right">Amount</th>
+                    <th className="p-2 text-left">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.rows.map((r) => {
+                    const isExcluded = excluded.has(r.externalId);
+                    return (
+                      <tr
+                        key={r.externalId}
+                        className={cn(
+                          "border-t",
+                          isExcluded && "opacity-50",
+                          r.duplicate && "bg-amber-50/40",
+                        )}
+                      >
+                        <td className="p-2">
+                          <input
+                            type="checkbox"
+                            checked={!isExcluded}
+                            onChange={() => toggleRow(r.externalId)}
+                            aria-label={`Include row ${r.rowIndex}`}
+                          />
+                        </td>
+                        <td className="p-2 tabular-nums">
+                          {dateFmt.format(new Date(`${r.occurredOn}T12:00:00Z`))}
+                        </td>
+                        <td className="max-w-[18rem] truncate p-2">
+                          {r.description}
+                        </td>
+                        <td className="p-2 text-xs text-muted-foreground">
+                          {r.reference ?? "—"}
+                        </td>
+                        <td
+                          className={cn(
+                            "p-2 text-right tabular-nums font-medium",
+                            r.amountCents < BigInt(0) ? "text-rose-600" : "text-emerald-600",
+                          )}
+                        >
+                          {formatMoney(r.amountCents, currency)}
+                        </td>
+                        <td className="p-2 text-xs">
+                          {r.duplicate ? (
+                            <span className="rounded bg-amber-100 px-1.5 py-0.5 text-amber-800">
+                              duplicate
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">new</span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+            <div className="flex items-center justify-end gap-2">
+              <Button variant="outline" onClick={() => setPreview(null)} disabled={pending}>
+                Cancel
+              </Button>
+              <Button onClick={onConfirm} disabled={pending || includedCount === 0}>
+                {pending ? "Importing…" : `Import ${includedCount} row(s)`}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/settings/import/page.tsx
+++ b/src/app/settings/import/page.tsx
@@ -1,0 +1,26 @@
+import { asc, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts } from "@/lib/db/schema";
+import { ImportForm } from "./import-form";
+
+export const dynamic = "force-dynamic";
+
+export default async function ImportPage() {
+  const accs = await db
+    .select({ id: accounts.id, name: accounts.name, currency: accounts.currency })
+    .from(accounts)
+    .where(eq(accounts.active, true))
+    .orderBy(asc(accounts.name));
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Import</h1>
+        <p className="text-sm text-muted-foreground">
+          Bulk-import transactions from a bank export.
+        </p>
+      </header>
+      <ImportForm accounts={accs} />
+    </main>
+  );
+}

--- a/src/lib/ingestion/xlsx-bancolombia.test.ts
+++ b/src/lib/ingestion/xlsx-bancolombia.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import * as XLSX from "xlsx";
+import { parseBancolombiaXlsx } from "./xlsx-bancolombia";
+
+function makeXlsx(rows: unknown[][]): Buffer {
+  const ws = XLSX.utils.aoa_to_sheet(rows);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "Hoja 1");
+  return XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+}
+
+describe("parseBancolombiaXlsx", () => {
+  it("parses headers + happy path rows", () => {
+    const buf = makeXlsx([
+      ["Fecha", "Descripción", "Referencia", "Valor"],
+      [new Date("2026-04-15T12:00:00Z"), "PAGO QR FOO", "0091498581", -92000],
+      [new Date("2026-04-14T12:00:00Z"), "TRANSF DE BAR", "null", 100000],
+    ]);
+    const { rows, skipped } = parseBancolombiaXlsx(buf, 1);
+    expect(skipped).toEqual([]);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].occurredOn).toBe("2026-04-15");
+    expect(rows[0].amountCents).toBe(BigInt(-9200000));
+    expect(rows[0].externalId).toMatch(/^bcol:1:[a-f0-9]{24}$/);
+    expect(rows[1].reference).toBeNull();
+    expect(rows[1].externalId).toMatch(/^bcol:1:[a-f0-9]{24}$/);
+    expect(rows[0].externalId).not.toBe(rows[1].externalId);
+  });
+
+  it("preserves decimal amounts without floating-point drift", () => {
+    const buf = makeXlsx([
+      ["Fecha", "Descripción", "Referencia", "Valor"],
+      [new Date("2026-04-15T12:00:00Z"), "PAGO TC", "", -1320564.6],
+    ]);
+    const { rows } = parseBancolombiaXlsx(buf, 1);
+    expect(rows[0].amountCents).toBe(BigInt(-132056460));
+  });
+
+  it("skips invalid rows but keeps valid ones", () => {
+    const buf = makeXlsx([
+      ["Fecha", "Descripción", "Referencia", "Valor"],
+      ["", "", "", ""],
+      [new Date("2026-04-15T12:00:00Z"), "OK", "REF1", -1000],
+      [new Date("2026-04-14T12:00:00Z"), "", "REF2", -2000],
+      [new Date("2026-04-13T12:00:00Z"), "ZERO", "REF3", 0],
+    ]);
+    const { rows, skipped } = parseBancolombiaXlsx(buf, 7);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].description).toBe("OK");
+    expect(skipped.map((s) => s.reason)).toEqual([
+      "Missing description",
+      "Invalid amount: 0",
+    ]);
+  });
+
+  it("rejects unexpected headers", () => {
+    const buf = makeXlsx([["Date", "Memo", "Ref", "Amount"]]);
+    const { rows, skipped } = parseBancolombiaXlsx(buf, 1);
+    expect(rows).toEqual([]);
+    expect(skipped[0].reason).toMatch(/Unexpected headers/);
+  });
+
+  it("produces stable externalId for same row on repeated parses", () => {
+    const rows = [
+      ["Fecha", "Descripción", "Referencia", "Valor"],
+      [new Date("2026-04-15T12:00:00Z"), "TRANSF", "", -5000],
+    ];
+    const a = parseBancolombiaXlsx(makeXlsx(rows), 1);
+    const b = parseBancolombiaXlsx(makeXlsx(rows), 1);
+    expect(a.rows[0].externalId).toBe(b.rows[0].externalId);
+  });
+
+  it("disambiguates rows with identical reference and amount on the same day", () => {
+    const buf = makeXlsx([
+      ["Fecha", "Descripción", "Referencia", "Valor"],
+      [new Date("2026-04-15T12:00:00Z"), "PAGO QR FOO", "988044474", -5000],
+      [new Date("2026-04-15T12:00:00Z"), "PAGO QR FOO", "988044474", -5000],
+      [new Date("2026-04-15T12:00:00Z"), "PAGO QR FOO", "988044474", -5000],
+    ]);
+    const { rows } = parseBancolombiaXlsx(buf, 1);
+    expect(rows).toHaveLength(3);
+    const ids = new Set(rows.map((r) => r.externalId));
+    expect(ids.size).toBe(3);
+  });
+});

--- a/src/lib/ingestion/xlsx-bancolombia.ts
+++ b/src/lib/ingestion/xlsx-bancolombia.ts
@@ -1,0 +1,156 @@
+import * as XLSX from "xlsx";
+import { createHash } from "node:crypto";
+
+export type ParsedRow = {
+  rowIndex: number;
+  occurredOn: string;
+  description: string;
+  reference: string | null;
+  amountCents: bigint;
+  externalId: string;
+};
+
+export type ParseResult = {
+  rows: ParsedRow[];
+  skipped: { rowIndex: number; reason: string }[];
+};
+
+const EXPECTED_HEADERS = ["Fecha", "Descripción", "Referencia", "Valor"] as const;
+
+function isEmptyRef(v: unknown): boolean {
+  if (v === null || v === undefined) return true;
+  const s = String(v).trim();
+  return s === "" || s.toLowerCase() === "null";
+}
+
+function toIsoDate(value: unknown): string | null {
+  if (value instanceof Date && !isNaN(value.getTime())) {
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === "number") {
+    const d = XLSX.SSF.parse_date_code(value);
+    if (!d) return null;
+    const mm = String(d.m).padStart(2, "0");
+    const dd = String(d.d).padStart(2, "0");
+    return `${d.y}-${mm}-${dd}`;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const match = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (match) return `${match[1]}-${match[2]}-${match[3]}`;
+    const parsed = new Date(trimmed);
+    if (!isNaN(parsed.getTime())) return parsed.toISOString().slice(0, 10);
+  }
+  return null;
+}
+
+function toCents(value: unknown): bigint | null {
+  if (typeof value === "number" && isFinite(value)) {
+    return BigInt(Math.round(value * 100));
+  }
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^\d.,-]/g, "").replace(/\.(?=\d{3}(\D|$))/g, "");
+    const normalized = cleaned.replace(",", ".");
+    const num = Number(normalized);
+    if (!isNaN(num)) return BigInt(Math.round(num * 100));
+  }
+  return null;
+}
+
+function buildExternalId(
+  accountId: number,
+  occurredOn: string,
+  amountCents: bigint,
+  description: string,
+  reference: string | null,
+  positionInDay: number,
+): string {
+  const ref = reference && !isEmptyRef(reference) ? reference.trim() : "";
+  const hash = createHash("sha256")
+    .update(
+      `${accountId}|${occurredOn}|${amountCents.toString()}|${description.trim()}|${ref}|${positionInDay}`,
+    )
+    .digest("hex")
+    .slice(0, 24);
+  return `bcol:${accountId}:${hash}`;
+}
+
+export function parseBancolombiaXlsx(
+  buffer: ArrayBuffer | Uint8Array | Buffer,
+  accountId: number,
+): ParseResult {
+  const wb = XLSX.read(buffer, { cellDates: true, type: "buffer" });
+  const sheet = wb.Sheets[wb.SheetNames[0]];
+  if (!sheet) {
+    return { rows: [], skipped: [{ rowIndex: 0, reason: "No sheet found" }] };
+  }
+
+  const aoa = XLSX.utils.sheet_to_json<unknown[]>(sheet, { header: 1, raw: true, defval: null });
+
+  if (aoa.length === 0) {
+    return { rows: [], skipped: [] };
+  }
+
+  const headerRow = aoa[0]?.map((h) => String(h ?? "").trim()) ?? [];
+  const headerOk = EXPECTED_HEADERS.every((h, i) => headerRow[i] === h);
+  if (!headerOk) {
+    return {
+      rows: [],
+      skipped: [
+        {
+          rowIndex: 0,
+          reason: `Unexpected headers: got [${headerRow.join(", ")}], expected [${EXPECTED_HEADERS.join(", ")}]`,
+        },
+      ],
+    };
+  }
+
+  const rows: ParsedRow[] = [];
+  const skipped: { rowIndex: number; reason: string }[] = [];
+  const dayCounters = new Map<string, number>();
+
+  for (let i = 1; i < aoa.length; i++) {
+    const raw = aoa[i];
+    if (!raw || raw.every((c) => c === null || c === "")) continue;
+
+    const occurredOn = toIsoDate(raw[0]);
+    const description = raw[1] != null ? String(raw[1]).trim() : "";
+    const reference = isEmptyRef(raw[2]) ? null : String(raw[2]).trim();
+    const amountCents = toCents(raw[3]);
+
+    if (!occurredOn) {
+      skipped.push({ rowIndex: i, reason: `Invalid date: ${String(raw[0])}` });
+      continue;
+    }
+    if (!description) {
+      skipped.push({ rowIndex: i, reason: "Missing description" });
+      continue;
+    }
+    if (amountCents === null || amountCents === BigInt(0)) {
+      skipped.push({ rowIndex: i, reason: `Invalid amount: ${String(raw[3])}` });
+      continue;
+    }
+
+    const dayKey = `${occurredOn}|${amountCents.toString()}|${description}|${reference ?? ""}`;
+    const positionInDay = dayCounters.get(dayKey) ?? 0;
+    dayCounters.set(dayKey, positionInDay + 1);
+
+    rows.push({
+      rowIndex: i,
+      occurredOn,
+      description,
+      reference,
+      amountCents,
+      externalId: buildExternalId(
+        accountId,
+        occurredOn,
+        amountCents,
+        description,
+        reference,
+        positionInDay,
+      ),
+    });
+  }
+
+  return { rows, skipped };
+}


### PR DESCRIPTION
## Summary
Pivot of #7 from CSV → XLSX (Bancolombia discontinued CSV exports for savings accounts).

- \`src/lib/ingestion/xlsx-bancolombia.ts\` — pure parser, takes ArrayBuffer + accountId, returns \`{ rows, skipped }\`. Handles Excel serial dates, decimal amounts, empty/\"null\" references.
- \`src/app/settings/import/page.tsx\` + \`import-form.tsx\` + \`actions.ts\` — upload UI with preview table (checkbox per row), duplicates pre-excluded, confirm → bulk insert.
- Auto-classification on import via existing \`classifyByRule\` (#3).
- Deterministic \`externalId\` = sha256(accountId|date|amount|description|reference|positionInDay), 24-char hex. Position counter disambiguates legitimate same-day repeated rows.
- Logs each run to \`ingestion_logs\`.

## Tests
- \`src/lib/ingestion/xlsx-bancolombia.test.ts\` — 6 cases: happy path, decimals, skip rules, header validation, stable IDs, same-day duplicate disambiguation.
- 11/11 vitest tests passing.

## Discoveries
- Bancolombia repeats values in the \`Referencia\` column for legitimately distinct transactions (and sometimes spills description text into it). Reference alone is NOT a unique key — full hash required.
- \`onConflictDoNothing\` against a **partial** unique index requires \`where\` matching the index predicate. Without it, postgres errors with \"no unique or exclusion constraint matching the ON CONFLICT specification\".
- Next.js 16 forms with file inputs MUST use \`<form action={fn}>\` pattern, not \`onSubmit + manual call\`. The latter triggers a full page reload.

## Test plan
- [x] \`bun run typecheck\` passes
- [x] \`bun run lint\` passes
- [x] \`bun run test\` — 11 passing
- [x] Manual: uploaded real Bancolombia xlsx, 45/45 rows imported, classified where rules matched
- [x] Re-upload of same file → all flagged as duplicates (idempotent)

Closes #7