### PR TITLE
feat(ingestion): SMS drift monitoring widget + settings page (#43)

### DIFF
--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -8,6 +8,7 @@ const pages = [
   { name: "budgets", path: "/budgets", hasDonut: false },
   { name: "insights", path: "/insights", hasDonut: false },
   { name: "settings", path: "/settings", hasDonut: false },
+  { name: "settings-ingestion", path: "/settings/ingestion", hasDonut: false },
 ];
 
 const modes = ["light", "dark"] as const;
@@ -20,6 +21,8 @@ for (const mode of modes) {
         window.localStorage.setItem("theme", m);
       }, mode);
       await page.goto(p.path, { waitUntil: "load" });
+      // Wait for streamed server-component content to replace any loading.tsx skeleton.
+      await page.waitForTimeout(600);
       if (p.hasDonut) {
         await page
           .locator(".recharts-pie-sector path")

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,9 +13,11 @@ import { AccountsGrid } from "@/components/dashboard/accounts-grid";
 import { UpcomingCard } from "@/components/dashboard/upcoming-card";
 import { MonthSwitcher } from "@/components/dashboard/month-switcher";
 import { RecurringInboxCard } from "@/components/dashboard/recurring-inbox-card";
+import { SmsHealthCard } from "@/components/dashboard/sms-health-card";
 import { getUpcomingForMonth } from "@/lib/recurring/upcoming";
 import { getOpenGaps } from "@/lib/recurring/gap-queries";
 import { getCurrentFxRate } from "@/lib/fx/repo";
+import { getSmsHealthSnapshot } from "@/lib/ingestion/sms-health";
 import {
   formatYearMonth,
   isFutureYearMonth,
@@ -39,7 +41,7 @@ export default async function DashboardPage({
   const [refYear, refMonth] = ym.split("-").map(Number);
 
   const fx = await getCurrentFxRate();
-  const [netWorth, flow, slices, top, accounts, upcoming, openGaps] = await Promise.all([
+  const [netWorth, flow, slices, top, accounts, upcoming, openGaps, smsHealth] = await Promise.all([
     getNetWorth(fx.rate),
     getMonthlyFlow(fx.rate, refDate),
     getCategoryBreakdown(fx.rate, refDate),
@@ -52,6 +54,7 @@ export default async function DashboardPage({
       today: now,
     }),
     getOpenGaps(),
+    getSmsHealthSnapshot(now),
   ]);
 
   const upcomingItems = upcoming.map((u) => ({
@@ -92,6 +95,7 @@ export default async function DashboardPage({
         <NetWorthCard data={netWorth} fx={fx} />
         <MonthlyFlowCard data={flow} monthLabel={monthLabel} isFuture={isFuture} />
         <CategoryDonut slices={donutSlices} monthLabel={monthLabel} isFuture={isFuture} />
+        <SmsHealthCard snapshot={smsHealth} />
       </section>
 
       <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">

--- a/src/app/settings/ingestion/page.tsx
+++ b/src/app/settings/ingestion/page.tsx
@@ -1,0 +1,170 @@
+import { AlertTriangleIcon } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  DRIFT_CONFIG,
+  getSmsHealthHistory,
+  getSmsHealthSnapshot,
+} from "@/lib/ingestion/sms-health";
+
+export const dynamic = "force-dynamic";
+
+const dateFmt = new Intl.DateTimeFormat("es-CO", {
+  weekday: "short",
+  day: "2-digit",
+  month: "short",
+  timeZone: "America/Bogota",
+});
+
+const timeFmt = new Intl.DateTimeFormat("es-CO", {
+  hour: "2-digit",
+  minute: "2-digit",
+  timeZone: "America/Bogota",
+});
+
+function formatCopDate(copDate: string): string {
+  const [y, m, d] = copDate.split("-").map(Number);
+  // Noon UTC to avoid tz boundary issues when formatting.
+  return dateFmt.format(new Date(Date.UTC(y, m - 1, d, 12, 0, 0)));
+}
+
+export default async function IngestionSettingsPage() {
+  const now = new Date();
+  const [snapshot, history] = await Promise.all([
+    getSmsHealthSnapshot(now),
+    getSmsHealthHistory(30, now),
+  ]);
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-h1">Ingesta</h1>
+        <p className="text-body text-muted-foreground">
+          Salud de la ingestión por SMS. Detecta &ldquo;días silenciosos&rdquo; cuando la
+          automatización de iOS 18 falla silenciosamente.
+        </p>
+      </header>
+
+      {snapshot.isDrift ? (
+        <div className="flex items-start gap-3 rounded border border-amber-300 bg-amber-50/60 p-4 dark:border-amber-900/40 dark:bg-amber-950/20">
+          <AlertTriangleIcon className="mt-0.5 size-5 text-amber-700 dark:text-amber-300" />
+          <div className="flex flex-col gap-1 text-sm">
+            <div className="font-medium text-amber-900 dark:text-amber-100">
+              Posible drift detectado
+            </div>
+            <div className="text-amber-800 dark:text-amber-200">
+              Hoy ingresaron {snapshot.todayInserted} SMS, pero el promedio de los últimos 7 días es{" "}
+              {snapshot.sevenDayAvgInserted.toFixed(1)}/día. Revisá la automatización de iOS y los
+              logs de iMessage.
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardDescription>Hoy (COP)</CardDescription>
+            <CardTitle className="text-base">{snapshot.todayCopDate}</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-1 text-sm">
+            <Stat label="Ingresados" value={snapshot.todayInserted} />
+            <Stat label="Duplicados" value={snapshot.todayDuplicated} />
+            <Stat label="Descartados" value={snapshot.todaySkipped} />
+            <Stat label="Con error" value={snapshot.todayError} />
+            <Stat
+              label="Último SMS"
+              value={snapshot.lastSmsAt ? timeFmt.format(snapshot.lastSmsAt) : "—"}
+            />
+            <Stat label="Avg 7d" value={`${snapshot.sevenDayAvgInserted.toFixed(2)}/día`} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardDescription>Configuración activa</CardDescription>
+            <CardTitle className="text-base">Regla de drift</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-1 text-sm">
+            <Stat
+              label="Drift ratio"
+              value={`< ${Math.round(DRIFT_CONFIG.ratio * 100)}% del avg 7d`}
+            />
+            <Stat
+              label="Hora de corte (COP)"
+              value={`≥ ${String(DRIFT_CONFIG.eveningHourCop).padStart(2, "0")}:00`}
+            />
+            <Stat label="Baseline mínimo" value={`${DRIFT_CONFIG.minBaseline} SMS/día`} />
+            <p className="text-muted-foreground mt-2 text-xs">
+              Read-only por ahora. Editable desde UI está en el issue{" "}
+              <a
+                href="https://github.com/ingamartinez/personal-financial-dashboard/issues/165"
+                target="_blank"
+                rel="noreferrer"
+                className="underline hover:no-underline"
+              >
+                #165
+              </a>
+              .
+            </p>
+          </CardContent>
+        </Card>
+      </section>
+
+      <Card>
+        <CardHeader>
+          <CardDescription>Últimos 30 días</CardDescription>
+          <CardTitle className="text-base">Historia de ingestión SMS</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {history.length === 0 ? (
+            <div className="text-muted-foreground text-sm">Sin ingestas registradas todavía.</div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Fecha</TableHead>
+                  <TableHead className="text-right">Ingresados</TableHead>
+                  <TableHead className="text-right">Duplicados</TableHead>
+                  <TableHead className="text-right">Descartados</TableHead>
+                  <TableHead className="text-right">Error</TableHead>
+                  <TableHead className="text-right">Último SMS</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {history.map((row) => (
+                  <TableRow key={row.copDate}>
+                    <TableCell className="font-medium">{formatCopDate(row.copDate)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{row.inserted}</TableCell>
+                    <TableCell className="text-right tabular-nums">{row.duplicated}</TableCell>
+                    <TableCell className="text-right tabular-nums">{row.skipped}</TableCell>
+                    <TableCell className="text-right tabular-nums">{row.error}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {row.lastSmsAt ? timeFmt.format(row.lastSmsAt) : "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="tabular-nums">{value}</span>
+    </div>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -13,6 +13,12 @@ const LINKS = [
     description:
       "Declare expected monthly items (rent, loan, subscriptions). Shows up as upcoming on the dashboard.",
   },
+  {
+    href: "/settings/ingestion",
+    title: "Ingesta SMS",
+    description:
+      "Salud de la ingestión por SMS: últimos 30 días, detección de drift y regla activa.",
+  },
 ];
 
 export default function SettingsPage() {

--- a/src/components/dashboard/sms-health-card.tsx
+++ b/src/components/dashboard/sms-health-card.tsx
@@ -1,0 +1,67 @@
+import { AlertTriangleIcon } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { SmsHealthSnapshot } from "@/lib/ingestion/sms-health";
+
+const timeFmt = new Intl.DateTimeFormat("es-CO", {
+  hour: "2-digit",
+  minute: "2-digit",
+  timeZone: "America/Bogota",
+});
+
+export function SmsHealthCard({ snapshot }: { snapshot: SmsHealthSnapshot }) {
+  const {
+    todayInserted,
+    todaySkipped,
+    todayDuplicated,
+    todayError,
+    lastSmsAt,
+    sevenDayAvgInserted,
+    isDrift,
+  } = snapshot;
+
+  const avgLabel = sevenDayAvgInserted > 0 ? sevenDayAvgInserted.toFixed(1) : "—";
+  const lastLabel = lastSmsAt ? timeFmt.format(lastSmsAt) : "sin SMS hoy";
+
+  const extras: string[] = [];
+  if (todayDuplicated > 0)
+    extras.push(`${todayDuplicated} duplicado${todayDuplicated === 1 ? "" : "s"}`);
+  if (todaySkipped > 0) extras.push(`${todaySkipped} descartado${todaySkipped === 1 ? "" : "s"}`);
+  if (todayError > 0) extras.push(`${todayError} con error`);
+
+  return (
+    <Card
+      className={cn(
+        isDrift && "border-amber-300 bg-amber-50/60 dark:border-amber-900/40 dark:bg-amber-950/20",
+      )}
+    >
+      <CardHeader>
+        <CardDescription>Ingesta SMS · hoy</CardDescription>
+        <CardTitle className="flex items-baseline gap-2 text-base">
+          <span className="text-2xl font-semibold tabular-nums">{todayInserted}</span>
+          <span className="text-muted-foreground text-sm font-normal">ingresados</span>
+          {isDrift ? (
+            <span className="ml-auto inline-flex items-center gap-1 rounded bg-amber-200 px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-amber-900 uppercase dark:bg-amber-900/60 dark:text-amber-100">
+              <AlertTriangleIcon className="size-3" />
+              Posible drift
+            </span>
+          ) : null}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-1 text-xs">
+        <div className="text-muted-foreground">
+          Último: <span className="text-foreground">{lastLabel}</span> · avg 7d:{" "}
+          <span className="text-foreground tabular-nums">{avgLabel}/día</span>
+        </div>
+        {extras.length > 0 ? (
+          <div className="text-muted-foreground">{extras.join(" · ")}</div>
+        ) : null}
+        {isDrift ? (
+          <div className="text-amber-800 dark:text-amber-200">
+            Muy por debajo del promedio de la última semana. Revisá la automatización de iOS.
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/ingestion/sms-health.test.ts
+++ b/src/lib/ingestion/sms-health.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { ingestionLogs } from "@/lib/db/schema";
+import {
+  computeIsDrift,
+  DRIFT_CONFIG,
+  getSmsHealthHistory,
+  getSmsHealthSnapshot,
+  hourInCop,
+  todayInCop,
+} from "./sms-health";
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM ingestion_logs WHERE source = 'sms'`);
+}
+
+describe("todayInCop / hourInCop", () => {
+  it("returns the COP calendar date even when UTC is already on the next day", () => {
+    // 02:00 UTC on Apr 17 is 21:00 COP on Apr 16.
+    const utc = new Date(Date.UTC(2026, 3, 17, 2, 0, 0));
+    expect(todayInCop(utc)).toBe("2026-04-16");
+    expect(hourInCop(utc)).toBe(21);
+  });
+
+  it("returns the UTC date when COP is mid-day", () => {
+    // 18:00 UTC on Apr 17 is 13:00 COP on Apr 17.
+    const utc = new Date(Date.UTC(2026, 3, 17, 18, 0, 0));
+    expect(todayInCop(utc)).toBe("2026-04-17");
+    expect(hourInCop(utc)).toBe(13);
+  });
+});
+
+describe("computeIsDrift", () => {
+  it("does not flag when baseline is below the floor", () => {
+    expect(computeIsDrift({ todayInserted: 0, sevenDayAvgInserted: 1, nowCopHour: 23 })).toBe(
+      false,
+    );
+  });
+
+  it("does not flag before the evening cutoff even with zero today", () => {
+    expect(
+      computeIsDrift({
+        todayInserted: 0,
+        sevenDayAvgInserted: 10,
+        nowCopHour: DRIFT_CONFIG.eveningHourCop - 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("flags after the cutoff when today is under ratio * avg", () => {
+    expect(
+      computeIsDrift({
+        todayInserted: 2,
+        sevenDayAvgInserted: 10,
+        nowCopHour: DRIFT_CONFIG.eveningHourCop,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not flag when today meets or exceeds ratio * avg", () => {
+    const threshold = 10 * DRIFT_CONFIG.ratio;
+    expect(
+      computeIsDrift({
+        todayInserted: threshold,
+        sevenDayAvgInserted: 10,
+        nowCopHour: 22,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("getSmsHealthHistory (integration)", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("returns an empty array when no SMS logs exist", async () => {
+    const history = await getSmsHealthHistory(7);
+    expect(history).toEqual([]);
+  });
+
+  it("groups rows by COP calendar day and counts per status", async () => {
+    // All three fall on 2026-04-17 in COP time:
+    // - 13:00 UTC = 08:00 COP Apr 17
+    // - 23:00 UTC = 18:00 COP Apr 17
+    // - 04:00 UTC next day = 23:00 COP Apr 17
+    const base = new Date(Date.UTC(2026, 3, 17, 13, 0, 0));
+    const later = new Date(Date.UTC(2026, 3, 17, 23, 0, 0));
+    const edge = new Date(Date.UTC(2026, 3, 18, 4, 0, 0));
+
+    await db.insert(ingestionLogs).values([
+      {
+        source: "sms",
+        status: "inserted",
+        itemsReceived: 1,
+        itemsInserted: 1,
+        startedAt: base,
+        finishedAt: base,
+      },
+      {
+        source: "sms",
+        status: "inserted",
+        itemsReceived: 1,
+        itemsInserted: 1,
+        startedAt: later,
+        finishedAt: later,
+      },
+      {
+        source: "sms",
+        status: "skipped",
+        itemsReceived: 1,
+        errorMessage: "non_transactional",
+        startedAt: edge,
+        finishedAt: edge,
+      },
+    ]);
+
+    const now = new Date(Date.UTC(2026, 3, 18, 5, 0, 0)); // 00:00 COP Apr 18
+    const history = await getSmsHealthHistory(7, now);
+
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({
+      copDate: "2026-04-17",
+      inserted: 2,
+      skipped: 1,
+      duplicated: 0,
+      error: 0,
+    });
+    expect(history[0].lastSmsAt?.toISOString()).toBe(edge.toISOString());
+  });
+
+  it("ignores logs from non-sms sources", async () => {
+    await db.insert(ingestionLogs).values({
+      source: "manual",
+      status: "inserted",
+      itemsReceived: 1,
+      itemsInserted: 1,
+      startedAt: new Date(Date.UTC(2026, 3, 17, 13, 0, 0)),
+      finishedAt: new Date(Date.UTC(2026, 3, 17, 13, 0, 0)),
+    });
+    const history = await getSmsHealthHistory(7);
+    expect(history).toEqual([]);
+  });
+});
+
+describe("getSmsHealthSnapshot (integration)", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("returns zeros when there are no logs", async () => {
+    const now = new Date(Date.UTC(2026, 3, 17, 18, 0, 0));
+    const snap = await getSmsHealthSnapshot(now);
+    expect(snap.todayInserted).toBe(0);
+    expect(snap.sevenDayAvgInserted).toBe(0);
+    expect(snap.lastSmsAt).toBeNull();
+    expect(snap.isDrift).toBe(false);
+  });
+
+  it("averages the previous 7 COP days across calendar gaps", async () => {
+    // Reference: now = 2026-04-17 18:00 COP → "today" = 2026-04-17.
+    // Previous 7 days = Apr 10..Apr 16. Insert 7 rows, one per day, each 'inserted'.
+    const values = [] as (typeof ingestionLogs.$inferInsert)[];
+    for (let d = 10; d <= 16; d += 1) {
+      const ts = new Date(Date.UTC(2026, 3, d, 18, 0, 0)); // 13:00 COP that day
+      values.push({
+        source: "sms",
+        status: "inserted",
+        itemsReceived: 1,
+        itemsInserted: 1,
+        startedAt: ts,
+        finishedAt: ts,
+      });
+    }
+    await db.insert(ingestionLogs).values(values);
+
+    const now = new Date(Date.UTC(2026, 3, 17, 23, 0, 0)); // 18:00 COP Apr 17
+    const snap = await getSmsHealthSnapshot(now);
+
+    expect(snap.todayCopDate).toBe("2026-04-17");
+    expect(snap.todayInserted).toBe(0);
+    expect(snap.sevenDayAvgInserted).toBe(1);
+    // 18:00 COP < evening cutoff (20) → no flag even though today is 0.
+    expect(snap.isDrift).toBe(false);
+  });
+});

--- a/src/lib/ingestion/sms-health.ts
+++ b/src/lib/ingestion/sms-health.ts
@@ -1,0 +1,130 @@
+import { and, eq, gte, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { ingestionLogs } from "@/lib/db/schema";
+
+// Drift detection thresholds. Hardcoded for now; editable UI tracked in issue #165.
+export const DRIFT_CONFIG = {
+  /** Today's inserted count must be below avg * ratio to flag drift. */
+  ratio: 0.5,
+  /** Flag only fires once local COP time is at/after this hour. */
+  eveningHourCop: 20,
+  /** If avg is below this floor, skip the drift check (baseline too sparse to matter). */
+  minBaseline: 2,
+} as const;
+
+// Colombia is UTC-5 year-round.
+const COP_OFFSET_HOURS = -5;
+const MS_PER_HOUR = 3_600_000;
+const MS_PER_DAY = 86_400_000;
+
+function toCopClock(now: Date): Date {
+  return new Date(now.getTime() + COP_OFFSET_HOURS * MS_PER_HOUR);
+}
+
+export function todayInCop(now: Date = new Date()): string {
+  return toCopClock(now).toISOString().slice(0, 10);
+}
+
+export function hourInCop(now: Date = new Date()): number {
+  return toCopClock(now).getUTCHours();
+}
+
+/** Compute the UTC Date corresponding to 00:00 COP on (today in COP - daysAgo). */
+function startOfCopDayUtc(now: Date, daysAgo: number): Date {
+  const cop = toCopClock(now);
+  const startOfTodayUtcMs = Date.UTC(
+    cop.getUTCFullYear(),
+    cop.getUTCMonth(),
+    cop.getUTCDate(),
+    -COP_OFFSET_HOURS,
+    0,
+    0,
+  );
+  return new Date(startOfTodayUtcMs - daysAgo * MS_PER_DAY);
+}
+
+export type SmsHealthDay = {
+  copDate: string;
+  inserted: number;
+  duplicated: number;
+  skipped: number;
+  error: number;
+  lastSmsAt: Date | null;
+};
+
+export type SmsHealthSnapshot = {
+  todayCopDate: string;
+  nowCopHour: number;
+  todayInserted: number;
+  todaySkipped: number;
+  todayDuplicated: number;
+  todayError: number;
+  lastSmsAt: Date | null;
+  sevenDayAvgInserted: number;
+  isDrift: boolean;
+};
+
+export function computeIsDrift(input: {
+  todayInserted: number;
+  sevenDayAvgInserted: number;
+  nowCopHour: number;
+}): boolean {
+  if (input.sevenDayAvgInserted < DRIFT_CONFIG.minBaseline) return false;
+  if (input.nowCopHour < DRIFT_CONFIG.eveningHourCop) return false;
+  return input.todayInserted < input.sevenDayAvgInserted * DRIFT_CONFIG.ratio;
+}
+
+export async function getSmsHealthHistory(
+  days = 30,
+  now: Date = new Date(),
+): Promise<SmsHealthDay[]> {
+  const cutoff = startOfCopDayUtc(now, days - 1);
+  const rows = await db
+    .select({
+      copDate: sql<string>`to_char(((${ingestionLogs.startedAt}) AT TIME ZONE 'America/Bogota')::date, 'YYYY-MM-DD')`,
+      inserted: sql<number>`count(*) FILTER (WHERE ${ingestionLogs.status} = 'inserted')::int`,
+      duplicated: sql<number>`count(*) FILTER (WHERE ${ingestionLogs.status} = 'duplicated')::int`,
+      skipped: sql<number>`count(*) FILTER (WHERE ${ingestionLogs.status} = 'skipped')::int`,
+      error: sql<number>`count(*) FILTER (WHERE ${ingestionLogs.status} = 'error')::int`,
+      lastSmsAt: sql<string | null>`max(${ingestionLogs.startedAt})`,
+    })
+    .from(ingestionLogs)
+    .where(and(eq(ingestionLogs.source, "sms"), gte(ingestionLogs.startedAt, cutoff)))
+    .groupBy(sql`((${ingestionLogs.startedAt}) AT TIME ZONE 'America/Bogota')::date`)
+    .orderBy(sql`((${ingestionLogs.startedAt}) AT TIME ZONE 'America/Bogota')::date DESC`);
+
+  return rows.map((r) => ({
+    copDate: r.copDate,
+    inserted: r.inserted,
+    duplicated: r.duplicated,
+    skipped: r.skipped,
+    error: r.error,
+    lastSmsAt: r.lastSmsAt ? new Date(r.lastSmsAt) : null,
+  }));
+}
+
+export async function getSmsHealthSnapshot(now: Date = new Date()): Promise<SmsHealthSnapshot> {
+  const history = await getSmsHealthHistory(8, now);
+  const todayCopDate = todayInCop(now);
+  const nowCopHour = hourInCop(now);
+
+  const today = history.find((h) => h.copDate === todayCopDate);
+  const previousDays = history.filter((h) => h.copDate !== todayCopDate).slice(0, 7);
+
+  const todayInserted = today?.inserted ?? 0;
+  // Average across 7 calendar days (missing days count as 0, so we divide by 7 regardless).
+  const totalPrevInserted = previousDays.reduce((sum, d) => sum + d.inserted, 0);
+  const sevenDayAvgInserted = totalPrevInserted / 7;
+
+  return {
+    todayCopDate,
+    nowCopHour,
+    todayInserted,
+    todaySkipped: today?.skipped ?? 0,
+    todayDuplicated: today?.duplicated ?? 0,
+    todayError: today?.error ?? 0,
+    lastSmsAt: today?.lastSmsAt ?? null,
+    sevenDayAvgInserted,
+    isDrift: computeIsDrift({ todayInserted, sevenDayAvgInserted, nowCopHour }),
+  };
+}


### PR DESCRIPTION
## Summary

- Adds **`SmsHealthCard`** on `/` — glanceable today-inserted count + last-SMS time, with an amber \"Posible drift\" badge when the daily count drops below 50% of the 7-day avg after 20:00 COP (and the avg is ≥ 2/day so we don't spam on sparse baselines).
- Adds **`/settings/ingestion`** — richer deep-dive view: today summary, active drift-rule config (read-only), and a 30-day history table.
- All drift logic lives in `src/lib/ingestion/sms-health.ts` as a single data module consumed by both surfaces. COP timezone math done in JS; grouping/aggregation pushed to Postgres via \`AT TIME ZONE 'America/Bogota'\`.
- Thresholds are hardcoded in \`DRIFT_CONFIG\`. A follow-up issue #165 tracks making them editable from the UI *only if* the defaults turn out to be wrong — avoiding premature config infrastructure for three numbers.

## Context

Closes #43. The user reported that iOS 18 SMS-triggered Automations silently fail, which causes data loss in the dashboard (balances drift, budgets undercount). We discussed three options (daily cron script, dashboard widget, anomaly alert) and agreed that a passive widget + conditional drift flag gives better ergonomics than a log nobody reads.

During planning the user asked for a settings surface too — \"se me puede olvidar\" — so both surfaces ship together, backed by the same module.

## Test plan

- [x] \`bun run lint\`
- [x] \`bun run typecheck\`
- [x] \`bun run format:check\`
- [x] \`bun run test\` — 11 new tests pass (pure drift logic + integration against \`findash_test\`); full suite 181 ✓
- [x] \`bun run test:e2e\` — screenshots regenerated for both pages, light and dark, chromium + mobile (30 ✓)
- [x] Dev server smoke test: \`/\`, \`/settings\`, \`/settings/ingestion\` all return 200 and render expected content

## Visuals

Dashboard widget (top row, 4th slot):

![light home](https://github.com/user-attachments/assets/placeholder-home-light)

Settings deep-dive page:

![light ingestion](https://github.com/user-attachments/assets/placeholder-ingestion-light)

(Screenshots available in \`e2e/screenshots/\` — gitignored per AGENTS.md.)

## Follow-ups

- #165 — make thresholds editable from the UI (only if defaults need tuning)

Closes #43