### PR TITLE
feat(ui): skeletons, empty states, and mutation toasts (#49)

### DIFF
--- a/src/app/budgets/budgets-manager.tsx
+++ b/src/app/budgets/budgets-manager.tsx
@@ -2,10 +2,11 @@
 
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
-import { ChevronLeftIcon, ChevronRightIcon, PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
+import { ChevronLeftIcon, ChevronRightIcon, PencilIcon, PiggyBankIcon, PlusIcon, Trash2Icon } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
 import {
   Dialog,
   DialogContent,
@@ -132,10 +133,17 @@ export function BudgetsManager({
 
       {items.length === 0 ? (
         <Card>
-          <CardContent className="flex flex-col items-center gap-2 py-12 text-center text-sm text-muted-foreground">
-            <p>No budgets for {formatMonth(ym)}.</p>
-            <p>Set spending caps per category to track progress.</p>
-          </CardContent>
+          <EmptyState
+            icon={<PiggyBankIcon />}
+            title={`No budgets for ${formatMonth(ym)}`}
+            description="Set spending caps per category to track progress each month."
+            action={
+              <Button onClick={() => setEditor({ open: true, editing: null })}>
+                <PlusIcon className="size-4" />
+                New budget
+              </Button>
+            }
+          />
         </Card>
       ) : (
         <div className="grid gap-3">

--- a/src/app/budgets/loading.tsx
+++ b/src/app/budgets/loading.tsx
@@ -1,0 +1,50 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function BudgetsLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header className="flex flex-col gap-2">
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-4 w-96 max-w-full" />
+      </header>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1">
+          <Skeleton className="h-7 w-7" />
+          <Skeleton className="mx-2 h-4 w-28" />
+          <Skeleton className="h-7 w-7" />
+        </div>
+        <Skeleton className="h-8 w-32" />
+      </div>
+
+      <Card>
+        <CardContent className="flex items-center justify-between py-3">
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-40" />
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i}>
+            <CardContent className="flex flex-col gap-2 py-3">
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-4 w-40" />
+                <div className="flex gap-1">
+                  <Skeleton className="h-7 w-7" />
+                  <Skeleton className="h-7 w-7" />
+                </div>
+              </div>
+              <Skeleton className="h-2 w-full rounded-full" />
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-3 w-32" />
+                <Skeleton className="h-3 w-28" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/insights/insights-viewer.tsx
+++ b/src/app/insights/insights-viewer.tsx
@@ -7,6 +7,7 @@ import ReactMarkdown from "react-markdown";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
 import { formatCop } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { generateInsight } from "./actions";
@@ -154,14 +155,17 @@ export function InsightsViewer({
         </Card>
       ) : (
         <Card>
-          <CardContent className="flex flex-col items-center gap-2 py-12 text-center text-sm text-muted-foreground">
-            <SparklesIcon className="size-8 text-muted-foreground/40" />
-            <p>No hay reporte para {formatMonth(ym)}.</p>
-            <p>
-              Generar un reporte llama a Claude Sonnet con el resumen del mes.
-              Se cachea por 24h.
-            </p>
-          </CardContent>
+          <EmptyState
+            icon={<SparklesIcon />}
+            title={`No hay reporte para ${formatMonth(ym)}`}
+            description="Generar un reporte llama a Claude Sonnet con el resumen del mes. Se cachea por 24h."
+            action={
+              <Button onClick={onGenerate} disabled={pending}>
+                <SparklesIcon className="size-4" />
+                {pending ? "Generando…" : "Generar reporte"}
+              </Button>
+            }
+          />
         </Card>
       )}
     </div>

--- a/src/app/insights/loading.tsx
+++ b/src/app/insights/loading.tsx
@@ -1,0 +1,41 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function InsightsLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-4xl flex-col gap-4 p-4 sm:p-6">
+      <header className="flex flex-col gap-2">
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-4 w-96 max-w-full" />
+      </header>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1">
+          <Skeleton className="h-7 w-7" />
+          <Skeleton className="mx-2 h-4 w-28" />
+          <Skeleton className="h-7 w-7" />
+        </div>
+        <Skeleton className="h-8 w-40" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i}>
+            <CardContent className="flex flex-col gap-1 py-3">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-5 w-24" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card>
+        <CardContent className="flex flex-col gap-3 py-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-4 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,56 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DashboardLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 sm:p-6">
+      <header className="flex flex-col gap-2">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-4 w-28" />
+      </header>
+
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="gap-2">
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-8 w-32" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-3 w-full" />
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader>
+              <Skeleton className="h-4 w-32" />
+            </CardHeader>
+            <CardContent className="flex flex-col gap-2">
+              {Array.from({ length: 4 }).map((_, j) => (
+                <Skeleton key={j} className="h-6 w-full" />
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <Skeleton className="h-6 w-28" />
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="flex flex-col gap-2 py-4">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-6 w-40" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/transactions/loading.tsx
+++ b/src/app/transactions/loading.tsx
@@ -1,0 +1,45 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function TransactionsLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-4 p-6">
+      <header className="flex items-end justify-between gap-3">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <Skeleton className="h-8 w-32" />
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-32" />
+        ))}
+      </div>
+
+      <div className="overflow-hidden rounded-md border bg-card">
+        <div className="border-b px-4 py-3">
+          <Skeleton className="h-4 w-full max-w-3xl" />
+        </div>
+        <div className="flex flex-col divide-y">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div
+              key={i}
+              className="grid grid-cols-[80px_1fr_120px_120px_80px_100px] items-center gap-3 px-4 py-3"
+            >
+              <Skeleton className="h-3 w-16" />
+              <div className="flex flex-col gap-1.5">
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-3 w-32" />
+              </div>
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-6 w-24" />
+              <Skeleton className="h-5 w-16" />
+              <Skeleton className="ml-auto h-4 w-24" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -1,4 +1,6 @@
+import { ReceiptTextIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
 import {
   Table,
   TableBody,
@@ -56,8 +58,12 @@ export function TransactionTable({
 }) {
   if (rows.length === 0) {
     return (
-      <div className="rounded-md border bg-card p-8 text-center text-sm text-muted-foreground">
-        No transactions match the current filters.
+      <div className="rounded-md border bg-card">
+        <EmptyState
+          icon={<ReceiptTextIcon />}
+          title="No transactions"
+          description="Nothing matches the current filters. Adjust the date range or clear a filter to see more."
+        />
       </div>
     );
   }

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,50 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  icon?: React.ReactNode
+  title: React.ReactNode
+  description?: React.ReactNode
+  action?: React.ReactNode
+}) {
+  return (
+    <div
+      data-slot="empty-state"
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 px-6 py-12 text-center",
+        className,
+      )}
+      {...props}
+    >
+      {icon ? (
+        <div
+          data-slot="empty-state-icon"
+          className="flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground [&_svg]:size-5"
+        >
+          {icon}
+        </div>
+      ) : null}
+      <div className="flex flex-col gap-1">
+        <div className="font-heading text-base font-medium text-foreground">
+          {title}
+        </div>
+        {description ? (
+          <p className="max-w-sm text-sm text-muted-foreground">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {action ? <div className="mt-1">{action}</div> : null}
+    </div>
+  )
+}
+
+export { EmptyState }

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
## Summary
- `skeleton.tsx` via shadcn + new `empty-state.tsx` (icon + title + desc + optional CTA)
- `loading.tsx` for `/`, `/transactions`, `/budgets`, `/insights` with page-shaped skeletons
- Replaced inline empty blocks with `<EmptyState>` on transactions, budgets, and insights

Toast coverage audit: every mutation across budgets, insights, recurring, transactions, import, OCR, and upcoming already fires `toast.success`/`toast.error`. No gaps found, nothing to add.

## Test plan
- [x] `bun run lint` passes
- [x] `bunx tsc --noEmit` passes
- [x] `bun run test:e2e` — all 10 screenshots pass (light + dark × 5 pages)
- [x] Empty states render inside card containers with consistent typography and tokens
- [x] Loading skeletons match the shape of each page

Closes #49