### PR TITLE
feat(ui): animated number transitions via @number-flow/react (#62)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "personal-financial-dashboard",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@number-flow/react": "^0.6.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
@@ -323,6 +324,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@number-flow/react": ["@number-flow/react@0.6.0", "", { "dependencies": { "esm-env": "^1.1.4", "number-flow": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-77Yfc9+zkV2UDSP8phhZzxJGuwxi/Tt1TikmipL+1r3e9GFKEYDZ1XwInj67NoSt3OnOB0KLvvcl3lfPZgBHVQ=="],
 
     "@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
@@ -960,6 +963,8 @@
 
     "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
     "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
@@ -1429,6 +1434,8 @@
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
+    "number-flow": ["number-flow@0.6.0", "", { "dependencies": { "esm-env": "^1.1.4" } }, "sha512-K8flNq2Wqus53vjp/btVo3qXFkagF8dIdYavreBfE7hlvFFG/b1HMGEH6nZL+mlrJ+4lbLP9OmPv3t2rmRkpSQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@number-flow/react": "^0.6.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",

--- a/src/components/dashboard/monthly-flow-card.tsx
+++ b/src/components/dashboard/monthly-flow-card.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { AnimatedMoney } from "@/components/ui/animated-money";
 import { cn } from "@/lib/utils";
-import { formatCop } from "@/lib/money";
 import type { MonthlyFlow } from "@/lib/dashboard/queries";
 
 export function MonthlyFlowCard({ data, monthLabel }: { data: MonthlyFlow; monthLabel: string }) {
@@ -15,21 +15,24 @@ export function MonthlyFlowCard({ data, monthLabel }: { data: MonthlyFlow; month
             positive ? "text-emerald-600" : "text-rose-600",
           )}
         >
-          {positive ? "+" : "−"}
-          {formatCop(data.netCopCents < BigInt(0) ? data.netCopCents * BigInt(-1) : data.netCopCents)}
+          <AnimatedMoney
+            cents={data.netCopCents}
+            currency="COP"
+            signDisplay="always"
+          />
         </CardTitle>
       </CardHeader>
       <CardContent className="grid grid-cols-2 gap-3 text-xs">
         <div>
           <div className="text-muted-foreground">Income</div>
           <div className="font-medium tabular-nums text-emerald-600">
-            {formatCop(data.incomeCopCents)}
+            <AnimatedMoney cents={data.incomeCopCents} currency="COP" />
           </div>
         </div>
         <div>
           <div className="text-muted-foreground">Expenses</div>
           <div className="font-medium tabular-nums text-rose-600">
-            {formatCop(data.expenseCopCents)}
+            <AnimatedMoney cents={data.expenseCopCents} currency="COP" />
           </div>
         </div>
       </CardContent>

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { formatCop, formatMoney } from "@/lib/money";
+import { AnimatedMoney } from "@/components/ui/animated-money";
 import type { NetWorth } from "@/lib/dashboard/queries";
 import type { FxRate } from "@/lib/fx/repo";
 
@@ -30,16 +30,16 @@ export function NetWorthCard({ data, fx }: { data: NetWorth; fx: FxRate }) {
       <CardHeader>
         <CardDescription>Net worth</CardDescription>
         <CardTitle className="text-3xl tabular-nums">
-          {formatCop(data.totalCopCents)}
+          <AnimatedMoney cents={data.totalCopCents} currency="COP" />
         </CardTitle>
       </CardHeader>
       <CardContent className="text-xs text-muted-foreground">
         <div className="flex flex-wrap gap-x-4 gap-y-1">
-          <span>
-            COP {formatMoney(data.copCents, "COP")}
+          <span className="inline-flex items-center gap-1">
+            COP <AnimatedMoney cents={data.copCents} currency="COP" />
           </span>
-          <span>
-            USD {formatMoney(data.usdCents, "USD")}
+          <span className="inline-flex items-center gap-1">
+            USD <AnimatedMoney cents={data.usdCents} currency="USD" />
           </span>
           <span className="opacity-60">{label}</span>
         </div>

--- a/src/components/ui/animated-money.tsx
+++ b/src/components/ui/animated-money.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import NumberFlow from "@number-flow/react";
+
+type Currency = "COP" | "USD";
+
+export function AnimatedMoney({
+  cents,
+  currency,
+  className,
+  signDisplay = "auto",
+}: {
+  cents: bigint;
+  currency: Currency;
+  className?: string;
+  signDisplay?: Intl.NumberFormatOptions["signDisplay"];
+}) {
+  const locale = currency === "USD" ? "en-US" : "es-CO";
+  const maximumFractionDigits = currency === "USD" ? 2 : 0;
+  const value = Number(cents) / 100;
+
+  return (
+    <NumberFlow
+      value={value}
+      locales={locale}
+      format={{
+        style: "currency",
+        currency,
+        maximumFractionDigits,
+        signDisplay,
+      }}
+      className={className}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Add `@number-flow/react` (~8kB gzip) — specialized library that handles digit-flip animation, `Intl.NumberFormat` locale/currency, and `prefers-reduced-motion` out of the box.
- New `AnimatedMoney` client component in `src/components/ui/animated-money.tsx`: takes `cents: bigint`, `currency: "COP" | "USD"`, optional `signDisplay`. Converts to `Number` for display (acceptable precision loss for UI).
- Wire into `NetWorthCard` (total + COP/USD breakdown) and `MonthlyFlowCard` (net with `signDisplay: "always"` + income + expenses).

## Why a library
`@number-flow/react` handles the digit-flip visual, tabular alignment, and reduced-motion correctly. A hand-rolled RAF tween would re-implement these with a high chance of subtle bugs.

## Test plan
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [ ] Trigger an SSE `transaction:created` (e.g. `POST /api/events/trigger`) and confirm NetWorth total + MonthlyFlow net/income/expenses animate smoothly
- [ ] Verify with DevTools emulation `prefers-reduced-motion: reduce` that numbers snap instantly
- [ ] Confirm no layout shift during animation (`tabular-nums` preserved)

Closes #62