### PR TITLE
fix(ui): switch typography utilities to @utility for Tailwind 4 (#57)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -130,37 +130,33 @@
   }
 }
 
-@layer components {
-  .text-display {
-    @apply text-3xl font-semibold tracking-tight leading-tight;
-  }
-  .text-h1 {
-    @apply text-2xl font-semibold tracking-tight leading-tight;
-  }
-  .text-h2 {
-    @apply text-lg font-semibold leading-snug;
-  }
-  .text-h3 {
-    @apply text-base font-semibold leading-snug;
-  }
-  .text-body {
-    @apply text-sm leading-normal;
-  }
-  .text-caption {
-    @apply text-xs text-muted-foreground leading-normal;
-  }
-  .money {
-    font-family: var(--font-numeric);
-    @apply tabular-nums font-medium;
-  }
-  .money-lg {
-    font-family: var(--font-numeric);
-    @apply text-3xl font-semibold tabular-nums tracking-tight;
-  }
+@utility text-display {
+  @apply text-3xl font-semibold tracking-tight leading-tight;
+}
+@utility text-h1 {
+  @apply text-2xl font-semibold tracking-tight leading-tight;
+}
+@utility text-h2 {
+  @apply text-lg font-semibold leading-snug;
+}
+@utility text-h3 {
+  @apply text-base font-semibold leading-snug;
+}
+@utility text-body {
+  @apply text-sm leading-normal;
+}
+@utility text-caption {
+  @apply text-xs text-muted-foreground leading-normal;
+}
+@utility money {
+  font-family: var(--font-numeric);
+  @apply tabular-nums font-medium;
+}
+@utility money-lg {
+  font-family: var(--font-numeric);
+  @apply text-3xl font-semibold tabular-nums tracking-tight;
 }
 
-@layer utilities {
-  .tabular-nums {
-    font-family: var(--font-numeric);
-  }
+.tabular-nums {
+  font-family: var(--font-numeric);
 }


### PR DESCRIPTION
## Summary
Hotfix: las clases \`text-h1\`, \`text-h2\`, \`text-body\`, \`money\`, etc. definidas en \`@layer components\` con \`@apply\` no se emiten en Tailwind 4 — las reemplazo por \`@utility\` (directiva nativa de v4).

## Why
Descubierto después de mergear #56: \"Dashboard\" en la home perdió su peso/tamaño, pero los montos seguían en JetBrains Mono. Diferencia: \`.tabular-nums\` estaba bajo \`@layer utilities\` con CSS plano (no @apply) — esa SÍ sobrevivió. Las otras usaban \`@layer components\` + \`@apply\` — silenciosamente dropeadas.

## Verification
- \`curl /_next/.../globals.css | grep text-h1\` antes del fix: 0 matches. Después: 1 match ✓
- Screenshots regenerados (\`bun run test:e2e\`) — el H1 \"Dashboard\" bold + H2 \"Accounts\" de vuelta.

Closes #57