### PR TITLE
feat(ui): month switcher on dashboard home with widgets re-scoped to selected month (#144)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,7 +80,7 @@ export default async function DashboardPage({
       </section>
 
       <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <TopExpensesCard rows={top} monthLabel={monthLabel} isFuture={isFuture} />
+        <TopExpensesCard rows={top} monthLabel={monthLabel} ym={ym} isFuture={isFuture} />
         <UpcomingCard items={upcomingItems} monthLabel={monthLabel} />
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,27 +11,41 @@ import { CategoryDonut } from "@/components/dashboard/category-donut";
 import { TopExpensesCard } from "@/components/dashboard/top-expenses-card";
 import { AccountsGrid } from "@/components/dashboard/accounts-grid";
 import { UpcomingCard } from "@/components/dashboard/upcoming-card";
+import { MonthSwitcher } from "@/components/dashboard/month-switcher";
 import { getUpcomingForMonth } from "@/lib/recurring/upcoming";
 import { getCurrentFxRate } from "@/lib/fx/repo";
+import {
+  formatYearMonth,
+  isFutureYearMonth,
+  parseYearMonthOrCurrent,
+  refDateFromYearMonth,
+} from "@/lib/date/year-month";
 
 export const dynamic = "force-dynamic";
 
-const monthFmt = new Intl.DateTimeFormat("es-CO", { month: "long", year: "numeric" });
-
-export default async function DashboardPage() {
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ym?: string }>;
+}) {
+  const params = await searchParams;
   const now = new Date();
-  const monthLabel = monthFmt.format(now);
+  const ym = parseYearMonthOrCurrent(params.ym, now);
+  const refDate = refDateFromYearMonth(ym);
+  const isFuture = isFutureYearMonth(ym, now);
+  const monthLabel = formatYearMonth(ym);
+  const [refYear, refMonth] = ym.split("-").map(Number);
 
   const fx = await getCurrentFxRate();
   const [netWorth, flow, slices, top, accounts, upcoming] = await Promise.all([
     getNetWorth(fx.rate),
-    getMonthlyFlow(fx.rate, now),
-    getCategoryBreakdown(fx.rate, now),
-    getTopExpenses(fx.rate, now, 5),
+    getMonthlyFlow(fx.rate, refDate),
+    getCategoryBreakdown(fx.rate, refDate),
+    getTopExpenses(fx.rate, refDate, 5),
     getAccountStatuses(),
     getUpcomingForMonth({
-      year: now.getFullYear(),
-      month: now.getMonth() + 1,
+      year: refYear,
+      month: refMonth,
       includeDismissed: true,
       today: now,
     }),
@@ -51,19 +65,22 @@ export default async function DashboardPage() {
 
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 sm:p-6">
-      <header>
-        <h1 className="text-h1">Dashboard</h1>
-        <p className="text-body text-muted-foreground capitalize">{monthLabel}</p>
+      <header className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-h1">Dashboard</h1>
+          <p className="text-body text-muted-foreground capitalize">{monthLabel}</p>
+        </div>
+        <MonthSwitcher ym={ym} />
       </header>
 
       <section className="grid grid-cols-1 gap-4 lg:grid-cols-4">
         <NetWorthCard data={netWorth} fx={fx} />
-        <MonthlyFlowCard data={flow} monthLabel={monthLabel} />
-        <CategoryDonut slices={donutSlices} monthLabel={monthLabel} />
+        <MonthlyFlowCard data={flow} monthLabel={monthLabel} isFuture={isFuture} />
+        <CategoryDonut slices={donutSlices} monthLabel={monthLabel} isFuture={isFuture} />
       </section>
 
       <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <TopExpensesCard rows={top} monthLabel={monthLabel} />
+        <TopExpensesCard rows={top} monthLabel={monthLabel} isFuture={isFuture} />
         <UpcomingCard items={upcomingItems} monthLabel={monthLabel} />
       </section>
 

--- a/src/components/dashboard/category-donut.tsx
+++ b/src/components/dashboard/category-donut.tsx
@@ -22,9 +22,11 @@ export type DonutSlice = {
 export function CategoryDonut({
   slices,
   monthLabel,
+  isFuture = false,
 }: {
   slices: DonutSlice[];
   monthLabel: string;
+  isFuture?: boolean;
 }) {
   const total = slices.reduce((acc, s) => acc + s.value, 0);
 
@@ -39,7 +41,7 @@ export function CategoryDonut({
       <CardContent>
         {slices.length === 0 ? (
           <div className="text-muted-foreground flex h-64 items-center justify-center text-sm">
-            No expenses this month
+            {isFuture ? "Sin datos todavía — este mes aún no ocurrió" : "No expenses this month"}
           </div>
         ) : (
           <div className="grid gap-4 md:grid-cols-[1fr_1fr]">

--- a/src/components/dashboard/month-switcher.tsx
+++ b/src/components/dashboard/month-switcher.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { formatYearMonth, shiftYearMonth } from "@/lib/date/year-month";
+
+export function MonthSwitcher({ ym, basePath = "/" }: { ym: string; basePath?: string }) {
+  const prev = shiftYearMonth(ym, -1);
+  const next = shiftYearMonth(ym, 1);
+  return (
+    <div className="flex items-center gap-1">
+      <Button asChild variant="outline" size="sm" aria-label="Mes anterior">
+        <Link href={`${basePath}?ym=${prev}`} prefetch={false} scroll={false}>
+          <ChevronLeftIcon className="size-4" />
+        </Link>
+      </Button>
+      <div className="px-2 text-sm font-medium capitalize tabular-nums">{formatYearMonth(ym)}</div>
+      <Button asChild variant="outline" size="sm" aria-label="Mes siguiente">
+        <Link href={`${basePath}?ym=${next}`} prefetch={false} scroll={false}>
+          <ChevronRightIcon className="size-4" />
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/src/components/dashboard/monthly-flow-card.tsx
+++ b/src/components/dashboard/monthly-flow-card.tsx
@@ -3,8 +3,31 @@ import { AnimatedMoney } from "@/components/ui/animated-money";
 import { cn } from "@/lib/utils";
 import type { MonthlyFlow } from "@/lib/dashboard/queries";
 
-export function MonthlyFlowCard({ data, monthLabel }: { data: MonthlyFlow; monthLabel: string }) {
+export function MonthlyFlowCard({
+  data,
+  monthLabel,
+  isFuture = false,
+}: {
+  data: MonthlyFlow;
+  monthLabel: string;
+  isFuture?: boolean;
+}) {
   const positive = data.netCopCents >= BigInt(0);
+  if (isFuture) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardDescription>Cash flow · {monthLabel}</CardDescription>
+          <CardTitle className="text-muted-foreground text-base font-normal">
+            Sin datos todavía
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-muted-foreground text-xs">
+          Este mes aún no ocurrió.
+        </CardContent>
+      </Card>
+    );
+  }
   return (
     <Card>
       <CardHeader>

--- a/src/components/dashboard/top-expenses-card.tsx
+++ b/src/components/dashboard/top-expenses-card.tsx
@@ -30,15 +30,17 @@ function buildDeepLink(tx: TopExpense): string {
 export function TopExpensesCard({
   rows,
   monthLabel,
+  ym,
   isFuture = false,
 }: {
   rows: TopExpense[];
   monthLabel: string;
+  ym: string;
   isFuture?: boolean;
 }) {
   const shouldReduceMotion = useReducedMotion();
   const rowIds = useMemo(() => rows.map((r) => r.id), [rows]);
-  const newIds = useNewIds(rowIds);
+  const newIds = useNewIds(rowIds, { resetKey: ym });
   const enterInitial = shouldReduceMotion ? false : { opacity: 0, y: -8 };
   const enterAnimate = { opacity: 1, y: 0 };
   const enterTransition = { duration: 0.25, ease: "easeOut" as const };

--- a/src/components/dashboard/top-expenses-card.tsx
+++ b/src/components/dashboard/top-expenses-card.tsx
@@ -27,7 +27,15 @@ function buildDeepLink(tx: TopExpense): string {
   return `/transactions?${params.toString()}`;
 }
 
-export function TopExpensesCard({ rows, monthLabel }: { rows: TopExpense[]; monthLabel: string }) {
+export function TopExpensesCard({
+  rows,
+  monthLabel,
+  isFuture = false,
+}: {
+  rows: TopExpense[];
+  monthLabel: string;
+  isFuture?: boolean;
+}) {
   const shouldReduceMotion = useReducedMotion();
   const rowIds = useMemo(() => rows.map((r) => r.id), [rows]);
   const newIds = useNewIds(rowIds);
@@ -43,7 +51,9 @@ export function TopExpensesCard({ rows, monthLabel }: { rows: TopExpense[]; mont
       </CardHeader>
       <CardContent>
         {rows.length === 0 ? (
-          <div className="text-muted-foreground text-sm">No expenses this month</div>
+          <div className="text-muted-foreground text-sm">
+            {isFuture ? "Sin datos todavía — este mes aún no ocurrió" : "No expenses this month"}
+          </div>
         ) : (
           <ul className="flex flex-col divide-y">
             <AnimatePresence initial={false}>

--- a/src/lib/date/year-month.ts
+++ b/src/lib/date/year-month.ts
@@ -1,0 +1,38 @@
+const YM_RE = /^\d{4}-\d{2}$/;
+
+export function isValidYearMonth(s: string): boolean {
+  if (!YM_RE.test(s)) return false;
+  const [, m] = s.split("-").map(Number);
+  return m >= 1 && m <= 12;
+}
+
+export function currentYearMonth(now: Date = new Date()): string {
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+export function parseYearMonthOrCurrent(input: string | undefined, now: Date = new Date()): string {
+  return input && isValidYearMonth(input) ? input : currentYearMonth(now);
+}
+
+export function shiftYearMonth(ym: string, delta: number): string {
+  const [y, m] = ym.split("-").map(Number);
+  const d = new Date(Date.UTC(y, m - 1 + delta, 1));
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+export function refDateFromYearMonth(ym: string): Date {
+  const [y, m] = ym.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, 1));
+}
+
+export function isFutureYearMonth(ym: string, now: Date = new Date()): boolean {
+  return ym > currentYearMonth(now);
+}
+
+export function formatYearMonth(ym: string, locale = "es-CO"): string {
+  return refDateFromYearMonth(ym).toLocaleDateString(locale, {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/src/lib/hooks/use-new-ids.ts
+++ b/src/lib/hooks/use-new-ids.ts
@@ -15,13 +15,19 @@ import { useEffect, useRef, useState } from "react";
  *   suppressions below are local and scoped.
  */
 /* eslint-disable react-hooks/purity */
-export function useNewIds<T extends string | number>(ids: readonly T[], ttlMs = 2500): Set<T> {
+export function useNewIds<T extends string | number>(
+  ids: readonly T[],
+  { ttlMs = 2500, resetKey }: { ttlMs?: number; resetKey?: string | number } = {},
+): Set<T> {
   const seenRef = useRef<Set<T> | null>(null);
   const expiryRef = useRef<Map<T, number>>(new Map());
+  const resetKeyRef = useRef<string | number | undefined>(resetKey);
   const [, force] = useState(0);
 
-  if (seenRef.current === null) {
+  if (seenRef.current === null || resetKeyRef.current !== resetKey) {
     seenRef.current = new Set(ids);
+    expiryRef.current.clear();
+    resetKeyRef.current = resetKey;
   }
 
   const now = Date.now();


### PR DESCRIPTION
## Summary

- Adds prev/current/next month switcher to the `/` dashboard header, powered by `?ym=YYYY-MM` (same param convention already used on `/budgets` and `/insights`)
- Re-scopes month-dependent widgets to the selected month: Monthly Flow, Category Donut, Top Expenses, Upcoming. `NetWorthCard` and `AccountsGrid` stay point-in-time
- Next button is NOT disabled at the current month — `UpcomingCard` is meant to plan ahead. Historical widgets render an explicit "Sin datos todavía — este mes aún no ocurrió" empty state when the selected month is in the future
- Navigation uses server-rendered `<Link>` (no client JS required)

## Files

- `src/lib/date/year-month.ts` — new shared utils (`parseYearMonthOrCurrent`, `shiftYearMonth`, `refDateFromYearMonth`, `isFutureYearMonth`, `formatYearMonth`). Not wired into `/budgets` or `/insights` — they keep their local copies for now; dedupe is a separate followup
- `src/components/dashboard/month-switcher.tsx` — server component, prev/current/next with `<Link>`
- `src/app/page.tsx` — awaits `searchParams`, parses `ym`, passes ref date to queries
- `monthly-flow-card.tsx`, `category-donut.tsx`, `top-expenses-card.tsx` — new optional `isFuture` prop, context-aware empty state

## Test plan

- [x] Typecheck clean (`bun run typecheck`)
- [x] Lint clean (`bun run lint`)
- [x] Vitest suite green (137 tests via pre-push hook)
- [x] `/` defaults to current month (abril de 2026)
- [x] `/?ym=2026-03` renders March, prev → `ym=2026-02`, next → `ym=2026-04`
- [x] Year boundary: `/?ym=2026-12` → next `ym=2027-01`; `/?ym=2026-01` → prev `ym=2025-12`
- [x] `/?ym=invalid` and `/?ym=2026-13` fall back to current month (no 500)
- [x] `/?ym=2099-12` (future) shows "Sin datos todavía — este mes aún no ocurrió" in Flow / Donut / Top Expenses

Closes #144