### PR TITLE
feat(ingestion): screenshot OCR for ARQ via Claude Vision (#8)

### DIFF
--- a/src/app/api/ingest/ocr/route.ts
+++ b/src/app/api/ingest/ocr/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { previewScreenshotOcr } from "@/app/settings/import/actions";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  const contentType = req.headers.get("content-type") ?? "";
+  if (!contentType.includes("multipart/form-data")) {
+    return NextResponse.json(
+      { error: "Expected multipart/form-data with fields 'accountId' and 'file'" },
+      { status: 415 },
+    );
+  }
+
+  try {
+    const formData = await req.formData();
+    const result = await previewScreenshotOcr(formData);
+    const rows = result.rows.map((r) => ({
+      ...r,
+      amountCents: r.amountCents.toString(),
+    }));
+    return NextResponse.json({ ...result, rows });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "OCR failed";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/settings/import/actions.ts
+++ b/src/app/settings/import/actions.ts
@@ -7,6 +7,11 @@ import { db } from "@/lib/db";
 import { accounts, ingestionLogs, transactions } from "@/lib/db/schema";
 import { classifyByRule } from "@/lib/classification/rules";
 import { parseBancolombiaXlsx, type ParsedRow } from "@/lib/ingestion/xlsx-bancolombia";
+import {
+  extractTransactionsFromImage,
+  type OcrMediaType,
+  type OcrParsedRow,
+} from "@/lib/ingestion/ocr";
 
 const previewSchema = z.object({
   accountId: z.coerce.number().int().positive(),
@@ -143,6 +148,172 @@ export async function confirmBancolombiaImport(input: ConfirmInput): Promise<Con
     itemsDuplicated: duplicated,
     errorMessage: errors.length ? errors.slice(0, 5).join("; ") : null,
     payload: { accountId: parsed.accountId, format: "xlsx-bancolombia" },
+    startedAt,
+    finishedAt: new Date(),
+  });
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+
+  return { inserted, duplicated };
+}
+
+const ocrPreviewSchema = z.object({
+  accountId: z.coerce.number().int().positive(),
+});
+
+const ALLOWED_MEDIA: OcrMediaType[] = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+];
+
+export type OcrPreviewRow = OcrParsedRow & { duplicate: boolean };
+
+export type OcrPreviewResult = {
+  accountId: number;
+  rows: OcrPreviewRow[];
+  skipped: { rowIndex: number; reason: string }[];
+  model: string;
+  usage: { inputTokens: number; outputTokens: number };
+  totals: { parsed: number; duplicates: number; new: number };
+};
+
+export async function previewScreenshotOcr(
+  formData: FormData,
+): Promise<OcrPreviewResult> {
+  const { accountId } = ocrPreviewSchema.parse({
+    accountId: formData.get("accountId"),
+  });
+  const file = formData.get("file");
+  if (!(file instanceof File)) throw new Error("No image uploaded");
+  if (file.size === 0) throw new Error("Image is empty");
+  if (file.size > 8 * 1024 * 1024) throw new Error("Image too large (>8MB)");
+  if (!ALLOWED_MEDIA.includes(file.type as OcrMediaType)) {
+    throw new Error(`Unsupported image type: ${file.type || "unknown"}`);
+  }
+
+  const [account] = await db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(eq(accounts.id, accountId))
+    .limit(1);
+  if (!account) throw new Error("Account not found");
+
+  const buf = Buffer.from(await file.arrayBuffer());
+  const imageBase64 = buf.toString("base64");
+
+  const result = await extractTransactionsFromImage({
+    imageBase64,
+    mediaType: file.type as OcrMediaType,
+    accountId,
+  });
+
+  const externalIds = result.rows.map((r) => r.externalId);
+  const existing = externalIds.length
+    ? await db
+        .select({ externalId: transactions.externalId })
+        .from(transactions)
+        .where(
+          and(
+            eq(transactions.accountId, accountId),
+            inArray(transactions.externalId, externalIds),
+          ),
+        )
+    : [];
+  const existingSet = new Set(existing.map((e) => e.externalId));
+
+  const rows: OcrPreviewRow[] = result.rows.map((r) => ({
+    ...r,
+    duplicate: existingSet.has(r.externalId),
+  }));
+
+  return {
+    accountId,
+    rows,
+    skipped: result.skipped,
+    model: result.model,
+    usage: result.usage,
+    totals: {
+      parsed: rows.length,
+      duplicates: rows.filter((r) => r.duplicate).length,
+      new: rows.filter((r) => !r.duplicate).length,
+    },
+  };
+}
+
+const confirmOcrSchema = z.object({
+  accountId: z.coerce.number().int().positive(),
+  rows: z.array(
+    z.object({
+      occurredOn: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      description: z.string().min(1).max(500),
+      amountCents: z.string().regex(/^-?\d+$/),
+      externalId: z.string().min(1).max(200),
+    }),
+  ),
+});
+
+export type ConfirmOcrInput = z.infer<typeof confirmOcrSchema>;
+
+export async function confirmOcrImport(
+  input: ConfirmOcrInput,
+): Promise<ConfirmResult> {
+  const parsed = confirmOcrSchema.parse(input);
+  const startedAt = new Date();
+
+  const [account] = await db
+    .select({ id: accounts.id, currency: accounts.currency })
+    .from(accounts)
+    .where(eq(accounts.id, parsed.accountId))
+    .limit(1);
+  if (!account) throw new Error("Account not found");
+
+  let inserted = 0;
+  let duplicated = 0;
+  const errors: string[] = [];
+
+  for (const r of parsed.rows) {
+    try {
+      const cls = await classifyByRule({ descriptionRaw: r.description });
+      const result = await db
+        .insert(transactions)
+        .values({
+          accountId: account.id,
+          occurredAt: new Date(`${r.occurredOn}T12:00:00Z`),
+          amountCents: BigInt(r.amountCents),
+          currency: account.currency,
+          descriptionRaw: r.description,
+          descriptionClean: null,
+          merchant: null,
+          categorySlug: cls?.categorySlug ?? null,
+          classificationMethod: cls ? "rule" : "unclassified",
+          classificationConfidence: cls?.confidence ?? null,
+          source: "ocr",
+          externalId: r.externalId,
+        })
+        .onConflictDoNothing({
+          target: [transactions.accountId, transactions.externalId],
+          where: sql`${transactions.externalId} IS NOT NULL`,
+        })
+        .returning({ id: transactions.id });
+
+      if (result.length > 0) inserted++;
+      else duplicated++;
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  await db.insert(ingestionLogs).values({
+    source: "ocr",
+    status: errors.length === 0 ? "ok" : "partial",
+    itemsReceived: parsed.rows.length,
+    itemsInserted: inserted,
+    itemsDuplicated: duplicated,
+    errorMessage: errors.length ? errors.slice(0, 5).join("; ") : null,
+    payload: { accountId: parsed.accountId, format: "screenshot-ocr" },
     startedAt,
     finishedAt: new Date(),
   });

--- a/src/app/settings/import/page.tsx
+++ b/src/app/settings/import/page.tsx
@@ -1,6 +1,7 @@
 import { asc, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts } from "@/lib/db/schema";
+import { ScreenshotUpload } from "@/components/import/screenshot-upload";
 import { ImportForm } from "./import-form";
 
 export const dynamic = "force-dynamic";
@@ -21,6 +22,7 @@ export default async function ImportPage() {
         </p>
       </header>
       <ImportForm accounts={accs} />
+      <ScreenshotUpload accounts={accs} />
     </main>
   );
 }

--- a/src/components/import/screenshot-upload.tsx
+++ b/src/components/import/screenshot-upload.tsx
@@ -1,0 +1,413 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { formatMoney } from "@/lib/money";
+import { cn } from "@/lib/utils";
+import {
+  confirmOcrImport,
+  previewScreenshotOcr,
+  type OcrPreviewResult,
+} from "@/app/settings/import/actions";
+
+type AccountOption = { id: number; name: string; currency: "COP" | "USD" };
+
+type EditableRow = {
+  occurredOn: string;
+  description: string;
+  amountCents: bigint;
+  externalId: string;
+  duplicate: boolean;
+};
+
+const dateFmt = new Intl.DateTimeFormat("es-CO", {
+  day: "2-digit",
+  month: "short",
+});
+
+function toEditable(preview: OcrPreviewResult): EditableRow[] {
+  return preview.rows.map((r) => ({
+    occurredOn: r.occurredOn,
+    description: r.description,
+    amountCents: r.amountCents,
+    externalId: r.externalId,
+    duplicate: r.duplicate,
+  }));
+}
+
+export function ScreenshotUpload({ accounts }: { accounts: AccountOption[] }) {
+  const router = useRouter();
+  const [accountId, setAccountId] = useState<string>(
+    accounts[0]?.id.toString() ?? "",
+  );
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [parsing, setParsing] = useState(false);
+  const [preview, setPreview] = useState<OcrPreviewResult | null>(null);
+  const [rows, setRows] = useState<EditableRow[]>([]);
+  const [excluded, setExcluded] = useState<Set<string>>(new Set());
+  const [isDragging, setIsDragging] = useState(false);
+  const [confirming, startTransition] = useTransition();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const account = accounts.find((a) => a.id.toString() === accountId);
+  const currency = account?.currency ?? "COP";
+
+  useEffect(() => {
+    if (!file) {
+      setPreviewUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  const pickFile = useCallback((next: File | null) => {
+    setFile(next);
+    setPreview(null);
+    setRows([]);
+    setExcluded(new Set());
+  }, []);
+
+  useEffect(() => {
+    function onPaste(e: ClipboardEvent) {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      for (const item of items) {
+        if (item.type.startsWith("image/")) {
+          const f = item.getAsFile();
+          if (f) {
+            pickFile(f);
+            toast.success("Image pasted");
+            e.preventDefault();
+            return;
+          }
+        }
+      }
+    }
+    window.addEventListener("paste", onPaste);
+    return () => window.removeEventListener("paste", onPaste);
+  }, [pickFile]);
+
+  function onDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setIsDragging(false);
+    const f = e.dataTransfer.files?.[0];
+    if (f && f.type.startsWith("image/")) pickFile(f);
+    else toast.error("Drop an image file (PNG, JPEG, WebP)");
+  }
+
+  async function onParse() {
+    if (!file) {
+      toast.error("Choose or paste an image first");
+      return;
+    }
+    if (!accountId) {
+      toast.error("Pick an account");
+      return;
+    }
+    setParsing(true);
+    try {
+      const fd = new FormData();
+      fd.set("accountId", accountId);
+      fd.set("file", file);
+      const result = await previewScreenshotOcr(fd);
+      setPreview(result);
+      setRows(toEditable(result));
+      setExcluded(
+        new Set(result.rows.filter((r) => r.duplicate).map((r) => r.externalId)),
+      );
+      toast.success(
+        `Extracted ${result.totals.parsed} · ${result.totals.new} new · ${result.totals.duplicates} duplicates`,
+      );
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "OCR failed");
+    } finally {
+      setParsing(false);
+    }
+  }
+
+  function toggleRow(externalId: string) {
+    setExcluded((prev) => {
+      const next = new Set(prev);
+      if (next.has(externalId)) next.delete(externalId);
+      else next.add(externalId);
+      return next;
+    });
+  }
+
+  function updateRow(idx: number, patch: Partial<EditableRow>) {
+    setRows((prev) => {
+      const next = [...prev];
+      next[idx] = { ...next[idx], ...patch };
+      return next;
+    });
+  }
+
+  function onConfirm() {
+    if (!preview) return;
+    const payload = rows
+      .filter((r) => !excluded.has(r.externalId))
+      .filter((r) => r.amountCents !== BigInt(0))
+      .map((r) => ({
+        occurredOn: r.occurredOn,
+        description: r.description,
+        amountCents: r.amountCents.toString(),
+        externalId: r.externalId,
+      }));
+    if (payload.length === 0) {
+      toast.error("Nothing to import");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        const res = await confirmOcrImport({
+          accountId: preview.accountId,
+          rows: payload,
+        });
+        toast.success(
+          `Imported ${res.inserted} · ${res.duplicated} skipped as duplicate`,
+        );
+        setFile(null);
+        setPreview(null);
+        setRows([]);
+        setExcluded(new Set());
+        router.push("/transactions");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Import failed");
+      }
+    });
+  }
+
+  const includedCount = rows.filter((r) => !excluded.has(r.externalId)).length;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Screenshot OCR · Claude Vision</CardTitle>
+          <CardDescription>
+            Paste (⌘/Ctrl+V), drop, or choose a screenshot of transactions (ARQ,
+            or any bank as fallback). Claude Vision will extract the rows.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="ocr-account">Account</Label>
+            <select
+              id="ocr-account"
+              value={accountId}
+              onChange={(e) => setAccountId(e.target.value)}
+              className="h-9 rounded-md border bg-background px-2 text-sm"
+              required
+            >
+              {accounts.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name} ({a.currency})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div
+            onDragOver={(e) => {
+              e.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragLeave={() => setIsDragging(false)}
+            onDrop={onDrop}
+            onClick={() => inputRef.current?.click()}
+            className={cn(
+              "flex cursor-pointer flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed p-8 text-sm transition",
+              isDragging
+                ? "border-primary bg-primary/5"
+                : "border-muted-foreground/30 hover:border-muted-foreground/60",
+            )}
+          >
+            {previewUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={previewUrl}
+                alt="Screenshot preview"
+                className="max-h-64 rounded border"
+              />
+            ) : (
+              <>
+                <span className="font-medium">Drop, paste, or click to upload</span>
+                <span className="text-xs text-muted-foreground">
+                  PNG, JPEG, WebP · up to 8MB
+                </span>
+              </>
+            )}
+            <Input
+              ref={inputRef}
+              type="file"
+              accept="image/png,image/jpeg,image/webp,image/gif"
+              className="hidden"
+              onChange={(e) => pickFile(e.target.files?.[0] ?? null)}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button onClick={onParse} disabled={!file || parsing}>
+              {parsing ? "Extracting…" : "Extract with Claude Vision"}
+            </Button>
+            {file && (
+              <Button
+                variant="outline"
+                onClick={() => pickFile(null)}
+                disabled={parsing}
+              >
+                Clear
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {preview && (
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              Preview · {includedCount} of {rows.length} selected
+            </CardTitle>
+            <CardDescription>
+              Model: {preview.model} · {preview.usage.inputTokens} in /{" "}
+              {preview.usage.outputTokens} out tokens. Edit any row before
+              importing.
+              {preview.skipped.length > 0
+                ? ` ${preview.skipped.length} row(s) skipped during parsing.`
+                : ""}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <div className="overflow-x-auto rounded-md border">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/50 text-xs uppercase text-muted-foreground">
+                  <tr>
+                    <th className="w-10 p-2"></th>
+                    <th className="p-2 text-left">Date</th>
+                    <th className="p-2 text-left">Description</th>
+                    <th className="p-2 text-right">Amount</th>
+                    <th className="p-2 text-left">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((r, idx) => {
+                    const isExcluded = excluded.has(r.externalId);
+                    return (
+                      <tr
+                        key={r.externalId}
+                        className={cn(
+                          "border-t",
+                          isExcluded && "opacity-50",
+                          r.duplicate && "bg-amber-50/40",
+                        )}
+                      >
+                        <td className="p-2">
+                          <input
+                            type="checkbox"
+                            checked={!isExcluded}
+                            onChange={() => toggleRow(r.externalId)}
+                            aria-label={`Include row ${idx}`}
+                          />
+                        </td>
+                        <td className="p-2 tabular-nums">
+                          <Input
+                            type="date"
+                            value={r.occurredOn}
+                            onChange={(e) =>
+                              updateRow(idx, { occurredOn: e.target.value })
+                            }
+                            className="h-8 w-36"
+                          />
+                        </td>
+                        <td className="p-2">
+                          <Input
+                            value={r.description}
+                            onChange={(e) =>
+                              updateRow(idx, { description: e.target.value })
+                            }
+                            className="h-8"
+                          />
+                        </td>
+                        <td className="p-2 text-right">
+                          <Input
+                            type="number"
+                            step="0.01"
+                            value={(Number(r.amountCents) / 100).toString()}
+                            onChange={(e) => {
+                              const n = Number(e.target.value);
+                              if (!Number.isFinite(n)) return;
+                              updateRow(idx, {
+                                amountCents: BigInt(Math.round(n * 100)),
+                              });
+                            }}
+                            className={cn(
+                              "h-8 w-32 text-right tabular-nums",
+                              r.amountCents < BigInt(0)
+                                ? "text-rose-600"
+                                : "text-emerald-600",
+                            )}
+                          />
+                          <div className="text-xs text-muted-foreground tabular-nums">
+                            {formatMoney(r.amountCents, currency)}
+                          </div>
+                          <div className="text-[10px] text-muted-foreground tabular-nums">
+                            {dateFmt.format(
+                              new Date(`${r.occurredOn}T12:00:00Z`),
+                            )}
+                          </div>
+                        </td>
+                        <td className="p-2 text-xs">
+                          {r.duplicate ? (
+                            <span className="rounded bg-amber-100 px-1.5 py-0.5 text-amber-800">
+                              duplicate
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">new</span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setPreview(null);
+                  setRows([]);
+                  setExcluded(new Set());
+                }}
+                disabled={confirming}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={onConfirm}
+                disabled={confirming || includedCount === 0}
+              >
+                {confirming ? "Importing…" : `Import ${includedCount} row(s)`}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/lib/ingestion/ocr.ts
+++ b/src/lib/ingestion/ocr.ts
@@ -1,0 +1,183 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+export type OcrMediaType = "image/png" | "image/jpeg" | "image/webp" | "image/gif";
+
+export type OcrParsedRow = {
+  rowIndex: number;
+  occurredOn: string;
+  description: string;
+  amountCents: bigint;
+  externalId: string;
+};
+
+export type OcrResult = {
+  rows: OcrParsedRow[];
+  skipped: { rowIndex: number; reason: string }[];
+  model: string;
+  usage: { inputTokens: number; outputTokens: number };
+};
+
+const responseSchema = z.object({
+  transactions: z.array(
+    z.object({
+      date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      description: z.string().min(1).max(500),
+      amount: z.number().finite(),
+    }),
+  ),
+});
+
+const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+
+const PROMPT = `You extract transactions from a bank app screenshot.
+
+Return ONLY valid JSON matching this shape (no prose, no markdown):
+{
+  "transactions": [
+    { "date": "YYYY-MM-DD", "description": "string", "amount": number }
+  ]
+}
+
+Rules:
+- "amount" is a NUMBER in the account's currency (no symbols). Use NEGATIVE for debits/expenses/withdrawals and POSITIVE for credits/deposits/refunds.
+- "date" in ISO YYYY-MM-DD. If the screenshot shows only day+month, use the most likely year from context; if ambiguous, use the current year.
+- Keep "description" concise (merchant + reference when visible).
+- Skip balance lines, totals, running balances, and UI chrome. Only real transactions.
+- If the screenshot is unreadable or contains no transactions, return {"transactions": []}.`;
+
+function toCents(amount: number): bigint {
+  return BigInt(Math.round(amount * 100));
+}
+
+function buildExternalId(
+  accountId: number,
+  occurredOn: string,
+  amountCents: bigint,
+  description: string,
+  positionInDay: number,
+): string {
+  const hash = createHash("sha256")
+    .update(
+      `${accountId}|${occurredOn}|${amountCents.toString()}|${description.trim()}|${positionInDay}`,
+    )
+    .digest("hex")
+    .slice(0, 24);
+  return `ocr:${accountId}:${hash}`;
+}
+
+function extractJson(text: string): unknown {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fenced ? fenced[1] : trimmed;
+  return JSON.parse(candidate);
+}
+
+export async function extractTransactionsFromImage(opts: {
+  imageBase64: string;
+  mediaType: OcrMediaType;
+  accountId: number;
+  model?: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<OcrResult> {
+  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
+
+  const model = opts.model ?? DEFAULT_MODEL;
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  const res = await doFetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 2048,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: opts.mediaType,
+                data: opts.imageBase64,
+              },
+            },
+            { type: "text", text: PROMPT },
+          ],
+        },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Anthropic API error ${res.status}: ${body.slice(0, 300)}`);
+  }
+
+  const payload = (await res.json()) as {
+    content: Array<{ type: string; text?: string }>;
+    usage?: { input_tokens: number; output_tokens: number };
+  };
+
+  const textBlock = payload.content?.find((c) => c.type === "text")?.text ?? "";
+  let parsedJson: unknown;
+  try {
+    parsedJson = extractJson(textBlock);
+  } catch {
+    throw new Error("Model returned invalid JSON");
+  }
+
+  const parsed = responseSchema.parse(parsedJson);
+
+  const rows: OcrParsedRow[] = [];
+  const skipped: { rowIndex: number; reason: string }[] = [];
+  const dayCounters = new Map<string, number>();
+
+  parsed.transactions.forEach((t, i) => {
+    const description = t.description.trim();
+    if (!description) {
+      skipped.push({ rowIndex: i, reason: "Missing description" });
+      return;
+    }
+    const amountCents = toCents(t.amount);
+    if (amountCents === BigInt(0)) {
+      skipped.push({ rowIndex: i, reason: "Zero amount" });
+      return;
+    }
+
+    const dayKey = `${t.date}|${amountCents.toString()}|${description}`;
+    const positionInDay = dayCounters.get(dayKey) ?? 0;
+    dayCounters.set(dayKey, positionInDay + 1);
+
+    rows.push({
+      rowIndex: i,
+      occurredOn: t.date,
+      description,
+      amountCents,
+      externalId: buildExternalId(
+        opts.accountId,
+        t.date,
+        amountCents,
+        description,
+        positionInDay,
+      ),
+    });
+  });
+
+  return {
+    rows,
+    skipped,
+    model,
+    usage: {
+      inputTokens: payload.usage?.input_tokens ?? 0,
+      outputTokens: payload.usage?.output_tokens ?? 0,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Claude Vision OCR pipeline: drag/drop/paste screenshot → extract transactions → editable preview → confirm INSERT (`source='ocr'`).
- New `src/lib/ingestion/ocr.ts` (direct Anthropic `/v1/messages` fetch, Haiku 4.5 default, Zod-validated JSON output).
- Server actions `previewScreenshotOcr` / `confirmOcrImport` mirror the existing XLSX flow (dedup via stable `ocr:<acct>:<hash>` external IDs, rule-engine classification, `ingestion_logs` entry).
- `POST /api/ingest/ocr` route (multipart: `accountId` + `file`) as the external-facing endpoint per issue spec.
- Wires `ScreenshotUpload` card into `/settings/import` below the XLSX importer.

Closes #8

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Manual: paste / drop an ARQ screenshot at `/settings/import`, verify preview extracts rows, edit and confirm, check `/transactions`
- [ ] Manual: re-upload same screenshot → rows marked `duplicate`, `onConflictDoNothing` skips inserts
- [ ] Manual: `curl -F accountId=6 -F file=@shot.png http://localhost:3100/api/ingest/ocr` returns JSON

## Notes
- OCR path not smoke-tested from the agent environment — needs a real screenshot + live Vision call.
- Followed the existing XLSX pattern: server actions for the UI, thin API route layered on top (vs. issue wording "POST to /api/ingest/ocr" doing all the work).