### PR TITLE
feat(ingestion): debug endpoint to capture raw iOS Shortcut payloads (#39)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# PostgreSQL — peer auth via Unix socket (Linux default)
+# Defaults: host=/var/run/postgresql, database=findash, user=$USER.
+# Dejá estas vars vacías para usar los defaults, o setealas para overridear.
+PGHOST=/var/run/postgresql
+PGDATABASE=findash
+PGUSER=
+
+# Claude API — requerido para clasificación AI, insights y OCR
+# Conseguí una key en https://console.anthropic.com/
+ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# Ingestion webhook token — secreto compartido server ↔ iOS Shortcut
+# Generá UNA VEZ: openssl rand -hex 32
+# Pegá el MISMO valor en .env.local y en el header Authorization del Shortcut.
+INGEST_WEBHOOK_TOKEN=replace-with-output-of-openssl-rand-hex-32

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Dashboard financiero personal para Colombia con clasificación AI, presupuestos 
 
 ```bash
 bun install
-# Crear .env.local con las variables de abajo (ver "Environment variables")
+cp .env.example .env.local
+# Editar .env.local: ANTHROPIC_API_KEY y INGEST_WEBHOOK_TOKEN (ver abajo)
 bun run db:push        # crea las tablas
 bun run db:seed        # cuentas, categorías y reglas colombianas
 bun run dev            # arranca en http://localhost:3100
@@ -23,26 +24,13 @@ bun run dev            # arranca en http://localhost:3100
 
 ## Environment variables
 
-`.env.local` no se commitea. Plantilla mínima para arrancar:
+`.env.example` tiene la plantilla. `.env.local` nunca se commitea.
 
-```bash
-# PostgreSQL — peer auth via Unix socket es el default en Linux.
-# Dejalas en blanco para usar host=/var/run/postgresql, database=findash, user=$USER.
-PGHOST=/var/run/postgresql
-PGDATABASE=findash
-PGUSER=
-PGPORT=
-PGPASSWORD=
-
-# Claude API — requerido para clasificación AI, insights y OCR
-# Obtené una key en https://console.anthropic.com/
-ANTHROPIC_API_KEY=sk-ant-...
-
-# Ingestion webhook token — usado por /api/ingest/* (Apple Pay Shortcut, SMS, etc.)
-# Se envía como: Authorization: Bearer <token>
-# Generá un string largo random (ej: `openssl rand -hex 32`).
-INGEST_WEBHOOK_TOKEN=change-me-to-a-long-random-string
-```
+| Variable | Qué es | Cómo obtenerla |
+|---|---|---|
+| `PGHOST`, `PGDATABASE`, `PGUSER`, `PGPORT`, `PGPASSWORD` | Conexión a PostgreSQL | Dejar en blanco usa defaults: `/var/run/postgresql` + `findash` + `$USER` (peer auth en Linux). |
+| `ANTHROPIC_API_KEY` | Clasificación AI, insights y OCR con Claude | https://console.anthropic.com/ |
+| `INGEST_WEBHOOK_TOKEN` | Bearer token para `/api/ingest/*` (iOS Shortcut Apple Pay, SMS, etc.) | Secreto compartido fijo entre server e iOS Shortcut. Generar una vez: `openssl rand -hex 32`. |
 
 ## Comandos DB
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,33 @@ Dashboard financiero personal para Colombia con clasificación AI, presupuestos 
 
 ```bash
 bun install
-cp .env.example .env.local
-# Editar .env.local con tu ANTHROPIC_API_KEY
+# Crear .env.local con las variables de abajo (ver "Environment variables")
 bun run db:push        # crea las tablas
 bun run db:seed        # cuentas, categorías y reglas colombianas
 bun run dev            # arranca en http://localhost:3100
+```
+
+## Environment variables
+
+`.env.local` no se commitea. Plantilla mínima para arrancar:
+
+```bash
+# PostgreSQL — peer auth via Unix socket es el default en Linux.
+# Dejalas en blanco para usar host=/var/run/postgresql, database=findash, user=$USER.
+PGHOST=/var/run/postgresql
+PGDATABASE=findash
+PGUSER=
+PGPORT=
+PGPASSWORD=
+
+# Claude API — requerido para clasificación AI, insights y OCR
+# Obtené una key en https://console.anthropic.com/
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Ingestion webhook token — usado por /api/ingest/* (Apple Pay Shortcut, SMS, etc.)
+# Se envía como: Authorization: Bearer <token>
+# Generá un string largo random (ej: `openssl rand -hex 32`).
+INGEST_WEBHOOK_TOKEN=change-me-to-a-long-random-string
 ```
 
 ## Comandos DB

--- a/ios-shortcuts/README.md
+++ b/ios-shortcuts/README.md
@@ -1,0 +1,91 @@
+# iOS Shortcuts — Findash
+
+iOS automations that feed transactions into Findash via authenticated webhooks.
+
+> **Prerequisites**
+> - iPhone on iOS 17 or later (Transaction trigger requires iOS 17+).
+> - Findash reachable over Tailscale (e.g. `https://ia-server.tailcabcc8.ts.net:3100`).
+> - `INGEST_WEBHOOK_TOKEN` set in the server's `.env.local` (see `.env.example`).
+
+---
+
+## Shortcut 1: Discovery — Capture raw Transaction payloads
+
+**Purpose (issue #39)**: Apple's documentation does not specify what fields the Transaction automation trigger actually exposes (`Card or Pass`, `Merchant`, `Amount` are confirmed, but the string format for card, whether currency/date/category are included, etc. vary by bank and iOS version). This shortcut captures EVERY available field from real purchases so we can design the final `/api/ingest/apple-pay` contract (#11) with real data, not guesses.
+
+The endpoint `/api/ingest/debug` stores the full request (headers + body) in the `ingestion_logs` table with `status='debug'`. No transactions are inserted from this path — it is pure capture.
+
+### Setup
+
+1. Open **Shortcuts → Automation → New Automation → Transaction**.
+2. *When I tap*: select **every card** you want to observe. *Any Merchant*, *Any Category*. Enable **Run Immediately**.
+3. Add action: **Get Contents of URL**.
+   - **URL**: `https://ia-server.tailcabcc8.ts.net:3100/api/ingest/debug`
+   - **Method**: `POST`
+   - **Headers**:
+     - `Authorization` → `Bearer <token>` (paste your `INGEST_WEBHOOK_TOKEN`)
+     - `Content-Type` → `application/json`
+   - **Request Body**: `JSON` — build an object with every variable available from the Shortcut Input. At minimum:
+
+     ```json
+     {
+       "cardOrPass": "<Shortcut Input → Card or Pass>",
+       "merchant":   "<Shortcut Input → Merchant>",
+       "amount":     "<Shortcut Input → Amount>",
+       "capturedAt": "<Current Date>",
+       "source":     "apple-pay-discovery"
+     }
+     ```
+
+     **Important**: when you tap the `Shortcut Input` variable inside a JSON field, iOS offers a sub-picker — add **one key per discoverable sub-property** you find. That is precisely what we are trying to learn. If the Card or Pass variable exposes `Name`, `Type`, `Last 4`, etc., send each as its own key:
+
+     ```json
+     {
+       "cardName":       "<Shortcut Input → Card or Pass → Name>",
+       "cardType":       "<Shortcut Input → Card or Pass → Type>",
+       "cardLast4":      "<Shortcut Input → Card or Pass → Last Four>",
+       "merchant":       "<Shortcut Input → Merchant>",
+       "amountNumber":   "<Shortcut Input → Amount → Number>",
+       "amountCurrency": "<Shortcut Input → Amount → Currency>",
+       "capturedAt":     "<Current Date>",
+       "source":         "apple-pay-discovery"
+     }
+     ```
+
+     Fields that do not exist will simply be empty — that is useful negative evidence.
+4. Save the automation.
+
+### Verify it works
+
+Make ONE small Apple Pay purchase (even a $1 test), then on the server:
+
+```bash
+psql -d findash -c "
+  SELECT id, started_at, payload->'bodyParsed'
+  FROM ingestion_logs
+  WHERE status='debug'
+  ORDER BY id DESC
+  LIMIT 5;
+"
+```
+
+You should see your payload. Comment the JSON dump on issue #39.
+
+### Capture goal
+
+Make 3–5 purchases across **different cards** (debit, credit #1, credit #2, e-card) so we see how the Card or Pass string differs per card. Ideally include:
+
+- A physical-card Apple Pay tap (in-store).
+- An online Apple Pay checkout (web/app).
+- A recurring subscription charge (if Apple Pay is used).
+- At least one refund if one happens naturally.
+
+---
+
+## Shortcut 2: SMS Bancolombia
+
+Tracked in issue #12 — not yet implemented.
+
+## Shortcut 3: Apple Pay ingest (post-discovery)
+
+Tracked in issue #11 — blocked on #39 until we know the real payload shape.

--- a/scripts/test-debug-ingest.sh
+++ b/scripts/test-debug-ingest.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Smoke test for POST /api/ingest/debug.
+#
+# Usage:
+#   INGEST_WEBHOOK_TOKEN=xxx ./scripts/test-debug-ingest.sh
+#   HOST=http://localhost:3100 INGEST_WEBHOOK_TOKEN=xxx ./scripts/test-debug-ingest.sh
+#
+# Requires the dev server running (`bun run dev`).
+
+set -euo pipefail
+
+HOST="${HOST:-http://localhost:3100}"
+: "${INGEST_WEBHOOK_TOKEN:?Set INGEST_WEBHOOK_TOKEN (must match .env.local)}"
+
+echo "==> POST JSON with valid bearer token (expect 200 + logId)"
+curl -sS -i -X POST "$HOST/api/ingest/debug" \
+  -H "Authorization: Bearer $INGEST_WEBHOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"test":"smoke","merchant":"CURL SMOKE TEST","amount":"1000","card":"Visa ···· 1234"}'
+printf '\n\n'
+
+echo "==> POST form-urlencoded (expect 200 + logId)"
+curl -sS -i -X POST "$HOST/api/ingest/debug" \
+  -H "Authorization: Bearer $INGEST_WEBHOOK_TOKEN" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d 'merchant=STARBUCKS&amount=14500&card=Mastercard+9876'
+printf '\n\n'
+
+echo "==> POST with wrong token (expect 401)"
+curl -sS -i -X POST "$HOST/api/ingest/debug" \
+  -H "Authorization: Bearer wrong-token" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+printf '\n\n'
+
+echo "==> POST with no auth (expect 401)"
+curl -sS -i -X POST "$HOST/api/ingest/debug" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+printf '\n\n'
+
+echo "==> Latest 3 debug captures from ingestion_logs:"
+psql -d findash -c "
+  SELECT id,
+         started_at,
+         payload->>'contentType'  AS content_type,
+         payload->'bodyParsed'    AS body
+  FROM ingestion_logs
+  WHERE status = 'debug'
+  ORDER BY id DESC
+  LIMIT 3;
+"

--- a/scripts/test-debug-ingest.sh
+++ b/scripts/test-debug-ingest.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Smoke test for POST /api/ingest/debug.
 #
-# Usage:
+# Usage (recommended):
+#   ./scripts/test-debug-ingest.sh
+#   (auto-loads INGEST_WEBHOOK_TOKEN from .env.local)
+#
+# Or pass the token explicitly:
 #   INGEST_WEBHOOK_TOKEN=xxx ./scripts/test-debug-ingest.sh
 #   HOST=http://localhost:3100 INGEST_WEBHOOK_TOKEN=xxx ./scripts/test-debug-ingest.sh
 #
@@ -9,8 +13,22 @@
 
 set -euo pipefail
 
+# Run from project root so .env.local is found reliably.
+cd "$(dirname "$0")/.."
+
+# Auto-load .env.local if the token is not already exported in the environment.
+# `set -a` auto-exports every variable assigned while it's on — the classic
+# idiom for sourcing an env file into the current shell.
+if [[ -z "${INGEST_WEBHOOK_TOKEN:-}" && -f .env.local ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env.local
+  set +a
+fi
+
+: "${INGEST_WEBHOOK_TOKEN:?Set INGEST_WEBHOOK_TOKEN (in .env.local or exported in shell)}"
+
 HOST="${HOST:-http://localhost:3100}"
-: "${INGEST_WEBHOOK_TOKEN:?Set INGEST_WEBHOOK_TOKEN (must match .env.local)}"
 
 echo "==> POST JSON with valid bearer token (expect 200 + logId)"
 curl -sS -i -X POST "$HOST/api/ingest/debug" \

--- a/src/app/api/ingest/debug/route.test.ts
+++ b/src/app/api/ingest/debug/route.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { POST } from "./route";
+
+const TEST_TOKEN = "test-token-vitest-debug-capture";
+const MARKER = "VITEST_DEBUG_CAPTURE_MARKER";
+
+function makeRequest(init: {
+  body?: string;
+  headers?: Record<string, string>;
+}) {
+  return new Request("http://localhost:3100/api/ingest/debug", {
+    method: "POST",
+    body: init.body,
+    headers: init.headers,
+  });
+}
+
+async function cleanup() {
+  await db.execute(sql`
+    DELETE FROM ingestion_logs
+    WHERE status = 'debug'
+      AND payload::text LIKE ${"%" + MARKER + "%"}
+  `);
+}
+
+describe("POST /api/ingest/debug", () => {
+  beforeEach(() => {
+    process.env.INGEST_WEBHOOK_TOKEN = TEST_TOKEN;
+  });
+  afterEach(cleanup);
+  afterAll(async () => {
+    delete process.env.INGEST_WEBHOOK_TOKEN;
+    await db.$client.end({ timeout: 1 });
+  });
+
+  it("returns 503 when INGEST_WEBHOOK_TOKEN is not configured", async () => {
+    delete process.env.INGEST_WEBHOOK_TOKEN;
+    const res = await POST(
+      makeRequest({
+        headers: { authorization: `Bearer ${TEST_TOKEN}` },
+      }),
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when bearer token does not match", async () => {
+    const res = await POST(
+      makeRequest({
+        headers: { authorization: "Bearer wrong-token" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts JSON body and persists parsed payload", async () => {
+    const body = JSON.stringify({
+      marker: MARKER,
+      merchant: "RAPPI*BURGER KING",
+      amount: "32000",
+      card: "Visa ···· 1234",
+    });
+    const res = await POST(
+      makeRequest({
+        body,
+        headers: {
+          authorization: `Bearer ${TEST_TOKEN}`,
+          "content-type": "application/json",
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; logId: number };
+    expect(json.ok).toBe(true);
+    expect(json.logId).toBeGreaterThan(0);
+
+    const rows = await db.execute<{ payload: Record<string, unknown> }>(sql`
+      SELECT payload FROM ingestion_logs WHERE id = ${json.logId}
+    `);
+    const payload = rows[0].payload;
+    expect(payload.kind).toBe("debug-capture");
+    expect(payload.bodyParsed).toEqual({
+      marker: MARKER,
+      merchant: "RAPPI*BURGER KING",
+      amount: "32000",
+      card: "Visa ···· 1234",
+    });
+    const headers = payload.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer ***redacted***");
+  });
+
+  it("parses form-urlencoded body", async () => {
+    const body = `marker=${MARKER}&merchant=STARBUCKS&amount=14500`;
+    const res = await POST(
+      makeRequest({
+        body,
+        headers: {
+          authorization: `Bearer ${TEST_TOKEN}`,
+          "content-type": "application/x-www-form-urlencoded",
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const { logId } = (await res.json()) as { logId: number };
+
+    const rows = await db.execute<{ payload: Record<string, unknown> }>(sql`
+      SELECT payload FROM ingestion_logs WHERE id = ${logId}
+    `);
+    expect(rows[0].payload.bodyParsed).toEqual({
+      marker: MARKER,
+      merchant: "STARBUCKS",
+      amount: "14500",
+    });
+  });
+
+  it("stores unparseable body as raw text with bodyParsed=null", async () => {
+    const body = `${MARKER} this is not json and not form`;
+    const res = await POST(
+      makeRequest({
+        body,
+        headers: {
+          authorization: `Bearer ${TEST_TOKEN}`,
+          "content-type": "text/plain",
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const { logId } = (await res.json()) as { logId: number };
+
+    const rows = await db.execute<{ payload: Record<string, unknown> }>(sql`
+      SELECT payload FROM ingestion_logs WHERE id = ${logId}
+    `);
+    expect(rows[0].payload.bodyRaw).toBe(body);
+    expect(rows[0].payload.bodyParsed).toBeNull();
+  });
+
+  it("rejects payloads larger than 50KB with 413", async () => {
+    const body = JSON.stringify({ marker: MARKER, pad: "x".repeat(60 * 1024) });
+    const res = await POST(
+      makeRequest({
+        body,
+        headers: {
+          authorization: `Bearer ${TEST_TOKEN}`,
+          "content-type": "application/json",
+        },
+      }),
+    );
+    expect(res.status).toBe(413);
+  });
+});

--- a/src/app/api/ingest/debug/route.ts
+++ b/src/app/api/ingest/debug/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { ingestionLogs } from "@/lib/db/schema";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_BODY_BYTES = 50 * 1024;
+
+export async function POST(req: Request) {
+  const startedAt = new Date();
+
+  const expectedToken = process.env.INGEST_WEBHOOK_TOKEN;
+  if (!expectedToken) {
+    return NextResponse.json(
+      { error: "INGEST_WEBHOOK_TOKEN not configured" },
+      { status: 503 },
+    );
+  }
+
+  const authHeader = req.headers.get("authorization") ?? "";
+  const providedToken = authHeader.replace(/^Bearer\s+/i, "").trim();
+  if (!providedToken || providedToken !== expectedToken) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const query = Object.fromEntries(url.searchParams.entries());
+  const contentType = req.headers.get("content-type") ?? "";
+
+  const headersRecord: Record<string, string> = {};
+  req.headers.forEach((value, key) => {
+    headersRecord[key] =
+      key.toLowerCase() === "authorization" ? "Bearer ***redacted***" : value;
+  });
+
+  const rawBody = await req.text();
+  if (rawBody.length > MAX_BODY_BYTES) {
+    return NextResponse.json(
+      { error: `Payload too large (max ${MAX_BODY_BYTES} bytes)` },
+      { status: 413 },
+    );
+  }
+
+  let bodyParsed: unknown = null;
+  let parseError: string | null = null;
+
+  if (rawBody.length > 0) {
+    try {
+      if (contentType.includes("application/json")) {
+        bodyParsed = JSON.parse(rawBody);
+      } else if (contentType.includes("application/x-www-form-urlencoded")) {
+        bodyParsed = Object.fromEntries(
+          new URLSearchParams(rawBody).entries(),
+        );
+      } else {
+        try {
+          bodyParsed = JSON.parse(rawBody);
+        } catch {
+          bodyParsed = null;
+        }
+      }
+    } catch (err) {
+      parseError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  const [log] = await db
+    .insert(ingestionLogs)
+    .values({
+      source: "apple_pay",
+      status: "debug",
+      itemsReceived: 0,
+      itemsInserted: 0,
+      itemsDuplicated: 0,
+      payload: {
+        kind: "debug-capture",
+        method: "POST",
+        url: req.url,
+        query,
+        headers: headersRecord,
+        contentType,
+        bodyRaw: rawBody,
+        bodyParsed,
+        parseError,
+      },
+      startedAt,
+      finishedAt: new Date(),
+    })
+    .returning({ id: ingestionLogs.id });
+
+  return NextResponse.json({ ok: true, logId: log.id });
+}
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    hint: "POST any payload with Authorization: Bearer <INGEST_WEBHOOK_TOKEN>",
+  });
+}


### PR DESCRIPTION
## Summary

- `POST /api/ingest/debug` — accepts ANY payload (JSON, form-urlencoded, raw text) and persists the full request (method, URL, query, headers, body raw + parsed) into `ingestion_logs` with `status='debug'`.
- Auth via `Authorization: Bearer $INGEST_WEBHOOK_TOKEN` (503 when env var unset, 401 on mismatch). Authorization header value is redacted in the stored payload.
- 50KB body cap to prevent accidental abuse.
- `ios-shortcuts/README.md` with step-by-step setup for the iOS Transaction trigger to POST here.
- `scripts/test-debug-ingest.sh` for curl-based smoke testing.
- README.md now documents required env vars inline (`.env.example` blocked by sandbox permissions — content lives in README).

## Why

Apple's docs don't specify what the iOS 17+ Transaction automation trigger actually exposes. Cross-referenced docs + forums + real apps confirm only three fields (`Card or Pass`, `Merchant`, `Amount`). Everything else (card string format, currency shape, date availability, categories, sub-properties) is empirical. This endpoint lets us capture 3-5 real purchases before designing the final `/api/ingest/apple-pay` contract in #11.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run test` — 18/18 tests passing (7 new tests for this route)
- [x] Smoke test vs live dev server on port 3100:
  - `GET /api/ingest/debug` → 200 + hint
  - `POST /api/ingest/debug` without auth → 401
- [ ] **User action required**: after merge, add `INGEST_WEBHOOK_TOKEN` to `.env.local` (restart dev server), then:
  - Run `INGEST_WEBHOOK_TOKEN=xxx ./scripts/test-debug-ingest.sh` to verify end-to-end insert into `ingestion_logs`.
  - Set up the iOS Shortcut per `ios-shortcuts/README.md` pointing to the Tailscale URL.
  - Make 3-5 Apple Pay purchases and comment the captured payloads on #39 to unblock #11.

Closes #39