### PR TITLE
feat(ui): dark mode toggle via next-themes (#45)

### DIFF
--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -19,6 +19,11 @@ for (const mode of modes) {
       }, mode);
       await page.goto(p.path);
       await page.waitForLoadState("networkidle");
+      const donutPath = page.locator(".recharts-pie-sector path").first();
+      await donutPath.waitFor({ state: "visible", timeout: 5_000 }).catch(() => {});
+      if (await donutPath.count()) {
+        await page.waitForTimeout(1_800);
+      }
       await page.screenshot({
         path: path.join("e2e/screenshots", `${mode}-${p.name}.png`),
         fullPage: true,

--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -9,13 +9,20 @@ const pages = [
   { name: "settings", path: "/settings" },
 ];
 
-for (const p of pages) {
-  test(`screenshot: ${p.name}`, async ({ page }) => {
-    await page.goto(p.path);
-    await page.waitForLoadState("networkidle");
-    await page.screenshot({
-      path: path.join("e2e/screenshots", `${p.name}.png`),
-      fullPage: true,
+const modes = ["light", "dark"] as const;
+
+for (const mode of modes) {
+  for (const p of pages) {
+    test(`screenshot: ${mode} ${p.name}`, async ({ page }) => {
+      await page.addInitScript((m) => {
+        window.localStorage.setItem("theme", m);
+      }, mode);
+      await page.goto(p.path);
+      await page.waitForLoadState("networkidle");
+      await page.screenshot({
+        path: path.join("e2e/screenshots", `${mode}-${p.name}.png`),
+        fullPage: true,
+      });
     });
-  });
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Header } from "@/components/layout/header";
 import { Breadcrumbs } from "@/components/layout/breadcrumbs";
 import { QuickExpenseFab } from "@/components/transactions/quick-expense-fab";
 import { Toaster } from "@/components/ui/sonner";
+import { ThemeProvider } from "@/components/providers/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,14 +30,22 @@ export default function RootLayout({
   return (
     <html
       lang="en"
+      suppressHydrationWarning
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
-        <Header />
-        <Breadcrumbs />
-        <div className="flex flex-1 flex-col">{children}</div>
-        <QuickExpenseFab />
-        <Toaster />
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <Header />
+          <Breadcrumbs />
+          <div className="flex flex-1 flex-col">{children}</div>
+          <QuickExpenseFab />
+          <Toaster />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/dashboard/category-donut.tsx
+++ b/src/components/dashboard/category-donut.tsx
@@ -54,6 +54,8 @@ export function CategoryDonut({
                     <Cell
                       key={s.slug}
                       fill={s.color ?? PALETTE[i % PALETTE.length]}
+                      stroke="var(--card)"
+                      strokeWidth={2}
                     />
                   ))}
                 </Pie>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -12,6 +12,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { Nav } from "./nav";
+import { ThemeToggle } from "./theme-toggle";
 
 export function Header() {
   const [open, setOpen] = useState(false);
@@ -28,22 +29,25 @@ export function Header() {
           <Nav orientation="horizontal" />
         </div>
 
-        <div className="ml-auto md:hidden">
-          <Sheet open={open} onOpenChange={setOpen}>
-            <SheetTrigger asChild>
-              <Button variant="ghost" size="icon" aria-label="Open menu">
-                <MenuIcon className="size-5" />
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="left" className="w-64 p-0">
-              <SheetHeader className="border-b">
-                <SheetTitle>Menu</SheetTitle>
-              </SheetHeader>
-              <div className="p-3">
-                <Nav orientation="vertical" onNavigate={() => setOpen(false)} />
-              </div>
-            </SheetContent>
-          </Sheet>
+        <div className="ml-auto flex items-center gap-1">
+          <ThemeToggle />
+          <div className="md:hidden">
+            <Sheet open={open} onOpenChange={setOpen}>
+              <SheetTrigger asChild>
+                <Button variant="ghost" size="icon" aria-label="Open menu">
+                  <MenuIcon className="size-5" />
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="left" className="w-64 p-0">
+                <SheetHeader className="border-b">
+                  <SheetTitle>Menu</SheetTitle>
+                </SheetHeader>
+                <div className="p-3">
+                  <Nav orientation="vertical" onNavigate={() => setOpen(false)} />
+                </div>
+              </SheetContent>
+            </Sheet>
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/layout/theme-toggle.tsx
+++ b/src/components/layout/theme-toggle.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Toggle theme"
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+    >
+      <Sun className="size-5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+      <Moon className="absolute size-5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+export function ThemeProvider(props: ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props} />;
+}


### PR DESCRIPTION
## Summary
- Wrap la app en un \`ThemeProvider\` (next-themes, ya instalado) con \`attribute=\"class\"\`, \`defaultTheme=\"system\"\`, \`enableSystem\`, \`disableTransitionOnChange\`.
- Agregar \`suppressHydrationWarning\` al \`<html>\` — requerido por next-themes porque lee localStorage client-side.
- Nuevo componente \`ThemeToggle\` en el header (desktop + móvil): un botón que renderiza Sun y Moon absolutos y los anima vía Tailwind \`dark:\` variant. SSR-safe sin el clásico \`mounted\` guard (que ESLint \`react-hooks/set-state-in-effect\` flagea).
- Extendido el spec de screenshots para capturar cada página en light **y** dark, inyectando el key \`theme\` en localStorage antes de navegar.

## Why
Los tokens dark ya existían (definidos en #47), pero no había forma de activar \`.dark\` en el DOM. Este PR cablea next-themes al CSS custom-variant (\`@custom-variant dark (&:is(.dark *))\`) y suma el toggle de UX.

## Verificación visual
Corrido con \`bun run test:e2e\` — 10 tests pasan (5 páginas × 2 modos). Screenshots en \`e2e/screenshots/{light,dark}-*.png\`.

**Light:** fondo blanco, primary naranja saturado, todo como estaba.
**Dark:** fondo casi negro, cards en gris oscuro, primary naranja más claro para que rebote bien sobre oscuro, texto blanco, chart colors ajustados por brillo. Sin regresiones.

## Patrón de toggle
Elegí el patrón de shadcn: renderizar ambos iconos y usar \`dark:\` variant + transform para animar el switch. Ventaja: no hay estado JS, no hay mismatch de hydration, ESLint contento. El \`aria-label\` queda genérico (\"Toggle theme\") para evitar cambios dinámicos SSR→client.

## Out of scope
- Persistir preferencia por cuenta/usuario (findash es single-user, localStorage alcanza).
- Transiciones animadas del cambio de tema (\`disableTransitionOnChange: true\` — evita flash mientras los tokens de cientos de elementos se interpolan).
- Dark mode en preview emails / PDFs.

Closes #45