### PR TITLE
feat(ingestion): parse ATM withdrawals (#75)

### DIFF
--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -256,6 +256,42 @@ describe("POST /api/ingest/sms", () => {
     expect(rows[0].merchant).toBe("ESTEBAN LEONARDO SARMIENTO GOMEZ");
   });
 
+  it("inserts an atm_withdrawal as expense from the savings linked to the debit card", async () => {
+    const body =
+      "Bancolombia: Retiraste $100.000,00 en 43AVENIDA de tu T.Deb **1802 el 19/02/2026 a las 16:36. Si tienes dudas, llamanos al 6045109095. Estamos cerca";
+    const res = await POST(
+      makeRequest({
+        body: jsonBody({ body }),
+        headers: authedHeaders(),
+      }),
+    );
+    const json = (await res.json()) as { status: string; txId?: number };
+    expect(json.status).toBe("inserted");
+
+    const rows = await db.execute<{
+      amount_cents: string;
+      merchant: string | null;
+      account_id: number;
+      category_slug: string | null;
+      classification_method: string;
+      description_raw: string;
+    }>(sql`
+      SELECT amount_cents, merchant, account_id, category_slug, classification_method, description_raw
+      FROM transactions WHERE id = ${json.txId!}
+    `);
+    expect(BigInt(rows[0].amount_cents)).toBe(BigInt(-10000000));
+    expect(rows[0].merchant).toBeNull();
+    expect(rows[0].category_slug).toBeNull();
+    expect(rows[0].classification_method).toBe("unclassified");
+    expect(rows[0].description_raw).toBe("Retiro ATM 43AVENIDA");
+
+    const accs = await db.execute<{ name: string; currency: string }>(sql`
+      SELECT name, currency FROM accounts WHERE id = ${rows[0].account_id}
+    `);
+    expect(accs[0].name).toBe("Bancolombia Ahorros");
+    expect(accs[0].currency).toBe("COP");
+  });
+
   it("inserts a provider_payment_sent (PSE) as expense from *6126", async () => {
     const body =
       "Bancolombia: Pagaste $430,997.00 a EMPRESAS PUBLICAS DE MEDELLIN desde tu producto *6126 el 13/02/2026 10:39:06. ¿Dudas? Llamanos al 6045109095. Estamos cerca";

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -216,6 +216,7 @@ function resolveAccountForParsed(
     case "qr_payment":
     case "tc_payment":
     case "provider_payment_sent":
+    case "atm_withdrawal":
       return resolveAccountFromLast4(
         parsed.fromLast4,
         parsed.currency,
@@ -303,6 +304,14 @@ function buildTxFields(parsed: ParsedSms): {
         amountCents: -parsed.amountCents,
         descriptionRaw: `Pago a ${parsed.providerName}`,
         merchant: parsed.providerName,
+        categorySlug: null,
+        method: "unclassified",
+      };
+    case "atm_withdrawal":
+      return {
+        amountCents: -parsed.amountCents,
+        descriptionRaw: `Retiro ATM ${parsed.atmCode}`,
+        merchant: null,
         categorySlug: null,
         method: "unclassified",
       };

--- a/src/lib/ingestion/sms-bancolombia.test.ts
+++ b/src/lib/ingestion/sms-bancolombia.test.ts
@@ -455,6 +455,43 @@ describe("parseSmsBancolombia — provider_payment_sent (PSE / bill-pay)", () =>
   });
 });
 
+describe("parseSmsBancolombia — atm_withdrawal", () => {
+  it("parses ATM withdrawal with alphanumeric code", () => {
+    const body =
+      "Bancolombia: Retiraste $100.000,00 en 43AVENIDA de tu T.Deb **1802 el 19/02/2026 a las 16:36. Si tienes dudas, llamanos al 6045109095. Estamos cerca";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("atm_withdrawal");
+    if (r.kind !== "atm_withdrawal") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(10000000));
+    expect(r.currency).toBe("COP");
+    expect(r.atmCode).toBe("43AVENIDA");
+    expect(r.fromLast4).toBe("1802");
+    expect(r.occurredOn).toBe("2026-02-19");
+    expect(r.occurredTime).toBe("16:36");
+    expect(r.externalId).toMatch(/^bcol-sms:[a-f0-9]{24}$/);
+  });
+
+  it("parses ATM withdrawal with code containing underscore", () => {
+    const body =
+      "Bancolombia: Retiraste $100.000,00 en PQ_ESTRELL1 de tu T.Deb **1802 el 26/02/2026 a las 20:47. Si tienes dudas, llamanos al 6045109095. Estamos cerca";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("atm_withdrawal");
+    if (r.kind !== "atm_withdrawal") throw new Error("type guard");
+    expect(r.atmCode).toBe("PQ_ESTRELL1");
+    expect(r.fromLast4).toBe("1802");
+  });
+
+  it("parses ATM withdrawal with single-asterisk last4", () => {
+    const body =
+      "Bancolombia: Retiraste $200.000,00 en CC_OVIEDO de tu T.Deb *1802 el 03/03/2026 a las 11:15. Si tienes dudas, llamanos al 6045109095. Estamos cerca";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("atm_withdrawal");
+    if (r.kind !== "atm_withdrawal") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(20000000));
+    expect(r.atmCode).toBe("CC_OVIEDO");
+  });
+});
+
 describe("parseSmsBancolombia — provider payment", () => {
   it("parses provider payment to Ahorros", () => {
     const body =

--- a/src/lib/ingestion/sms-bancolombia.ts
+++ b/src/lib/ingestion/sms-bancolombia.ts
@@ -48,6 +48,11 @@ export type ParsedSms =
       kind: "provider_payment_sent";
       providerName: string;
       fromLast4: string;
+    })
+  | (ParsedSmsBase & {
+      kind: "atm_withdrawal";
+      atmCode: string;
+      fromLast4: string;
     });
 
 export type SkippedSms = {
@@ -263,6 +268,13 @@ const PROVIDER_PAYMENT = new RegExp(
 // Time has seconds (HH:MM:SS) — kept optional. We discard the seconds.
 const PROVIDER_PAYMENT_SENT = new RegExp(
   `Pagaste\\s+${AMOUNT_GROUP}\\s+a\\s+(.+?)\\s+desde\\s+tu\\s+producto\\s+\\*?(\\d{4,})\\s+el\\s+${DATE_GROUP}\\s+${TIME_GROUP}(?::\\d{2})?`,
+  "i",
+);
+
+// ATM withdrawal: "Retiraste AMOUNT en ATM_CODE de tu T.Deb *NNNN el DATE a las TIME"
+// ATM code is short, alphanumeric, with no spaces (e.g. "43AVENIDA", "PQ_ESTRELL1").
+const ATM_WITHDRAWAL = new RegExp(
+  `Retiraste\\s+${AMOUNT_GROUP}\\s+en\\s+(\\S+)\\s+de\\s+tu\\s+T\\.Deb\\s+\\*+(\\d{4})\\s+el\\s+${DATE_TIME}`,
   "i",
 );
 
@@ -575,6 +587,36 @@ export function parseSmsBancolombia(body: string): ParseResult {
           "provider-payment-sent",
           fromLast4,
           providerName,
+          occurredOn,
+          occurredTime,
+          cents,
+        ]),
+        raw,
+      };
+    }
+  }
+
+  // ATM withdrawal
+  {
+    const m = raw.match(ATM_WITHDRAWAL);
+    if (m) {
+      const { cents, currency } = parseSmsAmount(m[1]);
+      const atmCode = m[2];
+      const fromLast4 = m[3];
+      const occurredOn = parseSmsDate(m[4]);
+      const occurredTime = m[5];
+      return {
+        kind: "atm_withdrawal",
+        amountCents: cents,
+        currency,
+        atmCode,
+        fromLast4,
+        occurredOn,
+        occurredTime,
+        externalId: hashId([
+          "atm-withdrawal",
+          fromLast4,
+          atmCode,
           occurredOn,
           occurredTime,
           cents,


### PR DESCRIPTION
## Summary
- New `ParsedSms` kind: `atm_withdrawal` for the template `Retiraste AMT en ATM_CODE de tu T.Deb *NNNN el DATE a las TIME`.
- ATM code captured as a single non-whitespace token (e.g. `43AVENIDA`, `PQ_ESTRELL1`).
- Only T.Deb is supported (no ATM withdrawals on credit cards).
- Routes via `fromLast4` → debit card's savings account.
- `categorySlug` left null + `unclassified` — there is no `retiros` or `efectivo` category in the seed; user categorizes manually.
- `descriptionRaw` is `Retiro ATM <ATM_CODE>` so the SMS is still searchable in the transactions table.

## Test plan
- [x] `bun run test src/lib/ingestion/sms-bancolombia.test.ts` → 52 pass (+3 new ATM cases).
- [x] `bun run test src/app/api/ingest/sms/route.test.ts` → 18 pass (+1 new end-to-end ATM into Ahorros).
- [x] `bunx tsc --noEmit` clean.
- [x] `bun run lint` clean.
- [ ] Re-run `scripts/analyze-sms-dump.ts` post-merge to confirm ATM no longer appears in `unknown`.

Closes #75