### PR TITLE
fix(ui): broadcast counterparty:updated SSE so sibling rows refresh (#107)

### DIFF
--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -180,6 +180,13 @@ export async function updateCounterparty(
     });
   }
 
+  emit({
+    type: "counterparty:updated",
+    id: parsed.id,
+    reason: "edit",
+    timestamp: Date.now(),
+  });
+
   revalidatePath("/");
   revalidatePath("/transactions");
 
@@ -294,6 +301,13 @@ export async function mergeCounterparty(
     type: "transaction:bulk-updated",
     count: result.movedTxCount,
     reason: "counterparty-updated",
+    timestamp: Date.now(),
+  });
+
+  emit({
+    type: "counterparty:updated",
+    id: parsed.targetId,
+    reason: "merge",
     timestamp: Date.now(),
   });
 

--- a/src/lib/events/bus.ts
+++ b/src/lib/events/bus.ts
@@ -21,6 +21,12 @@ export type AppEvent =
       reason: "counterparty-updated" | "counterparty-created";
       timestamp: number;
     }
+  | {
+      type: "counterparty:updated";
+      id: number;
+      reason: "edit" | "merge";
+      timestamp: number;
+    }
   | { type: "budget:updated"; timestamp: number };
 
 // globalThis singleton survives Turbopack HMR, which otherwise re-evaluates

--- a/src/lib/hooks/use-live-events.ts
+++ b/src/lib/hooks/use-live-events.ts
@@ -8,6 +8,7 @@ const DEFAULT_REFRESH_ON: AppEvent["type"][] = [
   "transaction:created",
   "transaction:updated",
   "transaction:bulk-updated",
+  "counterparty:updated",
   "budget:updated",
 ];
 


### PR DESCRIPTION
## Summary
- Add `counterparty:updated` event to the SSE bus and include it in `DEFAULT_REFRESH_ON` so all mounted clients call `router.refresh()` when a counterparty changes.
- Emit the event unconditionally from `updateCounterparty` (not only when a default category propagates) and from `mergeCounterparty`, so type/name/notes-only edits also reach every visible row.
- `revalidatePath` still runs for the caller; SSE covers sibling rows on the same page and other tabs, matching how net-worth / top-expenses / transactions already live-refresh.

Closes #107

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (131 pass)
- [x] Manual smoke via Chrome DevTools MCP: opened `/transactions` with a counterparty shared across 10 rows, changed `type` from Person to Merchant, confirmed all 10 sibling rows updated without a manual refresh.
- [x] Cross-tab smoke via Chrome DevTools MCP: with two tabs on `/transactions`, edited the counterparty in tab 2 and confirmed tab 1 refreshed the type badge on all 10 rows via SSE without interaction.