### PR TITLE
feat(ingestion): wire counterparty lookup + auto-create in SMS ingest (#89)

### DIFF
--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -24,6 +24,7 @@ async function cleanup() {
     DELETE FROM transactions WHERE external_id LIKE ${TEST_EXTERNAL_ID_PREFIX + "%"}
   `);
   await db.execute(sql`DELETE FROM ingestion_logs WHERE source = 'sms'`);
+  await db.execute(sql`DELETE FROM counterparties`);
 }
 
 function jsonBody(payload: Record<string, unknown>): string {
@@ -498,6 +499,199 @@ describe("POST /api/ingest/sms", () => {
       WHERE merchant = 'RAPPI COLOMBIA*DL' AND source = 'sms'
     `);
     expect(rows[0].c).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Counterparty lookup + auto-create (qr_payment + bre_b_transfer)
+  // ---------------------------------------------------------------------------
+
+  const QR_BODY =
+    "Bancolombia: ALEJANDRO RAFAEL MARTINEZ MALDONADO pagaste $92,000.00 por codigo QR desde tu cuenta *6126 a la llave 0091498581 el 15/04/2026 a las 00:20. Con codigo QR es facil y de una. Dudas al 018000912345";
+  const QR_KEY = "0091498581";
+
+  const BREB_BODY =
+    "Bancolombia: ALEJANDRO, transferiste $50,000.00 a la llave 3046262677 desde tu cuenta *6126 a MARIA PAZ TORRES CARRILLO el 01/04/26 a las 13:22. Con Bre-b es de una y gratis. Dudas al 018000912345.";
+  const BREB_KEY = "3046262677";
+
+  it("QR with new key does NOT auto-create counterparty; tx unclassified", async () => {
+    const res = await POST(
+      makeRequest({
+        body: jsonBody({ body: QR_BODY }),
+        headers: authedHeaders(),
+      }),
+    );
+    const json = (await res.json()) as { status: string; txId?: number };
+    expect(json.status).toBe("inserted");
+
+    const txRows = await db.execute<{
+      counterparty_id: number | null;
+      category_slug: string | null;
+      classification_method: string;
+    }>(sql`
+      SELECT counterparty_id, category_slug, classification_method
+      FROM transactions WHERE id = ${json.txId!}
+    `);
+    expect(txRows[0].counterparty_id).toBeNull();
+    expect(txRows[0].category_slug).toBeNull();
+    expect(txRows[0].classification_method).toBe("unclassified");
+
+    const cpRows = await db.execute<{ c: number }>(sql`
+      SELECT COUNT(*)::int AS c FROM counterparties WHERE key = ${QR_KEY}
+    `);
+    expect(cpRows[0].c).toBe(0);
+  });
+
+  it("QR with existing counterparty (no default category) links but stays unclassified", async () => {
+    await db.execute(sql`
+      INSERT INTO counterparties (key, display_name, type)
+      VALUES (${QR_KEY}, 'Panadería del Barrio', 'merchant')
+    `);
+    const res = await POST(
+      makeRequest({
+        body: jsonBody({ body: QR_BODY }),
+        headers: authedHeaders(),
+      }),
+    );
+    const json = (await res.json()) as { status: string; txId?: number };
+    expect(json.status).toBe("inserted");
+
+    const rows = await db.execute<{
+      counterparty_id: number | null;
+      category_slug: string | null;
+      classification_method: string;
+    }>(sql`
+      SELECT counterparty_id, category_slug, classification_method
+      FROM transactions WHERE id = ${json.txId!}
+    `);
+    expect(rows[0].counterparty_id).not.toBeNull();
+    expect(rows[0].category_slug).toBeNull();
+    expect(rows[0].classification_method).toBe("unclassified");
+
+    const cpRows = await db.execute<{ hit_count: number }>(sql`
+      SELECT hit_count FROM counterparties WHERE key = ${QR_KEY}
+    `);
+    expect(cpRows[0].hit_count).toBe(1);
+  });
+
+  it("QR with existing counterparty that has default_category inherits + method=rule", async () => {
+    await db.execute(sql`
+      INSERT INTO counterparties (key, display_name, type, default_category_slug)
+      VALUES (${QR_KEY}, 'Panadería del Barrio', 'merchant', 'alimentacion')
+    `);
+    const res = await POST(
+      makeRequest({
+        body: jsonBody({ body: QR_BODY }),
+        headers: authedHeaders(),
+      }),
+    );
+    const json = (await res.json()) as { status: string; txId?: number };
+    expect(json.status).toBe("inserted");
+
+    const rows = await db.execute<{
+      counterparty_id: number | null;
+      category_slug: string | null;
+      classification_method: string;
+    }>(sql`
+      SELECT counterparty_id, category_slug, classification_method
+      FROM transactions WHERE id = ${json.txId!}
+    `);
+    expect(rows[0].counterparty_id).not.toBeNull();
+    expect(rows[0].category_slug).toBe("alimentacion");
+    expect(rows[0].classification_method).toBe("rule");
+  });
+
+  it("Bre-b with new key auto-creates counterparty with recipient as display_name", async () => {
+    const res = await POST(
+      makeRequest({
+        body: jsonBody({ body: BREB_BODY }),
+        headers: authedHeaders(),
+      }),
+    );
+    const json = (await res.json()) as { status: string; txId?: number };
+    expect(json.status).toBe("inserted");
+
+    const cpRows = await db.execute<{
+      display_name: string;
+      type: string;
+      hit_count: number;
+      default_category_slug: string | null;
+    }>(sql`
+      SELECT display_name, type, hit_count, default_category_slug
+      FROM counterparties WHERE key = ${BREB_KEY}
+    `);
+    expect(cpRows).toHaveLength(1);
+    expect(cpRows[0].display_name).toBe("MARIA PAZ TORRES CARRILLO");
+    expect(cpRows[0].type).toBe("unknown");
+    expect(cpRows[0].hit_count).toBe(1);
+    expect(cpRows[0].default_category_slug).toBeNull();
+
+    const txRows = await db.execute<{
+      counterparty_id: number | null;
+      category_slug: string | null;
+      classification_method: string;
+    }>(sql`
+      SELECT counterparty_id, category_slug, classification_method
+      FROM transactions WHERE id = ${json.txId!}
+    `);
+    expect(txRows[0].counterparty_id).not.toBeNull();
+    expect(txRows[0].category_slug).toBeNull();
+    expect(txRows[0].classification_method).toBe("unclassified");
+  });
+
+  it("Bre-b repeat SMS increments hit_count without duplicating counterparty", async () => {
+    const first = await POST(
+      makeRequest({ body: jsonBody({ body: BREB_BODY }), headers: authedHeaders() }),
+    );
+    expect((await first.json()).status).toBe("inserted");
+
+    // Second SMS with different amount/time — same recipient key
+    const BREB_BODY_2 =
+      "Bancolombia: ALEJANDRO, transferiste $25,000.00 a la llave 3046262677 desde tu cuenta *6126 a MARIA PAZ TORRES CARRILLO el 02/04/26 a las 09:10. Con Bre-b es de una y gratis. Dudas al 018000912345.";
+    const second = await POST(
+      makeRequest({ body: jsonBody({ body: BREB_BODY_2 }), headers: authedHeaders() }),
+    );
+    expect((await second.json()).status).toBe("inserted");
+
+    const cpRows = await db.execute<{ c: number; hit_count: number }>(sql`
+      SELECT COUNT(*)::int AS c, MAX(hit_count) AS hit_count
+      FROM counterparties WHERE key = ${BREB_KEY}
+    `);
+    expect(cpRows[0].c).toBe(1);
+    expect(cpRows[0].hit_count).toBe(2);
+  });
+
+  it("Bre-b with existing counterparty + default_category inherits on new tx", async () => {
+    await db.execute(sql`
+      INSERT INTO counterparties (key, display_name, type, default_category_slug)
+      VALUES (${BREB_KEY}, 'Maria Paz', 'person', 'transferencias')
+    `);
+    const res = await POST(
+      makeRequest({
+        body: jsonBody({ body: BREB_BODY }),
+        headers: authedHeaders(),
+      }),
+    );
+    const json = (await res.json()) as { status: string; txId?: number };
+    expect(json.status).toBe("inserted");
+
+    const rows = await db.execute<{
+      counterparty_id: number | null;
+      category_slug: string | null;
+      classification_method: string;
+    }>(sql`
+      SELECT counterparty_id, category_slug, classification_method
+      FROM transactions WHERE id = ${json.txId!}
+    `);
+    expect(rows[0].counterparty_id).not.toBeNull();
+    expect(rows[0].category_slug).toBe("transferencias");
+    expect(rows[0].classification_method).toBe("rule");
+
+    // Upsert preserves the original display_name (does not overwrite with SMS recipient)
+    const cpRows = await db.execute<{ display_name: string; hit_count: number }>(sql`
+      SELECT display_name, hit_count FROM counterparties WHERE key = ${BREB_KEY}
+    `);
+    expect(cpRows[0].display_name).toBe("Maria Paz");
+    expect(cpRows[0].hit_count).toBe(1);
   });
 
   // ---------------------------------------------------------------------------

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { sql } from "drizzle-orm";
-import { db } from "@/lib/db";
+import { db, type DB } from "@/lib/db";
 import { accounts, ingestionLogs, transactions } from "@/lib/db/schema";
 import { classifyByRule } from "@/lib/classification/rules";
 import { emit } from "@/lib/events/bus";
@@ -139,10 +139,16 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
   const { amountCents, descriptionRaw, merchant, categorySlug, method } =
     buildTxFields(parsed);
 
+  // Counterparty lookup (and auto-create for bre_b). For kinds with toKey,
+  // this is the preferred classification path over text-pattern rules.
+  const cp = await resolveCounterparty(parsed, db);
+
   // Purchases and PSE outgoing payments get rule-based classification attempted.
-  // Other kinds have hardcoded categories (pago-tc, transferencias, ingresos).
-  let finalCategory = categorySlug;
-  let finalMethod: "rule" | "manual" | "unclassified" = method;
+  // Other kinds have hardcoded categories (pago-tc, transferencias, ingresos)
+  // or inherit from counterparty (qr_payment, bre_b_transfer).
+  let finalCategory = cp.inheritedCategory ?? categorySlug;
+  let finalMethod: "rule" | "manual" | "unclassified" =
+    cp.inheritedCategory ? "rule" : method;
   let confidence: number | null = null;
   if (parsed.kind === "purchase" || parsed.kind === "provider_payment_sent") {
     const cls = await classifyByRule({
@@ -170,6 +176,7 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
         descriptionClean: null,
         merchant,
         categorySlug: finalCategory,
+        counterpartyId: cp.counterpartyId,
         classificationMethod: finalMethod,
         classificationConfidence: confidence,
         source: "sms",
@@ -199,6 +206,73 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
       reason: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+type CounterpartyResolution = {
+  counterpartyId: number | null;
+  inheritedCategory: string | null;
+};
+
+/**
+ * For kinds that carry a counterparty key (qr_payment, bre_b_transfer):
+ * - qr_payment: SELECT only. If no counterparty exists, return nulls — user
+ *   will register it manually from the UI the first time.
+ * - bre_b_transfer: UPSERT by key, pre-filling display_name from the SMS
+ *   recipient. Always returns a counterparty id; inheritedCategory only set
+ *   if the counterparty already had a default_category_slug.
+ *
+ * Hit counter is bumped on every match/insert. Uses ON CONFLICT for race-safe
+ * auto-create under concurrent SMS bursts.
+ */
+export async function resolveCounterparty(
+  parsed: ParsedSms,
+  database: DB,
+): Promise<CounterpartyResolution> {
+  if (parsed.kind !== "qr_payment" && parsed.kind !== "bre_b_transfer") {
+    return { counterpartyId: null, inheritedCategory: null };
+  }
+
+  const key = parsed.toKey;
+
+  if (parsed.kind === "bre_b_transfer") {
+    const rows = await database.execute<{
+      id: number;
+      default_category_slug: string | null;
+    }>(sql`
+      INSERT INTO counterparties (key, display_name, type, hit_count, last_hit_at)
+      VALUES (${key}, ${parsed.recipientName}, 'unknown', 1, now())
+      ON CONFLICT (key) DO UPDATE
+        SET hit_count = counterparties.hit_count + 1,
+            last_hit_at = now(),
+            updated_at = now()
+      RETURNING id, default_category_slug
+    `);
+    const row = rows[0];
+    return {
+      counterpartyId: row.id,
+      inheritedCategory: row.default_category_slug,
+    };
+  }
+
+  // qr_payment — SELECT only, no auto-create
+  const existing = await database.execute<{
+    id: number;
+    default_category_slug: string | null;
+  }>(sql`
+    SELECT id, default_category_slug FROM counterparties WHERE key = ${key}
+  `);
+  if (existing.length === 0) {
+    return { counterpartyId: null, inheritedCategory: null };
+  }
+  await database.execute(sql`
+    UPDATE counterparties
+    SET hit_count = hit_count + 1, last_hit_at = now()
+    WHERE id = ${existing[0].id}
+  `);
+  return {
+    counterpartyId: existing[0].id,
+    inheritedCategory: existing[0].default_category_slug,
+  };
 }
 
 function resolveAccountForParsed(


### PR DESCRIPTION
Parte 2/3 del counterparty model (#72). Depende de #88 (ya mergeado).

## Summary
- `resolveCounterparty(parsed, db)` helper en `src/app/api/ingest/sms/route.ts`:
  - `qr_payment` → SELECT-only. Si no hay counterparty → tx queda con `counterparty_id: null` (usuario registra en UI).
  - `bre_b_transfer` → UPSERT race-safe con `ON CONFLICT (key)`. Auto-crea counterparty con `display_name = recipientName`, `type = 'unknown'`. Preserva display_name existente en el conflict branch.
  - Ambos casos bumpean `hit_count` + `last_hit_at`.
- Si el counterparty tiene `default_category_slug` → nueva tx lo hereda con `classification_method = 'rule'`.
- Rules de texto (`classifyByRule`) siguen corriendo solo para `purchase` y `provider_payment_sent` como antes — sin cambios de comportamiento ahí.

## Test plan
- [x] `bun run test` — 105/105 pasa (6 tests nuevos, 0 regresión)
  - QR con key nueva → no crea counterparty, tx unclassified
  - QR con counterparty existente sin categoría → linkea, unclassified
  - QR con counterparty existente + categoría → hereda categoría, method=rule
  - Bre-b con key nueva → auto-crea counterparty con recipient name
  - Bre-b repetido → NO duplica counterparty, incrementa hit_count a 2
  - Bre-b con counterparty existente + categoría → hereda, preserva display_name original
- [x] `bun run typecheck` pass
- [x] `bun run lint` pass
- [x] Dump re-analysis (405 SMS):
  - 40 qr_payment / 23 keys → 0 counterparties auto-creadas (esperado, sin name)
  - 1 bre_b_transfer → 1 counterparty auto-creada (esperado)

## Out of scope (parte 3 — #90)
- Endpoint `POST/PATCH /api/counterparties` para que el usuario registre contrapartes desde UI
- Dialog en `/transactions`
- Propagación retroactiva a tx históricas cuando se crea/actualiza una counterparty

Closes #89
Ref #72