### PR TITLE
feat(classification): Claude Haiku batch classifier with rules fallback (#10)

### DIFF
--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { accounts, categories, transactions } from "@/lib/db/schema";
+import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
 
 const updateSchema = z.object({
   txId: z.coerce.number().int().positive(),
@@ -84,4 +85,11 @@ export async function createManualExpense(input: {
 
   revalidatePath("/");
   revalidatePath("/transactions");
+}
+
+export async function runAiClassifier() {
+  const result = await classifyUnclassifiedBatch();
+  revalidatePath("/");
+  revalidatePath("/transactions");
+  return result;
 }

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { AiClassifyButton } from "@/components/transactions/ai-classify-button";
 import { Filters } from "@/components/transactions/filters";
 import { TransactionTable } from "@/components/transactions/transaction-table";
 import {
   countTotal,
+  countUnclassified,
   listAccounts,
   listCategories,
   listTransactions,
@@ -48,18 +50,20 @@ export default async function TransactionsPage({
     cursor: sp.cursor,
   };
 
-  const [{ rows, nextCursor }, accounts, categories, total] = await Promise.all([
-    listTransactions(filters),
-    listAccounts(),
-    listCategories(),
-    countTotal({
-      from: filters.from,
-      to: filters.to,
-      accountId: filters.accountId,
-      categorySlug: filters.categorySlug,
-      q: filters.q,
-    }),
-  ]);
+  const [{ rows, nextCursor }, accounts, categories, total, unclassified] =
+    await Promise.all([
+      listTransactions(filters),
+      listAccounts(),
+      listCategories(),
+      countTotal({
+        from: filters.from,
+        to: filters.to,
+        accountId: filters.accountId,
+        categorySlug: filters.categorySlug,
+        q: filters.q,
+      }),
+      countUnclassified(),
+    ]);
 
   const baseQuery = {
     from: sp.from,
@@ -71,13 +75,14 @@ export default async function TransactionsPage({
 
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-4 p-6">
-      <header className="flex items-end justify-between">
+      <header className="flex items-end justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Transactions</h1>
           <p className="text-sm text-muted-foreground">
-            {total.toLocaleString()} total · showing up to {PAGE_SIZE} per page
+            {total.toLocaleString()} total · {unclassified.toLocaleString()} unclassified · showing up to {PAGE_SIZE} per page
           </p>
         </div>
+        <AiClassifyButton unclassified={unclassified} />
       </header>
 
       <Filters

--- a/src/components/transactions/ai-classify-button.tsx
+++ b/src/components/transactions/ai-classify-button.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { runAiClassifier } from "@/app/transactions/actions";
+
+export function AiClassifyButton({ unclassified }: { unclassified: number }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  const batchSize = Math.min(unclassified, 20);
+  const disabled = pending || unclassified === 0;
+
+  function onClick() {
+    startTransition(async () => {
+      try {
+        const res = await runAiClassifier();
+        if (res.picked === 0) {
+          toast.info("Nothing to classify");
+          return;
+        }
+        toast.success(
+          `Classified ${res.aiClassified} via AI · ${res.ruleClassified} via rules · ${res.skipped} skipped`,
+        );
+        router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "AI classify failed");
+      }
+    });
+  }
+
+  return (
+    <Button variant="outline" size="sm" onClick={onClick} disabled={disabled}>
+      <Sparkles className="size-4" />
+      {pending
+        ? "Classifying…"
+        : unclassified === 0
+          ? "All classified"
+          : `Classify ${batchSize} with AI${unclassified > 20 ? ` (${unclassified} pending)` : ""}`}
+    </Button>
+  );
+}

--- a/src/lib/classification/ai.ts
+++ b/src/lib/classification/ai.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+
+export type AiClassifiable = {
+  id: number;
+  description: string;
+  amountCents: bigint;
+  currency: "COP" | "USD";
+};
+
+export type AiCategoryOption = {
+  slug: string;
+  name: string;
+  parentSlug?: string | null;
+};
+
+export type AiClassification = {
+  id: number;
+  categorySlug: string | null;
+  confidence: number;
+  reason?: string;
+};
+
+export type AiClassifyResult = {
+  classifications: AiClassification[];
+  model: string;
+  usage: { inputTokens: number; outputTokens: number };
+};
+
+const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+
+const responseSchema = z.object({
+  classifications: z.array(
+    z.object({
+      id: z.number().int(),
+      categorySlug: z.string().min(1).max(60).nullable(),
+      confidence: z.number().int().min(0).max(100),
+      reason: z.string().max(200).optional(),
+    }),
+  ),
+});
+
+function buildPrompt(
+  txs: AiClassifiable[],
+  cats: AiCategoryOption[],
+): string {
+  const categoryList = cats
+    .map((c) =>
+      c.parentSlug
+        ? `- ${c.slug} (${c.name}, subcategory of ${c.parentSlug})`
+        : `- ${c.slug} (${c.name})`,
+    )
+    .join("\n");
+
+  const txList = txs
+    .map(
+      (t) =>
+        `{ "id": ${t.id}, "description": ${JSON.stringify(t.description)}, "amount": ${(Number(t.amountCents) / 100).toFixed(2)}, "currency": "${t.currency}" }`,
+    )
+    .join(",\n  ");
+
+  return `You classify personal finance transactions for a Colombian user.
+
+Available categories (use the slug, exactly as written):
+${categoryList}
+
+Transactions to classify:
+[
+  ${txList}
+]
+
+For each transaction, pick the MOST specific category slug that fits. Prefer subcategories (e.g. "restaurantes" over "alimentacion"). If you genuinely cannot tell, return "otros".
+
+Confidence scale:
+- 90-100: obvious match (e.g. "NETFLIX" → "suscripciones")
+- 70-89: strong signal
+- 50-69: educated guess
+- 0-49: unsure — consider "otros"
+
+Return ONLY valid JSON (no prose, no markdown):
+{
+  "classifications": [
+    { "id": <number>, "categorySlug": "<slug-or-null>", "confidence": <0-100>, "reason": "<short phrase>" }
+  ]
+}
+
+Rules:
+- "categorySlug" MUST be one of the slugs above, or null if truly unclassifiable.
+- Include one entry per input transaction, same "id".
+- Keep "reason" under 80 chars.`;
+}
+
+function extractJson(text: string): unknown {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fenced ? fenced[1] : trimmed;
+  return JSON.parse(candidate);
+}
+
+export async function classifyBatchWithAi(opts: {
+  transactions: AiClassifiable[];
+  categories: AiCategoryOption[];
+  model?: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<AiClassifyResult> {
+  if (opts.transactions.length === 0) {
+    return {
+      classifications: [],
+      model: opts.model ?? DEFAULT_MODEL,
+      usage: { inputTokens: 0, outputTokens: 0 },
+    };
+  }
+
+  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
+
+  const model = opts.model ?? DEFAULT_MODEL;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const prompt = buildPrompt(opts.transactions, opts.categories);
+
+  const res = await doFetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 2048,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Anthropic API error ${res.status}: ${body.slice(0, 300)}`);
+  }
+
+  const payload = (await res.json()) as {
+    content: Array<{ type: string; text?: string }>;
+    usage?: { input_tokens: number; output_tokens: number };
+  };
+
+  const textBlock = payload.content?.find((c) => c.type === "text")?.text ?? "";
+  let parsedJson: unknown;
+  try {
+    parsedJson = extractJson(textBlock);
+  } catch {
+    throw new Error("Model returned invalid JSON");
+  }
+
+  const parsed = responseSchema.parse(parsedJson);
+  const validSlugs = new Set(opts.categories.map((c) => c.slug));
+  const classifications = parsed.classifications.map((c) => ({
+    ...c,
+    categorySlug:
+      c.categorySlug && validSlugs.has(c.categorySlug) ? c.categorySlug : null,
+  }));
+
+  return {
+    classifications,
+    model,
+    usage: {
+      inputTokens: payload.usage?.input_tokens ?? 0,
+      outputTokens: payload.usage?.output_tokens ?? 0,
+    },
+  };
+}

--- a/src/lib/classification/pipeline.ts
+++ b/src/lib/classification/pipeline.ts
@@ -1,0 +1,166 @@
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
+import { db as defaultDb, type DB } from "@/lib/db";
+import { categories, ingestionLogs, transactions } from "@/lib/db/schema";
+import { classifyBatchWithAi, type AiCategoryOption } from "./ai";
+import { classifyByRule } from "./rules";
+
+export const AI_BATCH_SIZE = 20;
+
+export type PipelineResult = {
+  picked: number;
+  aiClassified: number;
+  ruleClassified: number;
+  skipped: number;
+  model: string | null;
+  usage: { inputTokens: number; outputTokens: number };
+};
+
+export async function classifyUnclassifiedBatch(
+  database: DB = defaultDb,
+): Promise<PipelineResult> {
+  const startedAt = new Date();
+
+  const pending = await database
+    .select({
+      id: transactions.id,
+      description: transactions.descriptionRaw,
+      merchant: transactions.merchant,
+      descriptionClean: transactions.descriptionClean,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.classificationMethod, "unclassified"),
+        isNull(transactions.categorySlug),
+      ),
+    )
+    .orderBy(asc(transactions.id))
+    .limit(AI_BATCH_SIZE);
+
+  if (pending.length === 0) {
+    return {
+      picked: 0,
+      aiClassified: 0,
+      ruleClassified: 0,
+      skipped: 0,
+      model: null,
+      usage: { inputTokens: 0, outputTokens: 0 },
+    };
+  }
+
+  const cats = await database
+    .select({
+      slug: categories.slug,
+      name: categories.name,
+      parentSlug: categories.parentSlug,
+    })
+    .from(categories);
+  const catOptions: AiCategoryOption[] = cats;
+
+  let ruleClassified = 0;
+  const stillPending: typeof pending = [];
+  for (const tx of pending) {
+    const ruleHit = await classifyByRule(
+      {
+        descriptionRaw: tx.description,
+        descriptionClean: tx.descriptionClean,
+        merchant: tx.merchant,
+      },
+      database,
+    );
+    if (ruleHit) {
+      await database
+        .update(transactions)
+        .set({
+          categorySlug: ruleHit.categorySlug,
+          classificationMethod: "rule",
+          classificationConfidence: ruleHit.confidence,
+          updatedAt: new Date(),
+        })
+        .where(eq(transactions.id, tx.id));
+      ruleClassified++;
+    } else {
+      stillPending.push(tx);
+    }
+  }
+
+  if (stillPending.length === 0) {
+    return {
+      picked: pending.length,
+      aiClassified: 0,
+      ruleClassified,
+      skipped: 0,
+      model: null,
+      usage: { inputTokens: 0, outputTokens: 0 },
+    };
+  }
+
+  const aiResult = await classifyBatchWithAi({
+    transactions: stillPending.map((t) => ({
+      id: t.id,
+      description: t.descriptionClean ?? t.merchant ?? t.description,
+      amountCents: t.amountCents,
+      currency: t.currency,
+    })),
+    categories: catOptions,
+  });
+
+  const byId = new Map(aiResult.classifications.map((c) => [c.id, c]));
+  let aiClassified = 0;
+  let skipped = 0;
+  const ids = stillPending.map((t) => t.id);
+
+  for (const tx of stillPending) {
+    const hit = byId.get(tx.id);
+    if (!hit || !hit.categorySlug) {
+      skipped++;
+      continue;
+    }
+    await database
+      .update(transactions)
+      .set({
+        categorySlug: hit.categorySlug,
+        classificationMethod: "ai",
+        classificationConfidence: hit.confidence,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(transactions.id, tx.id),
+          inArray(transactions.id, ids),
+        ),
+      );
+    aiClassified++;
+  }
+
+  await database.insert(ingestionLogs).values({
+    source: "manual",
+    status: skipped === 0 ? "ok" : "partial",
+    itemsReceived: pending.length,
+    itemsInserted: aiClassified + ruleClassified,
+    itemsDuplicated: 0,
+    errorMessage: null,
+    payload: {
+      kind: "ai-classify",
+      model: aiResult.model,
+      usage: aiResult.usage,
+      picked: pending.length,
+      ruleClassified,
+      aiClassified,
+      skipped,
+    },
+    startedAt,
+    finishedAt: new Date(),
+  });
+
+  return {
+    picked: pending.length,
+    aiClassified,
+    ruleClassified,
+    skipped,
+    model: aiResult.model,
+    usage: aiResult.usage,
+  };
+}

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -127,6 +127,14 @@ export async function listCategories() {
     .orderBy(asc(categories.sortOrder), asc(categories.name));
 }
 
+export async function countUnclassified(): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(transactions)
+    .where(eq(transactions.classificationMethod, "unclassified"));
+  return row?.n ?? 0;
+}
+
 export async function countTotal(filters: Omit<TxFilters, "cursor">): Promise<number> {
   const conditions = [];
   if (filters.from) conditions.push(gte(transactions.occurredAt, new Date(filters.from)));


### PR DESCRIPTION
## Summary
- `src/lib/classification/ai.ts` — Haiku 4.5 batch classifier (direct Anthropic fetch, Zod-validated JSON, slug allowlist).
- `src/lib/classification/pipeline.ts` — orchestrator: re-checks rules first (in case new rules were added after ingestion), then sends the remainder (up to 20) to Haiku, writes back `classificationMethod='rule'` or `'ai'` + confidence, logs the run to \`ingestion_logs\`.
- Server action \`runAiClassifier\` + \`countUnclassified\` query.
- \`AiClassifyButton\` in \`/transactions\` header shows pending count and triggers one batch.

Closes #10

## Test plan
- [x] \`bun run typecheck\` passes
- [x] \`bun run lint\` passes
- [ ] Manual: \`/transactions\` shows unclassified count; click \"Classify N with AI\"; CINEMARK (and similar) get categorized (expected: \`entretenimiento\`) with \`method=ai\`
- [ ] Manual: re-running on empty set shows \"All classified\"

## Notes
- Batch size fixed at 20 per issue spec. For more than 20 pending, the button runs one batch at a time (cheap to click again).
- Pipeline re-runs rules before calling the AI so newly-added rules get a chance before paying for tokens.