### PR TITLE
feat(infra): add pre-push hook for typecheck + tests (#119)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+bun run typecheck && bun run test


### PR DESCRIPTION
Closes #119

## Summary

Adds `.husky/pre-push` that runs `bun run typecheck && bun run test` before every `git push`. Builds on the husky setup shipped in #118.

## How it works

Hook contents (`.husky/pre-push`):

\`\`\`sh
bun run typecheck && bun run test
\`\`\`

- `tsc --noEmit` first (full-project typecheck).
- `vitest run` second — but only if typecheck passes. The `&&` short-circuits on failure, so a broken type doesn't waste time running tests.
- Any non-zero exit = push rejected by git.

## Timing (measured on current `main`)

| Scenario | Time |
|---|---|
| Clean state (131 tests pass) | **2.3s** |
| Type error (short-circuit, no tests run) | ~1s |
| Test failure (tsc + vitest) | ~2.5s |

Well under the 30s target in the issue. As the test suite grows, revisit with `vitest --related` or a pre-push-only subset.

## Verification

**Positive (clean push):**

\`\`\`
$ git push
$ tsc --noEmit
$ vitest run
 Test Files  10 passed (10)
      Tests  131 passed (131)
   Duration  681ms
...
 * [new branch]      claude/phase-1/119-pre-push-typecheck-tests -> ...
\`\`\`

**Negative — type error:**

\`\`\`
$ tsc --noEmit
src/lib/_prepush-smoke.ts(2,45): error TS2322: Type 'number' is not assignable to type 'string'.
error: script "typecheck" exited with code 1
REAL EXIT: 1
\`\`\`

Push blocked, `vitest` never runs (short-circuit worked).

**Negative — failing test:**

\`\`\`
 FAIL  src/lib/_prepush-smoke.test.ts > pre-push smoke > deliberately fails
 Test Files  1 failed | 10 passed (11)
error: script "test" exited with code 1
REAL EXIT: 1
\`\`\`

Push blocked.

## Escape hatch

Standard `git push --no-verify` skips the hook. Use sparingly — CI is still the last line of defense, but the point of the hook is to not waste a CI run on something you could catch in 2 seconds locally.

## Out of scope (intentional)

- Playwright E2E — too slow; CI's job
- `next build` — too slow; CI's job
- `vitest --related` — current suite is fast enough that full run wins on simplicity

## Test plan

- [x] `git push` on a clean branch passes (verified pushing this branch itself)
- [x] `git push` fails when `tsc --noEmit` reports errors (smoke-tested locally)
- [x] `git push` fails when a vitest test fails (smoke-tested locally)
- [x] Hook total runtime < 30s (measured: 2.3s on clean state)