### PR TITLE
chore(infra): Playwright for visual verification + E2E foundation (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/e2e/screenshots/
+/test-results/
+/playwright-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,3 +127,28 @@ bun run db:seed:test      # seed accounts/categories/rules
 
 After changing the schema, re-run `db:migrate:test` so the test DB stays
 in sync with `findash`.
+
+## Visual verification (Playwright)
+
+For UI-affecting PRs, agents without human eyes available can capture
+screenshots of every page and attach them to the PR body.
+
+First-time setup on a fresh clone:
+
+```bash
+bun run test:e2e:install   # download headless chromium (~280 MiB)
+```
+
+Capture screenshots:
+
+```bash
+bun run dev                # in another shell, leave running
+bun run test:e2e           # generates e2e/screenshots/*.png
+```
+
+The current spec (`e2e/screenshots.spec.ts`) is capture-only — no
+assertions. It loads `/`, `/transactions`, `/budgets`, `/insights`,
+`/settings` and writes full-page PNGs. Screenshots and `test-results/`
+are gitignored; treat them as ephemeral artifacts. Functional E2E tests
+with assertions are out of scope until needed; when added, follow the
+same conventions cc uses (`cc/docs/E2E_TESTING.md`).

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/bun": "^1.3.12",
         "@types/node": "^20",
@@ -330,6 +331,8 @@
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -1033,7 +1036,7 @@
 
     "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1494,6 +1497,10 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1960,6 +1967,10 @@
     "string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -1,0 +1,21 @@
+import { test } from "@playwright/test";
+import path from "node:path";
+
+const pages = [
+  { name: "home", path: "/" },
+  { name: "transactions", path: "/transactions" },
+  { name: "budgets", path: "/budgets" },
+  { name: "insights", path: "/insights" },
+  { name: "settings", path: "/settings" },
+];
+
+for (const p of pages) {
+  test(`screenshot: ${p.name}`, async ({ page }) => {
+    await page.goto(p.path);
+    await page.waitForLoadState("networkidle");
+    await page.screenshot({
+      path: path.join("e2e/screenshots", `${p.name}.png`),
+      fullPage: true,
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "db:seed:test": "PGDATABASE=findash_test bun run src/lib/db/seed.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install chromium",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -42,6 +44,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/bun": "^1.3.12",
     "@types/node": "^20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  fullyParallel: false,
+  workers: 1,
+  reporter: "list",
+  outputDir: "./test-results",
+  use: {
+    baseURL: "http://localhost:3100",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "bun run dev",
+    url: "http://localhost:3100",
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Summary
- Instala \`@playwright/test\` + chromium (headless) para habilitar validación visual de PRs de UI sin ojos humanos disponibles.
- Config en raíz (\`playwright.config.ts\`) con \`reuseExistingServer: true\` — si el dev server ya corre en \`:3100\`, lo aprovecha; si no, lo levanta.
- Un spec \`e2e/screenshots.spec.ts\` capture-only: navega a \`/\`, \`/transactions\`, \`/budgets\`, \`/insights\`, \`/settings\` y guarda PNGs full-page.
- Scripts \`test:e2e\` y \`test:e2e:install\` en \`package.json\`.
- Screenshots, \`test-results/\` y \`playwright-report/\` gitignoreados — artefactos efímeros.
- Sección en \`AGENTS.md\` explicando el uso.

## Why
Con esto cualquier agente puede correr \`bun run test:e2e\` después de un cambio de UI, inspeccionar los PNGs y adjuntarlos al PR. También sienta la base para specs funcionales reales cuando haga falta (siguiendo el playbook de cc).

## Out of scope
- Tests funcionales con assertions.
- Auth flow (findash es single-user, no hace falta por ahora).
- CI integration — se agrega cuando tengamos más specs.
- Multi-project \`light\` + \`dark\` — se suma en #45.

## Test plan
- [x] \`bun run test:e2e:install\` instala chromium (170 MiB + headless shell 112 MiB)
- [x] \`bun run test:e2e\` corre los 5 screenshots en ~5.5s contra el dev server activo
- [x] \`bun run typecheck\` pasa
- [x] \`bun run lint\` pasa
- [x] PNGs aparecen en \`e2e/screenshots/\` y están gitignoreados

Closes #52