### PR TITLE
feat(ui): show counterparty in Top Expenses + deep-link to /transactions (#106)

### DIFF
--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -22,6 +22,7 @@ type SearchParams = Promise<{
   categorySlug?: string;
   q?: string;
   cursor?: string;
+  highlight?: string;
 }>;
 
 function buildHref(base: Record<string, string | undefined>, cursor: string | null) {
@@ -38,6 +39,8 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
   const sp = await searchParams;
 
   const accountId = sp.accountId ? Number(sp.accountId) : undefined;
+  const highlightRaw = sp.highlight ? Number(sp.highlight) : undefined;
+  const highlightId = Number.isFinite(highlightRaw) ? highlightRaw : undefined;
   const filters = {
     from: sp.from,
     to: sp.to,
@@ -96,7 +99,12 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
         }}
       />
 
-      <TransactionTable rows={rows} categories={categories} allCounterparties={allCounterparties} />
+      <TransactionTable
+        rows={rows}
+        categories={categories}
+        allCounterparties={allCounterparties}
+        highlightId={highlightId}
+      />
 
       <div className="flex items-center justify-between">
         <div className="text-muted-foreground text-xs">

--- a/src/components/dashboard/top-expenses-card.tsx
+++ b/src/components/dashboard/top-expenses-card.tsx
@@ -1,14 +1,31 @@
 "use client";
 
 import { useMemo } from "react";
+import Link from "next/link";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { useNewIds } from "@/lib/hooks/use-new-ids";
 import { formatMoney } from "@/lib/money";
+import { hasSecondaryDescription, primaryDescription } from "@/lib/transactions/description";
 import type { TopExpense } from "@/lib/dashboard/queries";
 
 const dateFmt = new Intl.DateTimeFormat("es-CO", { day: "2-digit", month: "short" });
+
+function offsetUtcDate(d: Date, days: number): string {
+  const copy = new Date(d);
+  copy.setUTCDate(copy.getUTCDate() + days);
+  return copy.toISOString().slice(0, 10);
+}
+
+function buildDeepLink(tx: TopExpense): string {
+  const params = new URLSearchParams({
+    from: offsetUtcDate(tx.occurredAt, -1),
+    to: offsetUtcDate(tx.occurredAt, 1),
+    highlight: String(tx.id),
+  });
+  return `/transactions?${params.toString()}`;
+}
 
 export function TopExpensesCard({ rows, monthLabel }: { rows: TopExpense[]; monthLabel: string }) {
   const shouldReduceMotion = useReducedMotion();
@@ -32,31 +49,39 @@ export function TopExpensesCard({ rows, monthLabel }: { rows: TopExpense[]; mont
             <AnimatePresence initial={false}>
               {rows.map((r) => {
                 const isNew = newIds.has(r.id);
+                const showSecondary = hasSecondaryDescription(r);
                 return (
                   <motion.li
                     key={r.id}
-                    className={cn(
-                      "flex items-start justify-between gap-3 py-2 text-sm",
-                      isNew && "tx-row-new",
-                    )}
+                    className={cn(isNew && "tx-row-new")}
                     initial={enterInitial}
                     animate={enterAnimate}
                     transition={enterTransition}
                   >
-                    <div className="min-w-0">
-                      <div className="truncate font-medium">{r.merchant ?? r.description}</div>
-                      <div className="text-muted-foreground text-xs">
-                        {dateFmt.format(r.occurredAt)} · {r.accountName}
-                        {r.categoryName ? ` · ${r.categoryName}` : ""}
+                    <Link
+                      href={buildDeepLink(r)}
+                      className="hover:bg-muted/50 flex items-start justify-between gap-3 rounded-sm px-2 py-2 text-sm transition-colors"
+                    >
+                      <div className="min-w-0">
+                        <div className="truncate font-medium">{primaryDescription(r)}</div>
+                        {showSecondary ? (
+                          <div className="text-muted-foreground line-clamp-1 text-xs">
+                            {r.descriptionRaw}
+                          </div>
+                        ) : null}
+                        <div className="text-muted-foreground text-xs">
+                          {dateFmt.format(r.occurredAt)} · {r.accountName}
+                          {r.categoryName ? ` · ${r.categoryName}` : ""}
+                        </div>
                       </div>
-                    </div>
-                    <div className="shrink-0 text-right font-medium text-rose-600 tabular-nums">
-                      −
-                      {formatMoney(
-                        r.amountCents < BigInt(0) ? r.amountCents * BigInt(-1) : r.amountCents,
-                        r.currency,
-                      )}
-                    </div>
+                      <div className="shrink-0 text-right font-medium text-rose-600 tabular-nums">
+                        −
+                        {formatMoney(
+                          r.amountCents < BigInt(0) ? r.amountCents * BigInt(-1) : r.amountCents,
+                          r.currency,
+                        )}
+                      </div>
+                    </Link>
                   </motion.li>
                 );
               })}

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { ReceiptTextIcon, UserIcon, BuildingIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { useNewIds } from "@/lib/hooks/use-new-ids";
+import { hasSecondaryDescription, primaryDescription } from "@/lib/transactions/description";
 import type { CounterpartyBrief, TxRow } from "@/lib/transactions/queries";
 import { CategoryCell, type CategoryOption } from "./category-cell";
 import { CounterpartyDialog } from "./counterparty-dialog";
@@ -83,22 +84,16 @@ function formatDate(d: Date) {
   });
 }
 
-function primaryDescription(tx: TxRow): string {
-  return tx.counterparty?.displayName ?? tx.merchant ?? tx.descriptionClean ?? tx.descriptionRaw;
-}
-
-function hasSecondaryDescription(tx: TxRow): boolean {
-  return Boolean(tx.counterparty || tx.merchant || tx.descriptionClean);
-}
-
 export function TransactionTable({
   rows,
   categories,
   allCounterparties,
+  highlightId,
 }: {
   rows: TxRow[];
   categories: CategoryOption[];
   allCounterparties: CounterpartyBrief[];
+  highlightId?: number;
 }) {
   const shouldReduceMotion = useReducedMotion();
   const rowIds = useMemo(() => rows.map((r) => r.id), [rows]);
@@ -106,6 +101,17 @@ export function TransactionTable({
   const enterInitial = shouldReduceMotion ? false : { opacity: 0, y: -8 };
   const enterAnimate = { opacity: 1, y: 0 };
   const enterTransition = { duration: 0.25, ease: "easeOut" as const };
+
+  useEffect(() => {
+    if (highlightId === undefined) return;
+    const els = document.querySelectorAll<HTMLElement>(`[data-highlight-row="${highlightId}"]`);
+    for (const el of els) {
+      if (el.offsetParent !== null) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        break;
+      }
+    }
+  }, [highlightId]);
 
   if (rows.length === 0) {
     return (
@@ -139,11 +145,13 @@ export function TransactionTable({
               {rows.map((tx) => {
                 const isExpense = tx.amountCents < BigInt(0);
                 const isNew = newIds.has(tx.id);
+                const isHighlighted = tx.id === highlightId;
                 return (
                   <motion.tr
                     key={tx.id}
                     data-slot="table-row"
-                    className={cn(ROW_CLASSES, isNew && "tx-row-new")}
+                    data-highlight-row={isHighlighted ? tx.id : undefined}
+                    className={cn(ROW_CLASSES, (isNew || isHighlighted) && "tx-row-new")}
                     initial={enterInitial}
                     animate={enterAnimate}
                     transition={enterTransition}
@@ -204,12 +212,14 @@ export function TransactionTable({
           {rows.map((tx) => {
             const isExpense = tx.amountCents < BigInt(0);
             const isNew = newIds.has(tx.id);
+            const isHighlighted = tx.id === highlightId;
             return (
               <motion.li
                 key={tx.id}
+                data-highlight-row={isHighlighted ? tx.id : undefined}
                 className={cn(
                   "bg-card flex flex-col gap-2 rounded-md border p-3",
-                  isNew && "tx-row-new",
+                  (isNew || isHighlighted) && "tx-row-new",
                 )}
                 initial={enterInitial}
                 animate={enterAnimate}

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, gte, lt, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, categories, transactions } from "@/lib/db/schema";
+import { accounts, categories, counterparties, transactions } from "@/lib/db/schema";
 import { toCop } from "@/lib/money";
 
 export function currentMonthRange(now = new Date()): { start: Date; end: Date } {
@@ -133,8 +133,14 @@ export async function getCategoryBreakdown(
 export type TopExpense = {
   id: number;
   occurredAt: Date;
-  description: string;
+  descriptionRaw: string;
+  descriptionClean: string | null;
   merchant: string | null;
+  counterparty: {
+    id: number;
+    displayName: string;
+    type: "person" | "merchant" | "unknown";
+  } | null;
   categoryName: string | null;
   amountCents: bigint;
   currency: "COP" | "USD";
@@ -160,10 +166,14 @@ export async function getTopExpenses(
       amountCents: transactions.amountCents,
       currency: transactions.currency,
       accountName: accounts.name,
+      cpId: counterparties.id,
+      cpDisplayName: counterparties.displayName,
+      cpType: counterparties.type,
     })
     .from(transactions)
     .innerJoin(accounts, eq(accounts.id, transactions.accountId))
     .leftJoin(categories, eq(categories.slug, transactions.categorySlug))
+    .leftJoin(counterparties, eq(counterparties.id, transactions.counterpartyId))
     .where(
       and(
         gte(transactions.occurredAt, start),
@@ -179,8 +189,10 @@ export async function getTopExpenses(
   return rows.map((r) => ({
     id: r.id,
     occurredAt: r.occurredAt,
-    description: r.descriptionClean ?? r.descriptionRaw,
+    descriptionRaw: r.descriptionRaw,
+    descriptionClean: r.descriptionClean,
     merchant: r.merchant,
+    counterparty: r.cpId ? { id: r.cpId, displayName: r.cpDisplayName!, type: r.cpType! } : null,
     categoryName: r.categoryName,
     amountCents: r.amountCents,
     currency: r.currency,

--- a/src/lib/transactions/description.ts
+++ b/src/lib/transactions/description.ts
@@ -1,0 +1,14 @@
+export type DescribedTx = {
+  descriptionRaw: string;
+  descriptionClean: string | null;
+  merchant: string | null;
+  counterparty: { displayName: string } | null;
+};
+
+export function primaryDescription(tx: DescribedTx): string {
+  return tx.counterparty?.displayName ?? tx.merchant ?? tx.descriptionClean ?? tx.descriptionRaw;
+}
+
+export function hasSecondaryDescription(tx: DescribedTx): boolean {
+  return Boolean(tx.counterparty || tx.merchant || tx.descriptionClean);
+}


### PR DESCRIPTION
## Summary

- Top Expenses ahora usa la misma lógica de `primaryDescription()` que `/transactions`: `counterparty?.displayName ?? merchant ?? descriptionClean ?? descriptionRaw`, con `description_raw` como secundario cuando hay counterparty/merchant resuelto.
- Cada fila es ahora un deep-link (Opción C) a `/transactions?from=<fecha-1d>&to=<fecha+1d>&highlight=<tx.id>`.
- En `/transactions`, el query param `highlight` aplica la animación `tx-row-new` (2.5s, fade) + `scrollIntoView({ block: 'center' })` al row que matchea, tanto en desktop como en mobile. Si el usuario recarga la URL con `highlight`, el highlight se respeta (animación replaya al remount).

## Implementation notes

- Extraje `primaryDescription` / `hasSecondaryDescription` a `src/lib/transactions/description.ts` con un tipo estructural (`DescribedTx`) que satisface tanto `TxRow` como `TopExpense`.
- `getTopExpenses()` ahora hace `leftJoin(counterparties)` y devuelve `descriptionRaw`, `descriptionClean`, `merchant`, `counterparty` separados.
- `TransactionTable` recibe `highlightId?: number` opcional. Se aplica `data-highlight-row="<id>"` al row coincidente (desktop + mobile). Un `useEffect` busca el primer match con `offsetParent !== null` (filtrando el container oculto por media query) y hace `scrollIntoView`.
- El hover sobre filas de Top Expenses usa `hover:bg-muted/50` para señalizar que son clickeables.

Closes #106

## Test plan

- [x] `bun run lint` + `bunx tsc --noEmit` clean
- [x] Full test suite via pre-push hook (131 tests passed)
- [x] Manual test con chrome-devtools MCP:
  - [x] Dashboard home (`/`) muestra "DILAN DEJANON" como primary + "Transferencia a cuenta *91218413213" como secondary en la row del tx #1200
  - [x] Click navega a `/transactions?from=2026-04-15&to=2026-04-17&highlight=1200`
  - [x] Row #1200 tiene `tx-row-new` class aplicada y está en viewport tras scroll-into-view
  - [x] Filtros `from` / `to` inputs reflejan el rango ±1 día
  - [x] Reload de la URL con `highlight` → animación `tx-row-highlight 2.5s` replaya
  - [x] Mobile viewport: el `<li>` mobile es el que scrollea (no el `<tr>` desktop oculto)