### PR TITLE
feat(fx): fetch live USD→COP rate from TRM + cache + show asOf (#65)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Generá UNA VEZ: openssl rand -hex 32
 # Pegá el MISMO valor en .env.local y en el header Authorization del Shortcut.
 INGEST_WEBHOOK_TOKEN=replace-with-output-of-openssl-rand-hex-32
+
+# FX refresh token — protege POST /api/fx/refresh (cron externo)
+# Generá con: openssl rand -hex 32
+FX_REFRESH_TOKEN=replace-with-output-of-openssl-rand-hex-32

--- a/drizzle/0005_kind_arachne.sql
+++ b/drizzle/0005_kind_arachne.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "fx_rates" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"base" varchar(3) NOT NULL,
+	"quote" varchar(3) NOT NULL,
+	"rate_micros" bigint NOT NULL,
+	"as_of" date NOT NULL,
+	"fetched_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"source" varchar(40) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "fx_rates_pair_asof_unique" ON "fx_rates" USING btree ("base","quote","as_of");--> statement-breakpoint
+CREATE INDEX "fx_rates_pair_fetched_idx" ON "fx_rates" USING btree ("base","quote","fetched_at");

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1299 @@
+{
+  "id": "fbe8f167-2714-4410-9140-a2ca70f9e166",
+  "prevId": "b04a2b57-b78e-4d47-9b20-ce660e607279",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_category_slug_categories_slug_fk": {
+          "name": "budgets_category_slug_categories_slug_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_priority_idx": {
+          "name": "rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_category_slug_categories_slug_fk": {
+          "name": "classification_rules_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "counterparties_default_category_slug_categories_slug_fk": {
+          "name": "counterparties_default_category_slug_categories_slug_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_kind_value_unique": {
+          "name": "counterparty_aliases_kind_value_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "insights_reports_year_month_unique": {
+          "name": "insights_reports_year_month_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year_month"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_category_slug_categories_slug_fk": {
+          "name": "recurring_transactions_category_slug_categories_slug_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_category_idx": {
+          "name": "transactions_category_idx",
+          "columns": [
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_counterparty_idx": {
+          "name": "transactions_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_occurred_idx": {
+          "name": "transactions_occurred_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_category_slug_categories_slug_fk": {
+          "name": "transactions_category_slug_categories_slug_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "ai",
+        "manual",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776370482638,
       "tag": "0004_nifty_trish_tilby",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776389894514,
+      "tag": "0005_kind_arachne",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -14,8 +14,14 @@ import {
 import { EmptyState } from "@/components/ui/empty-state";
 import { getNetWorth } from "@/lib/dashboard/queries";
 import { listAccountsDetailed, type AccountDetail } from "@/lib/accounts/queries";
-import { COP_PER_USD, formatCop, formatMoney } from "@/lib/money";
+import { getCurrentFxRate } from "@/lib/fx/repo";
+import { toCop, formatCop, formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
+
+const RATE_FMT = new Intl.NumberFormat("es-CO", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
 
 export const dynamic = "force-dynamic";
 
@@ -27,19 +33,20 @@ const TYPE_LABEL: Record<AccountDetail["type"], string> = {
 
 const TYPE_ORDER: AccountDetail["type"][] = ["savings", "credit_card", "loan"];
 
-function sumBalanceCopCents(list: AccountDetail[]): bigint {
+function sumBalanceCopCents(list: AccountDetail[], copPerUsd: number): bigint {
   let cop = BigInt(0);
   let usd = BigInt(0);
   for (const a of list) {
     if (a.currency === "USD") usd += a.balanceCents;
     else cop += a.balanceCents;
   }
-  return cop + usd * BigInt(COP_PER_USD);
+  return cop + toCop(usd, "USD", copPerUsd);
 }
 
 export default async function AccountsPage() {
+  const fx = await getCurrentFxRate();
   const [netWorth, all] = await Promise.all([
-    getNetWorth(),
+    getNetWorth(fx.rate),
     listAccountsDetailed(),
   ]);
 
@@ -57,7 +64,8 @@ export default async function AccountsPage() {
         <h1 className="text-h1">Accounts</h1>
         <p className="text-body text-muted-foreground">
           Saldos por cuenta agrupados por tipo. El patrimonio neto convierte USD
-          a COP a {COP_PER_USD.toLocaleString("es-CO")} COP/USD.
+          a COP a {RATE_FMT.format(fx.rate)} COP/USD
+          {fx.source === "fallback" ? " (fallback)" : ` (TRM ${fx.asOf})`}.
         </p>
       </header>
 
@@ -78,7 +86,7 @@ export default async function AccountsPage() {
       ) : null}
 
       {grouped.map(({ type, items }) => (
-        <AccountTypeSection key={type} type={type} items={items} />
+        <AccountTypeSection key={type} type={type} items={items} copPerUsd={fx.rate} />
       ))}
 
       {inactive.length > 0 ? (
@@ -126,16 +134,18 @@ function SummaryCard({
 function AccountTypeSection({
   type,
   items,
+  copPerUsd,
 }: {
   type: AccountDetail["type"];
   items: AccountDetail[];
+  copPerUsd: number;
 }) {
   const Icon = type === "credit_card"
     ? CreditCardIcon
     : type === "loan"
       ? LandmarkIcon
       : PiggyBankIcon;
-  const subtotal = sumBalanceCopCents(items);
+  const subtotal = sumBalanceCopCents(items, copPerUsd);
 
   return (
     <section className="flex flex-col gap-3">

--- a/src/app/api/fx/refresh/route.ts
+++ b/src/app/api/fx/refresh/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { fetchTrm } from "@/lib/fx/trm";
+import { upsertFxRate, getCurrentFxRate } from "@/lib/fx/repo";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  const expectedToken = process.env.FX_REFRESH_TOKEN;
+  if (!expectedToken) {
+    return NextResponse.json(
+      { error: "FX_REFRESH_TOKEN not configured" },
+      { status: 503 },
+    );
+  }
+
+  const authHeader = req.headers.get("authorization") ?? "";
+  const providedToken = authHeader.replace(/^Bearer\s+/i, "").trim();
+  if (!providedToken || providedToken !== expectedToken) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const trm = await fetchTrm();
+    await upsertFxRate({
+      base: "USD",
+      quote: "COP",
+      rate: trm.rate,
+      asOf: trm.asOf,
+      source: trm.source,
+    });
+    return NextResponse.json({
+      ok: true,
+      rate: trm.rate,
+      asOf: trm.asOf,
+      source: trm.source,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const current = await getCurrentFxRate().catch(() => null);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+        lastKnown: current,
+      },
+      { status: 502 },
+    );
+  }
+}
+
+export async function GET() {
+  const current = await getCurrentFxRate();
+  return NextResponse.json(current);
+}

--- a/src/app/insights/actions.ts
+++ b/src/app/insights/actions.ts
@@ -10,12 +10,14 @@ import {
   generateInsightsReport,
   hashSummary,
 } from "@/lib/ai/insights";
+import { getCurrentFxRate } from "@/lib/fx/repo";
 
 const ymSchema = z.string().regex(/^\d{4}-\d{2}$/);
 
 export async function generateInsight(ym: string) {
   const parsed = ymSchema.parse(ym);
-  const summary = await buildInsightsSummary(parsed);
+  const fx = await getCurrentFxRate();
+  const summary = await buildInsightsSummary(parsed, fx.rate);
   const inputHash = hashSummary(summary);
   const result = await generateInsightsReport({ summary });
 

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { insightsReports } from "@/lib/db/schema";
 import { buildInsightsSummary, hashSummary, isStale } from "@/lib/ai/insights";
+import { getCurrentFxRate } from "@/lib/fx/repo";
 import { InsightsViewer } from "./insights-viewer";
 
 export const dynamic = "force-dynamic";
@@ -21,7 +22,8 @@ export default async function InsightsPage({
     ? params.ym
     : currentYearMonth();
 
-  const summary = await buildInsightsSummary(ym);
+  const fx = await getCurrentFxRate();
+  const summary = await buildInsightsSummary(ym, fx.rate);
   const currentHash = hashSummary(summary);
 
   const [existing] = await db

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import { TopExpensesCard } from "@/components/dashboard/top-expenses-card";
 import { AccountsGrid } from "@/components/dashboard/accounts-grid";
 import { UpcomingCard } from "@/components/dashboard/upcoming-card";
 import { getUpcomingForMonth } from "@/lib/recurring/upcoming";
+import { getCurrentFxRate } from "@/lib/fx/repo";
 
 export const dynamic = "force-dynamic";
 
@@ -21,11 +22,12 @@ export default async function DashboardPage() {
   const now = new Date();
   const monthLabel = monthFmt.format(now);
 
+  const fx = await getCurrentFxRate();
   const [netWorth, flow, slices, top, accounts, upcoming] = await Promise.all([
-    getNetWorth(),
-    getMonthlyFlow(now),
-    getCategoryBreakdown(now),
-    getTopExpenses(now, 5),
+    getNetWorth(fx.rate),
+    getMonthlyFlow(fx.rate, now),
+    getCategoryBreakdown(fx.rate, now),
+    getTopExpenses(fx.rate, now, 5),
     getAccountStatuses(),
     getUpcomingForMonth({
       year: now.getFullYear(),
@@ -55,7 +57,7 @@ export default async function DashboardPage() {
       </header>
 
       <section className="grid grid-cols-1 gap-4 lg:grid-cols-4">
-        <NetWorthCard data={netWorth} />
+        <NetWorthCard data={netWorth} fx={fx} />
         <MonthlyFlowCard data={flow} monthLabel={monthLabel} />
         <CategoryDonut slices={donutSlices} monthLabel={monthLabel} />
       </section>

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -1,8 +1,30 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { COP_PER_USD, formatCop, formatMoney } from "@/lib/money";
+import { formatCop, formatMoney } from "@/lib/money";
 import type { NetWorth } from "@/lib/dashboard/queries";
+import type { FxRate } from "@/lib/fx/repo";
 
-export function NetWorthCard({ data }: { data: NetWorth }) {
+const SHORT_DATE = new Intl.DateTimeFormat("es-CO", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+});
+
+const RATE_FMT = new Intl.NumberFormat("es-CO", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatFxAsOf(asOf: string): string {
+  const [y, m, d] = asOf.split("-").map(Number);
+  if (!y || !m || !d) return asOf;
+  return SHORT_DATE.format(new Date(Date.UTC(y, m - 1, d)));
+}
+
+export function NetWorthCard({ data, fx }: { data: NetWorth; fx: FxRate }) {
+  const label = fx.source === "fallback"
+    ? `@ ${RATE_FMT.format(fx.rate)} COP/USD · fallback`
+    : `@ ${RATE_FMT.format(fx.rate)} COP/USD · TRM ${formatFxAsOf(fx.asOf)}`;
+
   return (
     <Card>
       <CardHeader>
@@ -19,7 +41,7 @@ export function NetWorthCard({ data }: { data: NetWorth }) {
           <span>
             USD {formatMoney(data.usdCents, "USD")}
           </span>
-          <span className="opacity-60">@ {COP_PER_USD.toLocaleString("es-CO")} COP/USD</span>
+          <span className="opacity-60">{label}</span>
         </div>
       </CardContent>
     </Card>

--- a/src/lib/ai/insights.ts
+++ b/src/lib/ai/insights.ts
@@ -63,15 +63,14 @@ function monthBounds(ym: string) {
   };
 }
 
-const COP_PER_USD_FX = 4000;
-
-function toCopNumber(cents: bigint, currency: "COP" | "USD"): number {
+function toCopNumber(cents: bigint, currency: "COP" | "USD", copPerUsd: number): number {
   const pesos = Number(cents) / 100;
-  return currency === "USD" ? pesos * COP_PER_USD_FX : pesos;
+  return currency === "USD" ? pesos * copPerUsd : pesos;
 }
 
 export async function buildInsightsSummary(
   ym: string,
+  copPerUsd: number,
   db: DB = defaultDb,
 ): Promise<InsightsSummary> {
   const prevYm = shiftMonth(ym, -1);
@@ -172,19 +171,19 @@ export async function buildInsightsSummary(
 
   const totals = { incomeCop: 0, expenseCop: 0, previousIncomeCop: 0, previousExpenseCop: 0 };
   for (const r of curTxTotals) {
-    totals.incomeCop += toCopNumber(BigInt(r.income), r.currency);
-    totals.expenseCop += toCopNumber(BigInt(r.expense), r.currency);
+    totals.incomeCop += toCopNumber(BigInt(r.income), r.currency, copPerUsd);
+    totals.expenseCop += toCopNumber(BigInt(r.expense), r.currency, copPerUsd);
   }
   for (const r of prevTxTotals) {
-    totals.previousIncomeCop += toCopNumber(BigInt(r.income), r.currency);
-    totals.previousExpenseCop += toCopNumber(BigInt(r.expense), r.currency);
+    totals.previousIncomeCop += toCopNumber(BigInt(r.income), r.currency, copPerUsd);
+    totals.previousExpenseCop += toCopNumber(BigInt(r.expense), r.currency, copPerUsd);
   }
 
   const catMap = new Map<string, { slug: string; name: string; spentCop: number; txCount: number }>();
   for (const r of curCats) {
     if (!r.slug) continue;
     const key = r.slug;
-    const cop = toCopNumber(BigInt(r.spent), r.currency);
+    const cop = toCopNumber(BigInt(r.spent), r.currency, copPerUsd);
     const existing = catMap.get(key);
     if (existing) {
       existing.spentCop += cop;
@@ -198,14 +197,14 @@ export async function buildInsightsSummary(
   const prevCatMap = new Map<string, number>();
   for (const r of prevCats) {
     if (!r.slug) continue;
-    prevCatMap.set(r.slug, (prevCatMap.get(r.slug) ?? 0) + toCopNumber(BigInt(r.spent), r.currency));
+    prevCatMap.set(r.slug, (prevCatMap.get(r.slug) ?? 0) + toCopNumber(BigInt(r.spent), r.currency, copPerUsd));
   }
   const categoriesPrevious = [...prevCatMap.entries()].map(([slug, spentCop]) => ({ slug, spentCop }));
 
   const merMap = new Map<string, { merchant: string; spentCop: number; txCount: number }>();
   for (const r of topMer) {
     if (!r.merchant) continue;
-    const cop = toCopNumber(BigInt(r.spent), r.currency);
+    const cop = toCopNumber(BigInt(r.spent), r.currency, copPerUsd);
     const existing = merMap.get(r.merchant);
     if (existing) {
       existing.spentCop += cop;
@@ -217,7 +216,7 @@ export async function buildInsightsSummary(
   const topMerchants = [...merMap.values()].sort((a, b) => b.spentCop - a.spentCop).slice(0, 10);
 
   const budgetsOut = budgetRows.map((b) => {
-    const amountCop = toCopNumber(b.amountCents, b.currency);
+    const amountCop = toCopNumber(b.amountCents, b.currency, copPerUsd);
     const spentCop = catMap.get(b.categorySlug)?.spentCop ?? 0;
     return {
       category: b.categorySlug,
@@ -230,7 +229,7 @@ export async function buildInsightsSummary(
   const recurringOut = recRows.map((r) => ({
     label: r.label,
     dayOfMonth: r.dayOfMonth,
-    amountCop: toCopNumber(r.amountCents, r.currency),
+    amountCop: toCopNumber(r.amountCents, r.currency, copPerUsd),
     categorySlug: r.categorySlug,
   }));
 
@@ -239,7 +238,7 @@ export async function buildInsightsSummary(
     institution: a.institution,
     type: a.type,
     currency: a.currency,
-    balanceCop: toCopNumber(a.balanceCents, a.currency),
+    balanceCop: toCopNumber(a.balanceCents, a.currency, copPerUsd),
   }));
 
   return {

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gte, lt, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, categories, transactions } from "@/lib/db/schema";
-import { COP_PER_USD, toCop } from "@/lib/money";
+import { toCop } from "@/lib/money";
 
 export function currentMonthRange(now = new Date()): { start: Date; end: Date } {
   const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
@@ -39,16 +39,15 @@ export type NetWorth = {
   usdCents: bigint;
 };
 
-export async function getNetWorth(): Promise<NetWorth> {
+export async function getNetWorth(copPerUsd: number): Promise<NetWorth> {
   const list = await getAccountStatuses();
   let copCents = BigInt(0);
   let usdCents = BigInt(0);
   for (const a of list) {
-    // savings positive, credit_card / loan typically negative balance.
     if (a.currency === "USD") usdCents += a.balanceCents;
     else copCents += a.balanceCents;
   }
-  const totalCopCents = copCents + usdCents * BigInt(COP_PER_USD);
+  const totalCopCents = copCents + toCop(usdCents, "USD", copPerUsd);
   return { totalCopCents, copCents, usdCents };
 }
 
@@ -58,7 +57,10 @@ export type MonthlyFlow = {
   netCopCents: bigint;
 };
 
-export async function getMonthlyFlow(now = new Date()): Promise<MonthlyFlow> {
+export async function getMonthlyFlow(
+  copPerUsd: number,
+  now = new Date(),
+): Promise<MonthlyFlow> {
   const { start, end } = currentMonthRange(now);
 
   const rows = await db
@@ -74,8 +76,8 @@ export async function getMonthlyFlow(now = new Date()): Promise<MonthlyFlow> {
   let incomeCopCents = BigInt(0);
   let expenseCopCents = BigInt(0);
   for (const r of rows) {
-    incomeCopCents += toCop(BigInt(r.incomeCents), r.currency);
-    expenseCopCents += toCop(BigInt(r.expenseCents), r.currency);
+    incomeCopCents += toCop(BigInt(r.incomeCents), r.currency, copPerUsd);
+    expenseCopCents += toCop(BigInt(r.expenseCents), r.currency, copPerUsd);
   }
   return {
     incomeCopCents,
@@ -91,7 +93,10 @@ export type CategorySlice = {
   amountCopCents: bigint;
 };
 
-export async function getCategoryBreakdown(now = new Date()): Promise<CategorySlice[]> {
+export async function getCategoryBreakdown(
+  copPerUsd: number,
+  now = new Date(),
+): Promise<CategorySlice[]> {
   const { start, end } = currentMonthRange(now);
 
   const rows = await db
@@ -117,7 +122,7 @@ export async function getCategoryBreakdown(now = new Date()): Promise<CategorySl
   for (const r of rows) {
     const slug = r.slug ?? "uncategorized";
     const name = r.name ?? "Uncategorized";
-    const cents = toCop(BigInt(r.sumCents), r.currency);
+    const cents = toCop(BigInt(r.sumCents), r.currency, copPerUsd);
     const existing = merged.get(slug);
     if (existing) {
       existing.amountCopCents += cents;
@@ -142,8 +147,13 @@ export type TopExpense = {
   accountName: string;
 };
 
-export async function getTopExpenses(now = new Date(), limit = 5): Promise<TopExpense[]> {
+export async function getTopExpenses(
+  copPerUsd: number,
+  now = new Date(),
+  limit = 5,
+): Promise<TopExpense[]> {
   const { start, end } = currentMonthRange(now);
+  const rateMicros = Math.round(copPerUsd * 1_000_000);
   const rows = await db
     .select({
       id: transactions.id,
@@ -167,7 +177,7 @@ export async function getTopExpenses(now = new Date(), limit = 5): Promise<TopEx
       ),
     )
     .orderBy(
-      sql`(CASE WHEN ${transactions.currency} = 'USD' THEN -${transactions.amountCents} * ${COP_PER_USD} ELSE -${transactions.amountCents} END) DESC`,
+      sql`(CASE WHEN ${transactions.currency} = 'USD' THEN -${transactions.amountCents} * ${sql.raw(String(rateMicros))} / 1000000 ELSE -${transactions.amountCents} END) DESC`,
     )
     .limit(limit);
 
@@ -179,7 +189,7 @@ export async function getTopExpenses(now = new Date(), limit = 5): Promise<TopEx
     categoryName: r.categoryName,
     amountCents: r.amountCents,
     currency: r.currency,
-    amountCopCents: toCop(BigInt(-1) * r.amountCents, r.currency),
+    amountCopCents: toCop(BigInt(-1) * r.amountCents, r.currency, copPerUsd),
     accountName: r.accountName,
   }));
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -245,6 +245,25 @@ export const insightsReports = pgTable("insights_reports", {
   outputTokens: integer("output_tokens").notNull().default(0),
 });
 
+export const fxRates = pgTable(
+  "fx_rates",
+  {
+    id: serial("id").primaryKey(),
+    base: varchar("base", { length: 3 }).notNull(),
+    quote: varchar("quote", { length: 3 }).notNull(),
+    rateMicros: bigint("rate_micros", { mode: "bigint" }).notNull(),
+    asOf: date("as_of").notNull(),
+    fetchedAt: timestamp("fetched_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    source: varchar("source", { length: 40 }).notNull(),
+  },
+  (t) => [
+    uniqueIndex("fx_rates_pair_asof_unique").on(t.base, t.quote, t.asOf),
+    index("fx_rates_pair_fetched_idx").on(t.base, t.quote, t.fetchedAt),
+  ],
+);
+
 export const accountSnapshots = pgTable(
   "account_snapshots",
   {

--- a/src/lib/fx/repo.test.ts
+++ b/src/lib/fx/repo.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { FALLBACK_COP_PER_USD } from "@/lib/money";
+import {
+  getCurrentFxRate,
+  microsToRate,
+  rateToMicros,
+  upsertFxRate,
+} from "./repo";
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM fx_rates WHERE base = 'USD' AND quote = 'COP'`);
+}
+
+describe("rateToMicros / microsToRate", () => {
+  it("roundtrips typical TRM values without losing precision", () => {
+    expect(microsToRate(rateToMicros(3615.1))).toBe(3615.1);
+    expect(microsToRate(rateToMicros(4200.55))).toBe(4200.55);
+    expect(microsToRate(rateToMicros(3999.999999))).toBe(3999.999999);
+  });
+});
+
+describe("getCurrentFxRate (integration)", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("returns fallback when fx_rates is empty", async () => {
+    const rate = await getCurrentFxRate();
+    expect(rate.source).toBe("fallback");
+    expect(rate.rate).toBe(FALLBACK_COP_PER_USD);
+    expect(rate.fetchedAt).toBeNull();
+  });
+
+  it("returns the most recent row after upsert", async () => {
+    await upsertFxRate({
+      base: "USD",
+      quote: "COP",
+      rate: 3615.1,
+      asOf: "2026-04-17",
+      source: "trm",
+    });
+    const rate = await getCurrentFxRate();
+    expect(rate.rate).toBe(3615.1);
+    expect(rate.asOf).toBe("2026-04-17");
+    expect(rate.source).toBe("trm");
+    expect(rate.fetchedAt).toBeInstanceOf(Date);
+  });
+
+  it("upsert replaces existing row for same (base, quote, asOf)", async () => {
+    await upsertFxRate({
+      base: "USD",
+      quote: "COP",
+      rate: 3600,
+      asOf: "2026-04-17",
+      source: "trm",
+    });
+    await upsertFxRate({
+      base: "USD",
+      quote: "COP",
+      rate: 3615.1,
+      asOf: "2026-04-17",
+      source: "trm",
+    });
+    const rate = await getCurrentFxRate();
+    expect(rate.rate).toBe(3615.1);
+
+    const countRows = await db.execute<{ c: string }>(
+      sql`SELECT COUNT(*)::text AS c FROM fx_rates WHERE base='USD' AND quote='COP'`,
+    );
+    expect(countRows[0]?.c).toBe("1");
+  });
+
+  it("returns the latest asOf when multiple days are present", async () => {
+    await upsertFxRate({
+      base: "USD",
+      quote: "COP",
+      rate: 3600,
+      asOf: "2026-04-15",
+      source: "trm",
+    });
+    await upsertFxRate({
+      base: "USD",
+      quote: "COP",
+      rate: 3620,
+      asOf: "2026-04-17",
+      source: "trm",
+    });
+    const rate = await getCurrentFxRate();
+    expect(rate.asOf).toBe("2026-04-17");
+    expect(rate.rate).toBe(3620);
+  });
+});

--- a/src/lib/fx/repo.ts
+++ b/src/lib/fx/repo.ts
@@ -1,0 +1,74 @@
+import { and, desc, eq } from "drizzle-orm";
+import { db as defaultDb, type DB } from "@/lib/db";
+import { fxRates } from "@/lib/db/schema";
+import { FALLBACK_COP_PER_USD } from "@/lib/money";
+
+export type FxRate = {
+  base: "USD";
+  quote: "COP";
+  rate: number;
+  asOf: string;
+  source: string;
+  fetchedAt: Date | null;
+};
+
+export function rateToMicros(rate: number): bigint {
+  return BigInt(Math.round(rate * 1_000_000));
+}
+
+export function microsToRate(micros: bigint): number {
+  return Number(micros) / 1_000_000;
+}
+
+export async function getCurrentFxRate(db: DB = defaultDb): Promise<FxRate> {
+  const rows = await db
+    .select()
+    .from(fxRates)
+    .where(and(eq(fxRates.base, "USD"), eq(fxRates.quote, "COP")))
+    .orderBy(desc(fxRates.asOf), desc(fxRates.fetchedAt))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) {
+    return {
+      base: "USD",
+      quote: "COP",
+      rate: FALLBACK_COP_PER_USD,
+      asOf: new Date().toISOString().slice(0, 10),
+      source: "fallback",
+      fetchedAt: null,
+    };
+  }
+  return {
+    base: row.base as "USD",
+    quote: row.quote as "COP",
+    rate: microsToRate(row.rateMicros),
+    asOf: row.asOf,
+    source: row.source,
+    fetchedAt: row.fetchedAt,
+  };
+}
+
+export async function upsertFxRate(
+  input: { base: "USD"; quote: "COP"; rate: number; asOf: string; source: string },
+  db: DB = defaultDb,
+): Promise<void> {
+  const micros = rateToMicros(input.rate);
+  await db
+    .insert(fxRates)
+    .values({
+      base: input.base,
+      quote: input.quote,
+      rateMicros: micros,
+      asOf: input.asOf,
+      source: input.source,
+    })
+    .onConflictDoUpdate({
+      target: [fxRates.base, fxRates.quote, fxRates.asOf],
+      set: {
+        rateMicros: micros,
+        source: input.source,
+        fetchedAt: new Date(),
+      },
+    });
+}

--- a/src/lib/fx/trm.test.ts
+++ b/src/lib/fx/trm.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { fetchTrm } from "./trm";
+
+function mockFetch(payload: unknown, ok = true, status = 200): typeof fetch {
+  const impl = async () =>
+    new Response(JSON.stringify(payload), {
+      status,
+      statusText: ok ? "OK" : "ERR",
+    });
+  return impl as unknown as typeof fetch;
+}
+
+describe("fetchTrm", () => {
+  it("parses datos.gov.co response into rate + asOf", async () => {
+    const fake = mockFetch([
+      { valor: "3615.1", unidad: "COP", vigenciadesde: "2026-04-17T00:00:00.000" },
+    ]);
+    const result = await fetchTrm(fake);
+    expect(result).toEqual({
+      rate: 3615.1,
+      asOf: "2026-04-17",
+      source: "trm",
+    });
+  });
+
+  it("throws when response is empty array", async () => {
+    const fake = mockFetch([]);
+    await expect(fetchTrm(fake)).rejects.toThrow(/no rows/i);
+  });
+
+  it("throws when valor is not a positive number", async () => {
+    const fake = mockFetch([
+      { valor: "abc", vigenciadesde: "2026-04-17T00:00:00.000" },
+    ]);
+    await expect(fetchTrm(fake)).rejects.toThrow(/invalid valor/i);
+  });
+
+  it("throws on non-2xx response", async () => {
+    const fake = mockFetch({}, false, 503);
+    await expect(fetchTrm(fake)).rejects.toThrow(/TRM API error 503/);
+  });
+});

--- a/src/lib/fx/trm.ts
+++ b/src/lib/fx/trm.ts
@@ -1,0 +1,23 @@
+export const TRM_URL = "https://www.datos.gov.co/resource/32sa-8pi3.json";
+
+export type TrmResult = {
+  rate: number;
+  asOf: string;
+  source: "trm";
+};
+
+export async function fetchTrm(fetchImpl: typeof fetch = fetch): Promise<TrmResult> {
+  const url = `${TRM_URL}?$limit=1&$order=vigenciadesde%20DESC`;
+  const res = await fetchImpl(url);
+  if (!res.ok) throw new Error(`TRM API error ${res.status}`);
+  const rows = (await res.json()) as Array<{ valor?: string; vigenciadesde?: string }>;
+  const row = rows[0];
+  if (!row?.valor || !row.vigenciadesde) {
+    throw new Error("TRM API returned no rows");
+  }
+  const rate = Number(row.valor);
+  if (!Number.isFinite(rate) || rate <= 0) {
+    throw new Error(`TRM API returned invalid valor: ${row.valor}`);
+  }
+  return { rate, asOf: row.vigenciadesde.slice(0, 10), source: "trm" };
+}

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,7 +1,13 @@
-export const COP_PER_USD = 4000;
+export const FALLBACK_COP_PER_USD = 4000;
 
-export function toCop(amountCents: bigint, currency: "COP" | "USD"): bigint {
-  return currency === "USD" ? amountCents * BigInt(COP_PER_USD) : amountCents;
+export function toCop(
+  amountCents: bigint,
+  currency: "COP" | "USD",
+  copPerUsd: number,
+): bigint {
+  if (currency === "COP") return amountCents;
+  const micros = BigInt(Math.round(copPerUsd * 1_000_000));
+  return (amountCents * micros) / BigInt(1_000_000);
 }
 
 export function formatCop(amountCents: bigint): string {


### PR DESCRIPTION
## Summary

- Nueva tabla `fx_rates` + fetcher de TRM oficial (`datos.gov.co`) + reader con fallback a `FALLBACK_COP_PER_USD=4000`
- `POST /api/fx/refresh` protegido por `FX_REFRESH_TOKEN` (para cron diario); `GET` devuelve el rate actual
- `getNetWorth / getMonthlyFlow / getCategoryBreakdown / getTopExpenses / buildInsightsSummary` ahora reciben el rate como parámetro explícito (sin const hardcodeada)
- `NetWorthCard` muestra `@ 3.615,10 COP/USD · TRM 17 de abr` (con fallback visible si la DB está vacía)
- Accounts page: descripción muestra el rate real y la fecha de TRM

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (131/131)
- [x] `bun run test:e2e` — screenshots light + dark + mobile, 26/26 verdes
- [x] Seed de TRM real funciona — `GET /api/fx/refresh` devuelve `{ rate: 3615.1, asOf: "2026-04-17", source: "trm", fetchedAt: <ts> }`
- [x] Fallback path cubierto por tests de integración contra `findash_test`

## Out of scope (cubierto en issue)

- Cron externo que llame a `/api/fx/refresh` diario — el endpoint queda listo, el cron se configura aparte
- Multi-currency más allá de COP/USD
- Conversión retroactiva de transacciones viejas

Closes #65