### PR TITLE
feat(classification): route QR payments to transferencias via rule engine (#44)

### DIFF
--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -235,7 +235,7 @@ describe("POST /api/ingest/sms", () => {
     expect(accs[0].name).toMatch(/Mastercard.*7291.*USD/);
   });
 
-  it("inserts a QR payment as expense from *6126 with unclassified category", async () => {
+  it("inserts a QR payment as expense from *6126 classified as transferencias via rule", async () => {
     const body =
       "Bancolombia: ALEJANDRO RAFAEL MARTINEZ MALDONADO pagaste $92,000.00 por codigo QR desde tu cuenta *6126 a la llave 0091498581 el 15/04/2026 a las 00:20. Con codigo QR es facil y de una. Dudas al 018000912345";
     const res = await POST(
@@ -256,8 +256,8 @@ describe("POST /api/ingest/sms", () => {
       FROM transactions WHERE id = ${json.txId!}
     `);
     expect(BigInt(rows[0].amount_cents)).toBe(BigInt(-9200000));
-    expect(rows[0].category_slug).toBeNull();
-    expect(rows[0].classification_method).toBe("unclassified");
+    expect(rows[0].category_slug).toBe("transferencias");
+    expect(rows[0].classification_method).toBe("rule");
   });
 
   it("inserts a TC payment as pago-tc expense from *6126", async () => {
@@ -560,7 +560,7 @@ describe("POST /api/ingest/sms", () => {
     "Bancolombia: ALEJANDRO, transferiste $50,000.00 a la llave 3046262677 desde tu cuenta *6126 a MARIA PAZ TORRES CARRILLO el 01/04/26 a las 13:22. Con Bre-b es de una y gratis. Dudas al 018000912345.";
   const BREB_KEY = "3046262677";
 
-  it("QR with new key auto-creates placeholder counterparty (key as display_name)", async () => {
+  it("QR with new key auto-creates placeholder counterparty and falls back to transferencias rule", async () => {
     const res = await POST(
       makeRequest({
         body: jsonBody({ body: QR_BODY }),
@@ -586,11 +586,11 @@ describe("POST /api/ingest/sms", () => {
       FROM transactions WHERE id = ${json.txId!}
     `);
     expect(txRows[0].counterparty_id).toBe(cp!.id);
-    expect(txRows[0].category_slug).toBeNull();
-    expect(txRows[0].classification_method).toBe("unclassified");
+    expect(txRows[0].category_slug).toBe("transferencias");
+    expect(txRows[0].classification_method).toBe("rule");
   });
 
-  it("QR with existing counterparty (no default category) links but stays unclassified", async () => {
+  it("QR with existing counterparty (no default category) links and falls back to transferencias rule", async () => {
     const cpId = await createCounterpartyWithAlias({
       kind: "qr",
       value: QR_KEY,
@@ -615,8 +615,8 @@ describe("POST /api/ingest/sms", () => {
       FROM transactions WHERE id = ${json.txId!}
     `);
     expect(rows[0].counterparty_id).toBe(cpId);
-    expect(rows[0].category_slug).toBeNull();
-    expect(rows[0].classification_method).toBe("unclassified");
+    expect(rows[0].category_slug).toBe("transferencias");
+    expect(rows[0].classification_method).toBe("rule");
 
     const cp = await findCounterpartyByAlias("qr", QR_KEY);
     expect(cp!.hit_count).toBe(1);

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -140,7 +140,12 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
   let finalCategory = cp.inheritedCategory ?? categorySlug;
   let finalMethod: Exclude<ClassificationMethod, "ai"> = cp.inheritedCategory ? "rule" : method;
   let confidence: number | null = null;
-  if (parsed.kind === "purchase" || parsed.kind === "provider_payment_sent") {
+  const shouldAttemptRule =
+    !cp.inheritedCategory &&
+    (parsed.kind === "purchase" ||
+      parsed.kind === "provider_payment_sent" ||
+      parsed.kind === "qr_payment");
+  if (shouldAttemptRule) {
     const cls = await classifyByRule({
       descriptionRaw,
       merchant,

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -169,6 +169,11 @@ const seedRules: Array<{ pattern: string; categorySlug: string; priority?: numbe
   { pattern: "%FARMATODO%", categorySlug: "medicamentos", priority: 10 },
   { pattern: "%CRUZ VERDE%", categorySlug: "medicamentos", priority: 10 },
   { pattern: "%LA REBAJA%", categorySlug: "medicamentos", priority: 10 },
+  // QR payments carry no merchant signal — the SMS only has an opaque "llave"
+  // (phone/account identifier). Route them to `transferencias` so they stop
+  // polluting `otros`. A user-mapped counterparty default_category still wins
+  // because counterparty inheritance happens before this rule in ingestParsed.
+  { pattern: "%Pago QR a llave%", categorySlug: "transferencias", priority: 50 },
 ];
 
 export async function runSeed() {


### PR DESCRIPTION
## Summary

- Adds a rule-engine entry `%Pago QR a llave%` → `transferencias` so QR payments stop falling as `unclassified` / `otros`
- Extends `ingestParsed` to invoke `classifyByRule` for `qr_payment` kind (previously only `purchase` and `provider_payment_sent` were rule-classified at ingest)
- Preserves counterparty precedence: if the user has mapped a QR `llave` to a counterparty with `default_category_slug`, that inheritance still wins over the generic rule

## Why

QR SMS from Bancolombia carries no merchant signal — only an opaque numeric `llave`. Today the tx falls as `unclassified` at ingest, and the batch AI classifier has nothing to work with so it returns `otros`, polluting reports and budgets. Per the direction in the issue comment, the interim is to add a rule at the engine level that routes these to the `transferencias` root. Long-term sub-categorization is manual via the counterparty dialog (unblocked by #110, already shipped).

## Scope NOT covered here

- No backfill of existing `otros`-classified QR tx (user confirmed this is fine — not productive yet, DB is disposable)
- No new rules admin UI — rules remain seed-defined, editable via psql

## Test plan

- [x] Existing test "QR with counterparty default_category inherits" still passes (counterparty wins over rule)
- [x] Updated 3 tests that asserted QR ends as `unclassified` — now assert `transferencias` + method `rule`
- [x] Full test suite green locally (170 passed)
- [x] Lint + typecheck + format:check all clean

Closes #44