### PR TITLE
fix(ui): fit transactions table to container so Amount stays visible (#158)

### DIFF
--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -128,16 +128,16 @@ export function TransactionTable({
   return (
     <>
       <div className="bg-card hidden rounded-md border md:block">
-        <Table>
+        <Table className="table-fixed">
           <TableHeader>
             <TableRow>
-              <TableHead className="w-[110px]">Date</TableHead>
+              <TableHead className="w-[140px]">Date</TableHead>
               <TableHead>Description</TableHead>
-              <TableHead className="w-[150px]">Account</TableHead>
-              <TableHead className="w-[200px]">Category</TableHead>
-              <TableHead className="w-[110px]">Source</TableHead>
-              <TableHead className="w-[110px]">Method</TableHead>
-              <TableHead className="w-[140px] text-right">Amount</TableHead>
+              <TableHead className="w-[170px]">Account</TableHead>
+              <TableHead className="w-[190px]">Category</TableHead>
+              <TableHead className="w-[80px]">Source</TableHead>
+              <TableHead className="w-[100px]">Method</TableHead>
+              <TableHead className="w-[120px] text-right">Amount</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -160,8 +160,8 @@ export function TransactionTable({
                       {formatDate(tx.occurredAt)}
                     </TableCell>
                     <TableCell>
-                      <div className="flex items-center gap-1.5">
-                        <span className="font-medium">{primaryDescription(tx)}</span>
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <span className="truncate font-medium">{primaryDescription(tx)}</span>
                         {tx.counterparty ? (
                           <CounterpartyTypeBadge type={tx.counterparty.type} />
                         ) : null}
@@ -179,7 +179,7 @@ export function TransactionTable({
                         </div>
                       ) : null}
                     </TableCell>
-                    <TableCell className="text-muted-foreground text-sm">
+                    <TableCell className="text-muted-foreground truncate text-sm">
                       {tx.accountName}
                     </TableCell>
                     <TableCell>


### PR DESCRIPTION
## Summary

- Switch the desktop transactions table to `table-fixed` so declared column widths are respected.
- Retune column widths (Date 140 · Account 170 · Category 190 · Source 80 · Method 100 · Amount 120) to sum under the 1230px `max-w-7xl` usable width, leaving Description as the flexible column.
- Add `truncate` to the Description primary label and the Account cell so long strings now ellipsis instead of forcing horizontal scroll.

## Why

With `table-layout: auto` + `whitespace-nowrap`, declared widths were hints — long values like `Bancolombia Visa *2575` blew columns past their declared size and the Amount column overflowed the viewport. On macOS overlay scrollbars the horizontal scroll was invisible, so users thought Amount was missing.

## Test plan

- [x] Verified with Chrome DevTools at 1480×900 desktop viewport: `scrollWidth == clientWidth` (1230), no horizontal overflow.
- [x] Amount column fully visible with color (red/green).
- [x] Dates render complete (`17 de abr de 2026`), Account truncates as `Bancolombia Visa *25…` with ellipsis.
- [x] Mobile card layout (`<md`) untouched.
- [ ] CI green.

Closes #158