### PR TITLE
refactor(ui): collapse tx table to 4 columns with vertical meta line (#160)

### DIFF
--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -77,11 +77,13 @@ function formatAmount(cents: bigint, currency: TxRow["currency"]) {
 }
 
 function formatDate(d: Date) {
-  return d.toLocaleDateString("es-CO", {
-    year: "numeric",
-    month: "short",
-    day: "2-digit",
-  });
+  return d
+    .toLocaleDateString("es-CO", {
+      year: "numeric",
+      month: "short",
+      day: "2-digit",
+    })
+    .replace(/\sde\s/g, " ");
 }
 
 export function TransactionTable({
@@ -128,15 +130,12 @@ export function TransactionTable({
   return (
     <>
       <div className="bg-card hidden rounded-md border md:block">
-        <Table>
+        <Table className="table-fixed">
           <TableHeader>
             <TableRow>
-              <TableHead className="w-[110px]">Date</TableHead>
+              <TableHead className="w-[100px]">Date</TableHead>
               <TableHead>Description</TableHead>
-              <TableHead className="w-[150px]">Account</TableHead>
-              <TableHead className="w-[200px]">Category</TableHead>
-              <TableHead className="w-[110px]">Source</TableHead>
-              <TableHead className="w-[110px]">Method</TableHead>
+              <TableHead className="w-[240px]">Category</TableHead>
               <TableHead className="w-[140px] text-right">Amount</TableHead>
             </TableRow>
           </TableHeader>
@@ -146,6 +145,7 @@ export function TransactionTable({
                 const isExpense = tx.amountCents < BigInt(0);
                 const isNew = newIds.has(tx.id);
                 const isHighlighted = tx.id === highlightId;
+                const isUnclassified = tx.classificationMethod === "unclassified";
                 return (
                   <motion.tr
                     key={tx.id}
@@ -156,12 +156,15 @@ export function TransactionTable({
                     animate={enterAnimate}
                     transition={enterTransition}
                   >
-                    <TableCell className="text-muted-foreground" suppressHydrationWarning>
+                    <TableCell
+                      className="text-muted-foreground align-top text-sm"
+                      suppressHydrationWarning
+                    >
                       {formatDate(tx.occurredAt)}
                     </TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-1.5">
-                        <span className="font-medium">{primaryDescription(tx)}</span>
+                    <TableCell className="align-top">
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <span className="truncate font-medium">{primaryDescription(tx)}</span>
                         {tx.counterparty ? (
                           <CounterpartyTypeBadge type={tx.counterparty.type} />
                         ) : null}
@@ -173,28 +176,35 @@ export function TransactionTable({
                           />
                         ) : null}
                       </div>
-                      {hasSecondaryDescription(tx) ? (
-                        <div className="text-muted-foreground line-clamp-1 text-xs">
-                          {tx.descriptionRaw}
-                        </div>
-                      ) : null}
+                      <div className="text-muted-foreground mt-0.5 flex min-w-0 items-center gap-1.5 text-xs">
+                        <span className="truncate">{tx.accountName}</span>
+                        <span aria-hidden="true">·</span>
+                        <span className="shrink-0">{sourceLabel[tx.source]}</span>
+                        <span aria-hidden="true">·</span>
+                        <span
+                          className={cn(
+                            "shrink-0",
+                            isUnclassified && "text-destructive font-medium",
+                          )}
+                        >
+                          {tx.classificationMethod}
+                        </span>
+                        {hasSecondaryDescription(tx) ? (
+                          <>
+                            <span aria-hidden="true">·</span>
+                            <span className="truncate">{tx.descriptionRaw}</span>
+                          </>
+                        ) : null}
+                      </div>
                     </TableCell>
-                    <TableCell className="text-muted-foreground text-sm">
-                      {tx.accountName}
-                    </TableCell>
-                    <TableCell>
+                    <TableCell className="align-top">
                       <CategoryCell txId={tx.id} value={tx.categorySlug} options={categories} />
                     </TableCell>
-                    <TableCell>
-                      <Badge variant="outline">{sourceLabel[tx.source]}</Badge>
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={methodVariant[tx.classificationMethod]}>
-                        {tx.classificationMethod}
-                      </Badge>
-                    </TableCell>
                     <TableCell
-                      className={`money text-right ${isExpense ? "text-destructive" : "text-emerald-600"}`}
+                      className={cn(
+                        "money text-right align-top font-medium",
+                        isExpense ? "text-destructive" : "text-emerald-600",
+                      )}
                       suppressHydrationWarning
                     >
                       {formatAmount(tx.amountCents, tx.currency)}


### PR DESCRIPTION
## Summary

- Desktop table collapses from **7 → 4** columns: `Date · Description · Category · Amount`.
- Account, Source, and Method move inside the Description cell as a muted, dot-separated meta line; the raw secondary description (when present) now lives at the end of that same line instead of its own row.
- Date format drops redundant `de`s (`17 abr 2026` instead of `17 de abr de 2026`).
- Switch to `table-fixed` with tuned widths (100 / flex / 240 / 140) so declared widths are respected.
- `unclassified` stays visually distinct (red, medium weight) in the meta line.

## Why

Context in #160 and #158 — the 7-column layout forced the Amount column off-screen on `max-w-7xl` viewports, and the pixel-fit attempt (closed #159) left Account and Category permanently ellipsised. A redesign is the honest fix.

## Test plan

Verified with Chrome DevTools MCP:

- [x] 1480×900 desktop: `scrollWidth == clientWidth (1230)`, no horizontal overflow.
- [x] Amount column fully visible with red/green color cues.
- [x] Account (`Bancolombia Visa *2575`) and Category (`Alimentación · Mercado`, `Alimentación · Delivery`) render without ellipsis in common cases; only `Alimentación · Restaurantes` ellipsises inside the combobox (expected).
- [x] Dark mode contrast verified.
- [x] Mobile card layout (`<md`) unchanged.
- [ ] CI green.

Closes #160
Closes #158