### PR TITLE
feat(ui): counterparty dialog notes field as 2-line textarea (#109)

### DIFF
--- a/src/components/transactions/counterparty-dialog.tsx
+++ b/src/components/transactions/counterparty-dialog.tsx
@@ -14,6 +14,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { updateCounterparty, mergeCounterparty } from "@/app/transactions/actions";
 import type { CategoryOption } from "./category-cell";
@@ -245,12 +246,14 @@ export function CounterpartyDialog({
 
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="cp-notes">Notes</Label>
-            <Input
+            <Textarea
               id="cp-notes"
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               placeholder="Optional"
               maxLength={500}
+              rows={2}
+              className="field-sizing-fixed min-h-0 resize-none"
             />
           </div>
 

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 flex field-sizing-content min-h-16 w-full rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 md:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };


### PR DESCRIPTION
## Summary
- Swap the single-line `<Input>` for the `Notes` field in the counterparty edit dialog with a shadcn `<Textarea rows={2}>`
- Accepts newlines without stealing vertical real estate from the dialog; overflow handled by internal scroll

## Implementation notes
- Added shadcn `textarea` component (`src/components/ui/textarea.tsx`) — not previously installed
- Overrode the default `field-sizing-content` + `min-h-16` classes with `field-sizing-fixed min-h-0 resize-none` so the textarea stays at 2 rows and scrolls internally. The issue explicitly put autogrow out of scope.
- `maxLength={500}`, persist-on-save, validation, and all surrounding behavior unchanged.

## Test plan
- [x] `bun run lint` — passes
- [x] `tsc --noEmit` — passes
- [x] pre-commit hooks (eslint + prettier) — passed
- [ ] Visual smoke test on `/transactions` → open any counterparty → edit pencil → notes field renders as 2-row textarea, accepts multi-line input, no layout break on mobile/desktop

Closes #109