### PR TITLE
feat(ingestion): parse outgoing PSE provider payments (#74)

### DIFF
--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -256,6 +256,38 @@ describe("POST /api/ingest/sms", () => {
     expect(rows[0].merchant).toBe("ESTEBAN LEONARDO SARMIENTO GOMEZ");
   });
 
+  it("inserts a provider_payment_sent (PSE) as expense from *6126", async () => {
+    const body =
+      "Bancolombia: Pagaste $430,997.00 a EMPRESAS PUBLICAS DE MEDELLIN desde tu producto *6126 el 13/02/2026 10:39:06. ¿Dudas? Llamanos al 6045109095. Estamos cerca";
+    const res = await POST(
+      makeRequest({
+        body: jsonBody({ body }),
+        headers: authedHeaders(),
+      }),
+    );
+    const json = (await res.json()) as { status: string; txId?: number };
+    expect(json.status).toBe("inserted");
+
+    const rows = await db.execute<{
+      amount_cents: string;
+      merchant: string | null;
+      account_id: number;
+      classification_method: string;
+    }>(sql`
+      SELECT amount_cents, merchant, account_id, classification_method
+      FROM transactions WHERE id = ${json.txId!}
+    `);
+    expect(BigInt(rows[0].amount_cents)).toBe(BigInt(-43099700));
+    expect(rows[0].merchant).toBe("EMPRESAS PUBLICAS DE MEDELLIN");
+
+    // Routes to the COP savings account that owns last4 6126
+    const accs = await db.execute<{ name: string; currency: string }>(sql`
+      SELECT name, currency FROM accounts WHERE id = ${rows[0].account_id}
+    `);
+    expect(accs[0].currency).toBe("COP");
+    expect(accs[0].name).toBe("Bancolombia Ahorros");
+  });
+
   it("inserts a provider_payment into Bancolombia Ahorros (no last-4 in SMS)", async () => {
     const body =
       "Bancolombia: Recibiste un pago PROVEEDOR de PEXTO COLOMBIA por $6,000,000.00 en tu cuenta de Ahorros el 14/04/2026 a las 21:43. Si tienes dudas, llamanos al 018000931987. A tu lado siempre.";

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -139,12 +139,12 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
   const { amountCents, descriptionRaw, merchant, categorySlug, method } =
     buildTxFields(parsed);
 
-  // Only purchases get rule-based classification attempted.
+  // Purchases and PSE outgoing payments get rule-based classification attempted.
   // Other kinds have hardcoded categories (pago-tc, transferencias, ingresos).
   let finalCategory = categorySlug;
   let finalMethod: "rule" | "manual" | "unclassified" = method;
   let confidence: number | null = null;
-  if (parsed.kind === "purchase") {
+  if (parsed.kind === "purchase" || parsed.kind === "provider_payment_sent") {
     const cls = await classifyByRule({
       descriptionRaw,
       merchant,
@@ -215,6 +215,7 @@ function resolveAccountForParsed(
     case "transfer_sent":
     case "qr_payment":
     case "tc_payment":
+    case "provider_payment_sent":
       return resolveAccountFromLast4(
         parsed.fromLast4,
         parsed.currency,
@@ -296,6 +297,14 @@ function buildTxFields(parsed: ParsedSms): {
         merchant: parsed.senderName,
         categorySlug: "ingresos",
         method: "manual",
+      };
+    case "provider_payment_sent":
+      return {
+        amountCents: -parsed.amountCents,
+        descriptionRaw: `Pago a ${parsed.providerName}`,
+        merchant: parsed.providerName,
+        categorySlug: null,
+        method: "unclassified",
       };
   }
 }

--- a/src/lib/ingestion/sms-bancolombia.test.ts
+++ b/src/lib/ingestion/sms-bancolombia.test.ts
@@ -380,6 +380,81 @@ describe("parseSmsBancolombia — transfer received", () => {
   });
 });
 
+describe("parseSmsBancolombia — provider_payment_sent (PSE / bill-pay)", () => {
+  it("parses utility payment with HH:MM:SS time", () => {
+    const body =
+      "Bancolombia: Pagaste $430,997.00 a EMPRESAS PUBLICAS DE MEDELLIN desde tu producto *6126 el 13/02/2026 10:39:06. ¿Dudas? Llamanos al 6045109095. Estamos cerca";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("provider_payment_sent");
+    if (r.kind !== "provider_payment_sent") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(43099700));
+    expect(r.currency).toBe("COP");
+    expect(r.providerName).toBe("EMPRESAS PUBLICAS DE MEDELLIN");
+    expect(r.fromLast4).toBe("6126");
+    expect(r.occurredOn).toBe("2026-02-13");
+    expect(r.occurredTime).toBe("10:39"); // seconds dropped
+    expect(r.externalId).toMatch(/^bcol-sms:[a-f0-9]{24}$/);
+  });
+
+  it("parses additional PSE samples from the historical dump", () => {
+    const samples = [
+      {
+        body:
+          "Bancolombia: Pagaste $1,839,400.00 a Arrendamientos Santa Fe EU desde tu producto *6126 el 02/01/2026 19:54:20. ¿Dudas? Llamanos al 6045109095. Estamos cerca",
+        cents: BigInt(183940000),
+        provider: "Arrendamientos Santa Fe EU",
+        date: "2026-01-02",
+        time: "19:54",
+      },
+      {
+        body:
+          "Bancolombia: Pagaste $413,300.00 a APORTES EN LINEA desde tu producto *6126 el 02/01/2026 19:59:18. ¿Dudas? Llamanos al 6045109095. Estamos cerca",
+        cents: BigInt(41330000),
+        provider: "APORTES EN LINEA",
+        date: "2026-01-02",
+        time: "19:59",
+      },
+      {
+        body:
+          "Bancolombia: Pagaste $71,090.00 a BANCO FALABELLA S A desde tu producto *6126 el 02/01/2026 20:06:46. ¿Dudas? Llamanos al 6045109095. Estamos cerca",
+        cents: BigInt(7109000),
+        provider: "BANCO FALABELLA S A",
+        date: "2026-01-02",
+        time: "20:06",
+      },
+      {
+        body:
+          "Bancolombia: Pagaste $1,350,000.00 a FIDEICOMISO P.A. PLAN ROMBO desde tu producto *6126 el 14/01/2026 19:54:39. ¿Dudas? Llamanos al 6045109095. Estamos cerca",
+        cents: BigInt(135000000),
+        provider: "FIDEICOMISO P.A. PLAN ROMBO",
+        date: "2026-01-14",
+        time: "19:54",
+      },
+    ] as const;
+
+    for (const s of samples) {
+      const r = parseSmsBancolombia(s.body);
+      expect(r.kind).toBe("provider_payment_sent");
+      if (r.kind !== "provider_payment_sent") throw new Error("type guard");
+      expect(r.amountCents).toBe(s.cents);
+      expect(r.providerName).toBe(s.provider);
+      expect(r.fromLast4).toBe("6126");
+      expect(r.occurredOn).toBe(s.date);
+      expect(r.occurredTime).toBe(s.time);
+    }
+  });
+
+  it("parses PSE without seconds in time", () => {
+    const body =
+      "Bancolombia: Pagaste $50,000.00 a EPM desde tu producto *6126 el 10/02/2026 14:30. ¿Dudas? Llamanos al 6045109095. Estamos cerca";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("provider_payment_sent");
+    if (r.kind !== "provider_payment_sent") throw new Error("type guard");
+    expect(r.providerName).toBe("EPM");
+    expect(r.occurredTime).toBe("14:30");
+  });
+});
+
 describe("parseSmsBancolombia — provider payment", () => {
   it("parses provider payment to Ahorros", () => {
     const body =

--- a/src/lib/ingestion/sms-bancolombia.ts
+++ b/src/lib/ingestion/sms-bancolombia.ts
@@ -43,6 +43,11 @@ export type ParsedSms =
   | (ParsedSmsBase & {
       kind: "provider_payment";
       senderName: string;
+    })
+  | (ParsedSmsBase & {
+      kind: "provider_payment_sent";
+      providerName: string;
+      fromLast4: string;
     });
 
 export type SkippedSms = {
@@ -250,6 +255,14 @@ const TRANSFER_RECV_B = new RegExp(
 // Provider payment: "Recibiste un pago PROVEEDOR de SENDER por AMOUNT en tu cuenta de Ahorros el DATE a las TIME"
 const PROVIDER_PAYMENT = new RegExp(
   `Recibiste\\s+un\\s+pago\\s+PROVEEDOR\\s+de\\s+(.+?)\\s+por\\s+${AMOUNT_GROUP}\\s+en\\s+tu\\s+cuenta\\s+de\\s+Ahorros\\s+el\\s+${DATE_TIME}`,
+  "i",
+);
+
+// Provider payment sent (PSE / bill-pay):
+// "Pagaste AMOUNT a PROVIDER desde tu producto *NNNN el DD/MM/YYYY HH:MM:SS"
+// Time has seconds (HH:MM:SS) — kept optional. We discard the seconds.
+const PROVIDER_PAYMENT_SENT = new RegExp(
+  `Pagaste\\s+${AMOUNT_GROUP}\\s+a\\s+(.+?)\\s+desde\\s+tu\\s+producto\\s+\\*?(\\d{4,})\\s+el\\s+${DATE_GROUP}\\s+${TIME_GROUP}(?::\\d{2})?`,
   "i",
 );
 
@@ -532,6 +545,36 @@ export function parseSmsBancolombia(body: string): ParseResult {
         externalId: hashId([
           "provider-payment",
           senderName,
+          occurredOn,
+          occurredTime,
+          cents,
+        ]),
+        raw,
+      };
+    }
+  }
+
+  // Provider payment sent (PSE / bill-pay)
+  {
+    const m = raw.match(PROVIDER_PAYMENT_SENT);
+    if (m) {
+      const { cents, currency } = parseSmsAmount(m[1]);
+      const providerName = m[2].trim();
+      const fromLast4 = m[3].slice(-4);
+      const occurredOn = parseSmsDate(m[4]);
+      const occurredTime = m[5];
+      return {
+        kind: "provider_payment_sent",
+        amountCents: cents,
+        currency,
+        providerName,
+        fromLast4,
+        occurredOn,
+        occurredTime,
+        externalId: hashId([
+          "provider-payment-sent",
+          fromLast4,
+          providerName,
           occurredOn,
           occurredTime,
           cents,


### PR DESCRIPTION
## Summary
- New `ParsedSms` kind: `provider_payment_sent` for PSE / bill-pay outgoing payments (rent, utilities, fund contributions, bank fees).
- Template: `Pagaste AMT a PROVIDER desde tu producto *NNNN el DD/MM/YYYY HH:MM:SS`.
- Time may include seconds (`HH:MM:SS`) — seconds are dropped before storage to keep `occurredTime` consistent across kinds.
- Routes via `fromLast4` (same path as `transfer_sent` / `qr_payment`).
- Sent through `classifyByRule` like `purchase` — provider names (EPM, banks, landlords) are valuable signal for rule-based classification.

## Test plan
- [x] `bun run test src/lib/ingestion/sms-bancolombia.test.ts` → 49 pass (46 prior + 3 new: utility, 4 dump samples, no-seconds variant).
- [x] `bun run test src/app/api/ingest/sms/route.test.ts` → 17 pass (16 prior + 1 new end-to-end PSE inserting into Bancolombia Ahorros).
- [x] `bunx tsc --noEmit` clean.
- [x] `bun run lint` clean.
- [ ] Re-run `scripts/analyze-sms-dump.ts` post-merge to confirm PSE no longer appears in `unknown`.

Closes #74