### PR TITLE
feat(counterparties): multi-key aliases + transfer_sent/received + merge (#94)

### DIFF
--- a/drizzle/0004_nifty_trish_tilby.sql
+++ b/drizzle/0004_nifty_trish_tilby.sql
@@ -1,0 +1,40 @@
+CREATE TYPE "public"."counterparty_key_kind" AS ENUM('qr', 'breb', 'account', 'name');--> statement-breakpoint
+CREATE TABLE "counterparty_aliases" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"counterparty_id" integer NOT NULL,
+	"kind" "counterparty_key_kind" NOT NULL,
+	"value" varchar(120) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "counterparties" DROP CONSTRAINT "counterparties_key_unique";--> statement-breakpoint
+DROP INDEX "counterparties_key_idx";--> statement-breakpoint
+ALTER TABLE "counterparty_aliases" ADD CONSTRAINT "counterparty_aliases_counterparty_id_counterparties_id_fk" FOREIGN KEY ("counterparty_id") REFERENCES "public"."counterparties"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "counterparty_aliases_kind_value_unique" ON "counterparty_aliases" USING btree ("kind","value");--> statement-breakpoint
+CREATE INDEX "counterparty_aliases_counterparty_idx" ON "counterparty_aliases" USING btree ("counterparty_id");--> statement-breakpoint
+-- Backfill aliases from existing counterparties.key using the kind inferred
+-- from linked transactions. Safe to re-run on fresh DBs where the source set
+-- is empty (both pre-filters yield zero rows).
+INSERT INTO "counterparty_aliases" ("counterparty_id", "kind", "value")
+SELECT DISTINCT ON (cp.id)
+  cp.id,
+  CASE tx.raw_data->>'kind'
+    WHEN 'qr_payment' THEN 'qr'::counterparty_key_kind
+    WHEN 'bre_b_transfer' THEN 'breb'::counterparty_key_kind
+  END,
+  cp.key
+FROM "counterparties" cp
+JOIN "transactions" tx ON tx.counterparty_id = cp.id
+WHERE tx.raw_data->>'kind' IN ('qr_payment','bre_b_transfer')
+  AND cp.key IS NOT NULL;
+--> statement-breakpoint
+-- Counterparties with no linked tx (edge case — shouldn't exist in practice
+-- but guard anyway): default their kind to 'qr' since that's the most common
+-- placeholder source historically.
+INSERT INTO "counterparty_aliases" ("counterparty_id", "kind", "value")
+SELECT cp.id, 'qr'::counterparty_key_kind, cp.key
+FROM "counterparties" cp
+LEFT JOIN "counterparty_aliases" a ON a.counterparty_id = cp.id
+WHERE a.id IS NULL AND cp.key IS NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "counterparties" DROP COLUMN "key";

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1188 @@
+{
+  "id": "b04a2b57-b78e-4d47-9b20-ce660e607279",
+  "prevId": "58180fb0-d8e5-41d8-8d73-74731b202da1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_category_slug_categories_slug_fk": {
+          "name": "budgets_category_slug_categories_slug_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_priority_idx": {
+          "name": "rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_category_slug_categories_slug_fk": {
+          "name": "classification_rules_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "counterparties_default_category_slug_categories_slug_fk": {
+          "name": "counterparties_default_category_slug_categories_slug_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_kind_value_unique": {
+          "name": "counterparty_aliases_kind_value_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "insights_reports_year_month_unique": {
+          "name": "insights_reports_year_month_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year_month"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_category_slug_categories_slug_fk": {
+          "name": "recurring_transactions_category_slug_categories_slug_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_category_idx": {
+          "name": "transactions_category_idx",
+          "columns": [
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_counterparty_idx": {
+          "name": "transactions_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_occurred_idx": {
+          "name": "transactions_occurred_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_category_slug_categories_slug_fk": {
+          "name": "transactions_category_slug_categories_slug_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "ai",
+        "manual",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776366825516,
       "tag": "0003_sharp_sleepwalker",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776370482638,
+      "tag": "0004_nifty_trish_tilby",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/replay-sms-dump.ts
+++ b/scripts/replay-sms-dump.ts
@@ -1,0 +1,147 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { sql } from "drizzle-orm";
+import { db } from "../src/lib/db";
+import { ingestParsed } from "../src/app/api/ingest/sms/route";
+import { parseSmsBancolombia } from "../src/lib/ingestion/sms-bancolombia";
+
+// imessage-exporter txt block layout (blank-line separated):
+//   line 1: timestamp header ("Dec 09, 2025  4:32:26 PM (...)")
+//   line 2: sender handle ("85540")
+//   line 3+: message body
+const HEADER_RE = /^[A-Z][a-z]{2}\s+\d{1,2},\s+\d{4}/;
+
+function loadFromImessageDir(dir: string): string[] {
+  const bodies: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (!entry.endsWith(".txt")) continue;
+    if (entry === "orphaned.txt") continue;
+    const raw = readFileSync(join(dir, entry), "utf-8");
+    const blocks = raw.split(/\n\s*\n/);
+    for (const block of blocks) {
+      const lines = block.split("\n").map((l) => l.trimEnd());
+      if (lines.length < 3) continue;
+      if (!HEADER_RE.test(lines[0])) continue;
+      const body = lines.slice(2).join(" ").trim();
+      if (body.length > 0) bodies.push(body);
+    }
+  }
+  return bodies;
+}
+
+async function main() {
+  const dir = process.argv[2];
+  if (!dir) {
+    throw new Error("usage: bun run scripts/replay-sms-dump.ts <imessage-export-dir>");
+  }
+
+  const bodies = loadFromImessageDir(dir);
+  console.log(`Loaded ${bodies.length} SMS bodies from ${dir}`);
+
+  const counts = {
+    inserted: 0,
+    duplicated: 0,
+    skipped: 0,
+    error: 0,
+  };
+  const byKind: Record<string, number> = {};
+  const errors: Array<{ reason: string; body: string }> = [];
+
+  for (const body of bodies) {
+    const parsed = parseSmsBancolombia(body);
+    const kind = parsed.kind === "skip" ? `skip:${parsed.reason}` : parsed.kind;
+    byKind[kind] = (byKind[kind] ?? 0) + 1;
+
+    const outcome = await ingestParsed(parsed);
+    counts[outcome.status] += 1;
+    if (outcome.status === "error") {
+      errors.push({ reason: outcome.reason, body: body.slice(0, 80) });
+    }
+  }
+
+  console.log("\n## Ingest outcomes");
+  console.log(`inserted:   ${counts.inserted}`);
+  console.log(`duplicated: ${counts.duplicated}`);
+  console.log(`skipped:    ${counts.skipped}`);
+  console.log(`error:      ${counts.error}`);
+
+  console.log("\n## By parsed kind");
+  for (const [k, v] of Object.entries(byKind).sort((a, b) => b[1] - a[1])) {
+    console.log(`${k.padEnd(30)} ${v}`);
+  }
+
+  if (errors.length > 0) {
+    console.log("\n## Errors (first 5)");
+    for (const e of errors.slice(0, 5)) {
+      console.log(`  ${e.reason}: ${e.body}…`);
+    }
+  }
+
+  // Post-ingest DB summary
+  const txStats = await db.execute<{
+    source: string;
+    kind: string | null;
+    c: number;
+  }>(sql`
+    SELECT source,
+           raw_data->>'kind' AS kind,
+           COUNT(*)::int AS c
+    FROM transactions
+    GROUP BY source, raw_data->>'kind'
+    ORDER BY c DESC
+  `);
+  console.log("\n## DB transactions by (source, kind)");
+  for (const r of txStats) {
+    console.log(`${r.source.padEnd(12)} ${(r.kind ?? "-").padEnd(25)} ${r.c}`);
+  }
+
+  const cpStats = await db.execute<{
+    c: number;
+    with_category: number;
+  }>(sql`
+    SELECT COUNT(*)::int AS c,
+           COUNT(*) FILTER (WHERE default_category_slug IS NOT NULL)::int AS with_category
+    FROM counterparties
+  `);
+  console.log(
+    `\n## Counterparties: ${cpStats[0].c} total, ${cpStats[0].with_category} with default category`,
+  );
+
+  const topCp = await db.execute<{
+    display_name: string;
+    hit_count: number;
+    aliases: string;
+  }>(sql`
+    SELECT c.display_name, c.hit_count,
+      (SELECT string_agg(a.kind || ':' || a.value, ', ' ORDER BY a.kind)
+       FROM counterparty_aliases a WHERE a.counterparty_id = c.id) AS aliases
+    FROM counterparties c
+    ORDER BY c.hit_count DESC, c.display_name ASC
+    LIMIT 10
+  `);
+  console.log("\n## Top 10 counterparties by hit_count");
+  for (const r of topCp) {
+    console.log(`  [${r.hit_count}] ${r.display_name.padEnd(40)} [${r.aliases}]`);
+  }
+
+  const classification = await db.execute<{
+    method: string;
+    c: number;
+  }>(sql`
+    SELECT classification_method::text AS method, COUNT(*)::int AS c
+    FROM transactions
+    GROUP BY classification_method
+    ORDER BY c DESC
+  `);
+  console.log("\n## Classification method breakdown");
+  for (const r of classification) {
+    console.log(`${r.method.padEnd(15)} ${r.c}`);
+  }
+
+  await db.$client.end({ timeout: 1 });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/ingest/sms/counterparty.test.ts
+++ b/src/app/api/ingest/sms/counterparty.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { normalizeName } from "./route";
+
+describe("normalizeName", () => {
+  it("uppercases and trims simple names", () => {
+    expect(normalizeName("juan perez")).toBe("JUAN PEREZ");
+    expect(normalizeName("  maria paz  ")).toBe("MARIA PAZ");
+  });
+
+  it("collapses internal whitespace so Bancolombia variations resolve to same alias", () => {
+    expect(normalizeName("DILAN  DEJANON")).toBe("DILAN DEJANON");
+    expect(normalizeName("DILAN\tDEJANON")).toBe("DILAN DEJANON");
+    expect(normalizeName("DILAN\n DEJANON")).toBe("DILAN DEJANON");
+  });
+
+  it("is idempotent", () => {
+    const v = normalizeName("  Dilan  dEjAnON  ");
+    expect(v).toBe("DILAN DEJANON");
+    expect(normalizeName(v)).toBe(v);
+  });
+
+  it("preserves accented chars (they uppercase consistently)", () => {
+    expect(normalizeName("José López")).toBe("JOSÉ LÓPEZ");
+  });
+});

--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -21,15 +21,66 @@ function makeRequest(init: {
 
 // Scoped to keys this file creates via SMS ingest, so parallel test files
 // touching `counterparties` don't stomp on each other.
+const QR_KEY_VALUES = ["0091498581"];
+const BREB_KEY_VALUES = ["3046262677"];
+const NAME_KEY_VALUES = ["ESTEBAN LEONARDO SARMIENTO GOMEZ"];
+
 async function cleanup() {
   await db.execute(sql`
     DELETE FROM transactions WHERE external_id LIKE ${TEST_EXTERNAL_ID_PREFIX + "%"}
   `);
   await db.execute(sql`DELETE FROM ingestion_logs WHERE source = 'sms'`);
   await db.execute(sql`
-    DELETE FROM counterparties WHERE key IN ('0091498581', '3046262677')
+    DELETE FROM counterparties WHERE id IN (
+      SELECT counterparty_id FROM counterparty_aliases
+      WHERE (kind = 'qr' AND value IN ('0091498581'))
+         OR (kind = 'breb' AND value IN ('3046262677'))
+         OR (kind = 'name' AND value IN ('ESTEBAN LEONARDO SARMIENTO GOMEZ'))
+    )
   `);
 }
+
+// Test helpers for the alias-based counterparty model.
+async function findCounterpartyByAlias(kind: string, value: string) {
+  const rows = await db.execute<{
+    id: number;
+    display_name: string;
+    type: string;
+    hit_count: number;
+    default_category_slug: string | null;
+  }>(sql`
+    SELECT c.id, c.display_name, c.type, c.hit_count, c.default_category_slug
+    FROM counterparty_aliases a
+    JOIN counterparties c ON c.id = a.counterparty_id
+    WHERE a.kind = ${kind}::counterparty_key_kind AND a.value = ${value}
+    LIMIT 1
+  `);
+  return rows[0] ?? null;
+}
+
+async function createCounterpartyWithAlias(args: {
+  kind: "qr" | "breb" | "account" | "name";
+  value: string;
+  displayName: string;
+  type?: "person" | "merchant" | "unknown";
+  defaultCategorySlug?: string | null;
+}) {
+  const rows = await db.execute<{ id: number }>(sql`
+    INSERT INTO counterparties (display_name, type, default_category_slug)
+    VALUES (
+      ${args.displayName},
+      ${args.type ?? "unknown"}::counterparty_type,
+      ${args.defaultCategorySlug ?? null}
+    )
+    RETURNING id
+  `);
+  await db.execute(sql`
+    INSERT INTO counterparty_aliases (counterparty_id, kind, value)
+    VALUES (${rows[0].id}, ${args.kind}::counterparty_key_kind, ${args.value})
+  `);
+  return rows[0].id;
+}
+void QR_KEY_VALUES; void BREB_KEY_VALUES; void NAME_KEY_VALUES;
 
 function jsonBody(payload: Record<string, unknown>): string {
   return JSON.stringify(payload);
@@ -527,20 +578,12 @@ describe("POST /api/ingest/sms", () => {
     const json = (await res.json()) as { status: string; txId?: number };
     expect(json.status).toBe("inserted");
 
-    const cpRows = await db.execute<{
-      display_name: string;
-      type: string;
-      hit_count: number;
-      default_category_slug: string | null;
-    }>(sql`
-      SELECT display_name, type, hit_count, default_category_slug
-      FROM counterparties WHERE key = ${QR_KEY}
-    `);
-    expect(cpRows).toHaveLength(1);
-    expect(cpRows[0].display_name).toBe(QR_KEY);
-    expect(cpRows[0].type).toBe("unknown");
-    expect(cpRows[0].hit_count).toBe(1);
-    expect(cpRows[0].default_category_slug).toBeNull();
+    const cp = await findCounterpartyByAlias("qr", QR_KEY);
+    expect(cp).not.toBeNull();
+    expect(cp!.display_name).toBe(QR_KEY);
+    expect(cp!.type).toBe("unknown");
+    expect(cp!.hit_count).toBe(1);
+    expect(cp!.default_category_slug).toBeNull();
 
     const txRows = await db.execute<{
       counterparty_id: number | null;
@@ -550,16 +593,18 @@ describe("POST /api/ingest/sms", () => {
       SELECT counterparty_id, category_slug, classification_method
       FROM transactions WHERE id = ${json.txId!}
     `);
-    expect(txRows[0].counterparty_id).not.toBeNull();
+    expect(txRows[0].counterparty_id).toBe(cp!.id);
     expect(txRows[0].category_slug).toBeNull();
     expect(txRows[0].classification_method).toBe("unclassified");
   });
 
   it("QR with existing counterparty (no default category) links but stays unclassified", async () => {
-    await db.execute(sql`
-      INSERT INTO counterparties (key, display_name, type)
-      VALUES (${QR_KEY}, 'Panadería del Barrio', 'merchant')
-    `);
+    const cpId = await createCounterpartyWithAlias({
+      kind: "qr",
+      value: QR_KEY,
+      displayName: "Panadería del Barrio",
+      type: "merchant",
+    });
     const res = await POST(
       makeRequest({
         body: jsonBody({ body: QR_BODY }),
@@ -577,21 +622,22 @@ describe("POST /api/ingest/sms", () => {
       SELECT counterparty_id, category_slug, classification_method
       FROM transactions WHERE id = ${json.txId!}
     `);
-    expect(rows[0].counterparty_id).not.toBeNull();
+    expect(rows[0].counterparty_id).toBe(cpId);
     expect(rows[0].category_slug).toBeNull();
     expect(rows[0].classification_method).toBe("unclassified");
 
-    const cpRows = await db.execute<{ hit_count: number }>(sql`
-      SELECT hit_count FROM counterparties WHERE key = ${QR_KEY}
-    `);
-    expect(cpRows[0].hit_count).toBe(1);
+    const cp = await findCounterpartyByAlias("qr", QR_KEY);
+    expect(cp!.hit_count).toBe(1);
   });
 
   it("QR with existing counterparty that has default_category inherits + method=rule", async () => {
-    await db.execute(sql`
-      INSERT INTO counterparties (key, display_name, type, default_category_slug)
-      VALUES (${QR_KEY}, 'Panadería del Barrio', 'merchant', 'alimentacion')
-    `);
+    await createCounterpartyWithAlias({
+      kind: "qr",
+      value: QR_KEY,
+      displayName: "Panadería del Barrio",
+      type: "merchant",
+      defaultCategorySlug: "alimentacion",
+    });
     const res = await POST(
       makeRequest({
         body: jsonBody({ body: QR_BODY }),
@@ -624,20 +670,12 @@ describe("POST /api/ingest/sms", () => {
     const json = (await res.json()) as { status: string; txId?: number };
     expect(json.status).toBe("inserted");
 
-    const cpRows = await db.execute<{
-      display_name: string;
-      type: string;
-      hit_count: number;
-      default_category_slug: string | null;
-    }>(sql`
-      SELECT display_name, type, hit_count, default_category_slug
-      FROM counterparties WHERE key = ${BREB_KEY}
-    `);
-    expect(cpRows).toHaveLength(1);
-    expect(cpRows[0].display_name).toBe("MARIA PAZ TORRES CARRILLO");
-    expect(cpRows[0].type).toBe("unknown");
-    expect(cpRows[0].hit_count).toBe(1);
-    expect(cpRows[0].default_category_slug).toBeNull();
+    const cp = await findCounterpartyByAlias("breb", BREB_KEY);
+    expect(cp).not.toBeNull();
+    expect(cp!.display_name).toBe("MARIA PAZ TORRES CARRILLO");
+    expect(cp!.type).toBe("unknown");
+    expect(cp!.hit_count).toBe(1);
+    expect(cp!.default_category_slug).toBeNull();
 
     const txRows = await db.execute<{
       counterparty_id: number | null;
@@ -647,7 +685,7 @@ describe("POST /api/ingest/sms", () => {
       SELECT counterparty_id, category_slug, classification_method
       FROM transactions WHERE id = ${json.txId!}
     `);
-    expect(txRows[0].counterparty_id).not.toBeNull();
+    expect(txRows[0].counterparty_id).toBe(cp!.id);
     expect(txRows[0].category_slug).toBeNull();
     expect(txRows[0].classification_method).toBe("unclassified");
   });
@@ -658,7 +696,6 @@ describe("POST /api/ingest/sms", () => {
     );
     expect((await first.json()).status).toBe("inserted");
 
-    // Second SMS with different amount/time — same recipient key
     const BREB_BODY_2 =
       "Bancolombia: ALEJANDRO, transferiste $25,000.00 a la llave 3046262677 desde tu cuenta *6126 a MARIA PAZ TORRES CARRILLO el 02/04/26 a las 09:10. Con Bre-b es de una y gratis. Dudas al 018000912345.";
     const second = await POST(
@@ -666,19 +703,24 @@ describe("POST /api/ingest/sms", () => {
     );
     expect((await second.json()).status).toBe("inserted");
 
-    const cpRows = await db.execute<{ c: number; hit_count: number }>(sql`
-      SELECT COUNT(*)::int AS c, MAX(hit_count) AS hit_count
-      FROM counterparties WHERE key = ${BREB_KEY}
+    const cp = await findCounterpartyByAlias("breb", BREB_KEY);
+    expect(cp!.hit_count).toBe(2);
+
+    const dupe = await db.execute<{ c: number }>(sql`
+      SELECT COUNT(*)::int AS c FROM counterparty_aliases
+      WHERE kind = 'breb'::counterparty_key_kind AND value = ${BREB_KEY}
     `);
-    expect(cpRows[0].c).toBe(1);
-    expect(cpRows[0].hit_count).toBe(2);
+    expect(dupe[0].c).toBe(1);
   });
 
   it("Bre-b with existing counterparty + default_category inherits on new tx", async () => {
-    await db.execute(sql`
-      INSERT INTO counterparties (key, display_name, type, default_category_slug)
-      VALUES (${BREB_KEY}, 'Maria Paz', 'person', 'transferencias')
-    `);
+    await createCounterpartyWithAlias({
+      kind: "breb",
+      value: BREB_KEY,
+      displayName: "Maria Paz",
+      type: "person",
+      defaultCategorySlug: "transferencias",
+    });
     const res = await POST(
       makeRequest({
         body: jsonBody({ body: BREB_BODY }),
@@ -700,12 +742,54 @@ describe("POST /api/ingest/sms", () => {
     expect(rows[0].category_slug).toBe("transferencias");
     expect(rows[0].classification_method).toBe("rule");
 
-    // Upsert preserves the original display_name (does not overwrite with SMS recipient)
-    const cpRows = await db.execute<{ display_name: string; hit_count: number }>(sql`
-      SELECT display_name, hit_count FROM counterparties WHERE key = ${BREB_KEY}
+    const cp = await findCounterpartyByAlias("breb", BREB_KEY);
+    expect(cp!.display_name).toBe("Maria Paz");
+    expect(cp!.hit_count).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Counterparty — transfer_sent (account kind) and transfer_received (name)
+  // ---------------------------------------------------------------------------
+
+  it("transfer_sent auto-creates counterparty by account number", async () => {
+    const body =
+      "Bancolombia: Transferiste $30,000.00 desde tu cuenta 6126 a la cuenta 91218413213, el 16/04/2026 12:00. ¿Dudas? Llamanos al 018000931987. Estamos cerca.";
+    const res = await POST(
+      makeRequest({ body: jsonBody({ body }), headers: authedHeaders() }),
+    );
+    const json = (await res.json()) as { status: string; txId?: number };
+    expect(json.status).toBe("inserted");
+
+    const cp = await findCounterpartyByAlias("account", "91218413213");
+    expect(cp).not.toBeNull();
+    expect(cp!.display_name).toBe("Cuenta *91218413213");
+
+    const txRows = await db.execute<{ counterparty_id: number | null }>(sql`
+      SELECT counterparty_id FROM transactions WHERE id = ${json.txId!}
     `);
-    expect(cpRows[0].display_name).toBe("Maria Paz");
-    expect(cpRows[0].hit_count).toBe(1);
+    expect(txRows[0].counterparty_id).toBe(cp!.id);
+  });
+
+  it("transfer_received normalizes sender name and auto-creates by name kind", async () => {
+    const body =
+      "Bancolombia: ALEJANDRO, recibiste una transferencia de ESTEBAN LEONARDO SARMIENTO GOMEZ por $100,000.00 en tu cuenta *6126 conectada a la llave 3012998429 el 14/04/26 a las 15:28. Con llaves es de una y gratis. Dudas al 018000912345";
+    const res = await POST(
+      makeRequest({ body: jsonBody({ body }), headers: authedHeaders() }),
+    );
+    const json = (await res.json()) as { status: string; txId?: number };
+    expect(json.status).toBe("inserted");
+
+    const cp = await findCounterpartyByAlias(
+      "name",
+      "ESTEBAN LEONARDO SARMIENTO GOMEZ",
+    );
+    expect(cp).not.toBeNull();
+    expect(cp!.display_name).toBe("ESTEBAN LEONARDO SARMIENTO GOMEZ");
+
+    const txRows = await db.execute<{ counterparty_id: number | null }>(sql`
+      SELECT counterparty_id FROM transactions WHERE id = ${json.txId!}
+    `);
+    expect(txRows[0].counterparty_id).toBe(cp!.id);
   });
 
   // ---------------------------------------------------------------------------

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -213,46 +213,105 @@ type CounterpartyResolution = {
   inheritedCategory: string | null;
 };
 
+type AliasKind = "qr" | "breb" | "account" | "name";
+
+type KeyForKind = {
+  kind: AliasKind;
+  value: string;
+  initialDisplayName: string;
+};
+
 /**
- * For kinds that carry a counterparty key (qr_payment, bre_b_transfer):
- * always UPSERT by key so every tx gets a counterparty_id. This unifies
- * retroactive propagation (plain FK join) and UI logic.
+ * Normalizes a sender name so small whitespace/case variations from Bancolombia
+ * do not cause duplicate name-aliases for the same person.
+ */
+export function normalizeName(raw: string): string {
+  return raw.trim().toUpperCase().replace(/\s+/g, " ");
+}
+
+function keyForParsed(parsed: ParsedSms): KeyForKind | null {
+  switch (parsed.kind) {
+    case "qr_payment":
+      return {
+        kind: "qr",
+        value: parsed.toKey,
+        initialDisplayName: parsed.toKey,
+      };
+    case "bre_b_transfer":
+      return {
+        kind: "breb",
+        value: parsed.toKey,
+        initialDisplayName: parsed.recipientName,
+      };
+    case "transfer_sent":
+      return {
+        kind: "account",
+        value: parsed.toAccount,
+        initialDisplayName: `Cuenta *${parsed.toAccount}`,
+      };
+    case "transfer_received":
+      return {
+        kind: "name",
+        value: normalizeName(parsed.senderName),
+        initialDisplayName: parsed.senderName,
+      };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolves (and lazily creates) a counterparty for any kind that carries an
+ * identifier: qr_payment, bre_b_transfer, transfer_sent, transfer_received.
  *
- * - bre_b_transfer: initial display_name = recipientName (from SMS).
- * - qr_payment: initial display_name = key (placeholder; user renames in UI).
+ * Lookup is by (alias.kind, alias.value). If the alias does not exist, a new
+ * counterparty + alias are inserted atomically in a transaction so we never
+ * leave an orphan counterparty if concurrent ingests race.
  *
- * ON CONFLICT preserves the existing display_name on subsequent hits, so
- * user renames stick. Hit counter bumped on every match/insert.
+ * Hit counter bumped on every match/insert.
  */
 export async function resolveCounterparty(
   parsed: ParsedSms,
   database: DB,
 ): Promise<CounterpartyResolution> {
-  if (parsed.kind !== "qr_payment" && parsed.kind !== "bre_b_transfer") {
-    return { counterpartyId: null, inheritedCategory: null };
-  }
+  const key = keyForParsed(parsed);
+  if (!key) return { counterpartyId: null, inheritedCategory: null };
 
-  const key = parsed.toKey;
-  const initialDisplayName =
-    parsed.kind === "bre_b_transfer" ? parsed.recipientName : key;
+  return database.transaction(async (trx) => {
+    const existing = await trx.execute<{
+      id: number;
+      default_category_slug: string | null;
+    }>(sql`
+      SELECT c.id, c.default_category_slug
+      FROM counterparty_aliases a
+      JOIN counterparties c ON c.id = a.counterparty_id
+      WHERE a.kind = ${key.kind}::counterparty_key_kind AND a.value = ${key.value}
+      LIMIT 1
+    `);
 
-  const rows = await database.execute<{
-    id: number;
-    default_category_slug: string | null;
-  }>(sql`
-    INSERT INTO counterparties (key, display_name, type, hit_count, last_hit_at)
-    VALUES (${key}, ${initialDisplayName}, 'unknown', 1, now())
-    ON CONFLICT (key) DO UPDATE
-      SET hit_count = counterparties.hit_count + 1,
-          last_hit_at = now(),
-          updated_at = now()
-    RETURNING id, default_category_slug
-  `);
-  const row = rows[0];
-  return {
-    counterpartyId: row.id,
-    inheritedCategory: row.default_category_slug,
-  };
+    if (existing.length > 0) {
+      await trx.execute(sql`
+        UPDATE counterparties
+        SET hit_count = hit_count + 1, last_hit_at = now()
+        WHERE id = ${existing[0].id}
+      `);
+      return {
+        counterpartyId: existing[0].id,
+        inheritedCategory: existing[0].default_category_slug,
+      };
+    }
+
+    const inserted = await trx.execute<{ id: number }>(sql`
+      INSERT INTO counterparties (display_name, type, hit_count, last_hit_at)
+      VALUES (${key.initialDisplayName}, 'unknown', 1, now())
+      RETURNING id
+    `);
+    await trx.execute(sql`
+      INSERT INTO counterparty_aliases (counterparty_id, kind, value)
+      VALUES (${inserted[0].id}, ${key.kind}::counterparty_key_kind, ${key.value})
+    `);
+    return { counterpartyId: inserted[0].id, inheritedCategory: null };
+  });
 }
 
 function resolveAccountForParsed(

--- a/src/app/transactions/actions.test.ts
+++ b/src/app/transactions/actions.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 
@@ -8,7 +8,7 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
-const { updateCounterparty } = await import("./actions");
+const { updateCounterparty, mergeCounterparty } = await import("./actions");
 
 // Scoped so parallel test files don't wipe each other's counterparty rows.
 async function cleanup() {
@@ -16,24 +16,34 @@ async function cleanup() {
     DELETE FROM transactions WHERE external_id LIKE 'test-cp-action:%'
   `);
   await db.execute(sql`
-    DELETE FROM counterparties WHERE key LIKE 'test-cp-%'
+    DELETE FROM counterparties WHERE id IN (
+      SELECT counterparty_id FROM counterparty_aliases WHERE value LIKE 'test-cp-%'
+    )
   `);
 }
 
 async function seedCounterparty(args: {
   key: string;
+  kind?: "qr" | "breb" | "account" | "name";
   displayName?: string;
   defaultCategory?: string | null;
 }): Promise<number> {
   const rows = await db.execute<{ id: number }>(sql`
-    INSERT INTO counterparties (key, display_name, type, default_category_slug)
+    INSERT INTO counterparties (display_name, type, default_category_slug)
     VALUES (
-      ${args.key},
       ${args.displayName ?? args.key},
       'unknown',
       ${args.defaultCategory ?? null}
     )
     RETURNING id
+  `);
+  await db.execute(sql`
+    INSERT INTO counterparty_aliases (counterparty_id, kind, value)
+    VALUES (
+      ${rows[0].id},
+      ${(args.kind ?? "qr")}::counterparty_key_kind,
+      ${args.key}
+    )
   `);
   return rows[0].id;
 }
@@ -67,10 +77,6 @@ async function seedTx(args: {
 
 describe("updateCounterparty", () => {
   afterEach(cleanup);
-  afterAll(async () => {
-    await db.$client.end({ timeout: 1 });
-  });
-
   beforeEach(async () => {
     await cleanup();
   });
@@ -189,5 +195,149 @@ describe("updateCounterparty", () => {
     });
 
     expect(result.propagatedCount).toBe(3);
+  });
+});
+
+describe("mergeCounterparty", () => {
+  afterEach(cleanup);
+  beforeEach(async () => {
+    await cleanup();
+  });
+
+  it("moves aliases and transactions from source to target, then deletes source", async () => {
+    const sourceId = await seedCounterparty({
+      key: "test-cp-source",
+      kind: "name",
+      displayName: "DILAN DEJANON",
+    });
+    const targetId = await seedCounterparty({
+      key: "test-cp-target",
+      kind: "account",
+      displayName: "Cuenta *91218413213",
+    });
+    const sourceTxA = await seedTx({
+      counterpartyId: sourceId,
+      externalId: "test-cp-action:mA",
+    });
+    const sourceTxB = await seedTx({
+      counterpartyId: sourceId,
+      externalId: "test-cp-action:mB",
+    });
+    const targetTx = await seedTx({
+      counterpartyId: targetId,
+      externalId: "test-cp-action:mT",
+    });
+
+    const result = await mergeCounterparty({ sourceId, targetId });
+
+    expect(result.movedTxCount).toBe(2);
+    expect(result.movedAliasCount).toBe(1);
+    expect(result.inheritedCategoryFromSource).toBe(false);
+
+    // Source deleted
+    const srcCheck = await db.execute<{ c: number }>(sql`
+      SELECT COUNT(*)::int AS c FROM counterparties WHERE id = ${sourceId}
+    `);
+    expect(srcCheck[0].c).toBe(0);
+
+    // All 3 tx now on target
+    const txs = await db.execute<{ counterparty_id: number | null }>(sql`
+      SELECT counterparty_id FROM transactions
+      WHERE id IN (${sourceTxA}, ${sourceTxB}, ${targetTx})
+    `);
+    for (const row of txs) {
+      expect(row.counterparty_id).toBe(targetId);
+    }
+
+    // Target has both aliases
+    const aliases = await db.execute<{ kind: string; value: string }>(sql`
+      SELECT kind::text, value FROM counterparty_aliases
+      WHERE counterparty_id = ${targetId}
+      ORDER BY kind
+    `);
+    expect(aliases).toHaveLength(2);
+    expect(aliases.map((a) => a.kind).sort()).toEqual(["account", "name"]);
+  });
+
+  it("inherits defaultCategory from source when target has none", async () => {
+    const sourceId = await seedCounterparty({
+      key: "test-cp-src2",
+      displayName: "Source",
+      defaultCategory: "alimentacion",
+    });
+    const targetId = await seedCounterparty({
+      key: "test-cp-tgt2",
+      displayName: "Target",
+    });
+
+    const result = await mergeCounterparty({ sourceId, targetId });
+
+    expect(result.inheritedCategoryFromSource).toBe(true);
+    const rows = await db.execute<{ default_category_slug: string }>(sql`
+      SELECT default_category_slug FROM counterparties WHERE id = ${targetId}
+    `);
+    expect(rows[0].default_category_slug).toBe("alimentacion");
+  });
+
+  it("does NOT override target's existing defaultCategory", async () => {
+    const sourceId = await seedCounterparty({
+      key: "test-cp-src3",
+      displayName: "Source",
+      defaultCategory: "alimentacion",
+    });
+    const targetId = await seedCounterparty({
+      key: "test-cp-tgt3",
+      displayName: "Target",
+      defaultCategory: "transferencias",
+    });
+
+    const result = await mergeCounterparty({ sourceId, targetId });
+
+    expect(result.inheritedCategoryFromSource).toBe(false);
+    const rows = await db.execute<{ default_category_slug: string }>(sql`
+      SELECT default_category_slug FROM counterparties WHERE id = ${targetId}
+    `);
+    expect(rows[0].default_category_slug).toBe("transferencias");
+  });
+
+  it("rejects merging a counterparty into itself", async () => {
+    const cpId = await seedCounterparty({ key: "test-cp-self" });
+    await expect(
+      mergeCounterparty({ sourceId: cpId, targetId: cpId }),
+    ).rejects.toThrow();
+  });
+
+  it("throws when source or target does not exist", async () => {
+    const cpId = await seedCounterparty({ key: "test-cp-exists" });
+    await expect(
+      mergeCounterparty({ sourceId: 999999, targetId: cpId }),
+    ).rejects.toThrow(/Source counterparty not found/);
+    await expect(
+      mergeCounterparty({ sourceId: cpId, targetId: 999999 }),
+    ).rejects.toThrow(/Target counterparty not found/);
+  });
+
+  it("accumulates hit_count from source into target", async () => {
+    const sourceId = await seedCounterparty({
+      key: "test-cp-hitA",
+      displayName: "A",
+    });
+    const targetId = await seedCounterparty({
+      key: "test-cp-hitB",
+      displayName: "B",
+    });
+    await db.execute(sql`
+      UPDATE counterparties SET hit_count = 5 WHERE id = ${sourceId}
+    `);
+    await db.execute(sql`
+      UPDATE counterparties SET hit_count = 3 WHERE id = ${targetId}
+    `);
+
+    await mergeCounterparty({ sourceId, targetId });
+
+    const rows = await db.execute<{ hit_count: number }>(sql`
+      SELECT hit_count FROM counterparties WHERE id = ${targetId}
+    `);
+    expect(rows[0].hit_count).toBe(8);
   });
 });

--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -190,3 +190,123 @@ export async function updateCounterparty(
 
   return { propagatedCount };
 }
+
+const mergeCounterpartySchema = z
+  .object({
+    sourceId: z.coerce.number().int().positive(),
+    targetId: z.coerce.number().int().positive(),
+  })
+  .refine((v) => v.sourceId !== v.targetId, {
+    message: "sourceId and targetId must differ",
+  });
+
+export type MergeCounterpartyInput = z.input<typeof mergeCounterpartySchema>;
+export type MergeCounterpartyResult = {
+  movedTxCount: number;
+  movedAliasCount: number;
+  inheritedCategoryFromSource: boolean;
+};
+
+/**
+ * Merges source counterparty into target: aliases and transactions are moved,
+ * source is deleted. If target has no default_category and source does, the
+ * category is inherited so users don't lose classification work.
+ *
+ * Alias collisions (same kind+value on both sides) shouldn't happen in
+ * practice because unique constraint would have prevented it at ingest. If it
+ * ever does, the source alias is silently dropped.
+ */
+export async function mergeCounterparty(
+  input: MergeCounterpartyInput,
+): Promise<MergeCounterpartyResult> {
+  const parsed = mergeCounterpartySchema.parse(input);
+
+  const result = await db.transaction(async (trx) => {
+    const [target] = await trx
+      .select({
+        id: counterparties.id,
+        defaultCategorySlug: counterparties.defaultCategorySlug,
+      })
+      .from(counterparties)
+      .where(eq(counterparties.id, parsed.targetId))
+      .limit(1);
+    const [source] = await trx
+      .select({
+        id: counterparties.id,
+        defaultCategorySlug: counterparties.defaultCategorySlug,
+        hitCount: counterparties.hitCount,
+      })
+      .from(counterparties)
+      .where(eq(counterparties.id, parsed.sourceId))
+      .limit(1);
+
+    if (!target) throw new Error("Target counterparty not found");
+    if (!source) throw new Error("Source counterparty not found");
+
+    const inheritCategory =
+      !target.defaultCategorySlug && !!source.defaultCategorySlug;
+    if (inheritCategory) {
+      await trx
+        .update(counterparties)
+        .set({
+          defaultCategorySlug: source.defaultCategorySlug,
+          updatedAt: new Date(),
+        })
+        .where(eq(counterparties.id, target.id));
+    }
+
+    // Move aliases (drop any that would violate unique kind+value on target).
+    const aliasMove = await trx.execute<{ id: number }>(sql`
+      UPDATE counterparty_aliases
+      SET counterparty_id = ${target.id}
+      WHERE counterparty_id = ${source.id}
+        AND NOT EXISTS (
+          SELECT 1 FROM counterparty_aliases existing
+          WHERE existing.counterparty_id = ${target.id}
+            AND existing.kind = counterparty_aliases.kind
+            AND existing.value = counterparty_aliases.value
+        )
+      RETURNING id
+    `);
+
+    // Reapunta todas las tx del source al target.
+    const txMove = await trx.execute<{ id: number }>(sql`
+      UPDATE transactions
+      SET counterparty_id = ${target.id}, updated_at = now()
+      WHERE counterparty_id = ${source.id}
+      RETURNING id
+    `);
+
+    // Accumulate hit_count so the merged entity reflects combined history.
+    await trx.execute(sql`
+      UPDATE counterparties
+      SET hit_count = hit_count + ${source.hitCount},
+          updated_at = now()
+      WHERE id = ${target.id}
+    `);
+
+    // Source counterparty (and any residual aliases / refs with SET NULL on
+    // tx FK — already moved above) removed. CASCADE cleans aliases.
+    await trx
+      .delete(counterparties)
+      .where(eq(counterparties.id, source.id));
+
+    return {
+      movedTxCount: txMove.length,
+      movedAliasCount: aliasMove.length,
+      inheritedCategoryFromSource: inheritCategory,
+    };
+  });
+
+  emit({
+    type: "transaction:bulk-updated",
+    count: result.movedTxCount,
+    reason: "counterparty-updated",
+    timestamp: Date.now(),
+  });
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+
+  return result;
+}

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -8,6 +8,7 @@ import {
   countUnclassified,
   listAccounts,
   listCategories,
+  listCounterparties,
   listTransactions,
   PAGE_SIZE,
 } from "@/lib/transactions/queries";
@@ -50,20 +51,27 @@ export default async function TransactionsPage({
     cursor: sp.cursor,
   };
 
-  const [{ rows, nextCursor }, accounts, categories, total, unclassified] =
-    await Promise.all([
-      listTransactions(filters),
-      listAccounts(),
-      listCategories(),
-      countTotal({
-        from: filters.from,
-        to: filters.to,
-        accountId: filters.accountId,
-        categorySlug: filters.categorySlug,
-        q: filters.q,
-      }),
-      countUnclassified(),
-    ]);
+  const [
+    { rows, nextCursor },
+    accounts,
+    categories,
+    total,
+    unclassified,
+    allCounterparties,
+  ] = await Promise.all([
+    listTransactions(filters),
+    listAccounts(),
+    listCategories(),
+    countTotal({
+      from: filters.from,
+      to: filters.to,
+      accountId: filters.accountId,
+      categorySlug: filters.categorySlug,
+      q: filters.q,
+    }),
+    countUnclassified(),
+    listCounterparties(),
+  ]);
 
   const baseQuery = {
     from: sp.from,
@@ -97,7 +105,11 @@ export default async function TransactionsPage({
         }}
       />
 
-      <TransactionTable rows={rows} categories={categories} />
+      <TransactionTable
+        rows={rows}
+        categories={categories}
+        allCounterparties={allCounterparties}
+      />
 
       <div className="flex items-center justify-between">
         <div className="text-xs text-muted-foreground">

--- a/src/components/transactions/counterparty-dialog.tsx
+++ b/src/components/transactions/counterparty-dialog.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { PencilIcon, UserIcon, BuildingIcon, CircleHelpIcon } from "lucide-react";
+import {
+  PencilIcon,
+  UserIcon,
+  BuildingIcon,
+  CircleHelpIcon,
+  MergeIcon,
+} from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -15,24 +21,58 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { updateCounterparty } from "@/app/transactions/actions";
+import { updateCounterparty, mergeCounterparty } from "@/app/transactions/actions";
 import type { CategoryOption } from "./category-cell";
+
+export type CounterpartyAlias = {
+  kind: "qr" | "breb" | "account" | "name";
+  value: string;
+};
 
 export type CounterpartyValue = {
   id: number;
-  key: string;
   displayName: string;
   type: "person" | "merchant" | "unknown";
   defaultCategorySlug: string | null;
   notes: string | null;
+  aliases: CounterpartyAlias[];
 };
+
+export type CounterpartyBrief = {
+  id: number;
+  displayName: string;
+  type: "person" | "merchant" | "unknown";
+};
+
+const ALIAS_KIND_LABELS: Record<CounterpartyAlias["kind"], string> = {
+  qr: "QR",
+  breb: "Bre-b",
+  account: "Cuenta",
+  name: "Nombre",
+};
+
+function isPlaceholderName(cp: CounterpartyValue): boolean {
+  // Placeholder means the display_name still equals one of the raw alias
+  // values (the initial seed when nothing was renamed yet). "Cuenta *NNNN"
+  // style initialDisplayName is also considered placeholder via prefix match.
+  if (cp.aliases.some((a) => a.value === cp.displayName)) return true;
+  if (
+    cp.aliases.some(
+      (a) => a.kind === "account" && cp.displayName === `Cuenta *${a.value}`,
+    )
+  )
+    return true;
+  return false;
+}
 
 export function CounterpartyDialog({
   counterparty,
   categories,
+  allCounterparties,
 }: {
   counterparty: CounterpartyValue;
   categories: CategoryOption[];
+  allCounterparties: CounterpartyBrief[];
 }) {
   const [open, setOpen] = useState(false);
   const [pending, startTransition] = useTransition();
@@ -42,14 +82,19 @@ export function CounterpartyDialog({
     counterparty.defaultCategorySlug ?? "",
   );
   const [notes, setNotes] = useState(counterparty.notes ?? "");
+  const [mergeTargetId, setMergeTargetId] = useState<string>("");
 
-  const placeholderName = counterparty.displayName === counterparty.key;
+  const placeholderName = isPlaceholderName(counterparty);
+  const mergeCandidates = allCounterparties.filter(
+    (c) => c.id !== counterparty.id,
+  );
 
   function reset() {
     setDisplayName(counterparty.displayName);
     setType(counterparty.type);
     setDefaultCategorySlug(counterparty.defaultCategorySlug ?? "");
     setNotes(counterparty.notes ?? "");
+    setMergeTargetId("");
   }
 
   function onSubmit(e: React.FormEvent) {
@@ -73,6 +118,36 @@ export function CounterpartyDialog({
         setOpen(false);
       } catch (err) {
         toast.error(err instanceof Error ? err.message : "Failed to update");
+      }
+    });
+  }
+
+  function onMerge() {
+    const targetId = Number(mergeTargetId);
+    if (!Number.isFinite(targetId) || targetId <= 0) {
+      toast.error("Pick a target counterparty");
+      return;
+    }
+    const target = mergeCandidates.find((c) => c.id === targetId);
+    if (!target) return;
+    const confirmed = window.confirm(
+      `Merge "${counterparty.displayName}" into "${target.displayName}"?\n\n` +
+        `All aliases and transactions will move to "${target.displayName}". ` +
+        `"${counterparty.displayName}" will be deleted.`,
+    );
+    if (!confirmed) return;
+    startTransition(async () => {
+      try {
+        const result = await mergeCounterparty({
+          sourceId: counterparty.id,
+          targetId,
+        });
+        toast.success(
+          `Merged · ${result.movedTxCount} tx moved to "${target.displayName}"`,
+        );
+        setOpen(false);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Merge failed");
       }
     });
   }
@@ -112,12 +187,28 @@ export function CounterpartyDialog({
             {placeholderName ? "Identify counterparty" : "Edit counterparty"}
           </DialogTitle>
           <DialogDescription>
-            Key: <span className="font-mono">{counterparty.key}</span>. Setting
-            a default category will recategorize all unclassified transactions
-            for this counterparty.
+            Setting a default category will recategorize all unclassified
+            transactions for this counterparty.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={onSubmit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label>Aliases</Label>
+            <div className="flex flex-wrap gap-1.5">
+              {counterparty.aliases.map((a) => (
+                <span
+                  key={`${a.kind}:${a.value}`}
+                  className="inline-flex items-center gap-1 rounded border bg-muted/50 px-1.5 py-0.5 text-xs font-mono text-muted-foreground"
+                >
+                  <span className="font-sans uppercase">
+                    {ALIAS_KIND_LABELS[a.kind]}
+                  </span>
+                  <span>{a.value}</span>
+                </span>
+              ))}
+            </div>
+          </div>
+
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="cp-name">Display name</Label>
             <Input
@@ -197,6 +288,41 @@ export function CounterpartyDialog({
             </Button>
           </DialogFooter>
         </form>
+
+        {mergeCandidates.length > 0 ? (
+          <div className="mt-2 flex flex-col gap-1.5 border-t pt-3">
+            <Label htmlFor="cp-merge">Merge into</Label>
+            <p className="text-xs text-muted-foreground">
+              Use this if another counterparty is the same person or merchant.
+              All aliases and transactions move to the target.
+            </p>
+            <div className="flex gap-2">
+              <select
+                id="cp-merge"
+                value={mergeTargetId}
+                onChange={(e) => setMergeTargetId(e.target.value)}
+                className="h-9 flex-1 rounded-md border bg-background px-2 text-sm"
+                disabled={pending}
+              >
+                <option value="">— pick target —</option>
+                {mergeCandidates.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.displayName}
+                  </option>
+                ))}
+              </select>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onMerge}
+                disabled={pending || !mergeTargetId}
+              >
+                <MergeIcon className="size-3.5" />
+                Merge
+              </Button>
+            </div>
+          </div>
+        ) : null}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -9,7 +9,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import type { TxRow } from "@/lib/transactions/queries";
+import type { CounterpartyBrief, TxRow } from "@/lib/transactions/queries";
 import { CategoryCell, type CategoryOption } from "./category-cell";
 import { CounterpartyDialog } from "./counterparty-dialog";
 
@@ -81,9 +81,11 @@ function formatDate(d: Date) {
 export function TransactionTable({
   rows,
   categories,
+  allCounterparties,
 }: {
   rows: TxRow[];
   categories: CategoryOption[];
+  allCounterparties: CounterpartyBrief[];
 }) {
   if (rows.length === 0) {
     return (
@@ -134,6 +136,7 @@ export function TransactionTable({
                       <CounterpartyDialog
                         counterparty={tx.counterparty}
                         categories={categories}
+                        allCounterparties={allCounterparties}
                       />
                     ) : null}
                   </div>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -46,6 +46,13 @@ export const counterpartyType = pgEnum("counterparty_type", [
   "unknown",
 ]);
 
+export const counterpartyKeyKind = pgEnum("counterparty_key_kind", [
+  "qr",
+  "breb",
+  "account",
+  "name",
+]);
+
 export const accounts = pgTable("accounts", {
   id: serial("id").primaryKey(),
   name: varchar("name", { length: 100 }).notNull(),
@@ -89,24 +96,36 @@ export const categories = pgTable("categories", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
-export const counterparties = pgTable(
-  "counterparties",
+export const counterparties = pgTable("counterparties", {
+  id: serial("id").primaryKey(),
+  displayName: varchar("display_name", { length: 120 }).notNull(),
+  type: counterpartyType("type").notNull().default("unknown"),
+  defaultCategorySlug: varchar("default_category_slug", { length: 60 }).references(
+    () => categories.slug,
+    { onDelete: "set null" },
+  ),
+  notes: text("notes"),
+  hitCount: integer("hit_count").notNull().default(0),
+  lastHitAt: timestamp("last_hit_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export const counterpartyAliases = pgTable(
+  "counterparty_aliases",
   {
     id: serial("id").primaryKey(),
-    key: varchar("key", { length: 60 }).notNull().unique(),
-    displayName: varchar("display_name", { length: 120 }).notNull(),
-    type: counterpartyType("type").notNull().default("unknown"),
-    defaultCategorySlug: varchar("default_category_slug", { length: 60 }).references(
-      () => categories.slug,
-      { onDelete: "set null" },
-    ),
-    notes: text("notes"),
-    hitCount: integer("hit_count").notNull().default(0),
-    lastHitAt: timestamp("last_hit_at", { withTimezone: true }),
+    counterpartyId: integer("counterparty_id")
+      .notNull()
+      .references(() => counterparties.id, { onDelete: "cascade" }),
+    kind: counterpartyKeyKind("kind").notNull(),
+    value: varchar("value", { length: 120 }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (t) => [index("counterparties_key_idx").on(t.key)],
+  (t) => [
+    uniqueIndex("counterparty_aliases_kind_value_unique").on(t.kind, t.value),
+    index("counterparty_aliases_counterparty_idx").on(t.counterpartyId),
+  ],
 );
 
 export const transactions = pgTable(

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -1,11 +1,17 @@
-import { and, asc, desc, eq, ilike, lt, lte, gte, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, ilike, lt, lte, gte, ne, or, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   accounts,
   categories,
   counterparties,
+  counterpartyAliases,
   transactions,
 } from "@/lib/db/schema";
+
+export type CounterpartyAlias = {
+  kind: "qr" | "breb" | "account" | "name";
+  value: string;
+};
 
 export const PAGE_SIZE = 50;
 
@@ -33,11 +39,11 @@ export type TxRow = {
   accountName: string;
   counterparty: {
     id: number;
-    key: string;
     displayName: string;
     type: "person" | "merchant" | "unknown";
     defaultCategorySlug: string | null;
     notes: string | null;
+    aliases: CounterpartyAlias[];
   } | null;
 };
 
@@ -111,11 +117,18 @@ export async function listTransactions(filters: TxFilters): Promise<TxListResult
       accountId: transactions.accountId,
       accountName: accounts.name,
       cpId: counterparties.id,
-      cpKey: counterparties.key,
       cpDisplayName: counterparties.displayName,
       cpType: counterparties.type,
       cpDefaultCategorySlug: counterparties.defaultCategorySlug,
       cpNotes: counterparties.notes,
+      cpAliases: sql<CounterpartyAlias[] | null>`(
+        SELECT COALESCE(
+          json_agg(json_build_object('kind', a.kind, 'value', a.value) ORDER BY a.id),
+          '[]'::json
+        )
+        FROM ${counterpartyAliases} a
+        WHERE a.counterparty_id = ${counterparties.id}
+      )`,
     })
     .from(transactions)
     .innerJoin(accounts, eq(accounts.id, transactions.accountId))
@@ -145,16 +158,55 @@ export async function listTransactions(filters: TxFilters): Promise<TxListResult
     counterparty: r.cpId
       ? {
           id: r.cpId,
-          key: r.cpKey!,
           displayName: r.cpDisplayName!,
           type: r.cpType!,
           defaultCategorySlug: r.cpDefaultCategorySlug,
           notes: r.cpNotes,
+          aliases: r.cpAliases ?? [],
         }
       : null,
   }));
 
   return { rows: shaped, nextCursor };
+}
+
+export type CounterpartyBrief = {
+  id: number;
+  displayName: string;
+  type: "person" | "merchant" | "unknown";
+};
+
+/**
+ * Compact counterparty list for the merge selector in CounterpartyDialog.
+ * Ordered by hit_count DESC so the most-used show first.
+ */
+export async function listCounterparties(): Promise<CounterpartyBrief[]> {
+  return db
+    .select({
+      id: counterparties.id,
+      displayName: counterparties.displayName,
+      type: counterparties.type,
+    })
+    .from(counterparties)
+    .orderBy(desc(counterparties.hitCount), asc(counterparties.displayName));
+}
+
+/**
+ * Same as `listCounterparties` but excludes one id (used when building the
+ * merge target select — a counterparty cannot merge into itself).
+ */
+export async function listCounterpartiesExcept(
+  excludeId: number,
+): Promise<CounterpartyBrief[]> {
+  return db
+    .select({
+      id: counterparties.id,
+      displayName: counterparties.displayName,
+      type: counterparties.type,
+    })
+    .from(counterparties)
+    .where(ne(counterparties.id, excludeId))
+    .orderBy(desc(counterparties.hitCount), asc(counterparties.displayName));
 }
 
 export async function listAccounts() {


### PR DESCRIPTION
Cierra el gap de identidad del counterparty model (#72 / #94). Dilan ya no aparece como 2 filas inconsistentes — ahora es una entidad con 2 aliases (\`name:DILAN DEJANON\` + \`account:91218413213\`) después del merge.

## Summary

### Schema — nueva tabla counterparty_aliases
\`\`\`
counterparty_aliases (id, counterparty_id FK CASCADE, kind, value, UNIQUE(kind, value))
enum counterparty_key_kind: 'qr' | 'breb' | 'account' | 'name'
\`\`\`
Migration drop counterparties.key + backfillea aliases desde la key existente inferiendo kind desde \`raw_data->>'kind'\` de la tx linkeada.

### Ingest — 2 kinds más + lookup por alias
\`resolveCounterparty\` ahora cubre 4 kinds:
- \`qr_payment\` → alias (qr, toKey)
- \`bre_b_transfer\` → alias (breb, toKey)
- \`transfer_sent\` → alias (account, toAccount), displayName = \`Cuenta *{toAccount}\`
- \`transfer_received\` → alias (name, normalizeName(senderName)), displayName = senderName

\`normalizeName\` uppercases + trims + collapsa whitespace → evita dupes por variaciones de Bancolombia.

Lookup es transaccional: SELECT by (kind, value) → si no existe, INSERT counterparty + alias en la misma tx. Rollback limpio si hay race/violación.

### Merge action
Nueva server action \`mergeCounterparty({ sourceId, targetId })\`:
- Mueve aliases del source al target (drop los que colisionen en kind+value)
- Reapunta \`tx.counterparty_id\` de source → target
- Acumula \`hit_count\` del source en el target
- Si target no tiene defaultCategory y source sí → hereda
- Borra el source (CASCADE limpia aliases residuales)
- Emite \`transaction:bulk-updated\` para SSE refresh

UI en el CounterpartyDialog: sección \"Merge into…\" con select de otras counterparties (ordenadas por hit_count DESC). Confirm dialog antes de ejecutar. Toast con count de tx movidas.

### Visual changes
- Aliases visibles en el dialog como tags (QR 0088044474, NOMBRE DILAN DEJANON, etc)
- Display name column en tx table ahora muestra el counterparty.displayName siempre que exista (incluyendo transfer_sent/received que antes no tenían)

## Test plan
- [x] \`bun run test\` — **122/122 pass** (10 nuevos)
  - normalizeName — 4 cases (case, whitespace, idempotencia, acentos)
  - transfer_sent / transfer_received auto-create counterparty con kind correcto
  - mergeCounterparty — 6 cases (move tx+aliases, inherit category, don't override, self-merge rechazado, not-found, hit_count accumulation)
  - Tests de #89/#90 migrados a la API de aliases
- [x] \`bun run lint\` pass
- [x] \`bun run typecheck\` pass
- [x] Migración aplicó clean en findash + findash_test; backfill de 24 aliases verificado
- [x] Replay completo de 405 SMS sobre DB limpia → 69 counterparties (antes: 24). Dilan aparece como 2 entidades separadas esperando merge:
  - \`DILAN DEJANON\` (name) — 11 hits
  - \`Cuenta *91218413213\` (account) — 9 hits

## Screenshots
\`e2e/screenshots/cp-dialog-open.png\` muestra el dialog con aliases section + merge section activa.

## Notas operacionales
- Migración dropea \`counterparties.key\` — forward-only, no rollback limpio. Pre-prod está OK (confirmado con usuario).
- \`backfill-counterparties.ts\` sigue siendo útil para casos donde hay tx con counterparty_id IS NULL (el caller re-parsea raw_data.sms y resuelve). No obsoleto.
- En prod-futuro aplicar con cuidado — el DROP COLUMN es irreversible una vez fuera de dev.

## Out of scope (issues futuras)
- \`provider_payment\`, \`provider_payment_sent\`, \`tc_credit_received\` como counterparties (rules ya cubren)
- Página \`/counterparties\` con listado + filtros de ruido (hit_count > 1, etc)
- Auto-sugerencia de merge por displayName match
- Multiple aliases per ingest kind (ej. múltiples cuentas de Dilan) — se agregan via merge manual hoy

Closes #94
Ref #72