### PR TITLE
feat(infra): add CodeQL security scanning (#125)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 9 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,12 +27,12 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
Closes #125

## Summary

Adds `.github/workflows/codeql.yml` — static security analysis of JS/TS code on every PR, every push to `main`, and weekly as a safety net.

## Config

- **Language**: `javascript-typescript` (single combined language in CodeQL v3)
- **Queries**: `security-and-quality` — catches vulnerability patterns AND correctness issues beyond what ESLint hits
- **Triggers**: `push → main`, `pull_request → main`, `cron: "0 9 * * 1"` (Monday 09:00 UTC)
- **Concurrency**: `cancel-in-progress: true` — outdated runs auto-cancel
- **Permissions** (least-privilege): `security-events: write`, `contents: read`, `actions: read`

## Why CodeQL is free here

Repo is public (`gh repo view` confirms `"visibility":"PUBLIC"`), so GitHub Advanced Security is not required. Zero cost.

## What happens after merge

1. Workflow runs on this PR — first scan, may surface findings that existed before
2. If findings appear → they show up in **Security tab → Code scanning alerts**, NOT as PR blockers (since the underlying code isn't what this PR changes)
3. Going forward, any new code that introduces a flagged pattern will be surfaced in the PR that adds it

## If findings come back from this first run

Triage in follow-up issues. Don't block this PR on historical findings — that'd conflate "enable the tool" with "fix everything it finds."

## Test plan

- [x] YAML formatted by pre-commit hook
- [x] CI workflow (from #121) should still pass on this PR (CodeQL runs in parallel, doesn't block CI)
- [ ] CodeQL job completes on this PR
- [ ] Security tab shows the first scan results