### PR TITLE
feat(ingestion): parse Bre-b transfer with named recipient (#86)

### DIFF
--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -256,6 +256,44 @@ describe("POST /api/ingest/sms", () => {
     expect(rows[0].merchant).toBe("ESTEBAN LEONARDO SARMIENTO GOMEZ");
   });
 
+  it("inserts a bre_b_transfer as expense from *6126 with recipient as merchant", async () => {
+    const body =
+      "Bancolombia: ALEJANDRO, transferiste $50,000.00 a la llave 3046262677 desde tu cuenta *6126 a MARIA PAZ TORRES CARRILLO el 01/04/26 a las 13:22. Con Bre-b es de una y gratis. Dudas al 018000912345.";
+    const res = await POST(
+      makeRequest({
+        body: jsonBody({ body }),
+        headers: authedHeaders(),
+      }),
+    );
+    const json = (await res.json()) as { status: string; txId?: number };
+    expect(json.status).toBe("inserted");
+
+    const rows = await db.execute<{
+      amount_cents: string;
+      merchant: string | null;
+      account_id: number;
+      category_slug: string | null;
+      classification_method: string;
+      description_raw: string;
+    }>(sql`
+      SELECT amount_cents, merchant, account_id, category_slug, classification_method, description_raw
+      FROM transactions WHERE id = ${json.txId!}
+    `);
+    expect(BigInt(rows[0].amount_cents)).toBe(BigInt(-5000000));
+    expect(rows[0].merchant).toBe("MARIA PAZ TORRES CARRILLO");
+    expect(rows[0].category_slug).toBeNull();
+    expect(rows[0].classification_method).toBe("unclassified");
+    expect(rows[0].description_raw).toBe(
+      "Transferencia Bre-b a MARIA PAZ TORRES CARRILLO",
+    );
+
+    const accs = await db.execute<{ name: string; currency: string }>(sql`
+      SELECT name, currency FROM accounts WHERE id = ${rows[0].account_id}
+    `);
+    expect(accs[0].name).toBe("Bancolombia Ahorros");
+    expect(accs[0].currency).toBe("COP");
+  });
+
   it("inserts a tc_credit_received as positive abono on the TC account", async () => {
     const body =
       "Bancolombia: AIDA MALDONADO hizo un abono por $2,125,092 a tu tarjeta de credito terminada en **2575, el 03/12/2025 13:40. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -217,6 +217,7 @@ function resolveAccountForParsed(
     case "tc_payment":
     case "provider_payment_sent":
     case "atm_withdrawal":
+    case "bre_b_transfer":
       return resolveAccountFromLast4(
         parsed.fromLast4,
         parsed.currency,
@@ -328,6 +329,14 @@ function buildTxFields(parsed: ParsedSms): {
         merchant: parsed.senderName,
         categorySlug: "pago-tc",
         method: "manual",
+      };
+    case "bre_b_transfer":
+      return {
+        amountCents: -parsed.amountCents,
+        descriptionRaw: `Transferencia Bre-b a ${parsed.recipientName}`,
+        merchant: parsed.recipientName,
+        categorySlug: null,
+        method: "unclassified",
       };
   }
 }

--- a/src/lib/ingestion/sms-bancolombia.test.ts
+++ b/src/lib/ingestion/sms-bancolombia.test.ts
@@ -298,6 +298,41 @@ describe("parseSmsBancolombia — transfer sent", () => {
   });
 });
 
+describe("parseSmsBancolombia — bre_b_transfer (named recipient + key)", () => {
+  it("parses real Bre-b sample from the historical dump", () => {
+    const body =
+      "Bancolombia: ALEJANDRO, transferiste $50,000.00 a la llave 3046262677 desde tu cuenta *6126 a MARIA PAZ TORRES CARRILLO el 01/04/26 a las 13:22. Con Bre-b es de una y gratis. Dudas al 018000912345.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("bre_b_transfer");
+    if (r.kind !== "bre_b_transfer") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(5000000));
+    expect(r.currency).toBe("COP");
+    expect(r.fromLast4).toBe("6126");
+    expect(r.toKey).toBe("3046262677");
+    expect(r.recipientName).toBe("MARIA PAZ TORRES CARRILLO");
+    expect(r.occurredOn).toBe("2026-04-01");
+    expect(r.occurredTime).toBe("13:22");
+    expect(r.externalId).toMatch(/^bcol-sms:[a-f0-9]{24}$/);
+  });
+
+  it("parses Bre-b with single-word recipient", () => {
+    const body =
+      "Bancolombia: ALEJANDRO, transferiste $25,000.00 a la llave 3001112233 desde tu cuenta *6126 a JUAN el 02/04/2026 a las 09:10. Con Bre-b es de una y gratis. Dudas al 018000912345.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("bre_b_transfer");
+    if (r.kind !== "bre_b_transfer") throw new Error("type guard");
+    expect(r.recipientName).toBe("JUAN");
+    expect(r.toKey).toBe("3001112233");
+  });
+
+  it("does NOT regress regular transfer_sent (which has no 'a la llave' segment)", () => {
+    const body =
+      "Bancolombia: Transferiste $30,000.00 desde tu cuenta 6126 a la cuenta *3137898857 el 15/04/2026 a las 15:01. ¿Dudas? Llamanos al 018000931987. Estamos cerca.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("transfer_sent");
+  });
+});
+
 describe("parseSmsBancolombia — QR payment", () => {
   it("parses QR payment with name prefix", () => {
     const body =

--- a/src/lib/ingestion/sms-bancolombia.ts
+++ b/src/lib/ingestion/sms-bancolombia.ts
@@ -58,6 +58,12 @@ export type ParsedSms =
       kind: "tc_credit_received";
       senderName: string;
       toCardLast4: string;
+    })
+  | (ParsedSmsBase & {
+      kind: "bre_b_transfer";
+      fromLast4: string;
+      toKey: string;
+      recipientName: string;
     });
 
 export type SkippedSms = {
@@ -291,6 +297,16 @@ const TC_CREDIT_RECEIVED = new RegExp(
   "i",
 );
 
+// Bre-b transfer (instant interbank with named recipient + key):
+// "Bancolombia: <USER>, transferiste AMOUNT a la llave NNNN desde tu cuenta *NNNN
+//  a <RECIPIENT_NAME> el DATE a las TIME. Con Bre-b es de una y gratis..."
+// Distinct from TRANSFER_SENT: the "desde tu cuenta" appears AFTER "a la llave",
+// not immediately after AMOUNT, so TRANSFER_SENT will not collide.
+const BRE_B_TRANSFER = new RegExp(
+  `transferiste\\s+${AMOUNT_GROUP}\\s+a\\s+la\\s+llave\\s+(\\d+)\\s+desde\\s+tu\\s+cuenta\\s+\\*?(\\d{4,})\\s+a\\s+(.+?)\\s+el\\s+${DATE_TIME}`,
+  "i",
+);
+
 // -----------------------------------------------------------------------------
 // Main parser
 // -----------------------------------------------------------------------------
@@ -423,6 +439,38 @@ export function parseSmsBancolombia(body: string): ParseResult {
           "transfer-sent",
           fromLast4,
           toAccount,
+          occurredOn,
+          occurredTime,
+          cents,
+        ]),
+        raw,
+      };
+    }
+  }
+
+  // Bre-b transfer
+  {
+    const m = raw.match(BRE_B_TRANSFER);
+    if (m) {
+      const { cents, currency } = parseSmsAmount(m[1]);
+      const toKey = m[2];
+      const fromLast4 = m[3].slice(-4);
+      const recipientName = m[4].trim();
+      const occurredOn = parseSmsDate(m[5]);
+      const occurredTime = m[6];
+      return {
+        kind: "bre_b_transfer",
+        amountCents: cents,
+        currency,
+        fromLast4,
+        toKey,
+        recipientName,
+        occurredOn,
+        occurredTime,
+        externalId: hashId([
+          "bre-b-transfer",
+          fromLast4,
+          toKey,
           occurredOn,
           occurredTime,
           cents,


### PR DESCRIPTION
## Summary
- New `ParsedSms` kind: `bre_b_transfer` for Colombia's instant interbank Bre-b transfers with named recipient + key.
- Template: `Bancolombia: USER, transferiste AMT a la llave NNNN desde tu cuenta *NNNN a RECIPIENT_NAME el DATE a las TIME. Con Bre-b es de una y gratis.`
- Distinct from existing `transfer_sent`: Bre-b inserts `a la llave NNNN` between AMOUNT and `desde tu cuenta`, while `transfer_sent` requires `desde tu cuenta` immediately after AMOUNT — **no regex collision** (verified by regression test).
- Routes via `fromLast4` → savings.
- Captures `recipientName` + `toKey` which feed directly into the **counterparty registry** work for #72 Phase B (richer than QR which only has the key).

## Result
After this change, the 405-SMS historical dump has **0 unknowns** (was 1 before this PR, 75 before the parser-gap sweep).

## Test plan
- [x] `bun run test src/lib/ingestion/sms-bancolombia.test.ts` → 58 pass (+3 new: real sample, single-word recipient, transfer_sent regression test).
- [x] `bun run test src/app/api/ingest/sms/route.test.ts` → 20 pass (+1 new end-to-end Bre-b into Bancolombia Ahorros).
- [x] `bunx tsc --noEmit` clean.
- [x] `bun run lint` clean.
- [x] `bun run scripts/analyze-sms-dump.ts imessage-dir /tmp/bancolombia-export` → 0 unknowns.

Closes #86