### PR TITLE
feat(ui): mobile-friendly transactions page (#95)

### DIFF
--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -14,7 +14,8 @@ const modes = ["light", "dark"] as const;
 
 for (const mode of modes) {
   for (const p of pages) {
-    test(`screenshot: ${mode} ${p.name}`, async ({ page }) => {
+    test(`screenshot: ${mode} ${p.name}`, async ({ page }, testInfo) => {
+      const projectName = testInfo.project.name;
       await page.addInitScript((m) => {
         window.localStorage.setItem("theme", m);
       }, mode);
@@ -27,7 +28,10 @@ for (const mode of modes) {
         await page.waitForTimeout(1_800);
       }
       await page.screenshot({
-        path: path.join("e2e/screenshots", `${mode}-${p.name}.png`),
+        path: path.join(
+          "e2e/screenshots",
+          `${projectName}-${mode}-${p.name}.png`,
+        ),
         fullPage: true,
       });
     });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,11 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "mobile",
+      use: { ...devices["Pixel 5"] },
+      testMatch: /screenshots\.spec\.ts/,
+    },
   ],
   webServer: {
     command: "bun run dev",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -156,6 +156,16 @@
   font-family: var(--font-numeric);
   @apply text-3xl font-semibold tabular-nums tracking-tight;
 }
+@utility chevron-select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-left: 0.75rem;
+  padding-right: 2rem;
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 0.75rem;
+  background-image: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%23888' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m3 4.5 3 3 3-3'/%3E%3C/svg%3E");
+}
 
 .tabular-nums {
   font-family: var(--font-numeric);

--- a/src/app/transactions/loading.tsx
+++ b/src/app/transactions/loading.tsx
@@ -2,8 +2,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function TransactionsLoading() {
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-col gap-4 p-6">
-      <header className="flex items-end justify-between gap-3">
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-4 p-4 sm:p-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div className="flex flex-col gap-2">
           <Skeleton className="h-8 w-48" />
           <Skeleton className="h-4 w-64" />
@@ -17,7 +17,7 @@ export default function TransactionsLoading() {
         ))}
       </div>
 
-      <div className="overflow-hidden rounded-md border bg-card">
+      <div className="hidden overflow-hidden rounded-md border bg-card md:block">
         <div className="border-b px-4 py-3">
           <Skeleton className="h-4 w-full max-w-3xl" />
         </div>
@@ -39,6 +39,22 @@ export default function TransactionsLoading() {
             </div>
           ))}
         </div>
+      </div>
+
+      <div className="flex flex-col gap-2 md:hidden">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex flex-col gap-2 rounded-md border bg-card p-3"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+            <Skeleton className="h-3 w-56" />
+            <Skeleton className="h-8 w-full" />
+          </div>
+        ))}
       </div>
     </main>
   );

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -82,8 +82,8 @@ export default async function TransactionsPage({
   };
 
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-col gap-4 p-6">
-      <header className="flex items-end justify-between gap-3">
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-4 p-4 sm:p-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-h1">Transactions</h1>
           <p className="text-body text-muted-foreground">

--- a/src/components/import/screenshot-upload.tsx
+++ b/src/components/import/screenshot-upload.tsx
@@ -210,7 +210,7 @@ export function ScreenshotUpload({ accounts }: { accounts: AccountOption[] }) {
               id="ocr-account"
               value={accountId}
               onChange={(e) => setAccountId(e.target.value)}
-              className="h-9 rounded-md border bg-background px-2 text-sm"
+              className="h-9 rounded-md border bg-background text-sm chevron-select"
               required
             >
               {accounts.map((a) => (

--- a/src/components/transactions/category-cell.tsx
+++ b/src/components/transactions/category-cell.tsx
@@ -36,7 +36,7 @@ export function CategoryCell({
           }
         });
       }}
-      className="h-8 w-full rounded-md border bg-background px-2 text-sm disabled:opacity-50"
+      className="h-8 w-full rounded-md border bg-background text-sm disabled:opacity-50 chevron-select"
     >
       <option value="">— unclassified —</option>
       {options.map((c) => (

--- a/src/components/transactions/counterparty-dialog.tsx
+++ b/src/components/transactions/counterparty-dialog.tsx
@@ -252,7 +252,7 @@ export function CounterpartyDialog({
               id="cp-cat"
               value={defaultCategorySlug}
               onChange={(e) => setDefaultCategorySlug(e.target.value)}
-              className="h-9 rounded-md border bg-background px-2 text-sm"
+              className="h-9 rounded-md border bg-background text-sm chevron-select"
             >
               <option value="">— none —</option>
               {categories.map((c) => (
@@ -301,7 +301,7 @@ export function CounterpartyDialog({
                 id="cp-merge"
                 value={mergeTargetId}
                 onChange={(e) => setMergeTargetId(e.target.value)}
-                className="h-9 flex-1 rounded-md border bg-background px-2 text-sm"
+                className="h-9 flex-1 rounded-md border bg-background text-sm chevron-select"
                 disabled={pending}
               >
                 <option value="">— pick target —</option>

--- a/src/components/transactions/filters.tsx
+++ b/src/components/transactions/filters.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import { ChevronDownIcon, SlidersHorizontalIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -16,80 +18,104 @@ export type FiltersProps = {
 };
 
 export function Filters({ accounts, categories, values }: FiltersProps) {
-  const hasAny =
-    values.from || values.to || values.accountId || values.categorySlug || values.q;
+  const activeCount = [
+    values.from,
+    values.to,
+    values.accountId,
+    values.categorySlug,
+    values.q,
+  ].filter((v) => Boolean(v && v.length > 0)).length;
+  const hasAny = activeCount > 0;
 
   return (
-    <form
-      method="GET"
-      action="/transactions"
-      className="grid grid-cols-1 gap-3 rounded-md border bg-card p-4 sm:grid-cols-2 lg:grid-cols-6"
+    <details
+      open={hasAny}
+      className="group rounded-md border bg-card"
     >
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="q">Search</Label>
-        <Input
-          id="q"
-          name="q"
-          type="search"
-          placeholder="merchant, description…"
-          defaultValue={values.q ?? ""}
-        />
-      </div>
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 [&::-webkit-details-marker]:hidden">
+        <div className="flex items-center gap-2">
+          <SlidersHorizontalIcon className="size-4 text-muted-foreground" />
+          <span className="font-medium">Filters</span>
+          {hasAny ? (
+            <Badge variant="secondary" className="font-normal">
+              {activeCount} active
+            </Badge>
+          ) : null}
+        </div>
+        <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-open:rotate-180" />
+      </summary>
 
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="from">From</Label>
-        <Input id="from" name="from" type="date" defaultValue={values.from ?? ""} />
-      </div>
+      <form
+        method="GET"
+        action="/transactions"
+        className="grid grid-cols-1 gap-3 border-t p-4 sm:grid-cols-2 lg:grid-cols-6"
+      >
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="q">Search</Label>
+          <Input
+            id="q"
+            name="q"
+            type="search"
+            placeholder="merchant, description…"
+            defaultValue={values.q ?? ""}
+          />
+        </div>
 
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="to">To</Label>
-        <Input id="to" name="to" type="date" defaultValue={values.to ?? ""} />
-      </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="from">From</Label>
+          <Input id="from" name="from" type="date" defaultValue={values.from ?? ""} />
+        </div>
 
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="accountId">Account</Label>
-        <select
-          id="accountId"
-          name="accountId"
-          defaultValue={values.accountId ?? ""}
-          className="h-9 rounded-md border bg-background px-2 text-sm"
-        >
-          <option value="">All</option>
-          {accounts.map((a) => (
-            <option key={a.id} value={a.id}>
-              {a.name}
-            </option>
-          ))}
-        </select>
-      </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="to">To</Label>
+          <Input id="to" name="to" type="date" defaultValue={values.to ?? ""} />
+        </div>
 
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="categorySlug">Category</Label>
-        <select
-          id="categorySlug"
-          name="categorySlug"
-          defaultValue={values.categorySlug ?? ""}
-          className="h-9 rounded-md border bg-background px-2 text-sm"
-        >
-          <option value="">All</option>
-          {categories.map((c) => (
-            <option key={c.slug} value={c.slug}>
-              {c.parentSlug ? `↳ ${c.name}` : c.name}
-            </option>
-          ))}
-        </select>
-      </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="accountId">Account</Label>
+          <select
+            id="accountId"
+            name="accountId"
+            defaultValue={values.accountId ?? ""}
+            className="h-9 rounded-md border bg-background px-2 text-sm"
+          >
+            <option value="">All</option>
+            {accounts.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+        </div>
 
-      <div className="flex items-end gap-2">
-        <Button type="submit" className="flex-1">
-          Apply
-        </Button>
-        {hasAny ? (
-          <Button asChild type="button" variant="outline">
-            <Link href="/transactions">Reset</Link>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="categorySlug">Category</Label>
+          <select
+            id="categorySlug"
+            name="categorySlug"
+            defaultValue={values.categorySlug ?? ""}
+            className="h-9 rounded-md border bg-background px-2 text-sm"
+          >
+            <option value="">All</option>
+            {categories.map((c) => (
+              <option key={c.slug} value={c.slug}>
+                {c.parentSlug ? `↳ ${c.name}` : c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex items-end gap-2">
+          <Button type="submit" className="flex-1">
+            Apply
           </Button>
-        ) : null}
-      </div>
-    </form>
+          {hasAny ? (
+            <Button asChild type="button" variant="outline">
+              <Link href="/transactions">Reset</Link>
+            </Button>
+          ) : null}
+        </div>
+      </form>
+    </details>
   );
 }

--- a/src/components/transactions/filters.tsx
+++ b/src/components/transactions/filters.tsx
@@ -77,7 +77,7 @@ export function Filters({ accounts, categories, values }: FiltersProps) {
             id="accountId"
             name="accountId"
             defaultValue={values.accountId ?? ""}
-            className="h-9 rounded-md border bg-background px-2 text-sm"
+            className="h-9 rounded-md border bg-background text-sm chevron-select"
           >
             <option value="">All</option>
             {accounts.map((a) => (
@@ -94,7 +94,7 @@ export function Filters({ accounts, categories, values }: FiltersProps) {
             id="categorySlug"
             name="categorySlug"
             defaultValue={values.categorySlug ?? ""}
-            className="h-9 rounded-md border bg-background px-2 text-sm"
+            className="h-9 rounded-md border bg-background text-sm chevron-select"
           >
             <option value="">All</option>
             {categories.map((c) => (

--- a/src/components/transactions/quick-expense-dialog.tsx
+++ b/src/components/transactions/quick-expense-dialog.tsx
@@ -99,11 +99,11 @@ export function QuickExpenseDialog({
       <DialogTrigger asChild>
         <Button
           size="lg"
-          className="fixed bottom-6 right-6 z-30 h-14 rounded-full shadow-lg"
+          className="fixed bottom-6 right-6 z-30 h-14 w-14 rounded-full p-0 shadow-lg sm:w-auto sm:px-6"
           aria-label="Add expense"
         >
           <PlusIcon className="size-5" />
-          <span className="ml-1">Expense</span>
+          <span className="ml-1 hidden sm:inline">Expense</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-md">

--- a/src/components/transactions/quick-expense-dialog.tsx
+++ b/src/components/transactions/quick-expense-dialog.tsx
@@ -164,7 +164,7 @@ export function QuickExpenseDialog({
               id="qe-account"
               value={accountId}
               onChange={(e) => setAccountId(e.target.value)}
-              className="h-9 rounded-md border bg-background px-2 text-sm"
+              className="h-9 rounded-md border bg-background text-sm chevron-select"
               required
             >
               {accounts.map((a) => (
@@ -181,7 +181,7 @@ export function QuickExpenseDialog({
               id="qe-cat"
               value={categorySlug}
               onChange={(e) => setCategorySlug(e.target.value)}
-              className="h-9 rounded-md border bg-background px-2 text-sm"
+              className="h-9 rounded-md border bg-background text-sm chevron-select"
             >
               <option value="">— unclassified —</option>
               {categories.map((c) => (

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -78,6 +78,19 @@ function formatDate(d: Date) {
   });
 }
 
+function primaryDescription(tx: TxRow): string {
+  return (
+    tx.counterparty?.displayName ??
+    tx.merchant ??
+    tx.descriptionClean ??
+    tx.descriptionRaw
+  );
+}
+
+function hasSecondaryDescription(tx: TxRow): boolean {
+  return Boolean(tx.counterparty || tx.merchant || tx.descriptionClean);
+}
+
 export function TransactionTable({
   rows,
   categories,
@@ -100,37 +113,97 @@ export function TransactionTable({
   }
 
   return (
-    <div className="rounded-md border bg-card">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-[110px]">Date</TableHead>
-            <TableHead>Description</TableHead>
-            <TableHead className="w-[150px]">Account</TableHead>
-            <TableHead className="w-[200px]">Category</TableHead>
-            <TableHead className="w-[110px]">Source</TableHead>
-            <TableHead className="w-[110px]">Method</TableHead>
-            <TableHead className="w-[140px] text-right">Amount</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {rows.map((tx) => {
-            const isExpense = tx.amountCents < BigInt(0);
-            return (
-              <TableRow key={tx.id}>
-                <TableCell
-                  className="text-muted-foreground"
-                  suppressHydrationWarning
-                >
-                  {formatDate(tx.occurredAt)}
-                </TableCell>
-                <TableCell>
+    <>
+      <div className="hidden rounded-md border bg-card md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[110px]">Date</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead className="w-[150px]">Account</TableHead>
+              <TableHead className="w-[200px]">Category</TableHead>
+              <TableHead className="w-[110px]">Source</TableHead>
+              <TableHead className="w-[110px]">Method</TableHead>
+              <TableHead className="w-[140px] text-right">Amount</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((tx) => {
+              const isExpense = tx.amountCents < BigInt(0);
+              return (
+                <TableRow key={tx.id}>
+                  <TableCell
+                    className="text-muted-foreground"
+                    suppressHydrationWarning
+                  >
+                    {formatDate(tx.occurredAt)}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1.5">
+                      <span className="font-medium">
+                        {primaryDescription(tx)}
+                      </span>
+                      {tx.counterparty ? (
+                        <CounterpartyTypeBadge type={tx.counterparty.type} />
+                      ) : null}
+                      {tx.counterparty ? (
+                        <CounterpartyDialog
+                          counterparty={tx.counterparty}
+                          categories={categories}
+                          allCounterparties={allCounterparties}
+                        />
+                      ) : null}
+                    </div>
+                    {hasSecondaryDescription(tx) ? (
+                      <div className="text-xs text-muted-foreground line-clamp-1">
+                        {tx.descriptionRaw}
+                      </div>
+                    ) : null}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {tx.accountName}
+                  </TableCell>
+                  <TableCell>
+                    <CategoryCell
+                      txId={tx.id}
+                      value={tx.categorySlug}
+                      options={categories}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline">{sourceLabel[tx.source]}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={methodVariant[tx.classificationMethod]}>
+                      {tx.classificationMethod}
+                    </Badge>
+                  </TableCell>
+                  <TableCell
+                    className={`text-right money ${isExpense ? "text-destructive" : "text-emerald-600"}`}
+                    suppressHydrationWarning
+                  >
+                    {formatAmount(tx.amountCents, tx.currency)}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      <ul className="flex flex-col gap-2 md:hidden">
+        {rows.map((tx) => {
+          const isExpense = tx.amountCents < BigInt(0);
+          return (
+            <li
+              key={tx.id}
+              className="flex flex-col gap-2 rounded-md border bg-card p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-1.5">
-                    <span className="font-medium">
-                      {tx.counterparty?.displayName ??
-                        tx.merchant ??
-                        tx.descriptionClean ??
-                        tx.descriptionRaw}
+                    <span className="truncate font-medium">
+                      {primaryDescription(tx)}
                     </span>
                     {tx.counterparty ? (
                       <CounterpartyTypeBadge type={tx.counterparty.type} />
@@ -143,43 +216,47 @@ export function TransactionTable({
                       />
                     ) : null}
                   </div>
-                  {tx.counterparty ||
-                  tx.merchant ||
-                  tx.descriptionClean ? (
-                    <div className="text-xs text-muted-foreground line-clamp-1">
+                  {hasSecondaryDescription(tx) ? (
+                    <p className="line-clamp-1 text-xs text-muted-foreground">
                       {tx.descriptionRaw}
-                    </div>
+                    </p>
                   ) : null}
-                </TableCell>
-                <TableCell className="text-sm text-muted-foreground">
-                  {tx.accountName}
-                </TableCell>
-                <TableCell>
-                  <CategoryCell
-                    txId={tx.id}
-                    value={tx.categorySlug}
-                    options={categories}
-                  />
-                </TableCell>
-                <TableCell>
-                  <Badge variant="outline">{sourceLabel[tx.source]}</Badge>
-                </TableCell>
-                <TableCell>
-                  <Badge variant={methodVariant[tx.classificationMethod]}>
-                    {tx.classificationMethod}
-                  </Badge>
-                </TableCell>
-                <TableCell
-                  className={`text-right money ${isExpense ? "text-destructive" : "text-emerald-600"}`}
+                </div>
+                <span
+                  className={`money shrink-0 text-right text-sm font-semibold ${
+                    isExpense ? "text-destructive" : "text-emerald-600"
+                  }`}
                   suppressHydrationWarning
                 >
                   {formatAmount(tx.amountCents, tx.currency)}
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+                </span>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                <span suppressHydrationWarning>{formatDate(tx.occurredAt)}</span>
+                <span aria-hidden="true">·</span>
+                <span className="truncate">{tx.accountName}</span>
+                <span aria-hidden="true">·</span>
+                <Badge variant="outline" className="font-normal">
+                  {sourceLabel[tx.source]}
+                </Badge>
+                <Badge
+                  variant={methodVariant[tx.classificationMethod]}
+                  className="font-normal"
+                >
+                  {tx.classificationMethod}
+                </Badge>
+              </div>
+
+              <CategoryCell
+                txId={tx.id}
+                value={tx.categorySlug}
+                options={categories}
+              />
+            </li>
+          );
+        })}
+      </ul>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Dual layout in `TransactionTable`: full `<Table>` on `md+`, stacked card list on `<md`. Same data, same interactive cells (CategoryCell, CounterpartyDialog), CSS-only switch.
- Page header + loading skeleton now stack vertically on mobile.
- `Filters` is now collapsible (`<details>`) on ALL viewports — collapsed by default, auto-opens when any filter is active, shows an "N active" badge.
- Quick expense FAB: circular icon-only button on mobile (`w-14 rounded-full`), pill with "Expense" label from `sm+`.
- Playwright: added a second project (`mobile`, Pixel 5 / chromium), scoped to `screenshots.spec.ts`. Screenshots are now prefixed by project name so desktop + mobile output can coexist.

## Why

The `/transactions` page rendered a 7-column table (fixed width ~820px) with no overflow container, making the page unusable at 375–414px. See #95 for details.

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes
- [x] `bun run test:e2e` — 26/26 passing (chromium + mobile Pixel 5, light + dark, all pages)
- [x] Manual verification via Playwright screenshots at 390×851 (mobile) and 1280×720 (desktop)
- [x] Verified no horizontal overflow on mobile at `/transactions`
- [x] Verified desktop layout unchanged
- [x] Verified filters `<details>` auto-opens when search params contain active filters
- [x] Verified other pages (home, accounts, budgets, insights, settings) do not overflow on mobile

## Screenshots

Generated by `bun run test:e2e`. Landed under `e2e/screenshots/`:

- `mobile-light-transactions.png` — card layout, collapsed filters, circular FAB
- `chromium-light-transactions.png` — table layout, collapsed filters, pill FAB
- `mobile-dark-transactions.png`, `chromium-dark-transactions.png` — dark mode

Closes #95