### PR TITLE
feat(realtime): SSE endpoint + useLiveEvents hook — push on ingestion (#50)

### DIFF
--- a/src/app/api/events/stream/route.ts
+++ b/src/app/api/events/stream/route.ts
@@ -1,0 +1,58 @@
+import { subscribe, type AppEvent } from "@/lib/events/bus";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const HEARTBEAT_MS = 20_000;
+
+export async function GET(req: Request) {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let closed = false;
+      const safeEnqueue = (chunk: string) => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(chunk));
+        } catch {
+          closed = true;
+        }
+      };
+
+      safeEnqueue(`: hello\n\n`);
+
+      const onEvent = (event: AppEvent) => {
+        safeEnqueue(`data: ${JSON.stringify(event)}\n\n`);
+      };
+      const unsubscribe = subscribe(onEvent);
+
+      const heartbeat = setInterval(() => {
+        safeEnqueue(`: heartbeat\n\n`);
+      }, HEARTBEAT_MS);
+
+      const cleanup = () => {
+        if (closed) return;
+        closed = true;
+        clearInterval(heartbeat);
+        unsubscribe();
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+      };
+
+      req.signal.addEventListener("abort", cleanup);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/src/app/api/events/trigger/route.ts
+++ b/src/app/api/events/trigger/route.ts
@@ -1,0 +1,21 @@
+import { emit } from "@/lib/events/bus";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  if (process.env.NODE_ENV === "production") {
+    return new Response("Not found", { status: 404 });
+  }
+  emit({
+    type: "transaction:created",
+    id: 0,
+    source: "sms",
+    timestamp: Date.now(),
+  });
+  return Response.json({
+    ok: true,
+    emitted: "transaction:created",
+    source: "sms",
+  });
+}

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -189,6 +189,7 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
     emit({
       type: "transaction:created",
       id: result[0].id,
+      source: "sms",
       timestamp: Date.now(),
     });
     return { status: "inserted", txId: result[0].id };

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -3,6 +3,7 @@ import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, ingestionLogs, transactions } from "@/lib/db/schema";
 import { classifyByRule } from "@/lib/classification/rules";
+import { emit } from "@/lib/events/bus";
 import {
   parseSmsBancolombia,
   resolveAccountFromLast4,
@@ -185,6 +186,11 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
       .returning({ id: transactions.id });
 
     if (result.length === 0) return { status: "duplicated" };
+    emit({
+      type: "transaction:created",
+      id: result[0].id,
+      timestamp: Date.now(),
+    });
     return { status: "inserted", txId: result[0].id };
   } catch (err) {
     return {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Breadcrumbs } from "@/components/layout/breadcrumbs";
 import { QuickExpenseFab } from "@/components/transactions/quick-expense-fab";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/providers/theme-provider";
+import { LiveRefresh } from "@/components/live-refresh";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -45,6 +46,7 @@ export default function RootLayout({
           <div className="flex flex-1 flex-col">{children}</div>
           <QuickExpenseFab />
           <Toaster />
+          <LiveRefresh />
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -93,6 +93,7 @@ export async function createManualExpense(input: {
   emit({
     type: "transaction:created",
     id: inserted.id,
+    source: "manual",
     timestamp: Date.now(),
   });
 }

--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { db } from "@/lib/db";
 import { accounts, categories, transactions } from "@/lib/db/schema";
 import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
+import { emit } from "@/lib/events/bus";
 
 const updateSchema = z.object({
   txId: z.coerce.number().int().positive(),
@@ -68,23 +69,32 @@ export async function createManualExpense(input: {
   const cents = Math.round(parsed.amount * 100);
   const occurredAt = new Date(`${parsed.occurredOn}T12:00:00Z`);
 
-  await db.insert(transactions).values({
-    accountId: account.id,
-    occurredAt,
-    amountCents: BigInt(-cents),
-    currency: account.currency,
-    descriptionRaw: parsed.notes ?? "Manual expense",
-    descriptionClean: null,
-    merchant: null,
-    categorySlug: parsed.categorySlug,
-    classificationMethod: parsed.categorySlug ? "manual" : "unclassified",
-    classificationConfidence: parsed.categorySlug ? 100 : null,
-    source: "manual",
-    notes: parsed.notes,
-  });
+  const [inserted] = await db
+    .insert(transactions)
+    .values({
+      accountId: account.id,
+      occurredAt,
+      amountCents: BigInt(-cents),
+      currency: account.currency,
+      descriptionRaw: parsed.notes ?? "Manual expense",
+      descriptionClean: null,
+      merchant: null,
+      categorySlug: parsed.categorySlug,
+      classificationMethod: parsed.categorySlug ? "manual" : "unclassified",
+      classificationConfidence: parsed.categorySlug ? 100 : null,
+      source: "manual",
+      notes: parsed.notes,
+    })
+    .returning({ id: transactions.id });
 
   revalidatePath("/");
   revalidatePath("/transactions");
+
+  emit({
+    type: "transaction:created",
+    id: inserted.id,
+    timestamp: Date.now(),
+  });
 }
 
 export async function runAiClassifier() {

--- a/src/components/live-refresh.tsx
+++ b/src/components/live-refresh.tsx
@@ -7,8 +7,9 @@ export function LiveRefresh() {
   useLiveEvents({
     onEvent: (event) => {
       if (event.type === "transaction:created" && event.source === "sms") {
-        toast.success("Nueva transacción", {
+        toast("Nueva transacción", {
           description: "Acaba de entrar un SMS de Bancolombia.",
+          duration: 8_000,
         });
       }
     },

--- a/src/components/live-refresh.tsx
+++ b/src/components/live-refresh.tsx
@@ -10,6 +10,10 @@ export function LiveRefresh() {
         toast("Nueva transacción", {
           description: "Acaba de entrar un SMS de Bancolombia.",
           duration: 8_000,
+          style: {
+            background: "var(--muted)",
+            borderColor: "var(--border)",
+          },
         });
       }
     },

--- a/src/components/live-refresh.tsx
+++ b/src/components/live-refresh.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { useLiveEvents } from "@/lib/hooks/use-live-events";
+
+export function LiveRefresh() {
+  useLiveEvents();
+  return null;
+}

--- a/src/components/live-refresh.tsx
+++ b/src/components/live-refresh.tsx
@@ -1,8 +1,17 @@
 "use client";
 
+import { toast } from "sonner";
 import { useLiveEvents } from "@/lib/hooks/use-live-events";
 
 export function LiveRefresh() {
-  useLiveEvents();
+  useLiveEvents({
+    onEvent: (event) => {
+      if (event.type === "transaction:created" && event.source === "sms") {
+        toast.success("Nueva transacción", {
+          description: "Acaba de entrar un SMS de Bancolombia.",
+        });
+      }
+    },
+  });
   return null;
 }

--- a/src/lib/events/bus.test.ts
+++ b/src/lib/events/bus.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { emit, subscribe, type AppEvent } from "./bus";
+
+describe("event bus", () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()!();
+  });
+
+  it("delivers an event to a subscriber", () => {
+    const received: AppEvent[] = [];
+    cleanups.push(subscribe((e) => received.push(e)));
+
+    emit({ type: "transaction:created", id: 42, timestamp: 1 });
+
+    expect(received).toEqual([
+      { type: "transaction:created", id: 42, timestamp: 1 },
+    ]);
+  });
+
+  it("delivers to multiple subscribers", () => {
+    const a: AppEvent[] = [];
+    const b: AppEvent[] = [];
+    cleanups.push(subscribe((e) => a.push(e)));
+    cleanups.push(subscribe((e) => b.push(e)));
+
+    emit({ type: "budget:updated", timestamp: 2 });
+
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+
+  it("stops delivering after unsubscribe", () => {
+    const received: AppEvent[] = [];
+    const off = subscribe((e) => received.push(e));
+
+    emit({ type: "transaction:created", id: 1, timestamp: 3 });
+    off();
+    emit({ type: "transaction:created", id: 2, timestamp: 4 });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ id: 1 });
+  });
+});

--- a/src/lib/events/bus.test.ts
+++ b/src/lib/events/bus.test.ts
@@ -12,10 +12,10 @@ describe("event bus", () => {
     const received: AppEvent[] = [];
     cleanups.push(subscribe((e) => received.push(e)));
 
-    emit({ type: "transaction:created", id: 42, timestamp: 1 });
+    emit({ type: "transaction:created", id: 42, source: "sms", timestamp: 1 });
 
     expect(received).toEqual([
-      { type: "transaction:created", id: 42, timestamp: 1 },
+      { type: "transaction:created", id: 42, source: "sms", timestamp: 1 },
     ]);
   });
 
@@ -35,9 +35,9 @@ describe("event bus", () => {
     const received: AppEvent[] = [];
     const off = subscribe((e) => received.push(e));
 
-    emit({ type: "transaction:created", id: 1, timestamp: 3 });
+    emit({ type: "transaction:created", id: 1, source: "manual", timestamp: 3 });
     off();
-    emit({ type: "transaction:created", id: 2, timestamp: 4 });
+    emit({ type: "transaction:created", id: 2, source: "manual", timestamp: 4 });
 
     expect(received).toHaveLength(1);
     expect(received[0]).toMatchObject({ id: 1 });

--- a/src/lib/events/bus.ts
+++ b/src/lib/events/bus.ts
@@ -1,8 +1,20 @@
 import { EventEmitter } from "node:events";
 
+export type TransactionSource = "sms" | "manual";
+
 export type AppEvent =
-  | { type: "transaction:created"; id: number; timestamp: number }
-  | { type: "transaction:updated"; id: number; timestamp: number }
+  | {
+      type: "transaction:created";
+      id: number;
+      source: TransactionSource;
+      timestamp: number;
+    }
+  | {
+      type: "transaction:updated";
+      id: number;
+      source: TransactionSource;
+      timestamp: number;
+    }
   | { type: "budget:updated"; timestamp: number };
 
 // globalThis singleton survives Turbopack HMR, which otherwise re-evaluates

--- a/src/lib/events/bus.ts
+++ b/src/lib/events/bus.ts
@@ -1,0 +1,33 @@
+import { EventEmitter } from "node:events";
+
+export type AppEvent =
+  | { type: "transaction:created"; id: number; timestamp: number }
+  | { type: "transaction:updated"; id: number; timestamp: number }
+  | { type: "budget:updated"; timestamp: number };
+
+// globalThis singleton survives Turbopack HMR, which otherwise re-evaluates
+// this module and would leave SSE subscribers attached to a stale bus.
+declare global {
+  var __findashEventBus: EventEmitter | undefined;
+}
+
+function getBus(): EventEmitter {
+  if (!globalThis.__findashEventBus) {
+    const bus = new EventEmitter();
+    bus.setMaxListeners(50);
+    globalThis.__findashEventBus = bus;
+  }
+  return globalThis.__findashEventBus;
+}
+
+export function emit(event: AppEvent): void {
+  getBus().emit("event", event);
+}
+
+export function subscribe(listener: (event: AppEvent) => void): () => void {
+  const bus = getBus();
+  bus.on("event", listener);
+  return () => {
+    bus.off("event", listener);
+  };
+}

--- a/src/lib/hooks/use-live-events.ts
+++ b/src/lib/hooks/use-live-events.ts
@@ -2,23 +2,17 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import type { AppEvent } from "@/lib/events/bus";
 
-type AppEventType =
-  | "transaction:created"
-  | "transaction:updated"
-  | "budget:updated";
-
-type WireEvent = { type: AppEventType };
-
-const DEFAULT_REFRESH_ON: AppEventType[] = [
+const DEFAULT_REFRESH_ON: AppEvent["type"][] = [
   "transaction:created",
   "transaction:updated",
   "budget:updated",
 ];
 
 export function useLiveEvents(options?: {
-  onEvent?: (type: AppEventType) => void;
-  refreshOn?: AppEventType[];
+  onEvent?: (event: AppEvent) => void;
+  refreshOn?: AppEvent["type"][];
 }) {
   const router = useRouter();
 
@@ -28,8 +22,8 @@ export function useLiveEvents(options?: {
 
     source.onmessage = (e) => {
       try {
-        const event = JSON.parse(e.data) as WireEvent;
-        options?.onEvent?.(event.type);
+        const event = JSON.parse(e.data) as AppEvent;
+        options?.onEvent?.(event);
         if (refreshOn.includes(event.type)) {
           router.refresh();
         }

--- a/src/lib/hooks/use-live-events.ts
+++ b/src/lib/hooks/use-live-events.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+type AppEventType =
+  | "transaction:created"
+  | "transaction:updated"
+  | "budget:updated";
+
+type WireEvent = { type: AppEventType };
+
+const DEFAULT_REFRESH_ON: AppEventType[] = [
+  "transaction:created",
+  "transaction:updated",
+  "budget:updated",
+];
+
+export function useLiveEvents(options?: {
+  onEvent?: (type: AppEventType) => void;
+  refreshOn?: AppEventType[];
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const refreshOn = options?.refreshOn ?? DEFAULT_REFRESH_ON;
+    const source = new EventSource("/api/events/stream");
+
+    source.onmessage = (e) => {
+      try {
+        const event = JSON.parse(e.data) as WireEvent;
+        options?.onEvent?.(event.type);
+        if (refreshOn.includes(event.type)) {
+          router.refresh();
+        }
+      } catch {
+        // malformed — ignore
+      }
+    };
+
+    return () => {
+      source.close();
+    };
+  }, [options, router]);
+}


### PR DESCRIPTION
## Summary
- Nuevo event bus en memoria (\`src/lib/events/bus.ts\`) — \`EventEmitter\` singleton montado sobre \`globalThis\` para sobrevivir HMR de Turbopack en dev.
- Nuevo endpoint \`GET /api/events/stream\` — SSE que suscribe al bus, hace heartbeat cada 20s y se desmonta en \`req.signal.abort\`.
- Nuevo hook \`useLiveEvents\` — abre \`EventSource\`, dispara \`router.refresh()\` por defecto en todo evento de mutación. Envuelto en un componente \`<LiveRefresh />\` montado una sola vez en \`layout.tsx\` — cualquier página que el usuario tenga abierta recibe los cambios.
- Emit de \`transaction:created\` desde:
  - Webhook SMS Bancolombia (\`/api/ingest/sms\`)
  - Server action de quick expense (\`createManualExpense\` en \`/app/transactions/actions.ts\`)
- Unit tests para el bus (\`src/lib/events/bus.test.ts\`): emit→subscribe, multi-subscriber, unsubscribe.

## Why SSE (recap)
- Unidireccional server→cliente. No necesitamos WS.
- HTTP nativo, cero infra extra. Funciona en App Router de Next.js 16 con \`runtime = \"nodejs\"\`.
- Reconexión automática en el browser.
- \`EventSource\` ignora \`:\`-comments y \`data:\` con JSON — heartbeat y payload separados.

## Test plan (manual)
- [x] \`bun run test src/lib/events/bus.test.ts\` — 3/3 pass
- [x] \`bun run typecheck\` ✓
- [x] \`bun run lint\` ✓
- [x] \`curl -N http://localhost:3100/api/events/stream\` — stream abre y manda \`: hello\`
- [ ] Manual E2E: abrir 2 pestañas en \`/\`, disparar un SMS webhook (o hacer clic en FAB \"+ Expense\" con monto en una pestaña) — la OTRA pestaña debería refrescar sola en < 2s. Dejo esto para tu prueba visual — no puedo validarlo desde el server sin display.

## Out of scope
- Auth en el stream (findash es single-user).
- Persistencia de eventos (efímero, al reconectar el cliente pierde los viejos).
- Multi-tab dedup (si hay 5 pestañas abiertas, las 5 refrescan).
- Apple Pay emit (#11 aún no está implementado).

## Architectural notes
- El bus es \`new EventEmitter()\` con \`setMaxListeners(50)\` — suficiente para este uso personal. Si en algún momento hay muchas conexiones simultáneas, hay que revisar.
- El stream usa \`ReadableStream\` + \`TextEncoder\`. El \`req.signal\` dispara cleanup cuando el browser cierra la conexión.
- \`router.refresh()\` de Next.js 16 re-fetcha server components sin perder estado cliente — es el refresh idiomático para este tipo de push.

Closes #50