### PR TITLE
feat(budgets,insights): roll up sub-category spend under root budget (#142)

### DIFF
--- a/src/app/budgets/actions.ts
+++ b/src/app/budgets/actions.ts
@@ -35,11 +35,14 @@ export async function upsertBudget(input: BudgetInput) {
   const { start, end } = monthRange(parsed.ym);
 
   const [cat] = await db
-    .select({ slug: categories.slug })
+    .select({ slug: categories.slug, parentSlug: categories.parentSlug })
     .from(categories)
     .where(eq(categories.slug, parsed.categorySlug))
     .limit(1);
   if (!cat) throw new Error("Category not found");
+  if (cat.parentSlug !== null) {
+    throw new Error("Budgets must target a root category (sub-categories roll up)");
+  }
 
   const amountCents = BigInt(Math.round(parsed.amount * 100));
 

--- a/src/app/budgets/budgets-manager.tsx
+++ b/src/app/budgets/budgets-manager.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { CategoryCombobox } from "@/components/transactions/category-combobox";
 import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { deleteBudget, upsertBudget } from "./actions";
@@ -257,7 +258,8 @@ function BudgetEditor({
 }) {
   const [pending, startTransition] = useTransition();
   const availableCategories = categories.filter(
-    (c) => !existingSlugs.has(c.slug) || c.slug === editing?.categorySlug,
+    (c) =>
+      c.parentSlug === null && (!existingSlugs.has(c.slug) || c.slug === editing?.categorySlug),
   );
 
   const [categorySlug, setCategorySlug] = useState(
@@ -310,20 +312,19 @@ function BudgetEditor({
         <form onSubmit={onSubmit} className="flex flex-col gap-3">
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="b-cat">Category</Label>
-            <select
-              id="b-cat"
-              value={categorySlug}
-              onChange={(e) => setCategorySlug(e.target.value)}
-              className="bg-background h-9 rounded-md border px-2 text-sm"
-              required
+            <CategoryCombobox
+              triggerId="b-cat"
+              value={categorySlug || null}
+              options={availableCategories}
+              onChange={(next) => setCategorySlug(next ?? "")}
+              placeholder="Pick a category"
+              allowClear={false}
+              rootsOnly
               disabled={!!editing}
-            >
-              {availableCategories.map((c) => (
-                <option key={c.slug} value={c.slug}>
-                  {c.parentSlug ? `↳ ${c.name}` : c.name}
-                </option>
-              ))}
-            </select>
+            />
+            <p className="text-muted-foreground text-xs">
+              Budgets roll up sub-categories, so they live at the root level.
+            </p>
           </div>
 
           <div className="grid grid-cols-[1fr_auto] gap-3">

--- a/src/app/budgets/page.tsx
+++ b/src/app/budgets/page.tsx
@@ -1,4 +1,4 @@
-import { and, asc, eq, gte, lte, sql } from "drizzle-orm";
+import { aliasedTable, and, asc, eq, gte, lte, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { budgets, categories, transactions } from "@/lib/db/schema";
 import { BudgetsManager } from "./budgets-manager";
@@ -56,19 +56,24 @@ export default async function BudgetsPage({
       .leftJoin(categories, eq(categories.slug, budgets.categorySlug))
       .where(eq(budgets.periodStart, startIso))
       .orderBy(asc(categories.sortOrder), asc(categories.name)),
-    db
-      .select({
-        categorySlug: transactions.categorySlug,
-        spentCents: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
-      })
-      .from(transactions)
-      .where(and(gte(transactions.occurredAt, start), lte(transactions.occurredAt, end)))
-      .groupBy(transactions.categorySlug),
+    (() => {
+      const txCategory = aliasedTable(categories, "tx_category");
+      const rootSlug = sql<string | null>`COALESCE(${txCategory.parentSlug}, ${txCategory.slug})`;
+      return db
+        .select({
+          rootSlug,
+          spentCents: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
+        })
+        .from(transactions)
+        .leftJoin(txCategory, eq(txCategory.slug, transactions.categorySlug))
+        .where(and(gte(transactions.occurredAt, start), lte(transactions.occurredAt, end)))
+        .groupBy(rootSlug);
+    })(),
   ]);
 
   const spentMap = new Map<string, bigint>();
   for (const s of spentRows) {
-    if (s.categorySlug) spentMap.set(s.categorySlug, BigInt(s.spentCents));
+    if (s.rootSlug) spentMap.set(s.rootSlug, BigInt(s.spentCents));
   }
 
   const items = rows.map((r) => ({

--- a/src/components/transactions/category-combobox.tsx
+++ b/src/components/transactions/category-combobox.tsx
@@ -65,6 +65,7 @@ export function CategoryCombobox({
   triggerId,
   triggerClassName,
   allowClear = true,
+  rootsOnly = false,
 }: {
   value: string | null;
   options: CategoryOption[];
@@ -74,6 +75,7 @@ export function CategoryCombobox({
   triggerId?: string;
   triggerClassName?: string;
   allowClear?: boolean;
+  rootsOnly?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const tree = useMemo(() => buildTree(options), [options]);
@@ -138,19 +140,21 @@ export function CategoryCombobox({
                     <span>{root.name}</span>
                     {value === root.slug ? <CheckIcon className="ml-auto size-4" /> : null}
                   </CommandItem>
-                  {children.map((child) => (
-                    <CommandItem
-                      key={child.slug}
-                      value={`${child.name} ${child.slug} ${parentKeywords}`}
-                      onSelect={() => {
-                        onChange(child.slug);
-                        setOpen(false);
-                      }}
-                    >
-                      <span className="text-muted-foreground pl-4">↳ {child.name}</span>
-                      {value === child.slug ? <CheckIcon className="ml-auto size-4" /> : null}
-                    </CommandItem>
-                  ))}
+                  {rootsOnly
+                    ? null
+                    : children.map((child) => (
+                        <CommandItem
+                          key={child.slug}
+                          value={`${child.name} ${child.slug} ${parentKeywords}`}
+                          onSelect={() => {
+                            onChange(child.slug);
+                            setOpen(false);
+                          }}
+                        >
+                          <span className="text-muted-foreground pl-4">↳ {child.name}</span>
+                          {value === child.slug ? <CheckIcon className="ml-auto size-4" /> : null}
+                        </CommandItem>
+                      ))}
                 </CommandGroup>
               );
             })}

--- a/src/lib/ai/insights.ts
+++ b/src/lib/ai/insights.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { aliasedTable, and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { db as defaultDb, type DB } from "@/lib/db";
 import {
   accounts,
@@ -110,29 +110,42 @@ export async function buildInsightsSummary(
           and(gte(transactions.occurredAt, prev.start), lte(transactions.occurredAt, prev.end)),
         )
         .groupBy(transactions.currency),
-      db
-        .select({
-          slug: transactions.categorySlug,
-          name: categories.name,
-          currency: transactions.currency,
-          spent: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
-          txCount: sql<number>`COUNT(*)::int`,
-        })
-        .from(transactions)
-        .leftJoin(categories, eq(categories.slug, transactions.categorySlug))
-        .where(and(gte(transactions.occurredAt, cur.start), lte(transactions.occurredAt, cur.end)))
-        .groupBy(transactions.categorySlug, categories.name, transactions.currency),
-      db
-        .select({
-          slug: transactions.categorySlug,
-          currency: transactions.currency,
-          spent: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
-        })
-        .from(transactions)
-        .where(
-          and(gte(transactions.occurredAt, prev.start), lte(transactions.occurredAt, prev.end)),
-        )
-        .groupBy(transactions.categorySlug, transactions.currency),
+      (() => {
+        const leaf = aliasedTable(categories, "cur_leaf");
+        const root = aliasedTable(categories, "cur_root");
+        const rootSlug = sql<string | null>`COALESCE(${leaf.parentSlug}, ${leaf.slug})`;
+        return db
+          .select({
+            slug: rootSlug,
+            name: root.name,
+            currency: transactions.currency,
+            spent: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
+            txCount: sql<number>`COUNT(*)::int`,
+          })
+          .from(transactions)
+          .leftJoin(leaf, eq(leaf.slug, transactions.categorySlug))
+          .leftJoin(root, eq(root.slug, rootSlug))
+          .where(
+            and(gte(transactions.occurredAt, cur.start), lte(transactions.occurredAt, cur.end)),
+          )
+          .groupBy(rootSlug, root.name, transactions.currency);
+      })(),
+      (() => {
+        const leaf = aliasedTable(categories, "prev_leaf");
+        const rootSlug = sql<string | null>`COALESCE(${leaf.parentSlug}, ${leaf.slug})`;
+        return db
+          .select({
+            slug: rootSlug,
+            currency: transactions.currency,
+            spent: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
+          })
+          .from(transactions)
+          .leftJoin(leaf, eq(leaf.slug, transactions.categorySlug))
+          .where(
+            and(gte(transactions.occurredAt, prev.start), lte(transactions.occurredAt, prev.end)),
+          )
+          .groupBy(rootSlug, transactions.currency);
+      })(),
       db
         .select({
           merchant: transactions.merchant,


### PR DESCRIPTION
## Summary

Follow-up to #110. Dashboard donut already rolls up leaves to root — this PR extends that same semantic to budgets and insights.

- **Budgets picker**: restricted to root categories (`parentSlug IS NULL`), enforced server-side in `budgets/actions.ts`. The native `<select>` swaps for `CategoryCombobox` with a new `rootsOnly` prop + a helper line explaining the rule.
- **Budgets spent**: `budgets/page.tsx` rewrites the spent query with a self-join (`COALESCE(c.parent_slug, c.slug)`) so a budget on `alimentacion` includes Mercado, Delivery, Restaurantes, etc.
- **Insights**: both `curCats` and `prevCats` queries in `lib/ai/insights.ts` roll up to root. Claude now sees `Alimentación: $5.6M` instead of three separate leaf slices. Budget-vs-spent logic is unchanged — it was already a map lookup by slug, now both sides use root slugs.

## Migration

DB had 0 existing budgets at time of merge — no data migration needed. Going forward the UI + server action both block leaf-level budget creation.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 137/137 pass
- [x] `bun run format:check` — clean
- [x] `bun run test:e2e` — all 26 screenshots pass
- [x] DB smoke: `alimentacion` leaf-only spent = $153k; rollup = $5.6M (matches donut)
- [x] DB smoke: inserted a test budget on `alimentacion` and confirmed spent query returns the rolled-up figure

Closes #142