### PR TITLE
fix(ui): suppress hydration warning on locale-formatted date/amount cells (#97)

### DIFF
--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -118,7 +118,10 @@ export function TransactionTable({
             const isExpense = tx.amountCents < BigInt(0);
             return (
               <TableRow key={tx.id}>
-                <TableCell className="text-muted-foreground">
+                <TableCell
+                  className="text-muted-foreground"
+                  suppressHydrationWarning
+                >
                   {formatDate(tx.occurredAt)}
                 </TableCell>
                 <TableCell>
@@ -168,6 +171,7 @@ export function TransactionTable({
                 </TableCell>
                 <TableCell
                   className={`text-right money ${isExpense ? "text-destructive" : "text-emerald-600"}`}
+                  suppressHydrationWarning
                 >
                   {formatAmount(tx.amountCents, tx.currency)}
                 </TableCell>


### PR DESCRIPTION
## Summary
Hydration mismatch en \`/transactions\` al recargar la página (confirmado por usuario — solo pasa en SSR, no en navegación cliente).

**Causa**: \`toLocaleDateString(\"es-CO\", ...)\` y \`Intl.NumberFormat\` producen strings ligeramente distintos en Node's ICU vs Chrome's ICU (p.ej. \`\"16 de abr de 2026\"\` vs \`\"16 abr 2026\"\`, o \`\"-\$ 920\"\` vs \`\"-\$920\"\`). El mensaje de error lo lista textualmente como causa.

**Fix**: \`suppressHydrationWarning\` en las 2 celdas locale-dependientes. Scope mínimo — sólo esas celdas, el resto del subtree sigue validándose normal. React usa el output del servidor en esas celdas y no compara con el cliente, que es el patrón textualmente recomendado por React para este caso.

## Test plan
- [x] typecheck + lint + 122/122 tests pasan
- [ ] User verifica recarga en \`/transactions\` — mismatch desaparece

Si el error persiste post-merge, hay OTRO mismatch en un subtree distinto; el component stack del overlay debería señalarlo.

Closes #97