### PR TITLE
feat(ingestion): parse third-party TC abono received (#76)

### DIFF
--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -256,6 +256,43 @@ describe("POST /api/ingest/sms", () => {
     expect(rows[0].merchant).toBe("ESTEBAN LEONARDO SARMIENTO GOMEZ");
   });
 
+  it("inserts a tc_credit_received as positive abono on the TC account", async () => {
+    const body =
+      "Bancolombia: AIDA MALDONADO hizo un abono por $2,125,092 a tu tarjeta de credito terminada en **2575, el 03/12/2025 13:40. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
+    const res = await POST(
+      makeRequest({
+        body: jsonBody({ body }),
+        headers: authedHeaders(),
+      }),
+    );
+    const json = (await res.json()) as { status: string; txId?: number };
+    expect(json.status).toBe("inserted");
+
+    const rows = await db.execute<{
+      amount_cents: string;
+      merchant: string | null;
+      account_id: number;
+      category_slug: string | null;
+      classification_method: string;
+      description_raw: string;
+    }>(sql`
+      SELECT amount_cents, merchant, account_id, category_slug, classification_method, description_raw
+      FROM transactions WHERE id = ${json.txId!}
+    `);
+    expect(BigInt(rows[0].amount_cents)).toBe(BigInt(212509200)); // positive — reduces TC debt
+    expect(rows[0].merchant).toBe("AIDA MALDONADO");
+    expect(rows[0].category_slug).toBe("pago-tc");
+    expect(rows[0].classification_method).toBe("manual");
+    expect(rows[0].description_raw).toBe("Abono de AIDA MALDONADO a TC *2575");
+
+    // Routes to the COP credit card with last4 2575
+    const accs = await db.execute<{ name: string; type: string }>(sql`
+      SELECT name, type FROM accounts WHERE id = ${rows[0].account_id}
+    `);
+    expect(accs[0].type).toBe("credit_card");
+    expect(accs[0].name).toMatch(/2575/);
+  });
+
   it("inserts an atm_withdrawal as expense from the savings linked to the debit card", async () => {
     const body =
       "Bancolombia: Retiraste $100.000,00 en 43AVENIDA de tu T.Deb **1802 el 19/02/2026 a las 16:36. Si tienes dudas, llamanos al 6045109095. Estamos cerca";

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -228,6 +228,12 @@ function resolveAccountForParsed(
         parsed.currency,
         allAccounts,
       );
+    case "tc_credit_received":
+      return resolveAccountFromLast4(
+        parsed.toCardLast4,
+        parsed.currency,
+        allAccounts,
+      );
     case "provider_payment": {
       // SMS says "en tu cuenta de Ahorros" — no last4. Default to the single
       // Bancolombia savings account in the matching currency.
@@ -314,6 +320,14 @@ function buildTxFields(parsed: ParsedSms): {
         merchant: null,
         categorySlug: null,
         method: "unclassified",
+      };
+    case "tc_credit_received":
+      return {
+        amountCents: parsed.amountCents,
+        descriptionRaw: `Abono de ${parsed.senderName} a TC *${parsed.toCardLast4}`,
+        merchant: parsed.senderName,
+        categorySlug: "pago-tc",
+        method: "manual",
       };
   }
 }

--- a/src/lib/ingestion/sms-bancolombia.test.ts
+++ b/src/lib/ingestion/sms-bancolombia.test.ts
@@ -492,6 +492,45 @@ describe("parseSmsBancolombia — atm_withdrawal", () => {
   });
 });
 
+describe("parseSmsBancolombia — tc_credit_received (third-party abono to my TC)", () => {
+  it("parses abono to TC *2575", () => {
+    const body =
+      "Bancolombia: AIDA MALDONADO hizo un abono por $2,125,092 a tu tarjeta de credito terminada en **2575, el 03/12/2025 13:40. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("tc_credit_received");
+    if (r.kind !== "tc_credit_received") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(212509200));
+    expect(r.currency).toBe("COP");
+    expect(r.senderName).toBe("AIDA MALDONADO");
+    expect(r.toCardLast4).toBe("2575");
+    expect(r.occurredOn).toBe("2025-12-03");
+    expect(r.occurredTime).toBe("13:40");
+    expect(r.externalId).toMatch(/^bcol-sms:[a-f0-9]{24}$/);
+  });
+
+  it("parses abono to a different TC (*7291) by the same sender", () => {
+    const body =
+      "Bancolombia: AIDA MALDONADO hizo un abono por $446,666 a tu tarjeta de credito terminada en **7291, el 03/12/2025 13:42. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("tc_credit_received");
+    if (r.kind !== "tc_credit_received") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(44666600));
+    expect(r.senderName).toBe("AIDA MALDONADO");
+    expect(r.toCardLast4).toBe("7291");
+  });
+
+  it("parses abono with multi-word sender", () => {
+    const body =
+      "Bancolombia: JOSE LUIS PEREZ GARCIA hizo un abono por $352,712 a tu tarjeta de credito terminada en **2575, el 13/12/2025 14:24. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("tc_credit_received");
+    if (r.kind !== "tc_credit_received") throw new Error("type guard");
+    expect(r.senderName).toBe("JOSE LUIS PEREZ GARCIA");
+    expect(r.toCardLast4).toBe("2575");
+    expect(r.amountCents).toBe(BigInt(35271200));
+  });
+});
+
 describe("parseSmsBancolombia — provider payment", () => {
   it("parses provider payment to Ahorros", () => {
     const body =

--- a/src/lib/ingestion/sms-bancolombia.ts
+++ b/src/lib/ingestion/sms-bancolombia.ts
@@ -53,6 +53,11 @@ export type ParsedSms =
       kind: "atm_withdrawal";
       atmCode: string;
       fromLast4: string;
+    })
+  | (ParsedSmsBase & {
+      kind: "tc_credit_received";
+      senderName: string;
+      toCardLast4: string;
     });
 
 export type SkippedSms = {
@@ -275,6 +280,14 @@ const PROVIDER_PAYMENT_SENT = new RegExp(
 // ATM code is short, alphanumeric, with no spaces (e.g. "43AVENIDA", "PQ_ESTRELL1").
 const ATM_WITHDRAWAL = new RegExp(
   `Retiraste\\s+${AMOUNT_GROUP}\\s+en\\s+(\\S+)\\s+de\\s+tu\\s+T\\.Deb\\s+\\*+(\\d{4})\\s+el\\s+${DATE_TIME}`,
+  "i",
+);
+
+// TC credit received (third party paid down my credit card):
+// "<SENDER> hizo un abono por AMOUNT a tu tarjeta de credito terminada en *NNNN, el DATE TIME"
+// Anchor on optional "Bancolombia:" prefix so it isn't captured into the sender name.
+const TC_CREDIT_RECEIVED = new RegExp(
+  `(?:Bancolombia:\\s*)?(.+?)\\s+hizo\\s+un\\s+abono\\s+por\\s+${AMOUNT_GROUP}\\s+a\\s+tu\\s+tarjeta\\s+de\\s+credito\\s+terminada\\s+en\\s+\\*+(\\d{4})[,.]?\\s+el\\s+${DATE_TIME}`,
   "i",
 );
 
@@ -617,6 +630,36 @@ export function parseSmsBancolombia(body: string): ParseResult {
           "atm-withdrawal",
           fromLast4,
           atmCode,
+          occurredOn,
+          occurredTime,
+          cents,
+        ]),
+        raw,
+      };
+    }
+  }
+
+  // TC credit received (third party paid down my credit card)
+  {
+    const m = raw.match(TC_CREDIT_RECEIVED);
+    if (m) {
+      const senderName = m[1].trim();
+      const { cents, currency } = parseSmsAmount(m[2]);
+      const toCardLast4 = m[3];
+      const occurredOn = parseSmsDate(m[4]);
+      const occurredTime = m[5];
+      return {
+        kind: "tc_credit_received",
+        amountCents: cents,
+        currency,
+        senderName,
+        toCardLast4,
+        occurredOn,
+        occurredTime,
+        externalId: hashId([
+          "tc-credit-received",
+          toCardLast4,
+          senderName,
           occurredOn,
           occurredTime,
           cents,


### PR DESCRIPTION
## Summary
- New `ParsedSms` kind: `tc_credit_received` for third-party payments to my credit card.
- Template: `<SENDER> hizo un abono por AMT a tu tarjeta de credito terminada en **NNNN, el DATE TIME`.
- Distinct from existing `tc_payment` (you paying YOUR own TC from your own savings). Here someone else pays down YOUR credit card.
- Routes via `toCardLast4` → credit card account.
- Stored as **positive** amount on the TC account (reduces debt). Category `pago-tc` (manual) — same bucket as your own TC payments; sign indicates direction.
- Regex anchors on optional `Bancolombia:` prefix so the bank header isn't captured into the sender name.

## Test plan
- [x] `bun run test src/lib/ingestion/sms-bancolombia.test.ts` → 55 pass (+3 new abono cases incl. multi-word sender).
- [x] `bun run test src/app/api/ingest/sms/route.test.ts` → 19 pass (+1 new end-to-end abono on TC *2575).
- [x] `bunx tsc --noEmit` clean.
- [x] `bun run lint` clean.
- [ ] Re-run `scripts/analyze-sms-dump.ts` post-merge to confirm abono no longer appears in `unknown`.

Closes #76