### PR TITLE
feat(counterparties): split action in counterparty dialog (#108)

### DIFF
--- a/src/app/api/ingest/sms/counterparty.test.ts
+++ b/src/app/api/ingest/sms/counterparty.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeName } from "./route";
+import { normalizeName } from "@/lib/counterparties/alias-key";
 
 describe("normalizeName", () => {
   it("uppercases and trims simple names", () => {

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -11,6 +11,7 @@ import {
   type ParsedSms,
   type RoutableAccount,
 } from "@/lib/ingestion/sms-bancolombia";
+import { keyForParsed } from "@/lib/counterparties/alias-key";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -199,53 +200,6 @@ type CounterpartyResolution = {
   counterpartyId: number | null;
   inheritedCategory: string | null;
 };
-
-type AliasKind = "qr" | "breb" | "account" | "name";
-
-type KeyForKind = {
-  kind: AliasKind;
-  value: string;
-  initialDisplayName: string;
-};
-
-/**
- * Normalizes a sender name so small whitespace/case variations from Bancolombia
- * do not cause duplicate name-aliases for the same person.
- */
-export function normalizeName(raw: string): string {
-  return raw.trim().toUpperCase().replace(/\s+/g, " ");
-}
-
-function keyForParsed(parsed: ParsedSms): KeyForKind | null {
-  switch (parsed.kind) {
-    case "qr_payment":
-      return {
-        kind: "qr",
-        value: parsed.toKey,
-        initialDisplayName: parsed.toKey,
-      };
-    case "bre_b_transfer":
-      return {
-        kind: "breb",
-        value: parsed.toKey,
-        initialDisplayName: parsed.recipientName,
-      };
-    case "transfer_sent":
-      return {
-        kind: "account",
-        value: parsed.toAccount,
-        initialDisplayName: `Cuenta *${parsed.toAccount}`,
-      };
-    case "transfer_received":
-      return {
-        kind: "name",
-        value: normalizeName(parsed.senderName),
-        initialDisplayName: parsed.senderName,
-      };
-    default:
-      return null;
-  }
-}
 
 /**
  * Resolves (and lazily creates) a counterparty for any kind that carries an

--- a/src/app/transactions/actions.test.ts
+++ b/src/app/transactions/actions.test.ts
@@ -8,17 +8,21 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
-const { updateCounterparty, mergeCounterparty } = await import("./actions");
+const { updateCounterparty, mergeCounterparty, splitCounterparty } = await import("./actions");
 
 // Scoped so parallel test files don't wipe each other's counterparty rows.
+// Matches by alias.value prefix OR display_name prefix so tests that mutate
+// alias values (split) are still cleanable.
 async function cleanup() {
   await db.execute(sql`
     DELETE FROM transactions WHERE external_id LIKE 'test-cp-action:%'
   `);
   await db.execute(sql`
-    DELETE FROM counterparties WHERE id IN (
+    DELETE FROM counterparties
+    WHERE id IN (
       SELECT counterparty_id FROM counterparty_aliases WHERE value LIKE 'test-cp-%'
     )
+       OR display_name LIKE 'test-cp-%'
   `);
 }
 
@@ -53,10 +57,12 @@ async function seedTx(args: {
   externalId: string;
   categorySlug?: string | null;
   method?: "unclassified" | "manual" | "rule";
+  smsBody?: string;
 }): Promise<number> {
   const [acc] = await db.execute<{ id: number }>(sql`
     SELECT id FROM accounts WHERE name = 'Bancolombia Ahorros' LIMIT 1
   `);
+  const rawData = args.smsBody ? JSON.stringify({ kind: "sms", sms: args.smsBody }) : "{}";
   const rows = await db.execute<{ id: number }>(sql`
     INSERT INTO transactions (
       account_id, occurred_at, amount_cents, currency, description_raw,
@@ -68,7 +74,42 @@ async function seedTx(args: {
       ${args.method ?? "unclassified"}::classification_method,
       'sms',
       ${args.externalId},
-      '{}'::jsonb
+      ${rawData}::jsonb
+    )
+    RETURNING id
+  `);
+  return rows[0].id;
+}
+
+async function seedAlias(args: {
+  counterpartyId: number;
+  kind: "qr" | "breb" | "account" | "name";
+  value: string;
+}): Promise<number> {
+  const rows = await db.execute<{ id: number }>(sql`
+    INSERT INTO counterparty_aliases (counterparty_id, kind, value)
+    VALUES (
+      ${args.counterpartyId},
+      ${args.kind}::counterparty_key_kind,
+      ${args.value}
+    )
+    RETURNING id
+  `);
+  return rows[0].id;
+}
+
+// Seeds a counterparty with NO aliases, so the caller can attach any combination
+// via `seedAlias`. Display name must be prefixed so cleanup() reaches it.
+async function seedBareCounterparty(args: {
+  displayName: string;
+  defaultCategory?: string | null;
+}): Promise<number> {
+  const rows = await db.execute<{ id: number }>(sql`
+    INSERT INTO counterparties (display_name, type, default_category_slug)
+    VALUES (
+      ${args.displayName},
+      'unknown',
+      ${args.defaultCategory ?? null}
     )
     RETURNING id
   `);
@@ -337,5 +378,198 @@ describe("mergeCounterparty", () => {
       SELECT hit_count FROM counterparties WHERE id = ${targetId}
     `);
     expect(rows[0].hit_count).toBe(8);
+  });
+});
+
+describe("splitCounterparty", () => {
+  afterEach(cleanup);
+  beforeEach(async () => {
+    await cleanup();
+  });
+
+  // Real Bancolombia fixtures. Parsers match them to (kind=qr, value=0051234567)
+  // and (kind=breb, value=3051234567) respectively. See sms-bancolombia.test.ts.
+  const QR_SMS = (amount = "$92,000.00") =>
+    `Bancolombia: ALEJANDRO RAFAEL MARTINEZ MALDONADO pagaste ${amount} por codigo QR desde tu cuenta *6126 a la llave 0051234567 el 15/04/2026 a las 00:20. Con codigo QR es facil y de una. Dudas al 018000912345`;
+  const BREB_SMS = (amount = "$50,000.00") =>
+    `Bancolombia: ALEJANDRO, transferiste ${amount} a la llave 3051234567 desde tu cuenta *6126 a MARIA PAZ TORRES CARRILLO el 01/04/26 a las 13:22. Con Bre-b es de una y gratis. Dudas al 018000912345.`;
+
+  it("extracts selected aliases into a new counterparty and reassigns matching txs", async () => {
+    const sourceId = await seedBareCounterparty({
+      displayName: "test-cp-split-merged-thing",
+      defaultCategory: "alimentacion",
+    });
+    const qrAliasId = await seedAlias({
+      counterpartyId: sourceId,
+      kind: "qr",
+      value: "0051234567",
+    });
+    const brebAliasId = await seedAlias({
+      counterpartyId: sourceId,
+      kind: "breb",
+      value: "3051234567",
+    });
+
+    const qrTxA = await seedTx({
+      counterpartyId: sourceId,
+      externalId: "test-cp-action:qr-A",
+      smsBody: QR_SMS("$10,000.00"),
+    });
+    const qrTxB = await seedTx({
+      counterpartyId: sourceId,
+      externalId: "test-cp-action:qr-B",
+      smsBody: QR_SMS("$20,000.00"),
+    });
+    const brebTxA = await seedTx({
+      counterpartyId: sourceId,
+      externalId: "test-cp-action:breb-A",
+      smsBody: BREB_SMS("$30,000.00"),
+    });
+    const brebTxB = await seedTx({
+      counterpartyId: sourceId,
+      externalId: "test-cp-action:breb-B",
+      smsBody: BREB_SMS("$40,000.00"),
+    });
+
+    const result = await splitCounterparty({
+      sourceId,
+      aliasIds: [qrAliasId],
+    });
+
+    expect(result.movedAliasCount).toBe(1);
+    expect(result.movedTxCount).toBe(2);
+    expect(result.newCounterpartyId).not.toBe(sourceId);
+
+    const aliasRows = await db.execute<{ id: number; counterparty_id: number; kind: string }>(sql`
+      SELECT id, counterparty_id, kind::text
+      FROM counterparty_aliases
+      WHERE id IN (${qrAliasId}, ${brebAliasId})
+      ORDER BY kind
+    `);
+    const byKind = Object.fromEntries(aliasRows.map((r) => [r.kind, r.counterparty_id]));
+    expect(byKind.qr).toBe(result.newCounterpartyId);
+    expect(byKind.breb).toBe(sourceId);
+
+    const txRows = await db.execute<{ id: number; counterparty_id: number | null }>(sql`
+      SELECT id, counterparty_id
+      FROM transactions
+      WHERE id IN (${qrTxA}, ${qrTxB}, ${brebTxA}, ${brebTxB})
+      ORDER BY id
+    `);
+    const byId = Object.fromEntries(txRows.map((r) => [r.id, r.counterparty_id]));
+    expect(byId[qrTxA]).toBe(result.newCounterpartyId);
+    expect(byId[qrTxB]).toBe(result.newCounterpartyId);
+    expect(byId[brebTxA]).toBe(sourceId);
+    expect(byId[brebTxB]).toBe(sourceId);
+
+    const newCp = await db.execute<{
+      display_name: string;
+      type: string;
+      default_category_slug: string | null;
+    }>(sql`
+      SELECT display_name, type::text, default_category_slug
+      FROM counterparties WHERE id = ${result.newCounterpartyId}
+    `);
+    expect(newCp[0].display_name).toBe("test-cp-split-merged-thing");
+    expect(newCp[0].default_category_slug).toBe("alimentacion");
+  });
+
+  it("honors newDisplayName override for the new counterparty", async () => {
+    const sourceId = await seedBareCounterparty({
+      displayName: "test-cp-split-old-name",
+    });
+    const qrAliasId = await seedAlias({
+      counterpartyId: sourceId,
+      kind: "qr",
+      value: "0051234567",
+    });
+    await seedAlias({
+      counterpartyId: sourceId,
+      kind: "breb",
+      value: "3051234567",
+    });
+
+    const result = await splitCounterparty({
+      sourceId,
+      aliasIds: [qrAliasId],
+      newDisplayName: "test-cp-split-fresh-name",
+    });
+
+    const newCp = await db.execute<{ display_name: string }>(sql`
+      SELECT display_name FROM counterparties WHERE id = ${result.newCounterpartyId}
+    `);
+    expect(newCp[0].display_name).toBe("test-cp-split-fresh-name");
+  });
+
+  it("rejects extracting every alias (source would be left with none)", async () => {
+    const sourceId = await seedBareCounterparty({
+      displayName: "test-cp-split-all",
+    });
+    const qrId = await seedAlias({
+      counterpartyId: sourceId,
+      kind: "qr",
+      value: "test-cp-splitall-qr",
+    });
+    const brebId = await seedAlias({
+      counterpartyId: sourceId,
+      kind: "breb",
+      value: "test-cp-splitall-breb",
+    });
+
+    await expect(
+      splitCounterparty({
+        sourceId,
+        aliasIds: [qrId, brebId],
+      }),
+    ).rejects.toThrow(/at least one must stay/);
+  });
+
+  it("rejects when source has only one alias", async () => {
+    const sourceId = await seedBareCounterparty({
+      displayName: "test-cp-split-single",
+    });
+    const aliasId = await seedAlias({
+      counterpartyId: sourceId,
+      kind: "qr",
+      value: "test-cp-single-qr",
+    });
+
+    await expect(splitCounterparty({ sourceId, aliasIds: [aliasId] })).rejects.toThrow(
+      /at least 2 aliases/,
+    );
+  });
+
+  it("rejects aliasIds that don't belong to the source", async () => {
+    const sourceId = await seedBareCounterparty({
+      displayName: "test-cp-split-wrong-src",
+    });
+    await seedAlias({
+      counterpartyId: sourceId,
+      kind: "qr",
+      value: "test-cp-wrong-src-qr",
+    });
+    await seedAlias({
+      counterpartyId: sourceId,
+      kind: "breb",
+      value: "test-cp-wrong-src-breb",
+    });
+    const otherCpId = await seedBareCounterparty({
+      displayName: "test-cp-split-other",
+    });
+    const otherAliasId = await seedAlias({
+      counterpartyId: otherCpId,
+      kind: "account",
+      value: "test-cp-other-account",
+    });
+
+    await expect(splitCounterparty({ sourceId, aliasIds: [otherAliasId] })).rejects.toThrow(
+      /do not belong to this counterparty/,
+    );
+  });
+
+  it("throws when source does not exist", async () => {
+    await expect(splitCounterparty({ sourceId: 9_999_999, aliasIds: [1] })).rejects.toThrow(
+      /Source counterparty not found/,
+    );
   });
 });

--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -7,6 +7,8 @@ import { db } from "@/lib/db";
 import { accounts, categories, counterparties, transactions } from "@/lib/db/schema";
 import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
 import { emit } from "@/lib/events/bus";
+import { keyForParsed } from "@/lib/counterparties/alias-key";
+import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
 
 const updateSchema = z.object({
   txId: z.coerce.number().int().positive(),
@@ -308,6 +310,179 @@ export async function mergeCounterparty(
     type: "counterparty:updated",
     id: parsed.targetId,
     reason: "merge",
+    timestamp: Date.now(),
+  });
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+
+  return result;
+}
+
+const splitCounterpartySchema = z.object({
+  sourceId: z.coerce.number().int().positive(),
+  aliasIds: z.array(z.coerce.number().int().positive()).min(1),
+  newDisplayName: z.string().trim().min(1).max(120).optional(),
+});
+
+export type SplitCounterpartyInput = z.input<typeof splitCounterpartySchema>;
+export type SplitCounterpartyResult = {
+  newCounterpartyId: number;
+  movedTxCount: number;
+  movedAliasCount: number;
+};
+
+/**
+ * Extracts a subset of a counterparty's aliases into a new counterparty and
+ * reassigns the historical transactions that matched those aliases at ingest.
+ *
+ * Transaction reassignment re-parses each source tx's raw SMS via the ingest
+ * parser and derives its original (kind, value) match. This gives 1:1 fidelity
+ * with the ingest-time counterparty match and avoids brittle text heuristics.
+ *
+ * Guards: at least one alias must stay on the source so the source never ends
+ * up orphaned. The new counterparty inherits displayName/type/defaultCategory
+ * from source; the caller can override the name via `newDisplayName`.
+ */
+export async function splitCounterparty(
+  input: SplitCounterpartyInput,
+): Promise<SplitCounterpartyResult> {
+  const parsed = splitCounterpartySchema.parse(input);
+  const aliasIdSet = new Set(parsed.aliasIds);
+  if (aliasIdSet.size !== parsed.aliasIds.length) {
+    throw new Error("aliasIds must be unique");
+  }
+
+  const [source] = await db.execute<{
+    id: number;
+    display_name: string;
+    type: "person" | "merchant" | "unknown";
+    default_category_slug: string | null;
+  }>(sql`
+    SELECT id, display_name, type, default_category_slug
+    FROM counterparties
+    WHERE id = ${parsed.sourceId}
+    LIMIT 1
+  `);
+  if (!source) throw new Error("Source counterparty not found");
+
+  const allAliases = await db.execute<{
+    id: number;
+    kind: "qr" | "breb" | "account" | "name";
+    value: string;
+  }>(sql`
+    SELECT id, kind, value
+    FROM counterparty_aliases
+    WHERE counterparty_id = ${parsed.sourceId}
+  `);
+  if (allAliases.length < 2) {
+    throw new Error("Counterparty needs at least 2 aliases to split");
+  }
+
+  const extractedAliases = allAliases.filter((a) => aliasIdSet.has(a.id));
+  if (extractedAliases.length !== aliasIdSet.size) {
+    throw new Error("Some aliasIds do not belong to this counterparty");
+  }
+  if (extractedAliases.length >= allAliases.length) {
+    throw new Error("Cannot extract every alias — at least one must stay");
+  }
+
+  const extractedKeys = new Set(extractedAliases.map((a) => `${a.kind}:${a.value}`));
+
+  // Re-parse every source tx to determine which ones belong to the extracted
+  // alias set. Parsing is pure/side-effect-free so we do it outside the DB
+  // transaction to keep the tx short.
+  const sourceTxs = await db.execute<{ id: number; raw_data: unknown }>(sql`
+    SELECT id, raw_data
+    FROM transactions
+    WHERE counterparty_id = ${parsed.sourceId}
+  `);
+
+  const movedTxIds: number[] = [];
+  for (const tx of sourceTxs) {
+    const raw = tx.raw_data as { sms?: unknown } | null;
+    const smsBody = raw && typeof raw.sms === "string" ? raw.sms : null;
+    if (!smsBody) continue;
+
+    const parseResult = parseSmsBancolombia(smsBody);
+    if (parseResult.kind === "skip") continue;
+
+    const key = keyForParsed(parseResult);
+    if (!key) continue;
+
+    if (extractedKeys.has(`${key.kind}:${key.value}`)) {
+      movedTxIds.push(tx.id);
+    }
+  }
+
+  const result = await db.transaction(async (trx) => {
+    const [inserted] = await trx.execute<{ id: number }>(sql`
+      INSERT INTO counterparties (display_name, type, default_category_slug, hit_count, last_hit_at)
+      VALUES (
+        ${parsed.newDisplayName ?? source.display_name},
+        ${source.type}::counterparty_type,
+        ${source.default_category_slug},
+        0,
+        NULL
+      )
+      RETURNING id
+    `);
+    const newId = inserted.id;
+
+    await trx.execute(sql`
+      UPDATE counterparty_aliases
+      SET counterparty_id = ${newId}
+      WHERE id = ANY(${sql`ARRAY[${sql.join(
+        parsed.aliasIds.map((id) => sql`${id}`),
+        sql`, `,
+      )}]::int[]`})
+    `);
+
+    let movedTxCount = 0;
+    if (movedTxIds.length > 0) {
+      const updated = await trx.execute<{ id: number }>(sql`
+        UPDATE transactions
+        SET counterparty_id = ${newId}, updated_at = now()
+        WHERE id = ANY(${sql`ARRAY[${sql.join(
+          movedTxIds.map((id) => sql`${id}`),
+          sql`, `,
+        )}]::int[]`})
+        RETURNING id
+      `);
+      movedTxCount = updated.length;
+    }
+
+    await trx
+      .update(counterparties)
+      .set({ updatedAt: new Date() })
+      .where(eq(counterparties.id, parsed.sourceId));
+
+    return {
+      newCounterpartyId: newId,
+      movedTxCount,
+      movedAliasCount: extractedAliases.length,
+    };
+  });
+
+  if (result.movedTxCount > 0) {
+    emit({
+      type: "transaction:bulk-updated",
+      count: result.movedTxCount,
+      reason: "counterparty-updated",
+      timestamp: Date.now(),
+    });
+  }
+
+  emit({
+    type: "counterparty:updated",
+    id: parsed.sourceId,
+    reason: "split",
+    timestamp: Date.now(),
+  });
+  emit({
+    type: "counterparty:updated",
+    id: result.newCounterpartyId,
+    reason: "split",
     timestamp: Date.now(),
   });
 

--- a/src/components/transactions/counterparty-dialog.tsx
+++ b/src/components/transactions/counterparty-dialog.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { PencilIcon, UserIcon, BuildingIcon, CircleHelpIcon, MergeIcon } from "lucide-react";
+import {
+  PencilIcon,
+  UserIcon,
+  BuildingIcon,
+  CircleHelpIcon,
+  MergeIcon,
+  SplitIcon,
+} from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,10 +23,15 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { updateCounterparty, mergeCounterparty } from "@/app/transactions/actions";
+import {
+  updateCounterparty,
+  mergeCounterparty,
+  splitCounterparty,
+} from "@/app/transactions/actions";
 import type { CategoryOption } from "./category-cell";
 
 export type CounterpartyAlias = {
+  id: number;
   kind: "qr" | "breb" | "account" | "name";
   value: string;
 };
@@ -74,9 +86,13 @@ export function CounterpartyDialog({
   );
   const [notes, setNotes] = useState(counterparty.notes ?? "");
   const [mergeTargetId, setMergeTargetId] = useState<string>("");
+  const [splitAliasIds, setSplitAliasIds] = useState<Set<number>>(() => new Set());
 
   const placeholderName = isPlaceholderName(counterparty);
   const mergeCandidates = allCounterparties.filter((c) => c.id !== counterparty.id);
+  const canSplit = counterparty.aliases.length >= 2;
+  const splitSelectedCount = splitAliasIds.size;
+  const splitValid = splitSelectedCount > 0 && splitSelectedCount < counterparty.aliases.length;
 
   function reset() {
     setDisplayName(counterparty.displayName);
@@ -84,6 +100,16 @@ export function CounterpartyDialog({
     setDefaultCategorySlug(counterparty.defaultCategorySlug ?? "");
     setNotes(counterparty.notes ?? "");
     setMergeTargetId("");
+    setSplitAliasIds(new Set());
+  }
+
+  function toggleSplitAlias(id: number) {
+    setSplitAliasIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   }
 
   function onSubmit(e: React.FormEvent) {
@@ -105,6 +131,33 @@ export function CounterpartyDialog({
         setOpen(false);
       } catch (err) {
         toast.error(err instanceof Error ? err.message : "Failed to update");
+      }
+    });
+  }
+
+  function onSplit() {
+    if (!splitValid) return;
+    const extracted = counterparty.aliases.filter((a) => splitAliasIds.has(a.id));
+    const confirmed = window.confirm(
+      `Split ${extracted.length} alias${extracted.length === 1 ? "" : "es"} out of ` +
+        `"${counterparty.displayName}" into a new counterparty?\n\n` +
+        `Historical transactions matching the extracted aliases will be reassigned ` +
+        `to the new counterparty. You can rename it afterwards.`,
+    );
+    if (!confirmed) return;
+    startTransition(async () => {
+      try {
+        const result = await splitCounterparty({
+          sourceId: counterparty.id,
+          aliasIds: Array.from(splitAliasIds),
+        });
+        toast.success(
+          `Split · ${result.movedAliasCount} alias${result.movedAliasCount === 1 ? "" : "es"} + ` +
+            `${result.movedTxCount} tx moved to new counterparty`,
+        );
+        setOpen(false);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Split failed");
       }
     });
   }
@@ -302,6 +355,57 @@ export function CounterpartyDialog({
               >
                 <MergeIcon className="size-3.5" />
                 Merge
+              </Button>
+            </div>
+          </div>
+        ) : null}
+
+        {canSplit ? (
+          <div className="mt-2 flex min-w-0 flex-col gap-1.5 border-t pt-3">
+            <Label>Split out aliases</Label>
+            <p className="text-muted-foreground text-xs">
+              Select aliases to extract into a new counterparty. Transactions matching those aliases
+              will move with them.
+            </p>
+            <div className="flex flex-col gap-1">
+              {counterparty.aliases.map((a) => {
+                const checked = splitAliasIds.has(a.id);
+                return (
+                  <label
+                    key={a.id}
+                    className="hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded border px-2 py-1.5 text-xs"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleSplitAlias(a.id)}
+                      disabled={pending}
+                      className="size-3.5"
+                    />
+                    <span className="text-muted-foreground font-sans uppercase">
+                      {ALIAS_KIND_LABELS[a.kind]}
+                    </span>
+                    <span className="font-mono">{a.value}</span>
+                  </label>
+                );
+              })}
+            </div>
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-muted-foreground text-xs">
+                {splitSelectedCount === 0
+                  ? "Pick at least one alias"
+                  : splitSelectedCount >= counterparty.aliases.length
+                    ? "At least one alias must stay"
+                    : `${splitSelectedCount} selected`}
+              </span>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onSplit}
+                disabled={pending || !splitValid}
+              >
+                <SplitIcon className="size-3.5" />
+                Split
               </Button>
             </div>
           </div>

--- a/src/lib/counterparties/alias-key.ts
+++ b/src/lib/counterparties/alias-key.ts
@@ -1,0 +1,53 @@
+import type { ParsedSms } from "@/lib/ingestion/sms-bancolombia";
+
+export type AliasKind = "qr" | "breb" | "account" | "name";
+
+export type KeyForKind = {
+  kind: AliasKind;
+  value: string;
+  initialDisplayName: string;
+};
+
+/**
+ * Normalizes a sender name so small whitespace/case variations from Bancolombia
+ * do not cause duplicate name-aliases for the same person.
+ */
+export function normalizeName(raw: string): string {
+  return raw.trim().toUpperCase().replace(/\s+/g, " ");
+}
+
+/**
+ * Derives the (alias.kind, alias.value) key a given parsed SMS matched against
+ * at ingest. The split action reuses this to reassign historical transactions
+ * to a newly-extracted counterparty with 1:1 fidelity to the original match.
+ */
+export function keyForParsed(parsed: ParsedSms): KeyForKind | null {
+  switch (parsed.kind) {
+    case "qr_payment":
+      return {
+        kind: "qr",
+        value: parsed.toKey,
+        initialDisplayName: parsed.toKey,
+      };
+    case "bre_b_transfer":
+      return {
+        kind: "breb",
+        value: parsed.toKey,
+        initialDisplayName: parsed.recipientName,
+      };
+    case "transfer_sent":
+      return {
+        kind: "account",
+        value: parsed.toAccount,
+        initialDisplayName: `Cuenta *${parsed.toAccount}`,
+      };
+    case "transfer_received":
+      return {
+        kind: "name",
+        value: normalizeName(parsed.senderName),
+        initialDisplayName: parsed.senderName,
+      };
+    default:
+      return null;
+  }
+}

--- a/src/lib/events/bus.ts
+++ b/src/lib/events/bus.ts
@@ -24,7 +24,7 @@ export type AppEvent =
   | {
       type: "counterparty:updated";
       id: number;
-      reason: "edit" | "merge";
+      reason: "edit" | "merge" | "split";
       timestamp: number;
     }
   | { type: "budget:updated"; timestamp: number };

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/db/schema";
 
 export type CounterpartyAlias = {
+  id: number;
   kind: "qr" | "breb" | "account" | "name";
   value: string;
 };
@@ -123,7 +124,7 @@ export async function listTransactions(filters: TxFilters): Promise<TxListResult
       cpNotes: counterparties.notes,
       cpAliases: sql<CounterpartyAlias[] | null>`(
         SELECT COALESCE(
-          json_agg(json_build_object('kind', a.kind, 'value', a.value) ORDER BY a.id),
+          json_agg(json_build_object('id', a.id, 'kind', a.kind, 'value', a.value) ORDER BY a.id),
           '[]'::json
         )
         FROM ${counterpartyAliases} a


### PR DESCRIPTION
## Summary
Inverse of the merge action: extract a subset of a counterparty's aliases into a new counterparty and reassign the historical transactions that originally matched those aliases at ingest.

## Server action — `splitCounterparty({ sourceId, aliasIds, newDisplayName? })`

Re-parses each source tx's `raw_data.sms` via the same Bancolombia parser that runs at ingest and derives the `(kind, value)` key the tx originally matched against. Txs whose derived key is in the extracted alias set move to the new counterparty; the rest stay with source. This gives **1:1 fidelity with the original ingest matching** instead of relying on brittle ILIKE heuristics over raw SMS text. (Decision documented in thread with the user: "prefiero la 1 ya que es data sensible".)

Guards enforced:
- `1 ≤ aliasIds.length < source.aliases.length` — at least one alias must stay on source
- aliasIds must all belong to source
- source must have ≥ 2 aliases
- source must exist

New counterparty inherits `displayName`, `type`, and `defaultCategorySlug` from source. Optional `newDisplayName` override on the input.

Emits `transaction:bulk-updated` + `counterparty:updated` for both source and new (so all mounted `useLiveEvents` clients refresh — same pattern as merge and the `counterparty:updated` SSE fix from #137).

## Refactor
Extracted `keyForParsed`, `AliasKind`, `KeyForKind`, and `normalizeName` from `src/app/api/ingest/sms/route.ts` to a new module `src/lib/counterparties/alias-key.ts`. Pure, no DB/HTTP deps — makes it reusable from server actions without importing a route file. Existing SMS route + counterparty test updated to import from the new location.

## UI
New "Split out aliases" section in the counterparty dialog, rendered below the Merge section and only when `aliases.length >= 2`. Checkboxes per alias, status text showing either "Pick at least one alias", "At least one alias must stay", or "N selected". Confirmation dialog describes the effect. Toast reports moved alias/tx counts.

## Data model touch
`CounterpartyAlias` type gained an `id: number` field so the UI can pass alias IDs to the server action. Query in `src/lib/transactions/queries.ts` now includes `a.id` in the `json_build_object`.

## Test plan
- [x] `bun run test` — 137 passed, including 6 new `splitCounterparty` integration tests:
  - happy path: extracts QR alias from a (QR + Bre-b) counterparty, moves only the QR txs
  - `newDisplayName` override honored
  - rejects extracting every alias
  - rejects when source has only one alias
  - rejects aliasIds from another counterparty
  - rejects non-existent source
- [x] `bun run lint` — clean
- [x] `tsc --noEmit` — clean
- [x] pre-commit hooks (eslint + prettier) — passed
- [ ] Visual smoke test on `/transactions` → counterparty with multiple aliases → open dialog → Split section visible → select subset → Split button → new counterparty appears, txs move

Closes #108