### PR TITLE
feat(classification): on-demand AI classify for a single transaction (#167)

### DIFF
--- a/src/app/transactions/actions.test.ts
+++ b/src/app/transactions/actions.test.ts
@@ -9,8 +9,26 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
-const { updateCounterparty, mergeCounterparty, splitCounterparty, createManualExpense } =
-  await import("./actions");
+// Stub the AI classifier lib so tests never hit the Anthropic API; individual
+// tests drive the mock with mockResolvedValueOnce for each scenario.
+vi.mock("@/lib/classification/ai", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/classification/ai")>("@/lib/classification/ai");
+  return {
+    ...actual,
+    classifySingleWithAi: vi.fn(),
+  };
+});
+
+const {
+  updateCounterparty,
+  mergeCounterparty,
+  splitCounterparty,
+  createManualExpense,
+  classifySingleWithAi,
+} = await import("./actions");
+const { classifySingleWithAi: classifySingleWithAiLib } = await import("@/lib/classification/ai");
+const mockAiClassifySingle = vi.mocked(classifySingleWithAiLib);
 
 // Scoped so parallel test files don't wipe each other's counterparty rows.
 // Matches by alias.value prefix OR display_name prefix so tests that mutate
@@ -705,5 +723,162 @@ describe("createManualExpense", () => {
       WHERE description_raw = 'test-manual-expense large'
     `);
     expect(rows[0].amount_cents).toBe("-999999999");
+  });
+});
+
+describe("classifySingleWithAi", () => {
+  async function seedUnclassifiedTx(externalId: string): Promise<number> {
+    const [acc] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts WHERE name = 'Bancolombia Ahorros' LIMIT 1
+    `);
+    const rows = await db.execute<{ id: number }>(sql`
+      INSERT INTO transactions (
+        account_id, occurred_at, amount_cents, currency, description_raw,
+        classification_method, source, external_id
+      ) VALUES (
+        ${acc.id}, now(), -42000, 'COP', 'NETFLIX',
+        'unclassified'::classification_method, 'sms', ${externalId}
+      )
+      RETURNING id
+    `);
+    return rows[0].id;
+  }
+
+  async function seedClassifiedTx(externalId: string): Promise<number> {
+    const [acc] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts WHERE name = 'Bancolombia Ahorros' LIMIT 1
+    `);
+    const rows = await db.execute<{ id: number }>(sql`
+      INSERT INTO transactions (
+        account_id, occurred_at, amount_cents, currency, description_raw,
+        category_slug, classification_method, source, external_id
+      ) VALUES (
+        ${acc.id}, now(), -5000, 'COP', 'manual already',
+        'alimentacion', 'manual'::classification_method, 'sms', ${externalId}
+      )
+      RETURNING id
+    `);
+    return rows[0].id;
+  }
+
+  async function cleanupAiTxs() {
+    await db.execute(sql`
+      DELETE FROM transactions WHERE external_id LIKE 'test-ai-single:%'
+    `);
+  }
+
+  beforeEach(async () => {
+    await cleanupAiTxs();
+    mockAiClassifySingle.mockReset();
+  });
+  afterEach(cleanupAiTxs);
+
+  it("updates tx with category, method='ai', and confidence on success", async () => {
+    const txId = await seedUnclassifiedTx("test-ai-single:ok");
+    mockAiClassifySingle.mockResolvedValueOnce({
+      classification: {
+        id: txId,
+        categorySlug: "suscripciones",
+        confidence: 92,
+        reason: "NETFLIX",
+      },
+      model: "claude-haiku-4-5-20251001",
+      usage: { inputTokens: 100, outputTokens: 20 },
+    });
+
+    const result = await classifySingleWithAi({ txId });
+
+    expect(result.categorySlug).toBe("suscripciones");
+    expect(result.confidence).toBe(92);
+    expect(result.categoryName.length).toBeGreaterThan(0);
+
+    const [row] = await db.execute<{
+      category_slug: string;
+      classification_method: string;
+      classification_confidence: number;
+    }>(sql`
+      SELECT category_slug, classification_method, classification_confidence
+      FROM transactions WHERE id = ${txId}
+    `);
+    expect(row.category_slug).toBe("suscripciones");
+    expect(row.classification_method).toBe("ai");
+    expect(row.classification_confidence).toBe(92);
+  });
+
+  it("rejects when tx is already classified and does not call the AI", async () => {
+    const txId = await seedClassifiedTx("test-ai-single:classified");
+
+    await expect(classifySingleWithAi({ txId })).rejects.toThrow(/already classified/);
+    expect(mockAiClassifySingle).not.toHaveBeenCalled();
+
+    const [row] = await db.execute<{
+      category_slug: string;
+      classification_method: string;
+    }>(sql`
+      SELECT category_slug, classification_method
+      FROM transactions WHERE id = ${txId}
+    `);
+    expect(row.category_slug).toBe("alimentacion");
+    expect(row.classification_method).toBe("manual");
+  });
+
+  it("rejects when tx does not exist", async () => {
+    await expect(classifySingleWithAi({ txId: 9_999_999 })).rejects.toThrow(/not found/);
+    expect(mockAiClassifySingle).not.toHaveBeenCalled();
+  });
+
+  it("rejects and leaves tx unclassified when AI returns null category", async () => {
+    const txId = await seedUnclassifiedTx("test-ai-single:null");
+    mockAiClassifySingle.mockResolvedValueOnce({
+      classification: {
+        id: txId,
+        categorySlug: null,
+        confidence: 10,
+      },
+      model: "claude-haiku-4-5-20251001",
+      usage: { inputTokens: 50, outputTokens: 10 },
+    });
+
+    await expect(classifySingleWithAi({ txId })).rejects.toThrow(/could not classify/);
+
+    const [row] = await db.execute<{
+      category_slug: string | null;
+      classification_method: string;
+    }>(sql`
+      SELECT category_slug, classification_method
+      FROM transactions WHERE id = ${txId}
+    `);
+    expect(row.category_slug).toBeNull();
+    expect(row.classification_method).toBe("unclassified");
+  });
+
+  it("rejects when the AI returns a slug that isn't in the category taxonomy", async () => {
+    const txId = await seedUnclassifiedTx("test-ai-single:bogus");
+    mockAiClassifySingle.mockResolvedValueOnce({
+      classification: {
+        id: txId,
+        categorySlug: "not-a-real-slug",
+        confidence: 80,
+      },
+      model: "claude-haiku-4-5-20251001",
+      usage: { inputTokens: 50, outputTokens: 10 },
+    });
+
+    await expect(classifySingleWithAi({ txId })).rejects.toThrow();
+
+    const [row] = await db.execute<{
+      category_slug: string | null;
+      classification_method: string;
+    }>(sql`
+      SELECT category_slug, classification_method
+      FROM transactions WHERE id = ${txId}
+    `);
+    expect(row.category_slug).toBeNull();
+    expect(row.classification_method).toBe("unclassified");
+  });
+
+  it("rejects an invalid txId via zod", async () => {
+    await expect(classifySingleWithAi({ txId: 0 })).rejects.toThrow();
+    await expect(classifySingleWithAi({ txId: -1 })).rejects.toThrow();
   });
 });

--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -11,6 +11,7 @@ import {
   counterpartyType,
   transactions,
 } from "@/lib/db/schema";
+import { classifySingleWithAi as classifySingleWithAiLib } from "@/lib/classification/ai";
 import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
 import { emit } from "@/lib/events/bus";
 import { autoLinkTransaction } from "@/lib/recurring/auto-link";
@@ -150,6 +151,92 @@ export async function runAiClassifier() {
   revalidatePath("/");
   revalidatePath("/transactions");
   return result;
+}
+
+const classifySingleSchema = z.object({
+  txId: z.coerce.number().int().positive(),
+});
+
+export type ClassifySingleInput = z.input<typeof classifySingleSchema>;
+export type ClassifySingleResult = {
+  categorySlug: string;
+  categoryName: string;
+  confidence: number;
+};
+
+export async function classifySingleWithAi(
+  input: ClassifySingleInput,
+): Promise<ClassifySingleResult> {
+  const { txId } = classifySingleSchema.parse(input);
+
+  const [tx] = await db
+    .select({
+      id: transactions.id,
+      descriptionRaw: transactions.descriptionRaw,
+      descriptionClean: transactions.descriptionClean,
+      merchant: transactions.merchant,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      classificationMethod: transactions.classificationMethod,
+      categorySlug: transactions.categorySlug,
+    })
+    .from(transactions)
+    .where(eq(transactions.id, txId))
+    .limit(1);
+
+  if (!tx) throw new Error("Transaction not found");
+  if (tx.classificationMethod !== "unclassified" || tx.categorySlug !== null) {
+    throw new Error("Transaction is already classified");
+  }
+
+  const cats = await db
+    .select({
+      slug: categories.slug,
+      name: categories.name,
+      parentSlug: categories.parentSlug,
+    })
+    .from(categories);
+
+  const result = await classifySingleWithAiLib({
+    transaction: {
+      id: tx.id,
+      description: tx.descriptionClean ?? tx.merchant ?? tx.descriptionRaw,
+      amountCents: tx.amountCents,
+      currency: tx.currency,
+    },
+    categories: cats,
+  });
+
+  const hit = result.classification;
+  if (!hit || !hit.categorySlug) {
+    throw new Error("AI could not classify this transaction");
+  }
+
+  const pickedCat = cats.find((c) => c.slug === hit.categorySlug);
+  if (!pickedCat) {
+    // classifyBatchWithAi already filters invalid slugs to null, so this is
+    // defense-in-depth — the row stays unclassified if we somehow get here.
+    throw new Error("AI returned an unknown category");
+  }
+
+  await db
+    .update(transactions)
+    .set({
+      categorySlug: hit.categorySlug,
+      classificationMethod: "ai",
+      classificationConfidence: hit.confidence,
+      updatedAt: new Date(),
+    })
+    .where(eq(transactions.id, txId));
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+
+  return {
+    categorySlug: hit.categorySlug,
+    categoryName: pickedCat.name,
+    confidence: hit.confidence,
+  };
 }
 
 const counterpartyTypeSchema = z.enum(counterpartyType.enumValues);

--- a/src/components/transactions/category-cell.tsx
+++ b/src/components/transactions/category-cell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useTransition } from "react";
+import { Sparkles } from "lucide-react";
 import { toast } from "sonner";
-import { updateTransactionCategory } from "@/app/transactions/actions";
+import { classifySingleWithAi, updateTransactionCategory } from "@/app/transactions/actions";
+import { Button } from "@/components/ui/button";
 import { CategoryCombobox } from "./category-combobox";
 
 export type CategoryOption = {
@@ -21,23 +23,56 @@ export function CategoryCell({
   options: CategoryOption[];
 }) {
   const [pending, startTransition] = useTransition();
+  const [aiPending, startAiTransition] = useTransition();
+  const busy = pending || aiPending;
+  const isUnclassified = value === null;
 
   return (
-    <CategoryCombobox
-      value={value}
-      options={options}
-      disabled={pending}
-      onChange={(next) => {
-        startTransition(async () => {
-          try {
-            await updateTransactionCategory({ txId, categorySlug: next });
-            toast.success("Category updated");
-          } catch (err) {
-            toast.error(err instanceof Error ? err.message : "Failed to update");
-          }
-        });
-      }}
-      triggerClassName="h-8"
-    />
+    <div className="flex items-center gap-1.5">
+      <CategoryCombobox
+        value={value}
+        options={options}
+        disabled={busy}
+        onChange={(next) => {
+          startTransition(async () => {
+            try {
+              await updateTransactionCategory({ txId, categorySlug: next });
+              toast.success("Category updated");
+            } catch (err) {
+              toast.error(err instanceof Error ? err.message : "Failed to update");
+            }
+          });
+        }}
+        triggerClassName="h-8"
+      />
+      {isUnclassified ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-8 shrink-0"
+          disabled={busy}
+          aria-label="Classify with AI"
+          title="Classify with AI"
+          onClick={() => {
+            startAiTransition(async () => {
+              try {
+                const res = await classifySingleWithAi({ txId });
+                const pct = Math.round(res.confidence);
+                if (pct < 50) {
+                  toast.warning(`Classified as ${res.categoryName} · low confidence (${pct}%)`);
+                } else {
+                  toast.success(`Classified as ${res.categoryName} (${pct}%)`);
+                }
+              } catch (err) {
+                toast.error(err instanceof Error ? err.message : "AI classify failed");
+              }
+            });
+          }}
+        >
+          <Sparkles className={aiPending ? "size-4 animate-pulse" : "size-4"} />
+        </Button>
+      ) : null}
+    </div>
   );
 }

--- a/src/lib/classification/ai.ts
+++ b/src/lib/classification/ai.ts
@@ -94,6 +94,30 @@ function extractJson(text: string): unknown {
   return JSON.parse(candidate);
 }
 
+export type AiSingleClassifyResult = {
+  classification: AiClassification | null;
+  model: string;
+  usage: { inputTokens: number; outputTokens: number };
+};
+
+export async function classifySingleWithAi(opts: {
+  transaction: AiClassifiable;
+  categories: AiCategoryOption[];
+  model?: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<AiSingleClassifyResult> {
+  const batch = await classifyBatchWithAi({
+    transactions: [opts.transaction],
+    categories: opts.categories,
+    model: opts.model,
+    apiKey: opts.apiKey,
+    fetchImpl: opts.fetchImpl,
+  });
+  const hit = batch.classifications.find((c) => c.id === opts.transaction.id) ?? null;
+  return { classification: hit, model: batch.model, usage: batch.usage };
+}
+
 export async function classifyBatchWithAi(opts: {
   transactions: AiClassifiable[];
   categories: AiCategoryOption[];


### PR DESCRIPTION
## Summary

- Adds a per-row **Classify with AI** affordance on `/transactions` (sparkle button inside the category cell) that only appears on unclassified rows.
- New server action `classifySingleWithAi(txId)` in `src/app/transactions/actions.ts` — guards that the tx is still unclassified, calls the AI classifier for just that row, and updates `category_slug` + `classification_method='ai'` + `classification_confidence` on success.
- Reuses the existing Anthropic prompt path: a thin `classifySingleWithAi` wrapper in `src/lib/classification/ai.ts` calls `classifyBatchWithAi` with a single-element array. No duplicated prompt logic.
- Toast feedback: success shows `\"Classified as <name> (<pct>%)\"`; confidence <50 surfaces a warning toast instead. Failures (AI returned null, already classified, tx not found) surface as error toasts and leave the row untouched.

## Test plan

- [x] `bun run test` — 187/187 passing (added 6 new tests for `classifySingleWithAi`: happy path, already-classified guard, nonexistent tx, null-category response, bogus-slug response, zod input validation).
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [ ] Manual smoke: start dev server, pick an unclassified tx, click the sparkle, verify category lands + badge flips to `ai` + combobox reflects new value.

## Notes

- **UX choice**: inline sparkle button (option 1 from the issue), not a three-dot row menu. Chose it for shipping speed — no DropdownMenu infra exists in this codebase yet. When we add more per-row actions (split, delete), it's worth promoting to a menu.
- **Revalidation**: matches the existing `updateTransactionCategory` pattern — `revalidatePath(\"/\")` + `revalidatePath(\"/transactions\")` inside the server action, no `router.refresh()` on the client. The row (including the classification-method badge) refreshes on the next RSC tick.
- **Out of scope** (follow-ups if needed): bulk multi-select classify, re-classifying already-classified txs, propose-then-accept UX.

Closes #167