### PR TITLE
feat(ui): apply new-row animation + highlight to Top Expenses card (#104)

### DIFF
--- a/src/components/dashboard/top-expenses-card.tsx
+++ b/src/components/dashboard/top-expenses-card.tsx
@@ -1,10 +1,23 @@
+"use client";
+
+import { useMemo } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { useNewIds } from "@/lib/hooks/use-new-ids";
 import { formatMoney } from "@/lib/money";
 import type { TopExpense } from "@/lib/dashboard/queries";
 
 const dateFmt = new Intl.DateTimeFormat("es-CO", { day: "2-digit", month: "short" });
 
 export function TopExpensesCard({ rows, monthLabel }: { rows: TopExpense[]; monthLabel: string }) {
+  const shouldReduceMotion = useReducedMotion();
+  const rowIds = useMemo(() => rows.map((r) => r.id), [rows]);
+  const newIds = useNewIds(rowIds);
+  const enterInitial = shouldReduceMotion ? false : { opacity: 0, y: -8 };
+  const enterAnimate = { opacity: 1, y: 0 };
+  const enterTransition = { duration: 0.25, ease: "easeOut" as const };
+
   return (
     <Card>
       <CardHeader>
@@ -16,22 +29,36 @@ export function TopExpensesCard({ rows, monthLabel }: { rows: TopExpense[]; mont
           <div className="text-sm text-muted-foreground">No expenses this month</div>
         ) : (
           <ul className="flex flex-col divide-y">
-            {rows.map((r) => (
-              <li key={r.id} className="flex items-start justify-between gap-3 py-2 text-sm">
-                <div className="min-w-0">
-                  <div className="truncate font-medium">
-                    {r.merchant ?? r.description}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    {dateFmt.format(r.occurredAt)} · {r.accountName}
-                    {r.categoryName ? ` · ${r.categoryName}` : ""}
-                  </div>
-                </div>
-                <div className="shrink-0 text-right tabular-nums font-medium text-rose-600">
-                  −{formatMoney(r.amountCents < BigInt(0) ? r.amountCents * BigInt(-1) : r.amountCents, r.currency)}
-                </div>
-              </li>
-            ))}
+            <AnimatePresence initial={false}>
+              {rows.map((r) => {
+                const isNew = newIds.has(r.id);
+                return (
+                  <motion.li
+                    key={r.id}
+                    className={cn(
+                      "flex items-start justify-between gap-3 py-2 text-sm",
+                      isNew && "tx-row-new",
+                    )}
+                    initial={enterInitial}
+                    animate={enterAnimate}
+                    transition={enterTransition}
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate font-medium">
+                        {r.merchant ?? r.description}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {dateFmt.format(r.occurredAt)} · {r.accountName}
+                        {r.categoryName ? ` · ${r.categoryName}` : ""}
+                      </div>
+                    </div>
+                    <div className="shrink-0 text-right tabular-nums font-medium text-rose-600">
+                      −{formatMoney(r.amountCents < BigInt(0) ? r.amountCents * BigInt(-1) : r.amountCents, r.currency)}
+                    </div>
+                  </motion.li>
+                );
+              })}
+            </AnimatePresence>
           </ul>
         )}
       </CardContent>


### PR DESCRIPTION
## Summary
- Convert `src/components/dashboard/top-expenses-card.tsx` to a client component.
- Reuse the `useNewIds` hook + `tx-row-new` Tailwind utility introduced in #103 so freshly-top-5 expenses slide+fade in and get the emerald highlight, matching the `/transactions` behavior.
- Wrap the list in `AnimatePresence initial={false}` so existing rows on initial `/` load don't animate.
- Respect `prefers-reduced-motion` via `useReducedMotion`.

## Test plan
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [ ] Insert an expense that becomes part of the top 5, hit `/api/events/trigger`, and confirm the new row on `/` animates like on `/transactions`

Closes #104