### PR TITLE
refactor(types): consolidate duplicated enums and DTOs into single source of truth (#147)

### DIFF
--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -5,6 +5,7 @@ import { getNetWorth } from "@/lib/dashboard/queries";
 import { listAccountsDetailed, type AccountDetail } from "@/lib/accounts/queries";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { toCop, formatCop, formatMoney } from "@/lib/money";
+import type { Currency } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 const RATE_FMT = new Intl.NumberFormat("es-CO", {
@@ -202,7 +203,7 @@ function CreditMeter({
   availableCents,
   balanceCents,
 }: {
-  currency: "COP" | "USD";
+  currency: Currency;
   limitCents: bigint;
   availableCents: bigint | null;
   balanceCents: bigint;

--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { POST } from "./route";
+import type { CounterpartyKind, CounterpartyType } from "@/lib/types";
 
 const TEST_TOKEN = "test-token-vitest-sms-ingest";
 // SMS bodies used in tests — we clean up by externalId, not by marker,
@@ -56,10 +57,10 @@ async function findCounterpartyByAlias(kind: string, value: string) {
 }
 
 async function createCounterpartyWithAlias(args: {
-  kind: "qr" | "breb" | "account" | "name";
+  kind: CounterpartyKind;
   value: string;
   displayName: string;
-  type?: "person" | "merchant" | "unknown";
+  type?: CounterpartyType;
   defaultCategorySlug?: string | null;
 }) {
   const rows = await db.execute<{ id: number }>(sql`

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -13,6 +13,7 @@ import {
   type RoutableAccount,
 } from "@/lib/ingestion/sms-bancolombia";
 import { keyForParsed } from "@/lib/counterparties/alias-key";
+import type { ClassificationMethod } from "@/lib/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -137,7 +138,7 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
   // Other kinds have hardcoded categories (pago-tc, transferencias, ingresos)
   // or inherit from counterparty (qr_payment, bre_b_transfer).
   let finalCategory = cp.inheritedCategory ?? categorySlug;
-  let finalMethod: "rule" | "manual" | "unclassified" = cp.inheritedCategory ? "rule" : method;
+  let finalMethod: Exclude<ClassificationMethod, "ai"> = cp.inheritedCategory ? "rule" : method;
   let confidence: number | null = null;
   if (parsed.kind === "purchase" || parsed.kind === "provider_payment_sent") {
     const cls = await classifyByRule({
@@ -295,7 +296,7 @@ function buildTxFields(parsed: ParsedSms): {
   descriptionRaw: string;
   merchant: string | null;
   categorySlug: string | null;
-  method: "rule" | "manual" | "unclassified";
+  method: Exclude<ClassificationMethod, "ai">;
 } {
   switch (parsed.kind) {
     case "purchase":

--- a/src/app/budgets/actions.ts
+++ b/src/app/budgets/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
-import { budgets, categories } from "@/lib/db/schema";
+import { budgets, categories, currency as currencyEnum } from "@/lib/db/schema";
 
 const ymSchema = z.string().regex(/^\d{4}-\d{2}$/);
 
@@ -20,7 +20,7 @@ const upsertSchema = z.object({
   id: z.coerce.number().int().positive().optional(),
   categorySlug: z.string().min(1).max(60),
   amount: z.coerce.number().finite().positive(),
-  currency: z.enum(["COP", "USD"]).default("COP"),
+  currency: z.enum(currencyEnum.enumValues).default("COP"),
   ym: ymSchema,
 });
 

--- a/src/app/budgets/budgets-manager.tsx
+++ b/src/app/budgets/budgets-manager.tsx
@@ -25,6 +25,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CategoryCombobox } from "@/components/transactions/category-combobox";
 import { formatMoney } from "@/lib/money";
+import type { Currency } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { deleteBudget, upsertBudget } from "./actions";
 
@@ -40,7 +41,7 @@ type BudgetRow = {
   categoryName: string;
   amountCents: string;
   spentCents: string;
-  currency: "COP" | "USD";
+  currency: Currency;
 };
 
 type EditorState = { open: boolean; editing: BudgetRow | null };
@@ -268,7 +269,7 @@ function BudgetEditor({
   const [amount, setAmount] = useState(
     editing ? (Number(BigInt(editing.amountCents)) / 100).toString() : "",
   );
-  const [currency, setCurrency] = useState<"COP" | "USD">(editing?.currency ?? "COP");
+  const [currency, setCurrency] = useState<Currency>(editing?.currency ?? "COP");
 
   function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -348,7 +349,7 @@ function BudgetEditor({
               <select
                 id="b-ccy"
                 value={currency}
-                onChange={(e) => setCurrency(e.target.value as "COP" | "USD")}
+                onChange={(e) => setCurrency(e.target.value as Currency)}
                 className="bg-background h-9 rounded-md border px-2 text-sm"
               >
                 <option value="COP">COP</option>

--- a/src/app/settings/import/import-form.tsx
+++ b/src/app/settings/import/import-form.tsx
@@ -11,8 +11,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { confirmBancolombiaImport, previewBancolombiaXlsx, type PreviewResult } from "./actions";
+import type { Currency } from "@/lib/types";
 
-type AccountOption = { id: number; name: string; currency: "COP" | "USD" };
+type AccountOption = { id: number; name: string; currency: Currency };
 
 function ParseButton() {
   const { pending } = useFormStatus();

--- a/src/app/settings/recurring/recurring-manager.tsx
+++ b/src/app/settings/recurring/recurring-manager.tsx
@@ -15,10 +15,11 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { formatMoney } from "@/lib/money";
+import type { Currency } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { deleteRecurring, toggleRecurringActive, upsertRecurring } from "./actions";
 
-type AccountOption = { id: number; name: string; currency: "COP" | "USD" };
+type AccountOption = { id: number; name: string; currency: Currency };
 type CategoryOption = {
   slug: string;
   name: string;
@@ -30,7 +31,7 @@ type RecurringRow = {
   accountName: string;
   label: string;
   amountCents: string;
-  currency: "COP" | "USD";
+  currency: Currency;
   categorySlug: string | null;
   dayOfMonth: number;
   active: boolean;

--- a/src/app/transactions/actions.test.ts
+++ b/src/app/transactions/actions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
+import type { CounterpartyKind } from "@/lib/types";
 
 // `revalidatePath` requires a Next.js request context that vitest's node
 // environment does not provide. No-op it so we can unit-test actions directly.
@@ -29,7 +30,7 @@ async function cleanup() {
 
 async function seedCounterparty(args: {
   key: string;
-  kind?: "qr" | "breb" | "account" | "name";
+  kind?: CounterpartyKind;
   displayName?: string;
   defaultCategory?: string | null;
 }): Promise<number> {
@@ -84,7 +85,7 @@ async function seedTx(args: {
 
 async function seedAlias(args: {
   counterpartyId: number;
-  kind: "qr" | "breb" | "account" | "name";
+  kind: CounterpartyKind;
   value: string;
 }): Promise<number> {
   const rows = await db.execute<{ id: number }>(sql`

--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -4,13 +4,20 @@ import { revalidatePath } from "next/cache";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
-import { accounts, categories, counterparties, transactions } from "@/lib/db/schema";
+import {
+  accounts,
+  categories,
+  counterparties,
+  counterpartyType,
+  transactions,
+} from "@/lib/db/schema";
 import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
 import { emit } from "@/lib/events/bus";
 import { autoLinkTransaction } from "@/lib/recurring/auto-link";
 import { keyForParsed } from "@/lib/counterparties/alias-key";
 import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
 import { decimalStringToCents } from "@/lib/money";
+import type { CounterpartyKind, CounterpartyType } from "@/lib/types";
 
 const updateSchema = z.object({
   txId: z.coerce.number().int().positive(),
@@ -145,7 +152,7 @@ export async function runAiClassifier() {
   return result;
 }
 
-const counterpartyTypeSchema = z.enum(["person", "merchant", "unknown"]);
+const counterpartyTypeSchema = z.enum(counterpartyType.enumValues);
 
 const updateCounterpartySchema = z.object({
   id: z.coerce.number().int().positive(),
@@ -394,7 +401,7 @@ export async function splitCounterparty(
   const [source] = await db.execute<{
     id: number;
     display_name: string;
-    type: "person" | "merchant" | "unknown";
+    type: CounterpartyType;
     default_category_slug: string | null;
   }>(sql`
     SELECT id, display_name, type, default_category_slug
@@ -406,7 +413,7 @@ export async function splitCounterparty(
 
   const allAliases = await db.execute<{
     id: number;
-    kind: "qr" | "breb" | "account" | "name";
+    kind: CounterpartyKind;
     value: string;
   }>(sql`
     SELECT id, kind, value

--- a/src/components/dashboard/recurring-gap-link-dialog.tsx
+++ b/src/components/dashboard/recurring-gap-link-dialog.tsx
@@ -16,6 +16,7 @@ import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { linkTxToRecurring } from "@/app/settings/recurring/actions";
 import type { LinkCandidate } from "@/lib/recurring/gap-queries";
+import type { Currency } from "@/lib/types";
 
 const dateFmt = new Intl.DateTimeFormat("es-CO", {
   day: "2-digit",
@@ -41,7 +42,7 @@ export function RecurringGapLinkDialog({
   yearMonth: string;
   label: string;
   expectedAmountCents: bigint;
-  currency: "COP" | "USD";
+  currency: Currency;
   candidates: LinkCandidate[] | null;
   selectedTxId: number | null;
   onSelect: (txId: number) => void;

--- a/src/components/dashboard/recurring-inbox-card.tsx
+++ b/src/components/dashboard/recurring-inbox-card.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/app/settings/recurring/actions";
 import { RecurringGapLinkDialog } from "@/components/dashboard/recurring-gap-link-dialog";
 import type { LinkCandidate } from "@/lib/recurring/gap-queries";
+import type { Currency } from "@/lib/types";
 
 export type RecurringGapItem = {
   gapId: number;
@@ -25,7 +26,7 @@ export type RecurringGapItem = {
   label: string;
   accountName: string;
   amountCents: string;
-  currency: "COP" | "USD";
+  currency: Currency;
   categoryName: string | null;
   dayOfMonth: number;
 };

--- a/src/components/import/screenshot-upload.tsx
+++ b/src/components/import/screenshot-upload.tsx
@@ -14,8 +14,9 @@ import {
   previewScreenshotOcr,
   type OcrPreviewResult,
 } from "@/app/settings/import/actions";
+import type { Currency } from "@/lib/types";
 
-type AccountOption = { id: number; name: string; currency: "COP" | "USD" };
+type AccountOption = { id: number; name: string; currency: Currency };
 
 type EditableRow = {
   occurredOn: string;

--- a/src/components/transactions/counterparty-dialog.tsx
+++ b/src/components/transactions/counterparty-dialog.tsx
@@ -28,29 +28,11 @@ import {
   mergeCounterparty,
   splitCounterparty,
 } from "@/app/transactions/actions";
+import type { CounterpartyAlias, CounterpartyBrief, CounterpartyValue } from "@/lib/types";
 import type { CategoryOption } from "./category-cell";
 import { CategoryCombobox } from "./category-combobox";
 
-export type CounterpartyAlias = {
-  id: number;
-  kind: "qr" | "breb" | "account" | "name";
-  value: string;
-};
-
-export type CounterpartyValue = {
-  id: number;
-  displayName: string;
-  type: "person" | "merchant" | "unknown";
-  defaultCategorySlug: string | null;
-  notes: string | null;
-  aliases: CounterpartyAlias[];
-};
-
-export type CounterpartyBrief = {
-  id: number;
-  displayName: string;
-  type: "person" | "merchant" | "unknown";
-};
+export type { CounterpartyAlias, CounterpartyBrief, CounterpartyValue };
 
 const ALIAS_KIND_LABELS: Record<CounterpartyAlias["kind"], string> = {
   qr: "QR",

--- a/src/components/transactions/quick-expense-dialog.tsx
+++ b/src/components/transactions/quick-expense-dialog.tsx
@@ -17,11 +17,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { createManualExpense } from "@/app/transactions/actions";
+import type { Currency } from "@/lib/types";
 
 export type AccountOption = {
   id: number;
   name: string;
-  currency: "COP" | "USD";
+  currency: Currency;
 };
 
 export type CategoryOption = {

--- a/src/components/ui/animated-money.tsx
+++ b/src/components/ui/animated-money.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import NumberFlow from "@number-flow/react";
-
-type Currency = "COP" | "USD";
+import type { Currency } from "@/lib/types";
 
 export function AnimatedMoney({
   cents,

--- a/src/lib/accounts/queries.ts
+++ b/src/lib/accounts/queries.ts
@@ -1,13 +1,14 @@
 import { asc } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, type AccountMetadata } from "@/lib/db/schema";
+import type { AccountType, Currency } from "@/lib/types";
 
 export type AccountDetail = {
   id: number;
   name: string;
   institution: string;
-  type: "savings" | "credit_card" | "loan";
-  currency: "COP" | "USD";
+  type: AccountType;
+  currency: Currency;
   balanceCents: bigint;
   active: boolean;
   metadata: AccountMetadata;

--- a/src/lib/ai/insights.ts
+++ b/src/lib/ai/insights.ts
@@ -8,6 +8,7 @@ import {
   recurringTransactions,
   transactions,
 } from "@/lib/db/schema";
+import type { Currency } from "@/lib/types";
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 export const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -20,7 +21,7 @@ export type InsightsSummary = {
     name: string;
     institution: string;
     type: string;
-    currency: "COP" | "USD";
+    currency: Currency;
     balanceCop: number;
   }>;
   totals: {
@@ -63,7 +64,7 @@ function monthBounds(ym: string) {
   };
 }
 
-function toCopNumber(cents: bigint, currency: "COP" | "USD", copPerUsd: number): number {
+function toCopNumber(cents: bigint, currency: Currency, copPerUsd: number): number {
   const pesos = Number(cents) / 100;
   return currency === "USD" ? pesos * copPerUsd : pesos;
 }

--- a/src/lib/classification/ai.ts
+++ b/src/lib/classification/ai.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
+import type { Currency } from "@/lib/types";
 
 export type AiClassifiable = {
   id: number;
   description: string;
   amountCents: bigint;
-  currency: "COP" | "USD";
+  currency: Currency;
 };
 
 export type AiCategoryOption = {

--- a/src/lib/counterparties/alias-key.ts
+++ b/src/lib/counterparties/alias-key.ts
@@ -1,9 +1,8 @@
 import type { ParsedSms } from "@/lib/ingestion/sms-bancolombia";
-
-export type AliasKind = "qr" | "breb" | "account" | "name";
+import type { CounterpartyKind } from "@/lib/types";
 
 export type KeyForKind = {
-  kind: AliasKind;
+  kind: CounterpartyKind;
   value: string;
   initialDisplayName: string;
 };

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -2,6 +2,7 @@ import { aliasedTable, and, asc, eq, gte, lt, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, categories, counterparties, transactions } from "@/lib/db/schema";
 import { toCop } from "@/lib/money";
+import type { AccountType, CounterpartyType, Currency } from "@/lib/types";
 
 export function currentMonthRange(now = new Date()): { start: Date; end: Date } {
   const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
@@ -13,8 +14,8 @@ export type AccountStatus = {
   id: number;
   name: string;
   institution: string;
-  type: "savings" | "credit_card" | "loan";
-  currency: "COP" | "USD";
+  type: AccountType;
+  currency: Currency;
   balanceCents: bigint;
 };
 
@@ -143,11 +144,11 @@ export type TopExpense = {
   counterparty: {
     id: number;
     displayName: string;
-    type: "person" | "merchant" | "unknown";
+    type: CounterpartyType;
   } | null;
   categoryName: string | null;
   amountCents: bigint;
-  currency: "COP" | "USD";
+  currency: Currency;
   amountCopCents: bigint;
   accountName: string;
 };

--- a/src/lib/db/seed-transactions.ts
+++ b/src/lib/db/seed-transactions.ts
@@ -1,13 +1,14 @@
 import { db } from "./index";
 import { accounts, transactions } from "./schema";
+import type { ClassificationMethod, TransactionSource } from "@/lib/types";
 
 type Sample = {
   description: string;
   merchant?: string;
   cents: number;
-  source: "apple_pay" | "sms" | "csv" | "recurring" | "manual";
+  source: TransactionSource;
   category?: string;
-  method?: "rule" | "ai" | "manual" | "unclassified";
+  method?: ClassificationMethod;
 };
 
 const samples: Sample[] = [

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -1,12 +1,13 @@
 import { inArray } from "drizzle-orm";
 import { db } from "./index";
 import { accounts, categories, classificationRules, type AccountMetadata } from "./schema";
+import type { AccountType, Currency } from "@/lib/types";
 
 const seedAccounts: Array<{
   name: string;
   institution: string;
-  type: "savings" | "credit_card" | "loan";
-  currency: "COP" | "USD";
+  type: AccountType;
+  currency: Currency;
   metadata?: AccountMetadata;
 }> = [
   {

--- a/src/lib/events/bus.ts
+++ b/src/lib/events/bus.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from "node:events";
-
-export type TransactionSource = "sms" | "manual" | "recurring" | "ocr";
+import type { TransactionSource } from "@/lib/types";
 
 export type AppEvent =
   | {

--- a/src/lib/ingestion/sms-bancolombia.ts
+++ b/src/lib/ingestion/sms-bancolombia.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 import type { AccountMetadata } from "@/lib/db/schema";
-
-export type Currency = "COP" | "USD";
+import type { Currency } from "@/lib/types";
 
 export type ParsedSmsBase = {
   occurredOn: string; // ISO date YYYY-MM-DD

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,3 +1,5 @@
+import type { Currency } from "@/lib/types";
+
 export const FALLBACK_COP_PER_USD = 4000;
 
 const DECIMAL_AMOUNT_RE = /^\d+(?:\.\d{1,2})?$/;
@@ -20,7 +22,7 @@ export function decimalStringToCents(input: string): bigint {
   return BigInt(whole) * BigInt(100) + BigInt(paddedFraction);
 }
 
-export function toCop(amountCents: bigint, currency: "COP" | "USD", copPerUsd: number): bigint {
+export function toCop(amountCents: bigint, currency: Currency, copPerUsd: number): bigint {
   if (currency === "COP") return amountCents;
   const micros = BigInt(Math.round(copPerUsd * 1_000_000));
   return (amountCents * micros) / BigInt(1_000_000);
@@ -35,7 +37,7 @@ export function formatCop(amountCents: bigint): string {
   }).format(pesos);
 }
 
-export function formatMoney(amountCents: bigint, currency: "COP" | "USD"): string {
+export function formatMoney(amountCents: bigint, currency: Currency): string {
   const value = Number(amountCents) / 100;
   return new Intl.NumberFormat(currency === "USD" ? "en-US" : "es-CO", {
     style: "currency",

--- a/src/lib/recurring/gap-queries.ts
+++ b/src/lib/recurring/gap-queries.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_WINDOW_AFTER_DAYS,
   DEFAULT_WINDOW_BEFORE_DAYS,
 } from "@/lib/recurring/gap-detector";
+import type { Currency } from "@/lib/types";
 
 export type OpenGap = {
   gapId: number;
@@ -20,7 +21,7 @@ export type OpenGap = {
   accountId: number;
   accountName: string;
   amountCents: bigint;
-  currency: "COP" | "USD";
+  currency: Currency;
   categorySlug: string | null;
   categoryName: string | null;
   dayOfMonth: number;

--- a/src/lib/recurring/upcoming.ts
+++ b/src/lib/recurring/upcoming.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_WINDOW_AFTER_DAYS,
   DEFAULT_WINDOW_BEFORE_DAYS,
 } from "@/lib/recurring/gap-detector";
+import type { Currency } from "@/lib/types";
 
 export type UpcomingStatus = "matched" | "upcoming" | "overdue" | "dismissed";
 
@@ -14,7 +15,7 @@ export type UpcomingItem = {
   accountId: number;
   accountName: string;
   amountCents: bigint;
-  currency: "COP" | "USD";
+  currency: Currency;
   categorySlug: string | null;
   categoryName: string | null;
   dayOfMonth: number;

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -7,12 +7,9 @@ import {
   counterpartyAliases,
   transactions,
 } from "@/lib/db/schema";
+import type { CounterpartyAlias, CounterpartyBrief, TxRow } from "@/lib/types";
 
-export type CounterpartyAlias = {
-  id: number;
-  kind: "qr" | "breb" | "account" | "name";
-  value: string;
-};
+export type { CounterpartyAlias, CounterpartyBrief, TxRow };
 
 export const PAGE_SIZE = 50;
 
@@ -23,29 +20,6 @@ export type TxFilters = {
   categorySlug?: string;
   q?: string;
   cursor?: string;
-};
-
-export type TxRow = {
-  id: number;
-  occurredAt: Date;
-  amountCents: bigint;
-  currency: "COP" | "USD";
-  descriptionRaw: string;
-  descriptionClean: string | null;
-  merchant: string | null;
-  categorySlug: string | null;
-  classificationMethod: "rule" | "ai" | "manual" | "unclassified";
-  source: "apple_pay" | "sms" | "ocr" | "csv" | "recurring" | "manual";
-  accountId: number;
-  accountName: string;
-  counterparty: {
-    id: number;
-    displayName: string;
-    type: "person" | "merchant" | "unknown";
-    defaultCategorySlug: string | null;
-    notes: string | null;
-    aliases: CounterpartyAlias[];
-  } | null;
 };
 
 export type TxListResult = {
@@ -170,12 +144,6 @@ export async function listTransactions(filters: TxFilters): Promise<TxListResult
 
   return { rows: shaped, nextCursor };
 }
-
-export type CounterpartyBrief = {
-  id: number;
-  displayName: string;
-  type: "person" | "merchant" | "unknown";
-};
 
 /**
  * Compact counterparty list for the merge selector in CounterpartyDialog.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,55 @@
+import {
+  accountType,
+  classificationMethod,
+  counterpartyKeyKind,
+  counterpartyType,
+  currency,
+  txSource,
+} from "@/lib/db/schema";
+
+// Enum types derived from Drizzle `pgEnum` definitions. Adding a variant in
+// schema.ts is the only place needed — every consumer picks it up via these
+// aliases. Never redeclare these as inline unions.
+export type AccountType = (typeof accountType.enumValues)[number];
+export type Currency = (typeof currency.enumValues)[number];
+export type TransactionSource = (typeof txSource.enumValues)[number];
+export type ClassificationMethod = (typeof classificationMethod.enumValues)[number];
+export type CounterpartyType = (typeof counterpartyType.enumValues)[number];
+export type CounterpartyKind = (typeof counterpartyKeyKind.enumValues)[number];
+
+export type CounterpartyAlias = {
+  id: number;
+  kind: CounterpartyKind;
+  value: string;
+};
+
+export type CounterpartyBrief = {
+  id: number;
+  displayName: string;
+  type: CounterpartyType;
+};
+
+export type CounterpartyValue = {
+  id: number;
+  displayName: string;
+  type: CounterpartyType;
+  defaultCategorySlug: string | null;
+  notes: string | null;
+  aliases: CounterpartyAlias[];
+};
+
+export type TxRow = {
+  id: number;
+  occurredAt: Date;
+  amountCents: bigint;
+  currency: Currency;
+  descriptionRaw: string;
+  descriptionClean: string | null;
+  merchant: string | null;
+  categorySlug: string | null;
+  classificationMethod: ClassificationMethod;
+  source: TransactionSource;
+  accountId: number;
+  accountName: string;
+  counterparty: CounterpartyValue | null;
+};


### PR DESCRIPTION
Closes #147

## Summary
- New `src/lib/types.ts` derives every domain enum type from the Drizzle `pgEnum` definitions in `schema.ts`. Adding a variant in schema is now the ONLY place needed — every consumer picks it up automatically.
- Canonical shapes for `TxRow`, `CounterpartyAlias`, `CounterpartyBrief`, `CounterpartyValue` live in `types.ts`; `queries.ts` re-exports them so existing imports still work.
- All inline `"COP" | "USD"`, `"savings" | "credit_card" | "loan"`, `"qr" | "breb" | "account" | "name"`, etc. unions across `src/` replaced with the derived alias. Same for `z.enum([...])` of known DB-enum values.
- Fixed a latent divergence in `events/bus.ts`: `TransactionSource` was `"sms" | "manual" | "recurring" | "ocr"` (missing `apple_pay` and `csv`), silently blocking those sources from emitting events. Now uses the full `txSource` enum.
- Removed duplicate local `AliasKind` in `counterparties/alias-key.ts`, duplicate `Currency` in `sms-bancolombia.ts` and `animated-money.tsx`, and the `CounterpartyAlias` / `CounterpartyBrief` / `CounterpartyValue` redeclarations in `counterparty-dialog.tsx`.

## Acceptance
- [x] `src/lib/types.ts` exports derived types for all DB enums (Account/Currency/TransactionSource/ClassificationMethod/CounterpartyType/CounterpartyKind)
- [x] `TxRow` / `CounterpartyAlias` / `AccountDetail` / `ParsedSms` each have a single declaration
- [x] All duplicate declarations removed across `src/`
- [x] `rg "type CounterpartyKind|type TransactionSource" src/` returns only the canonical definitions in `types.ts`
- [x] `bun run typecheck` clean
- [x] `bun run test` — 170/170 pass (no runtime regressions)

## Test plan
- [x] Typecheck, lint, format, tests all green locally
- [ ] Manual smoke: `/transactions`, `/budgets`, `/accounts`, `/settings/recurring` load and render as before