### PR TITLE
fix(transactions): stop exporting zod schema from use-server module (#156)

### DIFF
--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -46,7 +46,7 @@ export async function updateTransactionCategory(input: {
 // Amount arrives as a decimal STRING so we can parse to bigint cents via
 // integer arithmetic (see `decimalStringToCents`). Never accept a number
 // here — `number * 100` loses precision for values like 9.995.
-export const expenseSchema = z.object({
+const expenseSchema = z.object({
   accountId: z.coerce.number().int().positive(),
   amount: z
     .string()


### PR DESCRIPTION
## Summary

- Drop the `export` on `expenseSchema` in `src/app/transactions/actions.ts`.
- Next.js 16 rejects non-async exports from `"use server"` modules, so the file failed to load and every server action inside it 500'd — including `updateTransactionCategory` triggered by changing a transaction's category.
- Schema is only consumed by `createManualExpense` in the same file; no external caller.

## Test plan

- [x] Manually changed a transaction category in `/transactions` — request returns 200 and the list revalidates.
- [x] `createManualExpense` still validates via the (now private) schema.
- [ ] CI (lint + typecheck + tests + `next build`) green.

Closes #156