### PR TITLE
feat(ui,api): counterparty dialog + retroactive propagation (#90)

### DIFF
--- a/e2e/counterparty.spec.ts
+++ b/e2e/counterparty.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+test("counterparty: transactions page renders table with QR rows", async ({
+  page,
+}) => {
+  await page.goto("/transactions", { waitUntil: "domcontentloaded" });
+  await page.locator("table").waitFor({ state: "visible", timeout: 10_000 });
+  await expect(page.locator("table tbody tr").first()).toBeVisible();
+  await page.screenshot({
+    path: path.join("e2e/screenshots", "cp-transactions-loaded.png"),
+    fullPage: true,
+  });
+});
+
+test("counterparty: dialog opens on QR row and shows identify CTA", async ({
+  page,
+}) => {
+  await page.goto("/transactions", { waitUntil: "domcontentloaded" });
+  await page.locator("table").waitFor({ state: "visible", timeout: 10_000 });
+
+  const identifyButton = page.getByRole("button", { name: /identify/i }).first();
+  const hasIdentify = await identifyButton
+    .isVisible({ timeout: 2_000 })
+    .catch(() => false);
+  if (!hasIdentify) {
+    // No QR/Bre-b tx with placeholder counterparty in DB — fine, test ends here
+    // after capturing the empty state screenshot for PR.
+    await page.screenshot({
+      path: path.join("e2e/screenshots", "cp-no-qr-rows.png"),
+      fullPage: true,
+    });
+    return;
+  }
+
+  await identifyButton.click();
+  await page
+    .getByRole("dialog")
+    .waitFor({ state: "visible", timeout: 5_000 });
+
+  await page.screenshot({
+    path: path.join("e2e/screenshots", "cp-dialog-open.png"),
+    fullPage: true,
+  });
+
+  // Sanity: the dialog has the key displayed and the type buttons
+  await expect(
+    page.getByRole("button", { name: /person/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /merchant/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /unknown/i }),
+  ).toBeVisible();
+});

--- a/scripts/backfill-counterparties.ts
+++ b/scripts/backfill-counterparties.ts
@@ -1,0 +1,64 @@
+import { sql } from "drizzle-orm";
+import { db } from "../src/lib/db";
+import { resolveCounterparty } from "../src/app/api/ingest/sms/route";
+import { parseSmsBancolombia } from "../src/lib/ingestion/sms-bancolombia";
+
+// Backfills counterparty_id on historical tx that were ingested before the
+// qr_payment auto-create behavior landed. Re-parses the raw SMS body and
+// upserts the counterparty via the same resolveCounterparty used at ingest.
+
+async function main() {
+  const rows = await db.execute<{
+    id: number;
+    raw_data: { kind?: string; sms?: string };
+  }>(sql`
+    SELECT id, raw_data
+    FROM transactions
+    WHERE counterparty_id IS NULL
+      AND raw_data->>'kind' IN ('qr_payment','bre_b_transfer')
+  `);
+
+  if (rows.length === 0) {
+    console.log("Nothing to backfill.");
+    return;
+  }
+
+  console.log(`Backfilling ${rows.length} tx…`);
+  let updated = 0;
+  for (const row of rows) {
+    const rawSms = row.raw_data?.sms;
+    if (!rawSms) {
+      console.warn(`tx ${row.id}: no raw_data.sms — skipped`);
+      continue;
+    }
+    const parsed = parseSmsBancolombia(rawSms);
+    if (parsed.kind === "skip") {
+      console.warn(`tx ${row.id}: parser returned skip:${parsed.reason} — skipped`);
+      continue;
+    }
+    const cp = await resolveCounterparty(parsed, db);
+    if (cp.counterpartyId === null) {
+      console.warn(`tx ${row.id}: kind=${parsed.kind} has no counterparty — skipped`);
+      continue;
+    }
+    await db.execute(sql`
+      UPDATE transactions SET
+        counterparty_id = ${cp.counterpartyId},
+        category_slug = COALESCE(category_slug, ${cp.inheritedCategory}),
+        classification_method = CASE
+          WHEN category_slug IS NULL AND ${cp.inheritedCategory}::text IS NOT NULL THEN 'rule'::classification_method
+          ELSE classification_method
+        END,
+        updated_at = now()
+      WHERE id = ${row.id}
+    `);
+    updated += 1;
+  }
+  console.log(`Updated ${updated} tx.`);
+  await db.$client.end({ timeout: 1 });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -19,12 +19,16 @@ function makeRequest(init: {
   });
 }
 
+// Scoped to keys this file creates via SMS ingest, so parallel test files
+// touching `counterparties` don't stomp on each other.
 async function cleanup() {
   await db.execute(sql`
     DELETE FROM transactions WHERE external_id LIKE ${TEST_EXTERNAL_ID_PREFIX + "%"}
   `);
   await db.execute(sql`DELETE FROM ingestion_logs WHERE source = 'sms'`);
-  await db.execute(sql`DELETE FROM counterparties`);
+  await db.execute(sql`
+    DELETE FROM counterparties WHERE key IN ('0091498581', '3046262677')
+  `);
 }
 
 function jsonBody(payload: Record<string, unknown>): string {
@@ -513,7 +517,7 @@ describe("POST /api/ingest/sms", () => {
     "Bancolombia: ALEJANDRO, transferiste $50,000.00 a la llave 3046262677 desde tu cuenta *6126 a MARIA PAZ TORRES CARRILLO el 01/04/26 a las 13:22. Con Bre-b es de una y gratis. Dudas al 018000912345.";
   const BREB_KEY = "3046262677";
 
-  it("QR with new key does NOT auto-create counterparty; tx unclassified", async () => {
+  it("QR with new key auto-creates placeholder counterparty (key as display_name)", async () => {
     const res = await POST(
       makeRequest({
         body: jsonBody({ body: QR_BODY }),
@@ -523,6 +527,21 @@ describe("POST /api/ingest/sms", () => {
     const json = (await res.json()) as { status: string; txId?: number };
     expect(json.status).toBe("inserted");
 
+    const cpRows = await db.execute<{
+      display_name: string;
+      type: string;
+      hit_count: number;
+      default_category_slug: string | null;
+    }>(sql`
+      SELECT display_name, type, hit_count, default_category_slug
+      FROM counterparties WHERE key = ${QR_KEY}
+    `);
+    expect(cpRows).toHaveLength(1);
+    expect(cpRows[0].display_name).toBe(QR_KEY);
+    expect(cpRows[0].type).toBe("unknown");
+    expect(cpRows[0].hit_count).toBe(1);
+    expect(cpRows[0].default_category_slug).toBeNull();
+
     const txRows = await db.execute<{
       counterparty_id: number | null;
       category_slug: string | null;
@@ -531,14 +550,9 @@ describe("POST /api/ingest/sms", () => {
       SELECT counterparty_id, category_slug, classification_method
       FROM transactions WHERE id = ${json.txId!}
     `);
-    expect(txRows[0].counterparty_id).toBeNull();
+    expect(txRows[0].counterparty_id).not.toBeNull();
     expect(txRows[0].category_slug).toBeNull();
     expect(txRows[0].classification_method).toBe("unclassified");
-
-    const cpRows = await db.execute<{ c: number }>(sql`
-      SELECT COUNT(*)::int AS c FROM counterparties WHERE key = ${QR_KEY}
-    `);
-    expect(cpRows[0].c).toBe(0);
   });
 
   it("QR with existing counterparty (no default category) links but stays unclassified", async () => {

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -215,14 +215,14 @@ type CounterpartyResolution = {
 
 /**
  * For kinds that carry a counterparty key (qr_payment, bre_b_transfer):
- * - qr_payment: SELECT only. If no counterparty exists, return nulls — user
- *   will register it manually from the UI the first time.
- * - bre_b_transfer: UPSERT by key, pre-filling display_name from the SMS
- *   recipient. Always returns a counterparty id; inheritedCategory only set
- *   if the counterparty already had a default_category_slug.
+ * always UPSERT by key so every tx gets a counterparty_id. This unifies
+ * retroactive propagation (plain FK join) and UI logic.
  *
- * Hit counter is bumped on every match/insert. Uses ON CONFLICT for race-safe
- * auto-create under concurrent SMS bursts.
+ * - bre_b_transfer: initial display_name = recipientName (from SMS).
+ * - qr_payment: initial display_name = key (placeholder; user renames in UI).
+ *
+ * ON CONFLICT preserves the existing display_name on subsequent hits, so
+ * user renames stick. Hit counter bumped on every match/insert.
  */
 export async function resolveCounterparty(
   parsed: ParsedSms,
@@ -233,45 +233,25 @@ export async function resolveCounterparty(
   }
 
   const key = parsed.toKey;
+  const initialDisplayName =
+    parsed.kind === "bre_b_transfer" ? parsed.recipientName : key;
 
-  if (parsed.kind === "bre_b_transfer") {
-    const rows = await database.execute<{
-      id: number;
-      default_category_slug: string | null;
-    }>(sql`
-      INSERT INTO counterparties (key, display_name, type, hit_count, last_hit_at)
-      VALUES (${key}, ${parsed.recipientName}, 'unknown', 1, now())
-      ON CONFLICT (key) DO UPDATE
-        SET hit_count = counterparties.hit_count + 1,
-            last_hit_at = now(),
-            updated_at = now()
-      RETURNING id, default_category_slug
-    `);
-    const row = rows[0];
-    return {
-      counterpartyId: row.id,
-      inheritedCategory: row.default_category_slug,
-    };
-  }
-
-  // qr_payment — SELECT only, no auto-create
-  const existing = await database.execute<{
+  const rows = await database.execute<{
     id: number;
     default_category_slug: string | null;
   }>(sql`
-    SELECT id, default_category_slug FROM counterparties WHERE key = ${key}
+    INSERT INTO counterparties (key, display_name, type, hit_count, last_hit_at)
+    VALUES (${key}, ${initialDisplayName}, 'unknown', 1, now())
+    ON CONFLICT (key) DO UPDATE
+      SET hit_count = counterparties.hit_count + 1,
+          last_hit_at = now(),
+          updated_at = now()
+    RETURNING id, default_category_slug
   `);
-  if (existing.length === 0) {
-    return { counterpartyId: null, inheritedCategory: null };
-  }
-  await database.execute(sql`
-    UPDATE counterparties
-    SET hit_count = hit_count + 1, last_hit_at = now()
-    WHERE id = ${existing[0].id}
-  `);
+  const row = rows[0];
   return {
-    counterpartyId: existing[0].id,
-    inheritedCategory: existing[0].default_category_slug,
+    counterpartyId: row.id,
+    inheritedCategory: row.default_category_slug,
   };
 }
 

--- a/src/app/transactions/actions.test.ts
+++ b/src/app/transactions/actions.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+
+// `revalidatePath` requires a Next.js request context that vitest's node
+// environment does not provide. No-op it so we can unit-test actions directly.
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const { updateCounterparty } = await import("./actions");
+
+// Scoped so parallel test files don't wipe each other's counterparty rows.
+async function cleanup() {
+  await db.execute(sql`
+    DELETE FROM transactions WHERE external_id LIKE 'test-cp-action:%'
+  `);
+  await db.execute(sql`
+    DELETE FROM counterparties WHERE key LIKE 'test-cp-%'
+  `);
+}
+
+async function seedCounterparty(args: {
+  key: string;
+  displayName?: string;
+  defaultCategory?: string | null;
+}): Promise<number> {
+  const rows = await db.execute<{ id: number }>(sql`
+    INSERT INTO counterparties (key, display_name, type, default_category_slug)
+    VALUES (
+      ${args.key},
+      ${args.displayName ?? args.key},
+      'unknown',
+      ${args.defaultCategory ?? null}
+    )
+    RETURNING id
+  `);
+  return rows[0].id;
+}
+
+async function seedTx(args: {
+  counterpartyId: number;
+  externalId: string;
+  categorySlug?: string | null;
+  method?: "unclassified" | "manual" | "rule";
+}): Promise<number> {
+  const [acc] = await db.execute<{ id: number }>(sql`
+    SELECT id FROM accounts WHERE name = 'Bancolombia Ahorros' LIMIT 1
+  `);
+  const rows = await db.execute<{ id: number }>(sql`
+    INSERT INTO transactions (
+      account_id, occurred_at, amount_cents, currency, description_raw,
+      counterparty_id, category_slug, classification_method, source, external_id, raw_data
+    ) VALUES (
+      ${acc.id}, now(), -5000, 'COP', 'test',
+      ${args.counterpartyId},
+      ${args.categorySlug ?? null},
+      ${args.method ?? "unclassified"}::classification_method,
+      'sms',
+      ${args.externalId},
+      '{}'::jsonb
+    )
+    RETURNING id
+  `);
+  return rows[0].id;
+}
+
+describe("updateCounterparty", () => {
+  afterEach(cleanup);
+  afterAll(async () => {
+    await db.$client.end({ timeout: 1 });
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+  });
+
+  it("renames counterparty and leaves tx categories untouched when no default set", async () => {
+    const cpId = await seedCounterparty({ key: "test-cp-0088044474" });
+    const txId = await seedTx({
+      counterpartyId: cpId,
+      externalId: "test-cp-action:1",
+    });
+
+    const result = await updateCounterparty({
+      id: cpId,
+      displayName: "Panadería del Barrio",
+      type: "merchant",
+      defaultCategorySlug: null,
+      notes: null,
+    });
+
+    expect(result.propagatedCount).toBe(0);
+
+    const cp = await db.execute<{ display_name: string; type: string }>(sql`
+      SELECT display_name, type FROM counterparties WHERE id = ${cpId}
+    `);
+    expect(cp[0].display_name).toBe("Panadería del Barrio");
+    expect(cp[0].type).toBe("merchant");
+
+    const tx = await db.execute<{
+      category_slug: string | null;
+      classification_method: string;
+    }>(sql`
+      SELECT category_slug, classification_method FROM transactions WHERE id = ${txId}
+    `);
+    expect(tx[0].category_slug).toBeNull();
+    expect(tx[0].classification_method).toBe("unclassified");
+  });
+
+  it("propagates default category to unclassified tx only (preserves manual classifications)", async () => {
+    const cpId = await seedCounterparty({ key: "test-cp-0088044474" });
+    const unclassifiedTx = await seedTx({
+      counterpartyId: cpId,
+      externalId: "test-cp-action:unclass",
+    });
+    const manualTx = await seedTx({
+      counterpartyId: cpId,
+      externalId: "test-cp-action:manual",
+      categorySlug: "salud",
+      method: "manual",
+    });
+
+    const result = await updateCounterparty({
+      id: cpId,
+      displayName: "Panadería",
+      type: "merchant",
+      defaultCategorySlug: "alimentacion",
+      notes: null,
+    });
+
+    expect(result.propagatedCount).toBe(1);
+
+    const rows = await db.execute<{
+      id: number;
+      category_slug: string;
+      classification_method: string;
+    }>(sql`
+      SELECT id, category_slug, classification_method
+      FROM transactions WHERE id IN (${unclassifiedTx}, ${manualTx})
+      ORDER BY id
+    `);
+    const unclass = rows.find((r) => r.id === unclassifiedTx)!;
+    const manual = rows.find((r) => r.id === manualTx)!;
+    expect(unclass.category_slug).toBe("alimentacion");
+    expect(unclass.classification_method).toBe("rule");
+    expect(manual.category_slug).toBe("salud");
+    expect(manual.classification_method).toBe("manual");
+  });
+
+  it("throws on unknown category slug", async () => {
+    const cpId = await seedCounterparty({ key: "test-cp-0088044474" });
+    await expect(
+      updateCounterparty({
+        id: cpId,
+        displayName: "X",
+        type: "unknown",
+        defaultCategorySlug: "no-existe",
+        notes: null,
+      }),
+    ).rejects.toThrow(/Category not found/);
+  });
+
+  it("rejects empty displayName via zod", async () => {
+    const cpId = await seedCounterparty({ key: "test-cp-0088044474" });
+    await expect(
+      updateCounterparty({
+        id: cpId,
+        displayName: "   ",
+        type: "unknown",
+        defaultCategorySlug: null,
+        notes: null,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("updates across multiple tx linked to same counterparty", async () => {
+    const cpId = await seedCounterparty({ key: "test-cp-0088044474" });
+    await seedTx({ counterpartyId: cpId, externalId: "test-cp-action:a" });
+    await seedTx({ counterpartyId: cpId, externalId: "test-cp-action:b" });
+    await seedTx({ counterpartyId: cpId, externalId: "test-cp-action:c" });
+
+    const result = await updateCounterparty({
+      id: cpId,
+      displayName: "Shared",
+      type: "merchant",
+      defaultCategorySlug: "alimentacion",
+      notes: null,
+    });
+
+    expect(result.propagatedCount).toBe(3);
+  });
+});

--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -1,10 +1,15 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
-import { accounts, categories, transactions } from "@/lib/db/schema";
+import {
+  accounts,
+  categories,
+  counterparties,
+  transactions,
+} from "@/lib/db/schema";
 import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
 import { emit } from "@/lib/events/bus";
 
@@ -103,4 +108,85 @@ export async function runAiClassifier() {
   revalidatePath("/");
   revalidatePath("/transactions");
   return result;
+}
+
+const counterpartyTypeSchema = z.enum(["person", "merchant", "unknown"]);
+
+const updateCounterpartySchema = z.object({
+  id: z.coerce.number().int().positive(),
+  displayName: z.string().trim().min(1).max(120),
+  type: counterpartyTypeSchema,
+  defaultCategorySlug: z.string().min(1).max(60).nullable(),
+  notes: z.string().max(500).nullable(),
+});
+
+export type UpdateCounterpartyInput = z.input<typeof updateCounterpartySchema>;
+export type UpdateCounterpartyResult = {
+  propagatedCount: number;
+};
+
+/**
+ * Update a counterparty (rename, set type, set default category, notes).
+ *
+ * When defaultCategorySlug is set, propagates to all LINKED transactions that
+ * are still unclassified (category_slug IS NULL). Manually-classified tx are
+ * preserved — user intent wins over counterparty defaults.
+ *
+ * Returns the number of transactions whose category was updated by this call,
+ * for user feedback in the UI toast.
+ */
+export async function updateCounterparty(
+  input: UpdateCounterpartyInput,
+): Promise<UpdateCounterpartyResult> {
+  const parsed = updateCounterpartySchema.parse(input);
+
+  if (parsed.defaultCategorySlug) {
+    const [cat] = await db
+      .select({ slug: categories.slug })
+      .from(categories)
+      .where(eq(categories.slug, parsed.defaultCategorySlug))
+      .limit(1);
+    if (!cat) throw new Error("Category not found");
+  }
+
+  const propagatedCount = await db.transaction(async (trx) => {
+    await trx
+      .update(counterparties)
+      .set({
+        displayName: parsed.displayName,
+        type: parsed.type,
+        defaultCategorySlug: parsed.defaultCategorySlug,
+        notes: parsed.notes,
+        updatedAt: new Date(),
+      })
+      .where(eq(counterparties.id, parsed.id));
+
+    if (!parsed.defaultCategorySlug) return 0;
+
+    const updated = await trx.execute<{ id: number }>(sql`
+      UPDATE transactions SET
+        category_slug = ${parsed.defaultCategorySlug},
+        classification_method = 'rule'::classification_method,
+        classification_confidence = 100,
+        updated_at = now()
+      WHERE counterparty_id = ${parsed.id}
+        AND category_slug IS NULL
+      RETURNING id
+    `);
+    return updated.length;
+  });
+
+  if (propagatedCount > 0) {
+    emit({
+      type: "transaction:bulk-updated",
+      count: propagatedCount,
+      reason: "counterparty-updated",
+      timestamp: Date.now(),
+    });
+  }
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+
+  return { propagatedCount };
 }

--- a/src/components/transactions/counterparty-dialog.tsx
+++ b/src/components/transactions/counterparty-dialog.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { PencilIcon, UserIcon, BuildingIcon, CircleHelpIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { updateCounterparty } from "@/app/transactions/actions";
+import type { CategoryOption } from "./category-cell";
+
+export type CounterpartyValue = {
+  id: number;
+  key: string;
+  displayName: string;
+  type: "person" | "merchant" | "unknown";
+  defaultCategorySlug: string | null;
+  notes: string | null;
+};
+
+export function CounterpartyDialog({
+  counterparty,
+  categories,
+}: {
+  counterparty: CounterpartyValue;
+  categories: CategoryOption[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [displayName, setDisplayName] = useState(counterparty.displayName);
+  const [type, setType] = useState<CounterpartyValue["type"]>(counterparty.type);
+  const [defaultCategorySlug, setDefaultCategorySlug] = useState<string>(
+    counterparty.defaultCategorySlug ?? "",
+  );
+  const [notes, setNotes] = useState(counterparty.notes ?? "");
+
+  const placeholderName = counterparty.displayName === counterparty.key;
+
+  function reset() {
+    setDisplayName(counterparty.displayName);
+    setType(counterparty.type);
+    setDefaultCategorySlug(counterparty.defaultCategorySlug ?? "");
+    setNotes(counterparty.notes ?? "");
+  }
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    startTransition(async () => {
+      try {
+        const result = await updateCounterparty({
+          id: counterparty.id,
+          displayName: displayName.trim(),
+          type,
+          defaultCategorySlug: defaultCategorySlug || null,
+          notes: notes.trim() || null,
+        });
+        if (result.propagatedCount > 0) {
+          toast.success(
+            `Counterparty updated · ${result.propagatedCount} tx recategorized`,
+          );
+        } else {
+          toast.success("Counterparty updated");
+        }
+        setOpen(false);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to update");
+      }
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1 px-1.5 text-xs"
+          aria-label={
+            placeholderName ? "Identify counterparty" : "Edit counterparty"
+          }
+        >
+          {placeholderName ? (
+            <>
+              <CircleHelpIcon className="size-3.5" />
+              <span>Identify</span>
+            </>
+          ) : (
+            <>
+              <PencilIcon className="size-3" />
+            </>
+          )}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {placeholderName ? "Identify counterparty" : "Edit counterparty"}
+          </DialogTitle>
+          <DialogDescription>
+            Key: <span className="font-mono">{counterparty.key}</span>. Setting
+            a default category will recategorize all unclassified transactions
+            for this counterparty.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={onSubmit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="cp-name">Display name</Label>
+            <Input
+              id="cp-name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="e.g. Panadería del Barrio"
+              required
+              maxLength={120}
+              autoFocus
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>Type</Label>
+            <div className="flex gap-2">
+              <TypeButton
+                active={type === "person"}
+                onClick={() => setType("person")}
+                icon={<UserIcon className="size-3.5" />}
+                label="Person"
+              />
+              <TypeButton
+                active={type === "merchant"}
+                onClick={() => setType("merchant")}
+                icon={<BuildingIcon className="size-3.5" />}
+                label="Merchant"
+              />
+              <TypeButton
+                active={type === "unknown"}
+                onClick={() => setType("unknown")}
+                icon={<CircleHelpIcon className="size-3.5" />}
+                label="Unknown"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="cp-cat">Default category</Label>
+            <select
+              id="cp-cat"
+              value={defaultCategorySlug}
+              onChange={(e) => setDefaultCategorySlug(e.target.value)}
+              className="h-9 rounded-md border bg-background px-2 text-sm"
+            >
+              <option value="">— none —</option>
+              {categories.map((c) => (
+                <option key={c.slug} value={c.slug}>
+                  {c.parentSlug ? `↳ ${c.name}` : c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="cp-notes">Notes</Label>
+            <Input
+              id="cp-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Optional"
+              maxLength={500}
+            />
+          </div>
+
+          <DialogFooter className="mt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving…" : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function TypeButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex h-9 flex-1 items-center justify-center gap-1.5 rounded-md border text-sm transition-colors ${
+        active
+          ? "border-primary bg-primary text-primary-foreground"
+          : "bg-background text-muted-foreground hover:bg-muted"
+      }`}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -1,4 +1,4 @@
-import { ReceiptTextIcon } from "lucide-react";
+import { ReceiptTextIcon, UserIcon, BuildingIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import {
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/table";
 import type { TxRow } from "@/lib/transactions/queries";
 import { CategoryCell, type CategoryOption } from "./category-cell";
+import { CounterpartyDialog } from "./counterparty-dialog";
 
 const sourceLabel: Record<TxRow["source"], string> = {
   apple_pay: "Apple Pay",
@@ -30,6 +31,34 @@ const methodVariant: Record<
   manual: "outline",
   unclassified: "destructive",
 };
+
+function CounterpartyTypeBadge({
+  type,
+}: {
+  type: NonNullable<TxRow["counterparty"]>["type"];
+}) {
+  if (type === "person") {
+    return (
+      <span
+        className="inline-flex size-4 items-center justify-center rounded-full bg-muted text-muted-foreground"
+        title="Person"
+      >
+        <UserIcon className="size-2.5" />
+      </span>
+    );
+  }
+  if (type === "merchant") {
+    return (
+      <span
+        className="inline-flex size-4 items-center justify-center rounded-full bg-muted text-muted-foreground"
+        title="Merchant"
+      >
+        <BuildingIcon className="size-2.5" />
+      </span>
+    );
+  }
+  return null;
+}
 
 function formatAmount(cents: bigint, currency: TxRow["currency"]) {
   const n = Number(cents) / 100;
@@ -91,10 +120,26 @@ export function TransactionTable({
                   {formatDate(tx.occurredAt)}
                 </TableCell>
                 <TableCell>
-                  <div className="font-medium">
-                    {tx.merchant ?? tx.descriptionClean ?? tx.descriptionRaw}
+                  <div className="flex items-center gap-1.5">
+                    <span className="font-medium">
+                      {tx.counterparty?.displayName ??
+                        tx.merchant ??
+                        tx.descriptionClean ??
+                        tx.descriptionRaw}
+                    </span>
+                    {tx.counterparty ? (
+                      <CounterpartyTypeBadge type={tx.counterparty.type} />
+                    ) : null}
+                    {tx.counterparty ? (
+                      <CounterpartyDialog
+                        counterparty={tx.counterparty}
+                        categories={categories}
+                      />
+                    ) : null}
                   </div>
-                  {tx.merchant || tx.descriptionClean ? (
+                  {tx.counterparty ||
+                  tx.merchant ||
+                  tx.descriptionClean ? (
                     <div className="text-xs text-muted-foreground line-clamp-1">
                       {tx.descriptionRaw}
                     </div>

--- a/src/lib/events/bus.ts
+++ b/src/lib/events/bus.ts
@@ -15,6 +15,12 @@ export type AppEvent =
       source: TransactionSource;
       timestamp: number;
     }
+  | {
+      type: "transaction:bulk-updated";
+      count: number;
+      reason: "counterparty-updated" | "counterparty-created";
+      timestamp: number;
+    }
   | { type: "budget:updated"; timestamp: number };
 
 // globalThis singleton survives Turbopack HMR, which otherwise re-evaluates

--- a/src/lib/hooks/use-live-events.ts
+++ b/src/lib/hooks/use-live-events.ts
@@ -7,6 +7,7 @@ import type { AppEvent } from "@/lib/events/bus";
 const DEFAULT_REFRESH_ON: AppEvent["type"][] = [
   "transaction:created",
   "transaction:updated",
+  "transaction:bulk-updated",
   "budget:updated",
 ];
 

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -1,6 +1,11 @@
 import { and, asc, desc, eq, ilike, lt, lte, gte, or, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, categories, transactions } from "@/lib/db/schema";
+import {
+  accounts,
+  categories,
+  counterparties,
+  transactions,
+} from "@/lib/db/schema";
 
 export const PAGE_SIZE = 50;
 
@@ -26,6 +31,14 @@ export type TxRow = {
   source: "apple_pay" | "sms" | "ocr" | "csv" | "recurring" | "manual";
   accountId: number;
   accountName: string;
+  counterparty: {
+    id: number;
+    key: string;
+    displayName: string;
+    type: "person" | "merchant" | "unknown";
+    defaultCategorySlug: string | null;
+    notes: string | null;
+  } | null;
 };
 
 export type TxListResult = {
@@ -97,9 +110,16 @@ export async function listTransactions(filters: TxFilters): Promise<TxListResult
       source: transactions.source,
       accountId: transactions.accountId,
       accountName: accounts.name,
+      cpId: counterparties.id,
+      cpKey: counterparties.key,
+      cpDisplayName: counterparties.displayName,
+      cpType: counterparties.type,
+      cpDefaultCategorySlug: counterparties.defaultCategorySlug,
+      cpNotes: counterparties.notes,
     })
     .from(transactions)
     .innerJoin(accounts, eq(accounts.id, transactions.accountId))
+    .leftJoin(counterparties, eq(counterparties.id, transactions.counterpartyId))
     .where(conditions.length ? and(...conditions) : undefined)
     .orderBy(desc(transactions.occurredAt), desc(transactions.id))
     .limit(PAGE_SIZE + 1);
@@ -109,7 +129,32 @@ export async function listTransactions(filters: TxFilters): Promise<TxListResult
   const last = page.at(-1);
   const nextCursor = hasMore && last ? encodeCursor(last.occurredAt, last.id) : null;
 
-  return { rows: page, nextCursor };
+  const shaped: TxRow[] = page.map((r) => ({
+    id: r.id,
+    occurredAt: r.occurredAt,
+    amountCents: r.amountCents,
+    currency: r.currency,
+    descriptionRaw: r.descriptionRaw,
+    descriptionClean: r.descriptionClean,
+    merchant: r.merchant,
+    categorySlug: r.categorySlug,
+    classificationMethod: r.classificationMethod,
+    source: r.source,
+    accountId: r.accountId,
+    accountName: r.accountName,
+    counterparty: r.cpId
+      ? {
+          id: r.cpId,
+          key: r.cpKey!,
+          displayName: r.cpDisplayName!,
+          type: r.cpType!,
+          defaultCategorySlug: r.cpDefaultCategorySlug,
+          notes: r.cpNotes,
+        }
+      : null,
+  }));
+
+  return { rows: shaped, nextCursor };
 }
 
 export async function listAccounts() {


### PR DESCRIPTION
Parte 3/3 del counterparty model (#72). Depende de #88 y #89 (ambos mergeados).

## Summary

Cierra el loop end-to-end del counterparty model:

### Cambio de diseño vs ADR original
Unifico el auto-create para `qr_payment` (antes solo Bre-b lo hacía). QR usa el key como `display_name` placeholder. Esto simplifica masivamente la propagación retroactiva — ya no hace falta filtrar por `raw_data.toKey` en JSONB; alcanza con `WHERE counterparty_id = $id` por la FK. Todo tx de QR/Bre-b tiene counterparty_id desde ingesta.

### Ingest (delta a #89)
- `src/app/api/ingest/sms/route.ts`: QR ahora también auto-crea counterparty (displayName = key).
- Test actualizado para reflejar comportamiento unificado.

### Backfill
- `scripts/backfill-counterparties.ts` — re-parsea `raw_data.sms` de tx históricas sin counterparty_id y las linkea. Corrido sobre dev DB: 2 tx QR backfilleadas.

### Server action
- `updateCounterparty({ id, displayName, type, defaultCategorySlug, notes })` en `src/app/transactions/actions.ts`.
- Si `defaultCategorySlug` se setea → propaga a tx con `counterparty_id = id AND category_slug IS NULL` (NO pisa clasificaciones manuales).
- Emite `transaction:bulk-updated` con el count para el SSE refresh.

### UI
- `CounterpartyDialog` (`src/components/transactions/counterparty-dialog.tsx`) — pencil/identify button inline en filas con counterparty. Form con displayName, type (Person/Merchant/Unknown), defaultCategory, notes.
- `TransactionTable` renderiza `counterparty.displayName` como primary descriptor con badge de type (icon de persona/edificio).
- Toast muestra 'Counterparty updated · N tx recategorized' cuando hay propagación.

### Query
- `listTransactions` hace `leftJoin(counterparties)` y expone `TxRow.counterparty` shape.

### SSE
- `AppEvent` extendido con `transaction:bulk-updated` — `useLiveEvents` lo incluye en `DEFAULT_REFRESH_ON`.

## Test plan
- [x] Unit tests: 5 nuevos para `updateCounterparty` (rename sin propagación, propaga solo a unclassified, preserva manual, rechaza slug inválido, multi-tx)
- [x] Unit tests SMS ingest: 6 tests actualizados por la unificación QR auto-create — todos verdes
- [x] `bun run test` — 110/110 pass
- [x] `bun run lint` pass
- [x] `bun run typecheck` pass
- [x] e2e Playwright: `e2e/counterparty.spec.ts` — dialog abre, type buttons visibles, screenshot capturado
- [x] Backfill script corrido en dev DB — 2 tx QR históricas linkeadas a counterparties

## Screenshots
Ver `e2e/screenshots/cp-dialog-open.png` y `cp-transactions-loaded.png` en el branch (gitignored — capturados en dev).

## Notas operacionales
- Dev DB backfilleada en la branch. Prod DB requiere correr `bun run scripts/backfill-counterparties.ts` una vez post-merge.
- Test DB se limpia automáticamente; cleanups de counterparties scopeados para no pisar tests paralelos (fix al issue de shared state entre `route.test.ts` y `actions.test.ts`).

## Out of scope (issues futuras si se necesitan)
- Página `/counterparties` con CRUD
- Merge de llaves ('estas 2 son la misma persona')
- Vincular `recurring_transactions` a `counterparties`
- Cambio de defaultCategory → repropagar a tx ya clasificadas por rule (hoy solo toca unclassified)

Closes #90
Ref #72