### PR TITLE
feat(ui): /budgets — monthly budgets with progress tracking (#15)

### DIFF
--- a/src/app/budgets/actions.ts
+++ b/src/app/budgets/actions.ts
@@ -1,0 +1,86 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { budgets, categories } from "@/lib/db/schema";
+
+const ymSchema = z.string().regex(/^\d{4}-\d{2}$/);
+
+function monthRange(ym: string): { start: string; end: string } {
+  const [y, m] = ym.split("-").map(Number);
+  const start = `${ym}-01`;
+  const lastDay = new Date(Date.UTC(y, m, 0)).getUTCDate();
+  const end = `${ym}-${String(lastDay).padStart(2, "0")}`;
+  return { start, end };
+}
+
+const upsertSchema = z.object({
+  id: z.coerce.number().int().positive().optional(),
+  categorySlug: z.string().min(1).max(60),
+  amount: z.coerce.number().finite().positive(),
+  currency: z.enum(["COP", "USD"]).default("COP"),
+  ym: ymSchema,
+});
+
+export type BudgetInput = z.input<typeof upsertSchema>;
+
+function revalidate() {
+  revalidatePath("/budgets");
+}
+
+export async function upsertBudget(input: BudgetInput) {
+  const parsed = upsertSchema.parse(input);
+  const { start, end } = monthRange(parsed.ym);
+
+  const [cat] = await db
+    .select({ slug: categories.slug })
+    .from(categories)
+    .where(eq(categories.slug, parsed.categorySlug))
+    .limit(1);
+  if (!cat) throw new Error("Category not found");
+
+  const amountCents = BigInt(Math.round(parsed.amount * 100));
+
+  if (parsed.id) {
+    await db
+      .update(budgets)
+      .set({
+        categorySlug: parsed.categorySlug,
+        amountCents,
+        currency: parsed.currency,
+        periodStart: start,
+        periodEnd: end,
+      })
+      .where(eq(budgets.id, parsed.id));
+  } else {
+    const [dup] = await db
+      .select({ id: budgets.id })
+      .from(budgets)
+      .where(
+        and(
+          eq(budgets.categorySlug, parsed.categorySlug),
+          eq(budgets.periodStart, start),
+        ),
+      )
+      .limit(1);
+    if (dup) throw new Error("Budget for this category and month already exists");
+
+    await db.insert(budgets).values({
+      categorySlug: parsed.categorySlug,
+      amountCents,
+      currency: parsed.currency,
+      periodStart: start,
+      periodEnd: end,
+      active: true,
+    });
+  }
+
+  revalidate();
+}
+
+export async function deleteBudget(id: number) {
+  await db.delete(budgets).where(eq(budgets.id, id));
+  revalidate();
+}

--- a/src/app/budgets/budgets-manager.tsx
+++ b/src/app/budgets/budgets-manager.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { ChevronLeftIcon, ChevronRightIcon, PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { formatMoney } from "@/lib/money";
+import { cn } from "@/lib/utils";
+import { deleteBudget, upsertBudget } from "./actions";
+
+type CategoryOption = {
+  slug: string;
+  name: string;
+  parentSlug: string | null;
+};
+
+type BudgetRow = {
+  id: number;
+  categorySlug: string;
+  categoryName: string;
+  amountCents: string;
+  spentCents: string;
+  currency: "COP" | "USD";
+};
+
+type EditorState = { open: boolean; editing: BudgetRow | null };
+
+function shiftMonth(ym: string, delta: number): string {
+  const [y, m] = ym.split("-").map(Number);
+  const d = new Date(Date.UTC(y, m - 1 + delta, 1));
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function formatMonth(ym: string): string {
+  const [y, m] = ym.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, 1)).toLocaleDateString("es-CO", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export function BudgetsManager({
+  ym,
+  categories,
+  items,
+}: {
+  ym: string;
+  categories: CategoryOption[];
+  items: BudgetRow[];
+}) {
+  const router = useRouter();
+  const [editor, setEditor] = useState<EditorState>({
+    open: false,
+    editing: null,
+  });
+  const [pending, startTransition] = useTransition();
+
+  function goMonth(delta: number) {
+    router.push(`/budgets?ym=${shiftMonth(ym, delta)}`);
+  }
+
+  function onDelete(row: BudgetRow) {
+    if (!confirm(`Delete budget for ${row.categoryName}?`)) return;
+    startTransition(async () => {
+      try {
+        await deleteBudget(row.id);
+        toast.success("Deleted");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed");
+      }
+    });
+  }
+
+  const totalBudget = items.reduce((acc, r) => acc + BigInt(r.amountCents), BigInt(0));
+  const totalSpent = items.reduce((acc, r) => acc + BigInt(r.spentCents), BigInt(0));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => goMonth(-1)}
+            aria-label="Previous month"
+          >
+            <ChevronLeftIcon className="size-4" />
+          </Button>
+          <div className="px-2 text-sm font-medium capitalize tabular-nums">
+            {formatMonth(ym)}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => goMonth(1)}
+            aria-label="Next month"
+          >
+            <ChevronRightIcon className="size-4" />
+          </Button>
+        </div>
+        <Button onClick={() => setEditor({ open: true, editing: null })}>
+          <PlusIcon className="size-4" />
+          New budget
+        </Button>
+      </div>
+
+      {items.length > 0 && (
+        <Card>
+          <CardContent className="flex items-center justify-between py-3 text-sm">
+            <span className="text-muted-foreground">Total</span>
+            <span className="tabular-nums">
+              <span className={cn(totalSpent > totalBudget && "text-rose-600 font-medium")}>
+                {formatMoney(totalSpent, "COP")}
+              </span>
+              <span className="text-muted-foreground"> / {formatMoney(totalBudget, "COP")}</span>
+            </span>
+          </CardContent>
+        </Card>
+      )}
+
+      {items.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 py-12 text-center text-sm text-muted-foreground">
+            <p>No budgets for {formatMonth(ym)}.</p>
+            <p>Set spending caps per category to track progress.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-3">
+          {items.map((row) => (
+            <BudgetCard
+              key={row.id}
+              row={row}
+              onEdit={() => setEditor({ open: true, editing: row })}
+              onDelete={() => onDelete(row)}
+              disabled={pending}
+            />
+          ))}
+        </div>
+      )}
+
+      <BudgetEditor
+        key={editor.editing?.id ?? (editor.open ? "new" : "closed")}
+        open={editor.open}
+        editing={editor.editing}
+        ym={ym}
+        categories={categories}
+        existingSlugs={new Set(items.map((i) => i.categorySlug))}
+        onClose={() => setEditor({ open: false, editing: null })}
+      />
+    </div>
+  );
+}
+
+function BudgetCard({
+  row,
+  onEdit,
+  onDelete,
+  disabled,
+}: {
+  row: BudgetRow;
+  onEdit: () => void;
+  onDelete: () => void;
+  disabled: boolean;
+}) {
+  const amount = BigInt(row.amountCents);
+  const spent = BigInt(row.spentCents);
+  const pct = amount > BigInt(0) ? Number((spent * BigInt(10000)) / amount) / 100 : 0;
+  const over = spent > amount;
+  const warning = pct >= 80 && !over;
+  const remaining = amount - spent;
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-2 py-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="font-medium">{row.categoryName}</div>
+          <div className="flex gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onEdit}
+              disabled={disabled}
+              aria-label="Edit"
+            >
+              <PencilIcon className="size-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onDelete}
+              disabled={disabled}
+              aria-label="Delete"
+            >
+              <Trash2Icon className="size-4" />
+            </Button>
+          </div>
+        </div>
+        <div className="h-2 overflow-hidden rounded-full bg-muted">
+          <div
+            className={cn(
+              "h-full transition-all",
+              over ? "bg-rose-600" : warning ? "bg-amber-500" : "bg-emerald-600",
+            )}
+            style={{ width: `${Math.min(100, pct)}%` }}
+          />
+        </div>
+        <div className="flex items-center justify-between text-xs tabular-nums">
+          <span className={cn(over ? "text-rose-600 font-medium" : "text-muted-foreground")}>
+            {formatMoney(spent, row.currency)} / {formatMoney(amount, row.currency)}
+          </span>
+          <span className={cn("text-muted-foreground", over && "text-rose-600 font-medium")}>
+            {over
+              ? `${formatMoney(spent - amount, row.currency)} over`
+              : `${formatMoney(remaining, row.currency)} left · ${pct.toFixed(0)}%`}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function BudgetEditor({
+  open,
+  editing,
+  ym,
+  categories,
+  existingSlugs,
+  onClose,
+}: {
+  open: boolean;
+  editing: BudgetRow | null;
+  ym: string;
+  categories: CategoryOption[];
+  existingSlugs: Set<string>;
+  onClose: () => void;
+}) {
+  const [pending, startTransition] = useTransition();
+  const availableCategories = categories.filter(
+    (c) => !existingSlugs.has(c.slug) || c.slug === editing?.categorySlug,
+  );
+
+  const [categorySlug, setCategorySlug] = useState(
+    editing?.categorySlug ?? availableCategories[0]?.slug ?? "",
+  );
+  const [amount, setAmount] = useState(
+    editing ? (Number(BigInt(editing.amountCents)) / 100).toString() : "",
+  );
+  const [currency, setCurrency] = useState<"COP" | "USD">(editing?.currency ?? "COP");
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const amt = Number(amount);
+    if (!Number.isFinite(amt) || amt <= 0) {
+      toast.error("Amount must be > 0");
+      return;
+    }
+    if (!categorySlug) {
+      toast.error("Pick a category");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        await upsertBudget({
+          id: editing?.id,
+          categorySlug,
+          amount: amt,
+          currency,
+          ym,
+        });
+        toast.success(editing ? "Updated" : "Created");
+        onClose();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Save failed");
+      }
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {editing ? `Edit: ${editing.categoryName}` : "New budget"}
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={onSubmit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="b-cat">Category</Label>
+            <select
+              id="b-cat"
+              value={categorySlug}
+              onChange={(e) => setCategorySlug(e.target.value)}
+              className="h-9 rounded-md border bg-background px-2 text-sm"
+              required
+              disabled={!!editing}
+            >
+              {availableCategories.map((c) => (
+                <option key={c.slug} value={c.slug}>
+                  {c.parentSlug ? `↳ ${c.name}` : c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-[1fr_auto] gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="b-amount">Monthly cap</Label>
+              <Input
+                id="b-amount"
+                type="number"
+                inputMode="decimal"
+                step={currency === "USD" ? "0.01" : "1"}
+                min="0"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                required
+                autoFocus
+                className="tabular-nums"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="b-ccy">Currency</Label>
+              <select
+                id="b-ccy"
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value as "COP" | "USD")}
+                className="h-9 rounded-md border bg-background px-2 text-sm"
+              >
+                <option value="COP">COP</option>
+                <option value="USD">USD</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="text-xs text-muted-foreground">
+            Period: {ym}
+          </div>
+
+          <DialogFooter className="mt-2">
+            <Button type="button" variant="outline" onClick={onClose} disabled={pending}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving…" : editing ? "Save" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/budgets/page.tsx
+++ b/src/app/budgets/page.tsx
@@ -1,0 +1,107 @@
+import { and, asc, eq, gte, lte, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { budgets, categories, transactions } from "@/lib/db/schema";
+import { BudgetsManager } from "./budgets-manager";
+
+export const dynamic = "force-dynamic";
+
+function currentYearMonth(): string {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+}
+
+function monthRange(ym: string) {
+  const [y, m] = ym.split("-").map(Number);
+  const start = new Date(Date.UTC(y, m - 1, 1));
+  const end = new Date(Date.UTC(y, m, 0, 23, 59, 59));
+  return {
+    start,
+    end,
+    startIso: `${ym}-01`,
+    endIso: `${ym}-${String(new Date(Date.UTC(y, m, 0)).getUTCDate()).padStart(2, "0")}`,
+  };
+}
+
+export default async function BudgetsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ym?: string }>;
+}) {
+  const params = await searchParams;
+  const ym = params.ym && /^\d{4}-\d{2}$/.test(params.ym)
+    ? params.ym
+    : currentYearMonth();
+  const { start, end, startIso } = monthRange(ym);
+
+  const [cats, rows, spentRows] = await Promise.all([
+    db
+      .select({
+        slug: categories.slug,
+        name: categories.name,
+        parentSlug: categories.parentSlug,
+      })
+      .from(categories)
+      .orderBy(asc(categories.sortOrder), asc(categories.name)),
+    db
+      .select({
+        id: budgets.id,
+        categorySlug: budgets.categorySlug,
+        categoryName: categories.name,
+        amountCents: budgets.amountCents,
+        currency: budgets.currency,
+        periodStart: budgets.periodStart,
+        periodEnd: budgets.periodEnd,
+      })
+      .from(budgets)
+      .leftJoin(categories, eq(categories.slug, budgets.categorySlug))
+      .where(eq(budgets.periodStart, startIso))
+      .orderBy(asc(categories.sortOrder), asc(categories.name)),
+    db
+      .select({
+        categorySlug: transactions.categorySlug,
+        spentCents: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
+      })
+      .from(transactions)
+      .where(
+        and(
+          gte(transactions.occurredAt, start),
+          lte(transactions.occurredAt, end),
+        ),
+      )
+      .groupBy(transactions.categorySlug),
+  ]);
+
+  const spentMap = new Map<string, bigint>();
+  for (const s of spentRows) {
+    if (s.categorySlug) spentMap.set(s.categorySlug, BigInt(s.spentCents));
+  }
+
+  const items = rows.map((r) => ({
+    id: r.id,
+    categorySlug: r.categorySlug,
+    categoryName: r.categoryName ?? r.categorySlug,
+    amountCents: r.amountCents.toString(),
+    spentCents: (spentMap.get(r.categorySlug) ?? BigInt(0)).toString(),
+    currency: r.currency,
+  }));
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Budgets</h1>
+        <p className="text-sm text-muted-foreground">
+          Monthly spending caps per category. Each month starts fresh — no
+          rollover. Progress tracks expenses (negative transactions) in the
+          selected month.
+        </p>
+      </header>
+      <BudgetsManager
+        ym={ym}
+        categories={cats}
+        items={items}
+      />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `/budgets` page: monthly cap per category with a live progress bar vs. actual spend for the selected month
- Server actions for create/update/delete (`upsertBudget`, `deleteBudget`) with month-scoped uniqueness per category
- Month navigation via `?ym=YYYY-MM` — each month starts fresh (no rollover)

## Design notes
- Spend = sum of absolute value of negative `amount_cents` in `transactions` for the period, grouped by `category_slug`. Ingresos/transferencias excluidos implícitamente porque son positivos.
- Uses existing `budgets` table from `schema.ts` — no migration needed.
- Color states: green (<80%), amber (80–100%), red (over).
- Editing a budget locks the category (to avoid collapsing two budgets into one); delete + recreate to re-categorize.

## Test plan
- [ ] `/budgets` renders current month by default
- [ ] Prev/next month buttons update URL and reload data
- [ ] Create budget → appears with correct progress based on existing transactions
- [ ] Editing amount updates progress bar immediately after save
- [ ] Duplicate category+month rejected with toast error
- [ ] Delete removes the budget

Closes #15