### PR TITLE
fix(ingestion): expand SKIP_PATTERNS for rejected payments and marketing (#78)

### DIFF
--- a/src/lib/ingestion/sms-bancolombia.test.ts
+++ b/src/lib/ingestion/sms-bancolombia.test.ts
@@ -311,6 +311,56 @@ describe("parseSmsBancolombia — skip reasons", () => {
     expect(r.reason).toBe("non_transactional");
   });
 
+  it("skips payments rejected by insufficient balance as 'failed'", () => {
+    const body =
+      "Bancolombia: Ups! El pago en EXPERIAN COLOMBIA por $ 23,900 fue rechazada por saldo insuficiente. Tu saldo actual es $ 2,728. Usa el saldo de bolsillos si lo deseas, alli tienes $ 40,000. Mueve tu plata facilmente desde nuestra App.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("skip");
+    if (r.kind !== "skip") throw new Error("type guard");
+    expect(r.reason).toBe("failed");
+  });
+
+  it("skips calendar/marketing reminders as non_transactional", () => {
+    const bodies = [
+      "Bancolombia:ALEJANDRO, es hora! Hay una actividad pendiente en Tu calendario. Revisala ya en app Mi Bancolombia >Explorar >Dia a Dia. Ya lo hiciste? Genial",
+      "Bancolombia:Alejandro, planea, recuerda y paga facil tu tarjeta de credito con Tu calendario, lo nuevo de app Mi Bancolombia! Explorar >Dia a Dia >Tu calendario",
+      "Bancolombia: Alejandro, tu recordatorio de pago esta activo, no dejes que se apague. Entra hoy a app Mi Bancolombia >Explorar >Dia a Dia >Tu Calendario",
+    ];
+    for (const body of bodies) {
+      const r = parseSmsBancolombia(body);
+      expect(r.kind).toBe("skip");
+      if (r.kind !== "skip") throw new Error("type guard");
+      expect(r.reason).toBe("non_transactional");
+    }
+  });
+
+  it("skips yearly summary marketing as non_transactional", () => {
+    const bodies = [
+      "Bancolombia: Alejandro, tus gastos entre diciembre y enero cambiaron en $5.637.273. Conocelos en app Mi Bancolombia >Dia a Dia >Tus informes",
+      "Bancolombia: Alejandro, quedan pocas horas para consultar tus gastos de $153.377.560 en 2025. Mi Bancolombia>Dia a Dia>Tus informes antes de que desaparezca",
+      "Bancolombia: Alejandro, ChatGPT con $252.075 fue tu Top 1 en 2025. Actualizamos #TuInforme2025 en app Mi Bancolombia>Explorar>Dia a Dia>Tus Informes",
+    ];
+    for (const body of bodies) {
+      const r = parseSmsBancolombia(body);
+      expect(r.kind).toBe("skip");
+      if (r.kind !== "skip") throw new Error("type guard");
+      expect(r.reason).toBe("non_transactional");
+    }
+  });
+
+  it("skips subscription heads-up and third-party-account registration", () => {
+    const bodies = [
+      "Bancolombia: Muy pronto cobraremos una suscripción asociada a tu tarjeta. Asegúrate de tener saldo suficiente. Verifícalo fácil en tu app. Contamos contigo.",
+      "Bancolombia: Muy bien. Inscribiste la cuenta de un tercero desde APP Bancolombia. Si no fuiste tu, llamanos ahora: 6045109095 o 018000931987. Juntos en cada paso.",
+    ];
+    for (const body of bodies) {
+      const r = parseSmsBancolombia(body);
+      expect(r.kind).toBe("skip");
+      if (r.kind !== "skip") throw new Error("type guard");
+      expect(r.reason).toBe("non_transactional");
+    }
+  });
+
   it("skips unknown formats as 'unknown'", () => {
     const body = "Bancolombia: mensaje totalmente desconocido que no matchea nada";
     const r = parseSmsBancolombia(body);

--- a/src/lib/ingestion/sms-bancolombia.ts
+++ b/src/lib/ingestion/sms-bancolombia.ts
@@ -159,8 +159,15 @@ function hashId(parts: (string | bigint | number)[]): string {
 
 const SKIP_PATTERNS: Array<{ pattern: RegExp; reason: SkippedSms["reason"] }> = [
   { pattern: /no\s+fue\s+exitosa/i, reason: "failed" },
+  { pattern: /fue\s+rechazada\s+por\s+saldo\s+insuficiente/i, reason: "failed" },
   { pattern: /actualizaste\s+tu\s+informacion\s+personal/i, reason: "non_transactional" },
   { pattern: /te\s+identificaste/i, reason: "non_transactional" },
+  { pattern: /tu\s+calendario/i, reason: "non_transactional" },
+  { pattern: /tus\s+gastos\b/i, reason: "non_transactional" },
+  { pattern: /fue\s+tu\s+Top\s+\d+/i, reason: "non_transactional" },
+  { pattern: /recordatorio\s+de\s+pago/i, reason: "non_transactional" },
+  { pattern: /muy\s+pronto\s+cobraremos/i, reason: "non_transactional" },
+  { pattern: /inscribiste\s+la\s+cuenta\s+de\s+un\s+tercero/i, reason: "non_transactional" },
 ];
 
 function detectSkip(body: string): SkippedSms["reason"] | null {


### PR DESCRIPTION
## Summary

- Adds `fue rechazada por saldo insuficiente` to `SKIP_PATTERNS` as `failed` (transaction attempt, not a real charge)
- Adds 6 new `non_transactional` patterns: calendar reminders, yearly summaries/Top-N, recordatorio de pago, subscription heads-up, third-party account registration
- Patterns chosen to be narrow — only match marketing copy that never appears in transactional SMS templates

## Verification

Ran the analyzer from #72 against the 405-SMS iPhone backup dump:

| Bucket | Before | After | Δ |
|---|---:|---:|---:|
| `skip:unknown` | 75 | **40** | **-35** |
| `skip:failed` | 2 | 31 | +29 |
| `skip:non_transactional` | 2 | 8 | +6 |

The 35 SMS that moved out of `unknown` are correctly reclassified as `failed` (29 rejected charges) or `non_transactional` (6 marketing). All 6 transactional kinds (`purchase`, `transfer_sent`, `qr_payment`, `transfer_received`, `tc_payment`, `provider_payment`) unchanged — no regressions.

The remaining 40 `unknown` are the parser gaps tracked in #73, #74, #75, #76, #77.

## Test plan

- [x] `bun run test -- sms-bancolombia` — 41 tests pass (4 new tests across 3 new patterns + existing)
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes
- [x] Re-ran analyzer on 405-SMS dump: unknown drops 75 → 40 as expected

Closes #78