### PR TITLE
feat(infra): add Dependabot config (#124)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - infra
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - infra


### PR DESCRIPTION
Closes #124

## Summary

Adds `.github/dependabot.yml` watching two ecosystems on a weekly schedule.

## Config

- **npm** (`package.json` / `bun.lock`): weekly Monday, max 10 open PRs, `chore(deps):` prefix, `infra` label, **minor + patch bumps grouped into ONE PR** so weekly triage is one merge, not 30.
- **github-actions** (`.github/workflows/*.yml`): weekly Monday, same commit style + labels. Keeps `actions/checkout`, `oven-sh/setup-bun`, `github/codeql-action`, etc. fresh.

## Why grouping

Without grouping, an active week = 30+ PRs. Reviewing each is noise, especially since our CI gate (#121) already runs the full lint+typecheck+test+build against the combined diff. Groups reduce that to one decision: "did CI pass? yes → merge."

Major bumps are intentionally NOT grouped — they carry breaking-change risk and deserve individual review.

## What NOT to expect

Dependabot Alerts (security CVE notifications for public repos) are separate and already active. This file only controls proactive version-update PRs.

## Test plan

- [x] YAML validates (committed through pre-commit hook which runs Prettier on YAML)
- [x] CI passes on the PR (workflow only changes `.github/`, no code impact)
- [ ] First scheduled run fires on Monday after merge
- [ ] Verify a Dependabot PR appears with `chore(deps):` prefix and `infra` label

Next up: #125 (CodeQL).