### PR TITLE
feat(recurring): forecast-based recurring with auto-match, promote, dismiss (#14)

### DIFF
--- a/drizzle/0001_chemical_black_cat.sql
+++ b/drizzle/0001_chemical_black_cat.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "recurring_transactions" ADD COLUMN "skipped_months" jsonb DEFAULT '[]'::jsonb NOT NULL;--> statement-breakpoint
+ALTER TABLE "recurring_transactions" ADD COLUMN "notes" text;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,881 @@
+{
+  "id": "6414153b-124a-4b65-99dd-ad24a81858b7",
+  "prevId": "3f4a08bf-ded3-4188-bb5e-0919a1ab2837",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_category_slug_categories_slug_fk": {
+          "name": "budgets_category_slug_categories_slug_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_priority_idx": {
+          "name": "rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_category_slug_categories_slug_fk": {
+          "name": "classification_rules_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_category_slug_categories_slug_fk": {
+          "name": "recurring_transactions_category_slug_categories_slug_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_category_idx": {
+          "name": "transactions_category_idx",
+          "columns": [
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_occurred_idx": {
+          "name": "transactions_occurred_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_category_slug_categories_slug_fk": {
+          "name": "transactions_category_slug_categories_slug_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "ai",
+        "manual",
+        "unclassified"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776235752133,
       "tag": "0000_handy_texas_twister",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776244369030,
+      "tag": "0001_chemical_black_cat",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,8 @@ import { MonthlyFlowCard } from "@/components/dashboard/monthly-flow-card";
 import { CategoryDonut } from "@/components/dashboard/category-donut";
 import { TopExpensesCard } from "@/components/dashboard/top-expenses-card";
 import { AccountsGrid } from "@/components/dashboard/accounts-grid";
+import { UpcomingCard } from "@/components/dashboard/upcoming-card";
+import { getUpcomingForMonth } from "@/lib/recurring/upcoming";
 
 export const dynamic = "force-dynamic";
 
@@ -19,13 +21,24 @@ export default async function DashboardPage() {
   const now = new Date();
   const monthLabel = monthFmt.format(now);
 
-  const [netWorth, flow, slices, top, accounts] = await Promise.all([
+  const [netWorth, flow, slices, top, accounts, upcoming] = await Promise.all([
     getNetWorth(),
     getMonthlyFlow(now),
     getCategoryBreakdown(now),
     getTopExpenses(now, 5),
     getAccountStatuses(),
+    getUpcomingForMonth({
+      year: now.getFullYear(),
+      month: now.getMonth() + 1,
+      includeDismissed: true,
+      today: now,
+    }),
   ]);
+
+  const upcomingItems = upcoming.map((u) => ({
+    ...u,
+    amountCents: u.amountCents.toString(),
+  }));
 
   const donutSlices = slices.map((s) => ({
     slug: s.slug,
@@ -49,6 +62,7 @@ export default async function DashboardPage() {
 
       <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <TopExpensesCard rows={top} monthLabel={monthLabel} />
+        <UpcomingCard items={upcomingItems} monthLabel={monthLabel} />
       </section>
 
       <section className="flex flex-col gap-3">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const LINKS = [
+  {
+    href: "/settings/import",
+    title: "Import",
+    description: "Bulk-import from XLSX or drop a screenshot for OCR.",
+  },
+  {
+    href: "/settings/recurring",
+    title: "Recurring forecast",
+    description:
+      "Declare expected monthly items (rent, loan, subscriptions). Shows up as upcoming on the dashboard.",
+  },
+];
+
+export default function SettingsPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+      </header>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {LINKS.map((l) => (
+          <Link key={l.href} href={l.href}>
+            <Card className="transition hover:border-foreground/30">
+              <CardHeader>
+                <CardTitle>{l.title}</CardTitle>
+                <CardDescription>{l.description}</CardDescription>
+              </CardHeader>
+              <CardContent className="text-xs text-muted-foreground">
+                {l.href} →
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/settings/recurring/actions.ts
+++ b/src/app/settings/recurring/actions.ts
@@ -1,0 +1,206 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { and, eq, gte, lte, sql } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  categories,
+  recurringTransactions,
+  transactions,
+} from "@/lib/db/schema";
+import { classifyByRule } from "@/lib/classification/rules";
+import { yearMonth } from "@/lib/recurring/upcoming";
+
+const upsertSchema = z.object({
+  id: z.coerce.number().int().positive().optional(),
+  accountId: z.coerce.number().int().positive(),
+  label: z.string().min(1).max(120),
+  amount: z.coerce.number().finite(),
+  direction: z.enum(["expense", "income"]),
+  categorySlug: z.string().min(1).max(60).nullable(),
+  dayOfMonth: z.coerce.number().int().min(1).max(31),
+  active: z.coerce.boolean().default(true),
+  notes: z.string().max(500).nullable(),
+});
+
+export type RecurringInput = z.input<typeof upsertSchema>;
+
+function revalidate() {
+  revalidatePath("/");
+  revalidatePath("/transactions");
+  revalidatePath("/settings/recurring");
+}
+
+export async function upsertRecurring(input: RecurringInput) {
+  const parsed = upsertSchema.parse(input);
+
+  const [account] = await db
+    .select({ id: accounts.id, currency: accounts.currency })
+    .from(accounts)
+    .where(eq(accounts.id, parsed.accountId))
+    .limit(1);
+  if (!account) throw new Error("Account not found");
+
+  if (parsed.categorySlug) {
+    const [cat] = await db
+      .select({ slug: categories.slug })
+      .from(categories)
+      .where(eq(categories.slug, parsed.categorySlug))
+      .limit(1);
+    if (!cat) throw new Error("Category not found");
+  }
+
+  const signedCents =
+    Math.round(Math.abs(parsed.amount) * 100) *
+    (parsed.direction === "income" ? 1 : -1);
+
+  const values = {
+    accountId: parsed.accountId,
+    label: parsed.label,
+    amountCents: BigInt(signedCents),
+    currency: account.currency,
+    categorySlug: parsed.categorySlug,
+    dayOfMonth: parsed.dayOfMonth,
+    active: parsed.active,
+    notes: parsed.notes,
+  };
+
+  if (parsed.id) {
+    await db
+      .update(recurringTransactions)
+      .set(values)
+      .where(eq(recurringTransactions.id, parsed.id));
+  } else {
+    await db.insert(recurringTransactions).values(values);
+  }
+
+  revalidate();
+}
+
+export async function deleteRecurring(id: number) {
+  await db
+    .delete(recurringTransactions)
+    .where(eq(recurringTransactions.id, id));
+  revalidate();
+}
+
+export async function toggleRecurringActive(id: number, active: boolean) {
+  await db
+    .update(recurringTransactions)
+    .set({ active })
+    .where(eq(recurringTransactions.id, id));
+  revalidate();
+}
+
+const dismissSchema = z.object({
+  recurringId: z.coerce.number().int().positive(),
+  ym: z.string().regex(/^\d{4}-\d{2}$/),
+});
+
+export async function dismissUpcoming(input: z.input<typeof dismissSchema>) {
+  const { recurringId, ym } = dismissSchema.parse(input);
+  const [row] = await db
+    .select({ skippedMonths: recurringTransactions.skippedMonths })
+    .from(recurringTransactions)
+    .where(eq(recurringTransactions.id, recurringId))
+    .limit(1);
+  if (!row) throw new Error("Recurring not found");
+  const next = Array.from(new Set([...(row.skippedMonths ?? []), ym]));
+  await db
+    .update(recurringTransactions)
+    .set({ skippedMonths: next })
+    .where(eq(recurringTransactions.id, recurringId));
+  revalidate();
+}
+
+export async function undismissUpcoming(input: z.input<typeof dismissSchema>) {
+  const { recurringId, ym } = dismissSchema.parse(input);
+  const [row] = await db
+    .select({ skippedMonths: recurringTransactions.skippedMonths })
+    .from(recurringTransactions)
+    .where(eq(recurringTransactions.id, recurringId))
+    .limit(1);
+  if (!row) throw new Error("Recurring not found");
+  const next = (row.skippedMonths ?? []).filter((m) => m !== ym);
+  await db
+    .update(recurringTransactions)
+    .set({ skippedMonths: next })
+    .where(eq(recurringTransactions.id, recurringId));
+  revalidate();
+}
+
+const promoteSchema = z.object({
+  recurringId: z.coerce.number().int().positive(),
+  occurredOn: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+export async function promoteUpcoming(input: z.input<typeof promoteSchema>) {
+  const { recurringId, occurredOn } = promoteSchema.parse(input);
+
+  const [r] = await db
+    .select({
+      id: recurringTransactions.id,
+      accountId: recurringTransactions.accountId,
+      label: recurringTransactions.label,
+      amountCents: recurringTransactions.amountCents,
+      currency: recurringTransactions.currency,
+      categorySlug: recurringTransactions.categorySlug,
+      notes: recurringTransactions.notes,
+    })
+    .from(recurringTransactions)
+    .where(eq(recurringTransactions.id, recurringId))
+    .limit(1);
+  if (!r) throw new Error("Recurring not found");
+
+  const occurredAt = new Date(`${occurredOn}T12:00:00Z`);
+  const monthStart = new Date(
+    Date.UTC(occurredAt.getUTCFullYear(), occurredAt.getUTCMonth(), 1),
+  );
+  const monthEnd = new Date(
+    Date.UTC(occurredAt.getUTCFullYear(), occurredAt.getUTCMonth() + 1, 0, 23, 59, 59),
+  );
+
+  const [dup] = await db
+    .select({ id: transactions.id })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.accountId, r.accountId),
+        eq(transactions.amountCents, r.amountCents),
+        gte(transactions.occurredAt, monthStart),
+        lte(transactions.occurredAt, monthEnd),
+      ),
+    )
+    .limit(1);
+  if (dup) throw new Error(`Already exists this month as tx #${dup.id}`);
+
+  const cls = r.categorySlug
+    ? null
+    : await classifyByRule({ descriptionRaw: r.label });
+
+  await db.insert(transactions).values({
+    accountId: r.accountId,
+    occurredAt,
+    amountCents: r.amountCents,
+    currency: r.currency,
+    descriptionRaw: r.label,
+    descriptionClean: null,
+    merchant: null,
+    categorySlug: r.categorySlug ?? cls?.categorySlug ?? null,
+    classificationMethod: r.categorySlug
+      ? "manual"
+      : cls
+        ? "rule"
+        : "unclassified",
+    classificationConfidence: r.categorySlug ? 100 : (cls?.confidence ?? null),
+    source: "recurring",
+    notes: r.notes,
+    rawData: sql`${JSON.stringify({ promotedFromRecurringId: r.id })}::jsonb`,
+  });
+
+  revalidate();
+}
+
+export { yearMonth };

--- a/src/app/settings/recurring/page.tsx
+++ b/src/app/settings/recurring/page.tsx
@@ -1,0 +1,65 @@
+import { asc, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, categories, recurringTransactions } from "@/lib/db/schema";
+import { RecurringManager } from "./recurring-manager";
+
+export const dynamic = "force-dynamic";
+
+export default async function RecurringPage() {
+  const [accs, cats, items] = await Promise.all([
+    db
+      .select({
+        id: accounts.id,
+        name: accounts.name,
+        currency: accounts.currency,
+      })
+      .from(accounts)
+      .where(eq(accounts.active, true))
+      .orderBy(asc(accounts.name)),
+    db
+      .select({
+        slug: categories.slug,
+        name: categories.name,
+        parentSlug: categories.parentSlug,
+      })
+      .from(categories)
+      .orderBy(asc(categories.sortOrder), asc(categories.name)),
+    db
+      .select({
+        id: recurringTransactions.id,
+        accountId: recurringTransactions.accountId,
+        accountName: accounts.name,
+        label: recurringTransactions.label,
+        amountCents: recurringTransactions.amountCents,
+        currency: recurringTransactions.currency,
+        categorySlug: recurringTransactions.categorySlug,
+        dayOfMonth: recurringTransactions.dayOfMonth,
+        active: recurringTransactions.active,
+        notes: recurringTransactions.notes,
+      })
+      .from(recurringTransactions)
+      .innerJoin(accounts, eq(accounts.id, recurringTransactions.accountId))
+      .orderBy(asc(recurringTransactions.dayOfMonth)),
+  ]);
+
+  const rows = items.map((r) => ({
+    ...r,
+    amountCents: r.amountCents.toString(),
+  }));
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Recurring forecast
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Declare expected monthly items (rent, loan, subscriptions). These are
+          FORECASTS — not real transactions. They appear as &ldquo;upcoming&rdquo;
+          on the dashboard and auto-match when the real tx lands.
+        </p>
+      </header>
+      <RecurringManager accounts={accs} categories={cats} items={rows} />
+    </main>
+  );
+}

--- a/src/app/settings/recurring/recurring-manager.tsx
+++ b/src/app/settings/recurring/recurring-manager.tsx
@@ -1,0 +1,440 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { formatMoney } from "@/lib/money";
+import { cn } from "@/lib/utils";
+import {
+  deleteRecurring,
+  toggleRecurringActive,
+  upsertRecurring,
+} from "./actions";
+
+type AccountOption = { id: number; name: string; currency: "COP" | "USD" };
+type CategoryOption = {
+  slug: string;
+  name: string;
+  parentSlug: string | null;
+};
+type RecurringRow = {
+  id: number;
+  accountId: number;
+  accountName: string;
+  label: string;
+  amountCents: string;
+  currency: "COP" | "USD";
+  categorySlug: string | null;
+  dayOfMonth: number;
+  active: boolean;
+  notes: string | null;
+};
+
+type EditorState = {
+  open: boolean;
+  editing: RecurringRow | null;
+};
+
+export function RecurringManager({
+  accounts,
+  categories,
+  items,
+}: {
+  accounts: AccountOption[];
+  categories: CategoryOption[];
+  items: RecurringRow[];
+}) {
+  const [editor, setEditor] = useState<EditorState>({
+    open: false,
+    editing: null,
+  });
+  const [pending, startTransition] = useTransition();
+
+  function openCreate() {
+    setEditor({ open: true, editing: null });
+  }
+  function openEdit(row: RecurringRow) {
+    setEditor({ open: true, editing: row });
+  }
+  function close() {
+    setEditor({ open: false, editing: null });
+  }
+
+  function onToggle(row: RecurringRow) {
+    startTransition(async () => {
+      try {
+        await toggleRecurringActive(row.id, !row.active);
+        toast.success(row.active ? "Paused" : "Activated");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed");
+      }
+    });
+  }
+
+  function onDelete(row: RecurringRow) {
+    if (!confirm(`Delete recurring "${row.label}"? This cannot be undone.`))
+      return;
+    startTransition(async () => {
+      try {
+        await deleteRecurring(row.id);
+        toast.success("Deleted");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed");
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex justify-end">
+        <Button onClick={openCreate}>
+          <PlusIcon className="size-4" />
+          New recurring
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 py-12 text-center text-sm text-muted-foreground">
+            <p>No recurring items yet.</p>
+            <p>Add your rent, loan payment, and monthly subscriptions.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              {items.length} item{items.length !== 1 ? "s" : ""} ·{" "}
+              {items.filter((r) => r.active).length} active
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto rounded-md border">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/50 text-xs uppercase text-muted-foreground">
+                  <tr>
+                    <th className="p-2 text-left">Day</th>
+                    <th className="p-2 text-left">Label</th>
+                    <th className="p-2 text-left">Account</th>
+                    <th className="p-2 text-left">Category</th>
+                    <th className="p-2 text-right">Amount</th>
+                    <th className="p-2 text-left">Status</th>
+                    <th className="p-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((r) => {
+                    const cents = BigInt(r.amountCents);
+                    return (
+                      <tr
+                        key={r.id}
+                        className={cn("border-t", !r.active && "opacity-50")}
+                      >
+                        <td className="p-2 tabular-nums">{r.dayOfMonth}</td>
+                        <td className="p-2">
+                          <div className="font-medium">{r.label}</div>
+                          {r.notes ? (
+                            <div className="text-xs text-muted-foreground">
+                              {r.notes}
+                            </div>
+                          ) : null}
+                        </td>
+                        <td className="p-2 text-xs text-muted-foreground">
+                          {r.accountName}
+                        </td>
+                        <td className="p-2 text-xs text-muted-foreground">
+                          {r.categorySlug ?? "—"}
+                        </td>
+                        <td
+                          className={cn(
+                            "p-2 text-right tabular-nums font-medium",
+                            cents < BigInt(0)
+                              ? "text-rose-600"
+                              : "text-emerald-600",
+                          )}
+                        >
+                          {formatMoney(cents, r.currency)}
+                        </td>
+                        <td className="p-2 text-xs">
+                          <button
+                            type="button"
+                            onClick={() => onToggle(r)}
+                            disabled={pending}
+                            className={cn(
+                              "rounded px-1.5 py-0.5",
+                              r.active
+                                ? "bg-emerald-100 text-emerald-800"
+                                : "bg-muted text-muted-foreground",
+                            )}
+                          >
+                            {r.active ? "active" : "paused"}
+                          </button>
+                        </td>
+                        <td className="p-2 text-right">
+                          <div className="flex justify-end gap-1">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => openEdit(r)}
+                              disabled={pending}
+                              aria-label="Edit"
+                            >
+                              <PencilIcon className="size-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => onDelete(r)}
+                              disabled={pending}
+                              aria-label="Delete"
+                            >
+                              <Trash2Icon className="size-4" />
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <RecurringEditor
+        open={editor.open}
+        editing={editor.editing}
+        accounts={accounts}
+        categories={categories}
+        onClose={close}
+      />
+    </div>
+  );
+}
+
+function RecurringEditor({
+  open,
+  editing,
+  accounts,
+  categories,
+  onClose,
+}: {
+  open: boolean;
+  editing: RecurringRow | null;
+  accounts: AccountOption[];
+  categories: CategoryOption[];
+  onClose: () => void;
+}) {
+  const [pending, startTransition] = useTransition();
+  const initial = editing;
+  const initialCents = initial ? BigInt(initial.amountCents) : null;
+
+  const [accountId, setAccountId] = useState(
+    initial?.accountId.toString() ?? accounts[0]?.id.toString() ?? "",
+  );
+  const [label, setLabel] = useState(initial?.label ?? "");
+  const [direction, setDirection] = useState<"expense" | "income">(
+    initialCents !== null && initialCents >= BigInt(0) ? "income" : "expense",
+  );
+  const [amount, setAmount] = useState(
+    initialCents !== null
+      ? (
+          Math.abs(Number(initialCents)) / 100
+        ).toString()
+      : "",
+  );
+  const [categorySlug, setCategorySlug] = useState(initial?.categorySlug ?? "");
+  const [dayOfMonth, setDayOfMonth] = useState(
+    initial?.dayOfMonth.toString() ?? "1",
+  );
+  const [notes, setNotes] = useState(initial?.notes ?? "");
+
+  const selectedAccount = accounts.find((a) => a.id.toString() === accountId);
+  const currency = selectedAccount?.currency ?? "COP";
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const amtNum = Number(amount);
+    if (!Number.isFinite(amtNum) || amtNum <= 0) {
+      toast.error("Amount must be > 0");
+      return;
+    }
+    const dayNum = Number(dayOfMonth);
+    if (!Number.isInteger(dayNum) || dayNum < 1 || dayNum > 31) {
+      toast.error("Day must be 1–31");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        await upsertRecurring({
+          id: initial?.id,
+          accountId: Number(accountId),
+          label: label.trim(),
+          amount: amtNum,
+          direction,
+          categorySlug: categorySlug || null,
+          dayOfMonth: dayNum,
+          active: initial?.active ?? true,
+          notes: notes.trim() || null,
+        });
+        toast.success(initial ? "Updated" : "Created");
+        onClose();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Save failed");
+      }
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {initial ? `Edit: ${initial.label}` : "New recurring"}
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={onSubmit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="rec-label">Label</Label>
+            <Input
+              id="rec-label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="e.g. Cuota préstamo consolidado"
+              required
+              maxLength={120}
+              autoFocus={!initial}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="rec-amount">Amount ({currency})</Label>
+              <Input
+                id="rec-amount"
+                type="number"
+                inputMode="decimal"
+                step={currency === "USD" ? "0.01" : "1"}
+                min="0"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                required
+                className="tabular-nums"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="rec-day">Day of month</Label>
+              <Input
+                id="rec-day"
+                type="number"
+                min="1"
+                max="31"
+                value={dayOfMonth}
+                onChange={(e) => setDayOfMonth(e.target.value)}
+                required
+                className="tabular-nums"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="rec-dir">Direction</Label>
+              <select
+                id="rec-dir"
+                value={direction}
+                onChange={(e) =>
+                  setDirection(e.target.value as "expense" | "income")
+                }
+                className="h-9 rounded-md border bg-background px-2 text-sm"
+              >
+                <option value="expense">Expense (−)</option>
+                <option value="income">Income (+)</option>
+              </select>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="rec-account">Account</Label>
+              <select
+                id="rec-account"
+                value={accountId}
+                onChange={(e) => setAccountId(e.target.value)}
+                className="h-9 rounded-md border bg-background px-2 text-sm"
+                required
+              >
+                {accounts.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.name} ({a.currency})
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="rec-cat">Category</Label>
+            <select
+              id="rec-cat"
+              value={categorySlug}
+              onChange={(e) => setCategorySlug(e.target.value)}
+              className="h-9 rounded-md border bg-background px-2 text-sm"
+            >
+              <option value="">— unclassified —</option>
+              {categories.map((c) => (
+                <option key={c.slug} value={c.slug}>
+                  {c.parentSlug ? `↳ ${c.name}` : c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="rec-notes">Notes</Label>
+            <Input
+              id="rec-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Optional"
+              maxLength={500}
+            />
+          </div>
+
+          <DialogFooter className="mt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving…" : initial ? "Save" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/settings/recurring/recurring-manager.tsx
+++ b/src/app/settings/recurring/recurring-manager.tsx
@@ -219,6 +219,7 @@ export function RecurringManager({
       )}
 
       <RecurringEditor
+        key={editor.editing?.id ?? (editor.open ? "new" : "closed")}
         open={editor.open}
         editing={editor.editing}
         accounts={accounts}

--- a/src/components/dashboard/upcoming-card.tsx
+++ b/src/components/dashboard/upcoming-card.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { CheckCircle2Icon, CircleXIcon, UndoIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { formatMoney } from "@/lib/money";
+import { cn } from "@/lib/utils";
+import {
+  dismissUpcoming,
+  promoteUpcoming,
+  undismissUpcoming,
+} from "@/app/settings/recurring/actions";
+import type { UpcomingItem } from "@/lib/recurring/upcoming";
+
+export type UpcomingCardItem = Omit<UpcomingItem, "amountCents"> & {
+  amountCents: string;
+};
+
+const dateFmt = new Intl.DateTimeFormat("es-CO", {
+  day: "2-digit",
+  month: "short",
+});
+
+const statusStyles: Record<UpcomingItem["status"], string> = {
+  upcoming: "bg-sky-100 text-sky-800",
+  overdue: "bg-rose-100 text-rose-800",
+  matched: "bg-emerald-100 text-emerald-800",
+  dismissed: "bg-muted text-muted-foreground",
+};
+
+export function UpcomingCard({
+  items,
+  monthLabel,
+}: {
+  items: UpcomingCardItem[];
+  monthLabel: string;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  function onPromote(item: UpcomingCardItem) {
+    startTransition(async () => {
+      try {
+        await promoteUpcoming({
+          recurringId: item.recurringId,
+          occurredOn: item.expectedOn,
+        });
+        toast.success(`Imported "${item.label}"`);
+        router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Promote failed");
+      }
+    });
+  }
+
+  function onDismiss(item: UpcomingCardItem) {
+    startTransition(async () => {
+      try {
+        await dismissUpcoming({
+          recurringId: item.recurringId,
+          ym: item.yearMonth,
+        });
+        toast.success(`Skipped this month`);
+        router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Dismiss failed");
+      }
+    });
+  }
+
+  function onUndismiss(item: UpcomingCardItem) {
+    startTransition(async () => {
+      try {
+        await undismissUpcoming({
+          recurringId: item.recurringId,
+          ym: item.yearMonth,
+        });
+        toast.success("Restored");
+        router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Undismiss failed");
+      }
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-2">
+        <div>
+          <CardDescription>Upcoming · {monthLabel}</CardDescription>
+          <CardTitle className="text-lg">Recurring forecast</CardTitle>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/settings/recurring">Manage</Link>
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {items.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            No recurring items.{" "}
+            <Link
+              href="/settings/recurring"
+              className="underline underline-offset-2"
+            >
+              Add one
+            </Link>{" "}
+            to start tracking.
+          </p>
+        ) : (
+          <ul className="flex flex-col divide-y">
+            {items.map((item) => {
+              const cents = BigInt(item.amountCents);
+              return (
+                <li
+                  key={`${item.recurringId}-${item.yearMonth}`}
+                  className="flex items-center gap-3 py-2 text-sm"
+                >
+                  <div className="flex w-12 flex-col items-center text-xs text-muted-foreground">
+                    <span className="font-medium">
+                      {dateFmt.format(new Date(`${item.expectedOn}T12:00:00Z`))}
+                    </span>
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate font-medium">{item.label}</span>
+                      <span
+                        className={cn(
+                          "rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+                          statusStyles[item.status],
+                        )}
+                      >
+                        {item.status}
+                      </span>
+                    </div>
+                    <div className="truncate text-xs text-muted-foreground">
+                      {item.accountName}
+                      {item.categoryName ? ` · ${item.categoryName}` : ""}
+                      {item.matchedTransactionId
+                        ? ` · tx #${item.matchedTransactionId}`
+                        : ""}
+                    </div>
+                  </div>
+                  <div
+                    className={cn(
+                      "w-28 text-right tabular-nums font-medium",
+                      cents < BigInt(0) ? "text-rose-600" : "text-emerald-600",
+                    )}
+                  >
+                    {formatMoney(cents, item.currency)}
+                  </div>
+                  <div className="flex items-center gap-1">
+                    {item.status === "upcoming" || item.status === "overdue" ? (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={pending}
+                          onClick={() => onPromote(item)}
+                          aria-label="Promote to transaction"
+                          title="Import as real transaction"
+                        >
+                          <CheckCircle2Icon className="size-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={pending}
+                          onClick={() => onDismiss(item)}
+                          aria-label="Dismiss this month"
+                          title="Skip this month"
+                        >
+                          <CircleXIcon className="size-4" />
+                        </Button>
+                      </>
+                    ) : null}
+                    {item.status === "dismissed" ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={pending}
+                        onClick={() => onUndismiss(item)}
+                        aria-label="Undismiss"
+                        title="Restore this month"
+                      >
+                        <UndoIcon className="size-4" />
+                      </Button>
+                    ) : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -164,6 +164,8 @@ export const recurringTransactions = pgTable("recurring_transactions", {
   dayOfMonth: smallint("day_of_month").notNull(),
   active: boolean("active").notNull().default(true),
   lastGeneratedAt: timestamp("last_generated_at", { withTimezone: true }),
+  skippedMonths: jsonb("skipped_months").$type<string[]>().notNull().default([]),
+  notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 

--- a/src/lib/recurring/upcoming.ts
+++ b/src/lib/recurring/upcoming.ts
@@ -1,0 +1,158 @@
+import { and, asc, eq, gte, lte } from "drizzle-orm";
+import { db as defaultDb, type DB } from "@/lib/db";
+import { accounts, categories, recurringTransactions, transactions } from "@/lib/db/schema";
+
+export type UpcomingStatus = "matched" | "upcoming" | "overdue" | "dismissed";
+
+export type UpcomingItem = {
+  recurringId: number;
+  label: string;
+  accountId: number;
+  accountName: string;
+  amountCents: bigint;
+  currency: "COP" | "USD";
+  categorySlug: string | null;
+  categoryName: string | null;
+  dayOfMonth: number;
+  expectedOn: string;
+  status: UpcomingStatus;
+  matchedTransactionId: number | null;
+  yearMonth: string;
+  notes: string | null;
+};
+
+function daysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function toIso(year: number, month: number, day: number): string {
+  const mm = String(month).padStart(2, "0");
+  const dd = String(day).padStart(2, "0");
+  return `${year}-${mm}-${dd}`;
+}
+
+export function yearMonth(year: number, month: number): string {
+  return `${year}-${String(month).padStart(2, "0")}`;
+}
+
+export type UpcomingOptions = {
+  year: number;
+  month: number;
+  includeDismissed?: boolean;
+  includeMatched?: boolean;
+  matchWindowDays?: number;
+  today?: Date;
+};
+
+export async function getUpcomingForMonth(
+  opts: UpcomingOptions,
+  database: DB = defaultDb,
+): Promise<UpcomingItem[]> {
+  const {
+    year,
+    month,
+    includeDismissed = false,
+    includeMatched = true,
+    matchWindowDays = 3,
+    today = new Date(),
+  } = opts;
+
+  const ym = yearMonth(year, month);
+  const monthDays = daysInMonth(year, month);
+  const rangeStart = new Date(Date.UTC(year, month - 1, 1, 0, 0, 0));
+  const rangeEnd = new Date(Date.UTC(year, month, 0, 23, 59, 59));
+
+  const rows = await database
+    .select({
+      id: recurringTransactions.id,
+      label: recurringTransactions.label,
+      accountId: recurringTransactions.accountId,
+      accountName: accounts.name,
+      amountCents: recurringTransactions.amountCents,
+      currency: recurringTransactions.currency,
+      categorySlug: recurringTransactions.categorySlug,
+      categoryName: categories.name,
+      dayOfMonth: recurringTransactions.dayOfMonth,
+      active: recurringTransactions.active,
+      skippedMonths: recurringTransactions.skippedMonths,
+      notes: recurringTransactions.notes,
+    })
+    .from(recurringTransactions)
+    .innerJoin(accounts, eq(accounts.id, recurringTransactions.accountId))
+    .leftJoin(categories, eq(categories.slug, recurringTransactions.categorySlug))
+    .where(eq(recurringTransactions.active, true))
+    .orderBy(asc(recurringTransactions.dayOfMonth), asc(recurringTransactions.id));
+
+  if (rows.length === 0) return [];
+
+  const monthTxs = await database
+    .select({
+      id: transactions.id,
+      accountId: transactions.accountId,
+      amountCents: transactions.amountCents,
+      occurredAt: transactions.occurredAt,
+    })
+    .from(transactions)
+    .where(
+      and(
+        gte(transactions.occurredAt, new Date(rangeStart.getTime() - matchWindowDays * 86400000)),
+        lte(transactions.occurredAt, new Date(rangeEnd.getTime() + matchWindowDays * 86400000)),
+      ),
+    );
+
+  const todayDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+
+  const items: UpcomingItem[] = [];
+  for (const r of rows) {
+    const day = Math.min(r.dayOfMonth, monthDays);
+    const expectedOn = toIso(year, month, day);
+    const expectedDate = new Date(`${expectedOn}T00:00:00Z`);
+    const windowStart = new Date(expectedDate.getTime() - matchWindowDays * 86400000);
+    const windowEnd = new Date(expectedDate.getTime() + matchWindowDays * 86400000);
+
+    const isDismissed = (r.skippedMonths ?? []).includes(ym);
+
+    const match = monthTxs.find(
+      (tx) =>
+        tx.accountId === r.accountId &&
+        tx.amountCents === r.amountCents &&
+        tx.occurredAt >= windowStart &&
+        tx.occurredAt <= windowEnd,
+    );
+
+    let status: UpcomingStatus;
+    let matchedTransactionId: number | null = null;
+    if (match) {
+      status = "matched";
+      matchedTransactionId = match.id;
+    } else if (isDismissed) {
+      status = "dismissed";
+    } else if (expectedDate <= todayDate) {
+      status = "overdue";
+    } else {
+      status = "upcoming";
+    }
+
+    if (status === "dismissed" && !includeDismissed) continue;
+    if (status === "matched" && !includeMatched) continue;
+
+    items.push({
+      recurringId: r.id,
+      label: r.label,
+      accountId: r.accountId,
+      accountName: r.accountName,
+      amountCents: r.amountCents,
+      currency: r.currency,
+      categorySlug: r.categorySlug,
+      categoryName: r.categoryName,
+      dayOfMonth: r.dayOfMonth,
+      expectedOn,
+      status,
+      matchedTransactionId,
+      yearMonth: ym,
+      notes: r.notes,
+    });
+  }
+
+  return items;
+}


### PR DESCRIPTION
## Summary
Recurring items are FORECASTS, not auto-inserted transactions. No cron.

- Schema: adds \`skipped_months jsonb[]\` and \`notes\` to \`recurring_transactions\`.
- \`src/lib/recurring/upcoming.ts\` — derives each month's upcoming items. Auto-matches to a real tx in the same account, exact amount, within ±3 days of \`dayOfMonth\`.
- Status per item: \`matched\` / \`upcoming\` / \`overdue\` / \`dismissed\`.
- \`/settings/recurring\` CRUD: create, edit, toggle active, delete.
- \`/settings\` landing page linking Import + Recurring.
- Dashboard \"Upcoming\" card beside Top expenses:
  - **Promote** → inserts real tx with \`source='recurring'\`, checks for existing same-month duplicate first.
  - **Dismiss this month** → adds yyyy-mm to \`skipped_months\`.
  - **Undismiss** → removes it.
- Migration applied manually (\`drizzle-kit migrate\` exit-code quirk, SQL is in \`drizzle/0001_chemical_black_cat.sql\`).

Closes #14

## Test plan
- [x] \`bun run typecheck\` passes
- [x] \`bun run lint\` passes
- [ ] Add a recurring at \`/settings/recurring\` (e.g. day 15, \$50,000, expense) — appears as \`upcoming\` on dashboard if day ≥ today else \`overdue\`
- [ ] Manually create a tx for same account/amount within ±3 days of the day → recurring flips to \`matched\` with tx link
- [ ] Promote an upcoming → tx appears in \`/transactions\` with \`source='recurring'\`, recurring now \`matched\`
- [ ] Promote again same month → error (duplicate guard)
- [ ] Dismiss → status flips to \`dismissed\`, undismiss restores