### PR TITLE
fix(ingestion): parse SMS Bancolombia T.Deb purchases (#73)

### DIFF
--- a/src/lib/ingestion/sms-bancolombia.test.ts
+++ b/src/lib/ingestion/sms-bancolombia.test.ts
@@ -81,8 +81,8 @@ describe("parseSmsDate", () => {
   });
 });
 
-describe("parseSmsBancolombia — purchase TC (variant A: 'con tu T.Cred')", () => {
-  it("parses COP purchase", () => {
+describe("parseSmsBancolombia — purchase (variant A: 'con tu T.{Cred|Deb}')", () => {
+  it("parses COP credit purchase", () => {
     const body =
       "Bancolombia: Compraste COP35.450,00 en DLO*DiDi Food CO Pay con tu T.Cred *2575, el 15/04/2026 a las 20:34. Si tienes dudas, encuentranos aqui: 6045109095 o 018000931987. Estamos cerca.";
     const r = parseSmsBancolombia(body);
@@ -92,12 +92,13 @@ describe("parseSmsBancolombia — purchase TC (variant A: 'con tu T.Cred')", () 
     expect(r.currency).toBe("COP");
     expect(r.merchant).toBe("DLO*DiDi Food CO Pay");
     expect(r.cardLast4).toBe("2575");
+    expect(r.cardKind).toBe("credit");
     expect(r.occurredOn).toBe("2026-04-15");
     expect(r.occurredTime).toBe("20:34");
     expect(r.externalId).toMatch(/^bcol-sms:[a-f0-9]{24}$/);
   });
 
-  it("parses USD purchase", () => {
+  it("parses USD credit purchase", () => {
     const body =
       "Bancolombia: Compraste USD10,00 en ANTHROPIC con tu T.Cred *7291, el 15/04/2026 a las 02:58. Si tienes dudas, encuentranos aqui: 6045109095 o 018000931987. Estamos cerca.";
     const r = parseSmsBancolombia(body);
@@ -107,6 +108,7 @@ describe("parseSmsBancolombia — purchase TC (variant A: 'con tu T.Cred')", () 
     expect(r.currency).toBe("USD");
     expect(r.merchant).toBe("ANTHROPIC");
     expect(r.cardLast4).toBe("7291");
+    expect(r.cardKind).toBe("credit");
   });
 
   it("parses merchant with spaces and special chars", () => {
@@ -117,11 +119,27 @@ describe("parseSmsBancolombia — purchase TC (variant A: 'con tu T.Cred')", () 
     if (r.kind !== "purchase") throw new Error("type guard");
     expect(r.merchant).toBe("DROGUERIA CRUZ VERDE");
     expect(r.amountCents).toBe(BigInt(21702900));
+    expect(r.cardKind).toBe("credit");
+  });
+
+  it("parses COP debit purchase (the #73 bug fix)", () => {
+    const body =
+      "Bancolombia: Compraste $23.900,00 en EXPERIAN COLOMBIA con tu T.Deb *1802, el 16/04/2026 a las 06:30. Si tienes dudas, encuentranos aqui: 6045109095 o 018000931987. Estamos cerca.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("purchase");
+    if (r.kind !== "purchase") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(2390000));
+    expect(r.currency).toBe("COP");
+    expect(r.merchant).toBe("EXPERIAN COLOMBIA");
+    expect(r.cardLast4).toBe("1802");
+    expect(r.cardKind).toBe("debit");
+    expect(r.occurredOn).toBe("2026-04-16");
+    expect(r.occurredTime).toBe("06:30");
   });
 });
 
-describe("parseSmsBancolombia — purchase TC (variant B: 'Esta compra esta asociada')", () => {
-  it("parses COP purchase with alternate phrasing", () => {
+describe("parseSmsBancolombia — purchase (variant B: 'Esta compra esta asociada')", () => {
+  it("parses COP credit purchase with alternate phrasing", () => {
     const body =
       "Bancolombia: Compraste COP71.950,00 en RAPPI COLOMBIA*DL, el 15/04/2026 a las 12:50. Esta compra esta asociada a T.Cred *2575. Si tienes dudas, encuentranos aqui: 01800931987. Siempre contigo.";
     const r = parseSmsBancolombia(body);
@@ -131,9 +149,10 @@ describe("parseSmsBancolombia — purchase TC (variant B: 'Esta compra esta asoc
     expect(r.currency).toBe("COP");
     expect(r.merchant).toBe("RAPPI COLOMBIA*DL");
     expect(r.cardLast4).toBe("2575");
+    expect(r.cardKind).toBe("credit");
   });
 
-  it("parses USD purchase with alternate phrasing", () => {
+  it("parses USD credit purchase with alternate phrasing", () => {
     const body =
       "Bancolombia: Compraste USD195,26 en CLAUDE.AI SUBSCRIPTI, el 15/04/2026 a las 01:09. Esta compra esta asociada a T.Cred *7291. Si tienes dudas, encuentranos aqui: 01800931987. Siempre contigo.";
     const r = parseSmsBancolombia(body);
@@ -143,6 +162,19 @@ describe("parseSmsBancolombia — purchase TC (variant B: 'Esta compra esta asoc
     expect(r.currency).toBe("USD");
     expect(r.merchant).toBe("CLAUDE.AI SUBSCRIPTI");
     expect(r.cardLast4).toBe("7291");
+    expect(r.cardKind).toBe("credit");
+  });
+
+  it("parses COP debit purchase with alternate phrasing", () => {
+    const body =
+      "Bancolombia: Compraste $48.500,00 en SUPERMERCADO LA 14, el 14/04/2026 a las 11:22. Esta compra esta asociada a T.Deb *1802. Si tienes dudas, encuentranos aqui: 01800931987. Siempre contigo.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("purchase");
+    if (r.kind !== "purchase") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(4850000));
+    expect(r.merchant).toBe("SUPERMERCADO LA 14");
+    expect(r.cardLast4).toBe("1802");
+    expect(r.cardKind).toBe("debit");
   });
 });
 

--- a/src/lib/ingestion/sms-bancolombia.ts
+++ b/src/lib/ingestion/sms-bancolombia.ts
@@ -17,6 +17,7 @@ export type ParsedSms =
       kind: "purchase";
       merchant: string;
       cardLast4: string;
+      cardKind: "credit" | "debit";
     })
   | (ParsedSmsBase & {
       kind: "transfer_sent";
@@ -193,17 +194,21 @@ const DATE_GROUP = /(\d{1,4}\/\d{1,2}\/\d{1,4})/.source;
 const TIME_GROUP = /(\d{1,2}:\d{2})/.source;
 const DATE_TIME = `${DATE_GROUP}(?:\\s+a\\s+las\\s+|\\s+)${TIME_GROUP}`;
 
-// Purchase variant A: "Compraste AMOUNT en MERCHANT con tu T.Cred *NNNN, el DATE a las TIME"
+// Purchase variant A: "Compraste AMOUNT en MERCHANT con tu T.{Cred|Deb} *NNNN, el DATE a las TIME"
 const PURCHASE_A = new RegExp(
-  `Compraste\\s+${AMOUNT_GROUP}\\s+en\\s+(.+?)\\s+con\\s+tu\\s+T\\.Cred\\s+\\*(\\d{4})[,.]?\\s+el\\s+${DATE_TIME}`,
+  `Compraste\\s+${AMOUNT_GROUP}\\s+en\\s+(.+?)\\s+con\\s+tu\\s+T\\.(Cred|Deb)\\s+\\*(\\d{4})[,.]?\\s+el\\s+${DATE_TIME}`,
   "i",
 );
 
-// Purchase variant B: "Compraste AMOUNT en MERCHANT, el DATE a las TIME. Esta compra esta asociada a T.Cred *NNNN"
+// Purchase variant B: "Compraste AMOUNT en MERCHANT, el DATE a las TIME. Esta compra esta asociada a T.{Cred|Deb} *NNNN"
 const PURCHASE_B = new RegExp(
-  `Compraste\\s+${AMOUNT_GROUP}\\s+en\\s+(.+?),\\s+el\\s+${DATE_TIME}\\.\\s+Esta\\s+compra\\s+esta\\s+asociada\\s+a\\s+T\\.Cred\\s+\\*(\\d{4})`,
+  `Compraste\\s+${AMOUNT_GROUP}\\s+en\\s+(.+?),\\s+el\\s+${DATE_TIME}\\.\\s+Esta\\s+compra\\s+esta\\s+asociada\\s+a\\s+T\\.(Cred|Deb)\\s+\\*(\\d{4})`,
   "i",
 );
+
+function cardKindFromMatch(token: string): "credit" | "debit" {
+  return token.toLowerCase() === "deb" ? "debit" : "credit";
+}
 
 // Transfer sent: "Transferiste AMOUNT [por QR] desde tu cuenta *NNNN a la cuenta *NNNN[,] el DATE [a las] TIME"
 const TRANSFER_SENT = new RegExp(
@@ -257,15 +262,17 @@ export function parseSmsBancolombia(body: string): ParseResult {
     if (m) {
       const { cents, currency } = parseSmsAmount(m[1]);
       const merchant = m[2].trim();
-      const cardLast4 = m[3];
-      const occurredOn = parseSmsDate(m[4]);
-      const occurredTime = m[5];
+      const cardKind = cardKindFromMatch(m[3]);
+      const cardLast4 = m[4];
+      const occurredOn = parseSmsDate(m[5]);
+      const occurredTime = m[6];
       return {
         kind: "purchase",
         amountCents: cents,
         currency,
         merchant,
         cardLast4,
+        cardKind,
         occurredOn,
         occurredTime,
         externalId: hashId([
@@ -290,13 +297,15 @@ export function parseSmsBancolombia(body: string): ParseResult {
       const merchant = m[2].trim();
       const occurredOn = parseSmsDate(m[3]);
       const occurredTime = m[4];
-      const cardLast4 = m[5];
+      const cardKind = cardKindFromMatch(m[5]);
+      const cardLast4 = m[6];
       return {
         kind: "purchase",
         amountCents: cents,
         currency,
         merchant,
         cardLast4,
+        cardKind,
         occurredOn,
         occurredTime,
         externalId: hashId([


### PR DESCRIPTION
## Summary
- Relaxes both purchase regex variants from `T\.Cred` → `T\.(Cred|Deb)` so débito purchases stop falling through to `skip:unknown`.
- Adds `cardKind: "credit" | "debit"` field on `ParsedSms.purchase` (informational; downstream consumers can use it for display/routing).
- Routing via `resolveAccountFromLast4` is unchanged — the current account inventory has no last4 overlap between débito and crédito, so `(last4, currency)` already disambiguates.
- `cardKind` is intentionally **not** part of the `externalId` hash to keep idempotency stable for any re-ingestion of historical SMS.

## Test plan
- [x] `bun run test src/lib/ingestion/sms-bancolombia.test.ts` → 43 tests pass (41 existing + 2 new T.Deb cases for variants A and B).
- [x] `bunx tsc --noEmit` clean.
- [x] `bun run lint` clean.
- [ ] Re-ingest the `EXPERIAN COLOMBIA $23.900,00 T.Deb *1802` SMS from `ingestion_logs` (manual verification post-merge).

Closes #73