### PR TITLE
feat(ingestion): Telegram bot Fase 1 — texto libre con NLU + confirmación (#67)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,19 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Pegá el MISMO valor en .env.local y en el header Authorization del Shortcut.
 INGEST_WEBHOOK_TOKEN=replace-with-output-of-openssl-rand-hex-32
 
+# Telegram bot — canal unificado para ingreso mobile
+# Creá un bot con @BotFather (/newbot) y pegá el token acá.
+# Setealo vacío para desactivar el worker de long-poll.
+TELEGRAM_BOT_TOKEN=
+
+# Lista blanca de user IDs de Telegram, separados por coma.
+# Mandá /start a @userinfobot para ver tu id. Todo user fuera de esta lista
+# recibe "No autorizado". Si está vacío, el bot rechaza a todos.
+TELEGRAM_ALLOWED_USER_IDS=
+
+# Opcional — setealo a "1" para apagar el worker de Telegram sin tocar el token.
+# FINDASH_DISABLE_TELEGRAM=1
+
 # FX refresh token — protege POST /api/fx/refresh (cron externo)
 # Generá con: openssl rand -hex 32
 FX_REFRESH_TOKEN=replace-with-output-of-openssl-rand-hex-32

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -1,0 +1,140 @@
+# Telegram bot
+
+Canal unificado para ingresar transacciones desde el celular. Fase 1 cubre
+**sólo texto libre** (NLU con Claude Haiku). Foto/OCR y SMS forwardeado van
+en #169 (Fase 2). Nota de voz va en #170 (Fase 3).
+
+## Setup (una vez)
+
+### 1. Crear el bot
+
+1. Abrí Telegram y mandale `/newbot` a [@BotFather](https://t.me/BotFather).
+2. Elegí un display name (ej: `Findash`) y un username terminado en `bot`
+   (ej: `@fin_dash_bot`).
+3. BotFather te devuelve un token tipo `1234567890:AAH...`.
+4. Pegalo en `.env.local`:
+   ```
+   TELEGRAM_BOT_TOKEN=1234567890:AAH...
+   ```
+
+### 2. Conseguir tu user ID
+
+1. Mandale `/start` a [@userinfobot](https://t.me/userinfobot).
+2. Te devuelve tu `Id: 123456789`.
+3. Pegalo en `.env.local`:
+   ```
+   TELEGRAM_ALLOWED_USER_IDS=123456789
+   ```
+   Podés poner más de un id separado por coma.
+
+### 3. Arrancar el dashboard
+
+El bot corre dentro del mismo proceso que Next.js (hook de instrumentación,
+mismo patrón que el cron de recurring-gap). No hay servicio separado.
+
+```bash
+bun run dev
+```
+
+Al arrancar, en los logs vas a ver:
+
+```
+[findash] recurring-gap cron registered (...)
+[telegram] long-poll worker started (offset=N)
+```
+
+Si ves `[findash] TELEGRAM_BOT_TOKEN not set — telegram worker skipped`, el
+token no está cargado. Revisá que `.env.local` esté al lado de `package.json`.
+
+### 4. Probarlo
+
+Mandale `/start` al bot. Debería responder con la bienvenida. Si no, chequeá:
+
+- `Id` del `/start` matchea `TELEGRAM_ALLOWED_USER_IDS`.
+- El bot no está en modo privado ni en un grupo — usalo en DM con el bot.
+
+## Uso
+
+Mandale un mensaje describiendo una transacción. Ejemplos:
+
+| Mensaje                                  | Interpretación                          |
+| ---------------------------------------- | --------------------------------------- |
+| `pagué 45k en el restaurante`            | Gasto 45.000 COP, categoría restaurantes |
+| `70 mil uber`                            | Gasto 70.000 COP, categoría transporte  |
+| `mercado 123.450 con la visa *2575`      | Gasto 123.450 COP, cuenta Visa *2575    |
+| `ayer gasté 30k en gasolina`             | Gasto 30.000 COP, fecha ayer            |
+| `ingresé 2 millones del sueldo`          | Ingreso 2.000.000 COP                   |
+
+El bot te muestra un resumen con inline keyboard:
+
+- ✅ **Confirmar** — inserta la transacción y dispara el evento `transaction:created`
+- ❌ **Cancelar** — descarta el draft
+- ✏️ **Cuenta** — elegir cuenta de una lista
+- ✏️ **Categoría** — elegir categoría de una lista
+
+Si falta el monto o la cuenta, el bot pregunta antes de mostrar el card de
+confirmación. La sesión expira a los 30 minutos de inactividad.
+
+## Operación
+
+### Apagar el bot sin tocar el token
+
+```
+FINDASH_DISABLE_TELEGRAM=1
+```
+
+### Apagar TODOS los workers en background
+
+```
+FINDASH_DISABLE_CRON=1
+```
+
+### Reiniciar el offset de long-poll
+
+Si el bot dejó mensajes sin procesar (por ejemplo, error persistente), el
+offset queda apuntando al último update procesado. Para descartar pendientes:
+
+```sql
+UPDATE telegram_poll_state SET last_update_id = (
+  SELECT COALESCE(MAX((data->>'update_id')::bigint), 0)
+  FROM <...>
+) WHERE id = 1;
+```
+
+O más simple — reiniciar en 0:
+
+```sql
+UPDATE telegram_poll_state SET last_update_id = 0 WHERE id = 1;
+```
+
+### Logs
+
+Todo va a stdout del proceso de Next.js:
+
+- `[telegram] long-poll worker started (offset=N)`
+- `[telegram] handler error: <stack>` — error procesando un update específico (no mata al worker)
+- `[telegram] poll error: <stack>` — error en `getUpdates` (backoff + reintento)
+
+## Troubleshooting
+
+### "No pude procesar el mensaje"
+
+El NLU (Claude Haiku) falló. Causas típicas:
+
+- `ANTHROPIC_API_KEY` sin saldo o mal seteada.
+- Rate limit (el bot reintenta el siguiente mensaje, no reintenta éste).
+- Anthropic caído.
+
+### El bot ignora mis mensajes
+
+- Verificá que tu `Id` está en `TELEGRAM_ALLOWED_USER_IDS` (sin espacios).
+- Verificá que el worker arrancó (`[telegram] long-poll worker started` en logs).
+- Mandale `/start` — si responde, la conectividad está OK.
+
+### Mensajes duplicados
+
+El `externalId` de cada transacción Telegram es `tg:<chatId>:<messageId>`, con
+`onConflictDoNothing` sobre `(accountId, externalId)`. Si el mismo `messageId`
+llega dos veces (típicamente tras un crash del worker), la segunda vez se
+descarta como `duplicated`. Si te pasa en uso normal, revisá
+`telegram_poll_state` — puede estar en 0 y reprocesando todo el buffer de 24h.

--- a/drizzle/0008_skinny_spyke.sql
+++ b/drizzle/0008_skinny_spyke.sql
@@ -1,0 +1,14 @@
+ALTER TYPE "public"."tx_source" ADD VALUE 'telegram';--> statement-breakpoint
+CREATE TABLE "telegram_poll_state" (
+	"id" integer PRIMARY KEY NOT NULL,
+	"last_update_id" bigint DEFAULT 0 NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "telegram_sessions" (
+	"chat_id" bigint PRIMARY KEY NOT NULL,
+	"user_id" bigint NOT NULL,
+	"state" jsonb NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL
+);

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1527 @@
+{
+  "id": "b0e43477-787d-4548-bc1b-589ea4c3b29c",
+  "prevId": "ceccc0cb-f6da-4afd-b402-0c31ba860509",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_category_slug_categories_slug_fk": {
+          "name": "budgets_category_slug_categories_slug_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_slug_categories_slug_fk": {
+          "name": "categories_parent_slug_categories_slug_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_priority_idx": {
+          "name": "rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_category_slug_categories_slug_fk": {
+          "name": "classification_rules_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "counterparties_default_category_slug_categories_slug_fk": {
+          "name": "counterparties_default_category_slug_categories_slug_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_kind_value_unique": {
+          "name": "counterparty_aliases_kind_value_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "insights_reports_year_month_unique": {
+          "name": "insights_reports_year_month_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year_month"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_category_slug_categories_slug_fk": {
+          "name": "recurring_transactions_category_slug_categories_slug_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_poll_state": {
+      "name": "telegram_poll_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_update_id": {
+          "name": "last_update_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_category_idx": {
+          "name": "transactions_category_idx",
+          "columns": [
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_counterparty_idx": {
+          "name": "transactions_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_occurred_idx": {
+          "name": "transactions_occurred_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_category_slug_categories_slug_fk": {
+          "name": "transactions_category_slug_categories_slug_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "ai",
+        "manual",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776442930499,
       "tag": "0007_yummy_lockheed",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776469746515,
+      "tag": "0008_skinny_spyke",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -30,6 +30,7 @@ const sourceLabel: Record<TxRow["source"], string> = {
   csv: "CSV",
   recurring: "Recurring",
   manual: "Manual",
+  telegram: "Telegram",
 };
 
 const methodVariant: Record<

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,12 +1,24 @@
+// globalThis singleton guards against Turbopack/HMR re-entering register() and
+// spawning duplicate long-poll workers or duplicate cron schedules.
+declare global {
+  var __findashBgRegistered: boolean | undefined;
+  var __findashTelegramAbort: AbortController | undefined;
+}
+
 /**
- * Next.js 16 instrumentation hook — runs once per worker on boot. Used here
- * to register the recurring-gap detector cron. Runs only in the Node.js
- * runtime (skipped on Edge) and can be disabled entirely via
- * `FINDASH_DISABLE_CRON=1` for tests or one-shot scripts.
+ * Next.js 16 instrumentation hook — runs once per worker on boot. Registers:
+ * - recurring-gap detector cron (monthly)
+ * - Telegram long-poll worker (if TELEGRAM_BOT_TOKEN is set)
+ *
+ * Runs only in the Node.js runtime (skipped on Edge). Disable all background
+ * work with `FINDASH_DISABLE_CRON=1`; disable only Telegram with
+ * `FINDASH_DISABLE_TELEGRAM=1`.
  */
 export async function register() {
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
   if (process.env.FINDASH_DISABLE_CRON === "1") return;
+  if (globalThis.__findashBgRegistered) return;
+  globalThis.__findashBgRegistered = true;
 
   const cron = (await import("node-cron")).default;
   const { closePreviousMonth } = await import("@/lib/recurring/gap-detector");
@@ -30,4 +42,30 @@ export async function register() {
   );
 
   console.log("[findash] recurring-gap cron registered (0 6 5 * * America/Bogota)");
+
+  if (process.env.FINDASH_DISABLE_TELEGRAM === "1") {
+    console.log("[findash] telegram worker disabled via FINDASH_DISABLE_TELEGRAM=1");
+    return;
+  }
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    console.log("[findash] TELEGRAM_BOT_TOKEN not set — telegram worker skipped");
+    return;
+  }
+
+  const { runPollWorker } = await import("@/lib/telegram/poll-worker");
+  const abort = new AbortController();
+  globalThis.__findashTelegramAbort = abort;
+
+  void runPollWorker({
+    token,
+    allowedUserIds: process.env.TELEGRAM_ALLOWED_USER_IDS,
+    signal: abort.signal,
+  }).catch((err) => {
+    console.error("[findash] telegram worker crashed:", err);
+  });
+
+  const shutdown = () => abort.abort();
+  process.once("SIGTERM", shutdown);
+  process.once("SIGINT", shutdown);
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,7 +2,6 @@
 // spawning duplicate long-poll workers or duplicate cron schedules.
 declare global {
   var __findashBgRegistered: boolean | undefined;
-  var __findashTelegramAbort: AbortController | undefined;
 }
 
 /**
@@ -54,18 +53,14 @@ export async function register() {
   }
 
   const { runPollWorker } = await import("@/lib/telegram/poll-worker");
-  const abort = new AbortController();
-  globalThis.__findashTelegramAbort = abort;
 
+  // runPollWorker wires its own SIGTERM/SIGINT handlers. Keeping those out of
+  // this file avoids Next.js flagging `process.once` during the Edge-runtime
+  // static analysis of the instrumentation hook.
   void runPollWorker({
     token,
     allowedUserIds: process.env.TELEGRAM_ALLOWED_USER_IDS,
-    signal: abort.signal,
   }).catch((err) => {
     console.error("[findash] telegram worker crashed:", err);
   });
-
-  const shutdown = () => abort.abort();
-  process.once("SIGTERM", shutdown);
-  process.once("SIGINT", shutdown);
 }

--- a/src/lib/ai/transaction-nlu.test.ts
+++ b/src/lib/ai/transaction-nlu.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseTransactionMessage,
+  type NluAccountOption,
+  type NluCategoryOption,
+} from "./transaction-nlu";
+
+function mockFetch(responseJson: unknown): typeof fetch {
+  const impl: typeof fetch = async () =>
+    new Response(JSON.stringify(responseJson), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  return impl;
+}
+
+function anthropicResponse(jsonBody: unknown) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(jsonBody) }],
+    usage: { input_tokens: 100, output_tokens: 50 },
+  };
+}
+
+const ACCOUNTS: NluAccountOption[] = [
+  { id: 1, name: "Ahorros", institution: "Bancolombia", currency: "COP" },
+  { id: 2, name: "Visa", institution: "Bancolombia", currency: "COP", last4s: ["2575"] },
+  { id: 3, name: "ARQ", institution: "ARQ", currency: "USD" },
+];
+
+const CATEGORIES: NluCategoryOption[] = [
+  { slug: "restaurantes", name: "Restaurantes", parentSlug: "alimentacion" },
+  { slug: "transporte", name: "Transporte", parentSlug: null },
+  { slug: "mercado", name: "Mercado", parentSlug: "alimentacion" },
+  { slug: "gasolina", name: "Gasolina", parentSlug: "transporte" },
+  { slug: "ingresos", name: "Ingresos", parentSlug: null },
+];
+
+const FIXED_NOW = new Date("2026-04-17T18:00:00Z"); // 13:00 Bogota
+
+describe("parseTransactionMessage", () => {
+  it('handles "45k" shorthand for expense in a restaurant', async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse({
+        amountCents: "4500000",
+        currency: "COP",
+        direction: "expense",
+        merchant: "Restaurante",
+        description: "pagué 45k en el restaurante",
+        occurredOn: null,
+        accountId: null,
+        categorySlug: "restaurantes",
+        confidence: 85,
+      }),
+    );
+
+    const result = await parseTransactionMessage({
+      text: "pagué 45k en el restaurante",
+      context: { now: FIXED_NOW, accounts: ACCOUNTS, categories: CATEGORIES },
+      apiKey: "test-key",
+      fetchImpl,
+    });
+
+    expect(result.draft.amountCents).toBe("4500000");
+    expect(result.draft.currency).toBe("COP");
+    expect(result.draft.direction).toBe("expense");
+    expect(result.draft.categorySlug).toBe("restaurantes");
+    expect(result.draft.accountId).toBeNull();
+  });
+
+  it('parses "70 mil uber" as transport expense', async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse({
+        amountCents: "7000000",
+        currency: "COP",
+        direction: "expense",
+        merchant: "Uber",
+        description: "uber",
+        occurredOn: null,
+        accountId: null,
+        categorySlug: "transporte",
+        confidence: 90,
+      }),
+    );
+
+    const result = await parseTransactionMessage({
+      text: "70 mil uber",
+      context: { now: FIXED_NOW, accounts: ACCOUNTS, categories: CATEGORIES },
+      apiKey: "test-key",
+      fetchImpl,
+    });
+
+    expect(result.draft.amountCents).toBe("7000000");
+    expect(result.draft.merchant).toBe("Uber");
+    expect(result.draft.categorySlug).toBe("transporte");
+  });
+
+  it("parses Colombian thousand separator (123.450)", async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse({
+        amountCents: "12345000",
+        currency: "COP",
+        direction: "expense",
+        merchant: null,
+        description: "mercado",
+        occurredOn: null,
+        accountId: null,
+        categorySlug: "mercado",
+        confidence: 80,
+      }),
+    );
+
+    const result = await parseTransactionMessage({
+      text: "mercado 123.450",
+      context: { now: FIXED_NOW, accounts: ACCOUNTS, categories: CATEGORIES },
+      apiKey: "test-key",
+      fetchImpl,
+    });
+
+    expect(result.draft.amountCents).toBe("12345000");
+    expect(result.draft.categorySlug).toBe("mercado");
+  });
+
+  it('resolves "ayer" relative to context.now (Bogota)', async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse({
+        amountCents: "3000000",
+        currency: "COP",
+        direction: "expense",
+        merchant: null,
+        description: "gasolina",
+        occurredOn: "2026-04-16",
+        accountId: null,
+        categorySlug: "gasolina",
+        confidence: 88,
+      }),
+    );
+
+    const result = await parseTransactionMessage({
+      text: "ayer gasté 30k en gasolina",
+      context: { now: FIXED_NOW, accounts: ACCOUNTS, categories: CATEGORIES },
+      apiKey: "test-key",
+      fetchImpl,
+    });
+
+    expect(result.draft.occurredOn).toBe("2026-04-16");
+    expect(result.draft.direction).toBe("expense");
+  });
+
+  it('recognizes income with "ingresé"', async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse({
+        amountCents: "200000000",
+        currency: "COP",
+        direction: "income",
+        merchant: null,
+        description: "sueldo",
+        occurredOn: null,
+        accountId: 1,
+        categorySlug: "ingresos",
+        confidence: 95,
+      }),
+    );
+
+    const result = await parseTransactionMessage({
+      text: "ingresé 2 millones del sueldo",
+      context: { now: FIXED_NOW, accounts: ACCOUNTS, categories: CATEGORIES },
+      apiKey: "test-key",
+      fetchImpl,
+    });
+
+    expect(result.draft.direction).toBe("income");
+    expect(result.draft.amountCents).toBe("200000000");
+    expect(result.draft.accountId).toBe(1);
+    expect(result.draft.categorySlug).toBe("ingresos");
+  });
+
+  it("resolves account by last4 hint", async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse({
+        amountCents: "8000000",
+        currency: "COP",
+        direction: "expense",
+        merchant: null,
+        description: "mercado",
+        occurredOn: null,
+        accountId: 2,
+        categorySlug: "mercado",
+        confidence: 85,
+      }),
+    );
+
+    const result = await parseTransactionMessage({
+      text: "mercado 80k con la *2575",
+      context: { now: FIXED_NOW, accounts: ACCOUNTS, categories: CATEGORIES },
+      apiKey: "test-key",
+      fetchImpl,
+    });
+
+    expect(result.draft.accountId).toBe(2);
+  });
+
+  it("filters out invalid category slugs", async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse({
+        amountCents: "5000000",
+        currency: "COP",
+        direction: "expense",
+        merchant: null,
+        description: "algo",
+        occurredOn: null,
+        accountId: null,
+        categorySlug: "categoria_inventada",
+        confidence: 40,
+      }),
+    );
+
+    const result = await parseTransactionMessage({
+      text: "algo 50k",
+      context: { now: FIXED_NOW, accounts: ACCOUNTS, categories: CATEGORIES },
+      apiKey: "test-key",
+      fetchImpl,
+    });
+
+    expect(result.draft.categorySlug).toBeNull();
+  });
+
+  it("filters out invalid account ids", async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse({
+        amountCents: "1000000",
+        currency: "COP",
+        direction: "expense",
+        merchant: null,
+        description: "test",
+        occurredOn: null,
+        accountId: 999,
+        categorySlug: null,
+        confidence: 50,
+      }),
+    );
+
+    const result = await parseTransactionMessage({
+      text: "10k test",
+      context: { now: FIXED_NOW, accounts: ACCOUNTS, categories: CATEGORIES },
+      apiKey: "test-key",
+      fetchImpl,
+    });
+
+    expect(result.draft.accountId).toBeNull();
+  });
+
+  it("throws on invalid JSON from model", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "not-json-at-all" }],
+          usage: { input_tokens: 10, output_tokens: 0 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+
+    await expect(
+      parseTransactionMessage({
+        text: "foo",
+        context: { now: FIXED_NOW, accounts: ACCOUNTS, categories: CATEGORIES },
+        apiKey: "test-key",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("invalid JSON");
+  });
+
+  it("throws on API error", async () => {
+    const fetchImpl: typeof fetch = async () => new Response("rate limit", { status: 429 });
+
+    await expect(
+      parseTransactionMessage({
+        text: "foo",
+        context: { now: FIXED_NOW, accounts: ACCOUNTS, categories: CATEGORIES },
+        apiKey: "test-key",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("Anthropic API error 429");
+  });
+});

--- a/src/lib/ai/transaction-nlu.ts
+++ b/src/lib/ai/transaction-nlu.ts
@@ -1,0 +1,200 @@
+import { z } from "zod";
+
+export type NluAccountOption = {
+  id: number;
+  name: string;
+  institution: string;
+  currency: "COP" | "USD";
+  last4s?: string[];
+};
+
+export type NluCategoryOption = {
+  slug: string;
+  name: string;
+  parentSlug?: string | null;
+};
+
+export type NluContext = {
+  now: Date;
+  accounts: NluAccountOption[];
+  categories: NluCategoryOption[];
+};
+
+export type NluDraft = {
+  amountCents: string | null;
+  currency: "COP" | "USD" | null;
+  direction: "expense" | "income" | null;
+  merchant: string | null;
+  description: string | null;
+  occurredOn: string | null;
+  accountId: number | null;
+  categorySlug: string | null;
+  confidence: number;
+  notes?: string;
+};
+
+export type NluResult = {
+  draft: NluDraft;
+  model: string;
+  usage: { inputTokens: number; outputTokens: number };
+};
+
+const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+
+const nluResponseSchema = z.object({
+  amountCents: z.string().regex(/^\d+$/).nullable(),
+  currency: z.enum(["COP", "USD"]).nullable(),
+  direction: z.enum(["expense", "income"]).nullable(),
+  merchant: z.string().max(200).nullable(),
+  description: z.string().max(500).nullable(),
+  occurredOn: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .nullable(),
+  accountId: z.number().int().nullable(),
+  categorySlug: z.string().max(60).nullable(),
+  confidence: z.number().int().min(0).max(100),
+  notes: z.string().max(200).optional(),
+});
+
+function formatBogotaDate(now: Date): string {
+  const bogotaMs = now.getTime() - 5 * 60 * 60 * 1000;
+  const d = new Date(bogotaMs);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function buildPrompt(text: string, ctx: NluContext): string {
+  const today = formatBogotaDate(ctx.now);
+  const accList = ctx.accounts
+    .map((a) => {
+      const last4Part = a.last4s?.length ? ` — termina en ${a.last4s.join(", ")}` : "";
+      return `- id=${a.id}: ${a.name} (${a.institution}, ${a.currency})${last4Part}`;
+    })
+    .join("\n");
+
+  const catList = ctx.categories
+    .map((c) => (c.parentSlug ? `- ${c.slug} (sub de ${c.parentSlug})` : `- ${c.slug}`))
+    .join("\n");
+
+  return `Sos un parser de transacciones financieras personales para un usuario colombiano. Extraés datos estructurados de mensajes en español informal.
+
+Hoy es ${today} (America/Bogota, UTC-5). Moneda default: COP.
+
+Cuentas disponibles:
+${accList}
+
+Categorías disponibles (usá el slug EXACTO):
+${catList}
+
+Mensaje del usuario:
+"""
+${text}
+"""
+
+Reglas de parsing:
+- "45k", "45 mil", "45K" = 45000. "2 millones", "2M" = 2000000. "450 lucas" = 450000.
+- Separador decimal colombiano = coma (45,50 = 45.50). Puntos son separadores de miles: "45.000" = 45000, "1.234.567" = 1234567.
+- amountCents: multiplicá el valor monetario por 100 y devolvelo como STRING de dígitos (ej: 45000 pesos → "4500000"; 1.50 USD → "150").
+- direction: "expense" por default. "income" sólo si dice "me pagaron", "ingresó", "me llegó", "sueldo", "me transfirieron", "recibí", "cobré".
+- occurredOn (YYYY-MM-DD): resolvé "hoy"/"ayer"/"anteayer"/"el viernes"/"hace 3 días" relativo a ${today}. Si no hay señal temporal → null.
+- accountId: devolvé un id SOLO si el mensaje identifica la cuenta de forma inequívoca (por nombre, institución o últimos 4 dígitos). Si dice "la visa" y hay 2 visas → null. Si dice "*2575" → buscar por last4.
+- categorySlug: devolvé un slug SOLO con señal fuerte (ej: "pagué en el restaurante" → "restaurantes"; "uber" → "transporte_uber_didi" si existe, si no "transporte"). Ante duda → null (el pipeline usará rules+AI después).
+- currency: COP por default. USD sólo si dice explícitamente "dólares", "USD", "$USD", o la cuenta elegida es USD.
+- merchant: extraelo si aparece. Para "en el Éxito" → "Éxito". Para "pagué 45k" sin lugar → null.
+- description: descripción corta en español, max ~80 chars.
+- confidence: 0-100. Bajá si falta monto, si la dirección es ambigua, si hay múltiples interpretaciones.
+- notes: opcional, ≤200 chars. Usalo si hay algo raro o ambiguo que el usuario debería confirmar.
+
+Devolvé SOLO JSON válido (sin markdown, sin prosa, sin fences):
+{
+  "amountCents": "<digits-or-null>",
+  "currency": "COP" | "USD" | null,
+  "direction": "expense" | "income" | null,
+  "merchant": "<string-or-null>",
+  "description": "<string-or-null>",
+  "occurredOn": "YYYY-MM-DD" | null,
+  "accountId": <number-or-null>,
+  "categorySlug": "<slug-or-null>",
+  "confidence": <0-100>,
+  "notes": "<optional-string>"
+}`;
+}
+
+function extractJson(text: string): unknown {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fenced ? fenced[1] : trimmed;
+  return JSON.parse(candidate);
+}
+
+export async function parseTransactionMessage(opts: {
+  text: string;
+  context: NluContext;
+  model?: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<NluResult> {
+  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
+
+  const model = opts.model ?? DEFAULT_MODEL;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const prompt = buildPrompt(opts.text, opts.context);
+
+  const res = await doFetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 512,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Anthropic API error ${res.status}: ${body.slice(0, 300)}`);
+  }
+
+  const payload = (await res.json()) as {
+    content: Array<{ type: string; text?: string }>;
+    usage?: { input_tokens: number; output_tokens: number };
+  };
+
+  const textBlock = payload.content?.find((c) => c.type === "text")?.text ?? "";
+  let parsedJson: unknown;
+  try {
+    parsedJson = extractJson(textBlock);
+  } catch {
+    throw new Error("NLU model returned invalid JSON");
+  }
+
+  const parsed = nluResponseSchema.parse(parsedJson);
+
+  const validAccountIds = new Set(opts.context.accounts.map((a) => a.id));
+  const validCategorySlugs = new Set(opts.context.categories.map((c) => c.slug));
+  const draft: NluDraft = {
+    ...parsed,
+    accountId: parsed.accountId && validAccountIds.has(parsed.accountId) ? parsed.accountId : null,
+    categorySlug:
+      parsed.categorySlug && validCategorySlugs.has(parsed.categorySlug)
+        ? parsed.categorySlug
+        : null,
+  };
+
+  return {
+    draft,
+    model,
+    usage: {
+      inputTokens: payload.usage?.input_tokens ?? 0,
+      outputTokens: payload.usage?.output_tokens ?? 0,
+    },
+  };
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -28,6 +28,7 @@ export const txSource = pgEnum("tx_source", [
   "csv",
   "recurring",
   "manual",
+  "telegram",
 ]);
 
 export const classificationMethod = pgEnum("classification_method", [
@@ -295,3 +296,46 @@ export const accountSnapshots = pgTable(
   },
   (t) => [uniqueIndex("snapshots_account_date_unique").on(t.accountId, t.snapshotDate)],
 );
+
+export type TelegramSessionStep =
+  | "idle"
+  | "awaiting_account"
+  | "awaiting_amount"
+  | "awaiting_category"
+  | "awaiting_confirm";
+
+export type TelegramDraft = {
+  amountCents?: string;
+  currency?: "COP" | "USD";
+  direction?: "expense" | "income";
+  merchant?: string;
+  description?: string;
+  occurredOn?: string;
+  accountId?: number;
+  categorySlug?: string;
+  notes?: string;
+};
+
+export type TelegramSessionState = {
+  step: TelegramSessionStep;
+  draft: TelegramDraft;
+  sourceChatId: number;
+  sourceMessageId?: number;
+  promptMessageId?: number;
+};
+
+export const telegramSessions = pgTable("telegram_sessions", {
+  chatId: bigint("chat_id", { mode: "bigint" }).primaryKey(),
+  userId: bigint("user_id", { mode: "bigint" }).notNull(),
+  state: jsonb("state").$type<TelegramSessionState>().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+});
+
+export const telegramPollState = pgTable("telegram_poll_state", {
+  id: integer("id").primaryKey(),
+  lastUpdateId: bigint("last_update_id", { mode: "bigint" })
+    .notNull()
+    .default(sql`0`),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/src/lib/telegram/allowlist.test.ts
+++ b/src/lib/telegram/allowlist.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { isAllowed, parseAllowlist } from "./allowlist";
+
+describe("parseAllowlist", () => {
+  it("parses a comma-separated list", () => {
+    const set = parseAllowlist("123,456,789");
+    expect(set).toEqual(new Set([123, 456, 789]));
+  });
+
+  it("trims whitespace", () => {
+    const set = parseAllowlist(" 100 , 200 , 300 ");
+    expect(set).toEqual(new Set([100, 200, 300]));
+  });
+
+  it("returns empty set for undefined", () => {
+    expect(parseAllowlist(undefined).size).toBe(0);
+  });
+
+  it("returns empty set for empty string", () => {
+    expect(parseAllowlist("").size).toBe(0);
+  });
+
+  it("skips non-integer values", () => {
+    expect(parseAllowlist("123,abc,456")).toEqual(new Set([123, 456]));
+  });
+
+  it("rejects negative and zero", () => {
+    expect(parseAllowlist("123,0,-1,456")).toEqual(new Set([123, 456]));
+  });
+});
+
+describe("isAllowed", () => {
+  const allowlist = new Set([100, 200]);
+
+  it("accepts allowlisted ids", () => {
+    expect(isAllowed(100, allowlist)).toBe(true);
+    expect(isAllowed(200, allowlist)).toBe(true);
+  });
+
+  it("rejects non-allowlisted ids", () => {
+    expect(isAllowed(999, allowlist)).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isAllowed(undefined, allowlist)).toBe(false);
+  });
+});

--- a/src/lib/telegram/allowlist.ts
+++ b/src/lib/telegram/allowlist.ts
@@ -1,0 +1,15 @@
+export function parseAllowlist(raw: string | undefined): Set<number> {
+  if (!raw) return new Set();
+  const ids = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => Number(s))
+    .filter((n) => Number.isInteger(n) && n > 0);
+  return new Set(ids);
+}
+
+export function isAllowed(userId: number | undefined, allowlist: Set<number>): boolean {
+  if (typeof userId !== "number") return false;
+  return allowlist.has(userId);
+}

--- a/src/lib/telegram/client.ts
+++ b/src/lib/telegram/client.ts
@@ -1,6 +1,7 @@
+import { request, type RequestOptions } from "node:https";
 import type { EditMessageOptions, SendMessageOptions, TelegramUpdate } from "@/lib/telegram/types";
 
-const TELEGRAM_API = "https://api.telegram.org";
+const TELEGRAM_HOST = "api.telegram.org";
 
 type TelegramResponse<T> = { ok: true; result: T } | { ok: false; description: string };
 
@@ -15,48 +16,99 @@ export type TelegramClient = {
   answerCallbackQuery: (opts: { callback_query_id: string; text?: string }) => Promise<void>;
 };
 
-export function createTelegramClient(opts: {
-  token: string;
-  fetchImpl?: typeof fetch;
-}): TelegramClient {
-  const doFetch = opts.fetchImpl ?? fetch;
-  const base = `${TELEGRAM_API}/bot${opts.token}`;
+// Built on node:https (not fetch) because undici's default fetch in Node 20+
+// enables Happy Eyeballs at the socket level (autoSelectFamily: true). On
+// networks where IPv6 egress is broken (ia-server's ISP), the IPv6 connection
+// attempt dominates the 30s long-poll window and the fetch times out before
+// falling back to IPv4. node:https.request respects `dns.setDefaultResultOrder`
+// and lets us pin `family: 4`, which bypasses the issue entirely.
+type RawResponse = { status: number; body: string };
 
-  async function call<T>(method: string, body: unknown, signal?: AbortSignal): Promise<T> {
-    const res = await doFetch(`${base}/${method}`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-      signal,
+function httpsJson(opts: {
+  method: string;
+  path: string;
+  body?: unknown;
+  timeoutMs: number;
+}): Promise<RawResponse> {
+  const payload = opts.body == null ? "" : JSON.stringify(opts.body);
+  const reqOpts: RequestOptions = {
+    host: TELEGRAM_HOST,
+    port: 443,
+    path: opts.path,
+    method: opts.method,
+    family: 4,
+    headers: {
+      "content-type": "application/json",
+      "content-length": Buffer.byteLength(payload).toString(),
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    const req = request(reqOpts, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (c: Buffer) => chunks.push(c));
+      res.on("end", () => {
+        resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf8") });
+      });
+      res.on("error", reject);
     });
-    const payload = (await res.json()) as TelegramResponse<T>;
+    req.setTimeout(opts.timeoutMs, () => {
+      req.destroy(new Error(`Telegram request timed out after ${opts.timeoutMs}ms`));
+    });
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+export function createTelegramClient(opts: { token: string }): TelegramClient {
+  const basePath = `/bot${opts.token}`;
+
+  async function call<T>(method: string, body: unknown, timeoutMs: number): Promise<T> {
+    const res = await httpsJson({
+      method: "POST",
+      path: `${basePath}/${method}`,
+      body,
+      timeoutMs,
+    });
+    let payload: TelegramResponse<T>;
+    try {
+      payload = JSON.parse(res.body) as TelegramResponse<T>;
+    } catch {
+      throw new Error(`Telegram API ${method} returned non-JSON (status ${res.status})`);
+    }
     if (!payload.ok) {
-      throw new Error(`Telegram API ${method} failed: ${payload.description}`);
+      throw new Error(`Telegram API ${method} failed (${res.status}): ${payload.description}`);
     }
     return payload.result;
   }
 
   return {
     async getUpdates({ offset, timeout = 30, allowedUpdates }) {
-      // Long-poll can take up to `timeout` seconds + network. Give it a bit
-      // of headroom before AbortSignal fires and we need to retry.
-      return call<TelegramUpdate[]>("getUpdates", {
-        offset,
-        timeout,
-        allowed_updates: allowedUpdates ?? ["message", "callback_query"],
-      });
+      // Telegram holds the connection open for up to `timeout` seconds waiting
+      // for new updates. Add ~15s of network headroom on top before we give up.
+      return call<TelegramUpdate[]>(
+        "getUpdates",
+        {
+          offset,
+          timeout,
+          allowed_updates: allowedUpdates ?? ["message", "callback_query"],
+        },
+        (timeout + 15) * 1000,
+      );
     },
     async sendMessage(opts) {
-      return call<{ message_id: number }>("sendMessage", opts);
+      return call<{ message_id: number }>("sendMessage", opts, 15_000);
     },
     async editMessage(opts) {
-      await call<unknown>("editMessageText", opts);
+      await call<unknown>("editMessageText", opts, 15_000);
     },
     async answerCallbackQuery(opts) {
-      await call<unknown>("answerCallbackQuery", {
-        callback_query_id: opts.callback_query_id,
-        text: opts.text,
-      });
+      await call<unknown>(
+        "answerCallbackQuery",
+        { callback_query_id: opts.callback_query_id, text: opts.text },
+        10_000,
+      );
     },
   };
 }

--- a/src/lib/telegram/client.ts
+++ b/src/lib/telegram/client.ts
@@ -1,0 +1,62 @@
+import type { EditMessageOptions, SendMessageOptions, TelegramUpdate } from "@/lib/telegram/types";
+
+const TELEGRAM_API = "https://api.telegram.org";
+
+type TelegramResponse<T> = { ok: true; result: T } | { ok: false; description: string };
+
+export type TelegramClient = {
+  getUpdates: (opts: {
+    offset?: number;
+    timeout?: number;
+    allowedUpdates?: string[];
+  }) => Promise<TelegramUpdate[]>;
+  sendMessage: (opts: SendMessageOptions) => Promise<{ message_id: number }>;
+  editMessage: (opts: EditMessageOptions) => Promise<void>;
+  answerCallbackQuery: (opts: { callback_query_id: string; text?: string }) => Promise<void>;
+};
+
+export function createTelegramClient(opts: {
+  token: string;
+  fetchImpl?: typeof fetch;
+}): TelegramClient {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const base = `${TELEGRAM_API}/bot${opts.token}`;
+
+  async function call<T>(method: string, body: unknown, signal?: AbortSignal): Promise<T> {
+    const res = await doFetch(`${base}/${method}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal,
+    });
+    const payload = (await res.json()) as TelegramResponse<T>;
+    if (!payload.ok) {
+      throw new Error(`Telegram API ${method} failed: ${payload.description}`);
+    }
+    return payload.result;
+  }
+
+  return {
+    async getUpdates({ offset, timeout = 30, allowedUpdates }) {
+      // Long-poll can take up to `timeout` seconds + network. Give it a bit
+      // of headroom before AbortSignal fires and we need to retry.
+      return call<TelegramUpdate[]>("getUpdates", {
+        offset,
+        timeout,
+        allowed_updates: allowedUpdates ?? ["message", "callback_query"],
+      });
+    },
+    async sendMessage(opts) {
+      return call<{ message_id: number }>("sendMessage", opts);
+    },
+    async editMessage(opts) {
+      await call<unknown>("editMessageText", opts);
+    },
+    async answerCallbackQuery(opts) {
+      await call<unknown>("answerCallbackQuery", {
+        callback_query_id: opts.callback_query_id,
+        text: opts.text,
+      });
+    },
+  };
+}

--- a/src/lib/telegram/commands.ts
+++ b/src/lib/telegram/commands.ts
@@ -1,0 +1,32 @@
+import type { TelegramClient } from "@/lib/telegram/client";
+import { clearSession } from "@/lib/telegram/session";
+import { renderCanceled, renderHelp, renderStart } from "@/lib/telegram/formatter";
+
+export type CommandName = "/start" | "/help" | "/cancel";
+
+export function parseCommand(text: string): CommandName | null {
+  const trimmed = text.trim().toLowerCase().split(/\s+/)[0];
+  const base = trimmed?.split("@")[0] ?? "";
+  if (base === "/start" || base === "/help" || base === "/cancel") return base;
+  return null;
+}
+
+export async function handleCommand(opts: {
+  command: CommandName;
+  chatId: number;
+  client: TelegramClient;
+}): Promise<void> {
+  const { command, chatId, client } = opts;
+  switch (command) {
+    case "/start":
+      await client.sendMessage({ chat_id: chatId, text: renderStart(), parse_mode: "Markdown" });
+      return;
+    case "/help":
+      await client.sendMessage({ chat_id: chatId, text: renderHelp(), parse_mode: "Markdown" });
+      return;
+    case "/cancel":
+      await clearSession(chatId);
+      await client.sendMessage({ chat_id: chatId, text: renderCanceled() });
+      return;
+  }
+}

--- a/src/lib/telegram/confirm.ts
+++ b/src/lib/telegram/confirm.ts
@@ -1,0 +1,101 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { transactions, type TelegramDraft } from "@/lib/db/schema";
+import { classifyByRule } from "@/lib/classification/rules";
+import { emit } from "@/lib/events/bus";
+
+export type ConfirmResult =
+  | { status: "inserted"; txId: number }
+  | { status: "duplicated" }
+  | { status: "error"; reason: string };
+
+export function isDraftComplete(draft: TelegramDraft): boolean {
+  return (
+    typeof draft.amountCents === "string" &&
+    draft.amountCents.length > 0 &&
+    draft.currency != null &&
+    draft.direction != null &&
+    typeof draft.accountId === "number"
+  );
+}
+
+export async function insertFromDraft(opts: {
+  draft: TelegramDraft;
+  chatId: number;
+  sourceMessageId?: number;
+}): Promise<ConfirmResult> {
+  const { draft, chatId, sourceMessageId } = opts;
+
+  if (!isDraftComplete(draft)) {
+    return { status: "error", reason: "draft is incomplete" };
+  }
+
+  const magnitude = BigInt(draft.amountCents as string);
+  const signed = draft.direction === "income" ? magnitude : -magnitude;
+
+  const descriptionRaw = draft.description ?? draft.merchant ?? "Telegram entry";
+  const occurredAt = draft.occurredOn ? new Date(`${draft.occurredOn}T12:00:00-05:00`) : new Date();
+
+  let categorySlug = draft.categorySlug ?? null;
+  let classificationMethod: "rule" | "manual" | "unclassified" = categorySlug
+    ? "manual"
+    : "unclassified";
+  let confidence: number | null = categorySlug ? 100 : null;
+
+  if (!categorySlug) {
+    const match = await classifyByRule({
+      descriptionRaw,
+      merchant: draft.merchant ?? null,
+    });
+    if (match) {
+      categorySlug = match.categorySlug;
+      classificationMethod = "rule";
+      confidence = match.confidence;
+    }
+  }
+
+  const externalId = sourceMessageId ? `tg:${chatId}:${sourceMessageId}` : null;
+
+  try {
+    const result = await db
+      .insert(transactions)
+      .values({
+        accountId: draft.accountId as number,
+        occurredAt,
+        amountCents: signed,
+        currency: draft.currency as "COP" | "USD",
+        descriptionRaw,
+        descriptionClean: null,
+        merchant: draft.merchant ?? null,
+        categorySlug,
+        counterpartyId: null,
+        classificationMethod,
+        classificationConfidence: confidence,
+        source: "telegram",
+        externalId,
+        rawData: {
+          source: "telegram",
+          chatId,
+          sourceMessageId,
+          notes: draft.notes,
+        },
+      })
+      .onConflictDoNothing({
+        target: [transactions.accountId, transactions.externalId],
+        where: sql`${transactions.externalId} IS NOT NULL`,
+      })
+      .returning({ id: transactions.id });
+
+    if (result.length === 0) return { status: "duplicated" };
+
+    emit({
+      type: "transaction:created",
+      id: result[0].id,
+      source: "telegram",
+      timestamp: Date.now(),
+    });
+    return { status: "inserted", txId: result[0].id };
+  } catch (err) {
+    return { status: "error", reason: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/lib/telegram/formatter.ts
+++ b/src/lib/telegram/formatter.ts
@@ -1,0 +1,123 @@
+import type { TelegramDraft } from "@/lib/db/schema";
+import type { NluAccountOption, NluCategoryOption } from "@/lib/ai/transaction-nlu";
+
+function formatAmount(amountCentsStr: string, currency: "COP" | "USD"): string {
+  const cents = BigInt(amountCentsStr);
+  const HUNDRED = BigInt(100);
+  const whole = Number(cents / HUNDRED);
+  if (currency === "COP") {
+    return `${whole.toLocaleString("es-CO")} COP`;
+  }
+  const major = Number(cents / HUNDRED);
+  const fraction = Number(cents % HUNDRED);
+  return `${major.toLocaleString("en-US")}.${String(fraction).padStart(2, "0")} USD`;
+}
+
+function directionEmoji(direction: TelegramDraft["direction"]): string {
+  if (direction === "income") return "💰 Ingreso";
+  if (direction === "expense") return "💸 Gasto";
+  return "💱 Movimiento";
+}
+
+export function renderConfirmCard(opts: {
+  draft: TelegramDraft;
+  accounts: NluAccountOption[];
+  categories: NluCategoryOption[];
+}): string {
+  const { draft, accounts, categories } = opts;
+  const lines: string[] = [];
+
+  if (draft.amountCents && draft.currency) {
+    lines.push(
+      `${directionEmoji(draft.direction)} · ${formatAmount(draft.amountCents, draft.currency)}`,
+    );
+  } else {
+    lines.push(directionEmoji(draft.direction));
+  }
+
+  if (draft.merchant) {
+    lines.push(`🏪 ${draft.merchant}`);
+  } else if (draft.description) {
+    lines.push(`📝 ${draft.description}`);
+  }
+
+  const account = accounts.find((a) => a.id === draft.accountId);
+  lines.push(`💳 ${account ? `${account.name} (${account.institution})` : "⚠️ Falta cuenta"}`);
+
+  if (draft.occurredOn) {
+    lines.push(`📅 ${draft.occurredOn}`);
+  } else {
+    lines.push(`📅 Hoy`);
+  }
+
+  const category = categories.find((c) => c.slug === draft.categorySlug);
+  if (category) lines.push(`🏷️ ${category.name}`);
+  else lines.push(`🏷️ (sin categoría — se clasifica después)`);
+
+  if (draft.notes) lines.push(`\n📌 ${draft.notes}`);
+
+  lines.push("");
+  lines.push("¿Confirmar?");
+  return lines.join("\n");
+}
+
+export function renderAskAmount(): string {
+  return "¿Cuánto fue? Respondeme con el monto (ej: 45000, 45k, 2 millones).";
+}
+
+export function renderAskAccount(): string {
+  return "¿De qué cuenta fue?";
+}
+
+export function renderAskCategory(): string {
+  return "¿Qué categoría?";
+}
+
+export function renderUnauthorized(): string {
+  return "No autorizado.";
+}
+
+export function renderStart(): string {
+  return [
+    "¡Hola! Soy tu bot de Findash.",
+    "",
+    "Mandame un mensaje con una transacción y la registro por vos. Por ejemplo:",
+    "• `pagué 45k en el restaurante`",
+    "• `70 mil uber`",
+    "• `ayer gasté 123.450 en el mercado con la visa`",
+    "• `ingresé 2 millones del sueldo`",
+    "",
+    "Comandos:",
+    "/help — ayuda",
+    "/cancel — descartar el draft actual",
+  ].join("\n");
+}
+
+export function renderHelp(): string {
+  return [
+    "Cómo usar el bot:",
+    "",
+    "1. Mandame un mensaje describiendo una transacción.",
+    "2. Te muestro un resumen para que confirmes.",
+    "3. Si falta algo (cuenta, monto), te pregunto.",
+    "",
+    "Atajos:",
+    "• `45k` = 45.000 · `2M` = 2.000.000 · `450 lucas` = 450.000",
+    "• Decimales con coma: `12,50`",
+    "• Fechas: `hoy`, `ayer`, `el viernes`",
+    "",
+    "/cancel — descartar draft",
+  ].join("\n");
+}
+
+export function renderCanceled(): string {
+  return "Listo, descartado. Mandame otro mensaje cuando quieras.";
+}
+
+export function renderInserted(txId: number): string {
+  return `✅ Guardada (#${txId}). Mandame otra cuando quieras.`;
+}
+
+export function renderError(msg: string): string {
+  return `⚠️ ${msg}`;
+}

--- a/src/lib/telegram/keyboard.ts
+++ b/src/lib/telegram/keyboard.ts
@@ -1,0 +1,60 @@
+import type { InlineKeyboardMarkup } from "@/lib/telegram/types";
+import type { NluAccountOption, NluCategoryOption } from "@/lib/ai/transaction-nlu";
+
+export const CALLBACK = {
+  CONFIRM: "c",
+  CANCEL: "x",
+  EDIT_ACCOUNT: "ea",
+  EDIT_CATEGORY: "ec",
+  ACCOUNT_PREFIX: "a:",
+  CATEGORY_PREFIX: "k:",
+  BACK: "b",
+} as const;
+
+export function confirmKeyboard(): InlineKeyboardMarkup {
+  return {
+    inline_keyboard: [
+      [
+        { text: "✅ Confirmar", callback_data: CALLBACK.CONFIRM },
+        { text: "❌ Cancelar", callback_data: CALLBACK.CANCEL },
+      ],
+      [
+        { text: "✏️ Cuenta", callback_data: CALLBACK.EDIT_ACCOUNT },
+        { text: "✏️ Categoría", callback_data: CALLBACK.EDIT_CATEGORY },
+      ],
+    ],
+  };
+}
+
+export function accountsKeyboard(accounts: NluAccountOption[]): InlineKeyboardMarkup {
+  const rows: InlineKeyboardMarkup["inline_keyboard"] = [];
+  for (const a of accounts) {
+    const last4 = a.last4s?.[0] ? ` *${a.last4s[0]}` : "";
+    rows.push([
+      {
+        text: `${a.name}${last4} (${a.currency})`,
+        callback_data: `${CALLBACK.ACCOUNT_PREFIX}${a.id}`,
+      },
+    ]);
+  }
+  rows.push([{ text: "⬅️ Volver", callback_data: CALLBACK.BACK }]);
+  return { inline_keyboard: rows };
+}
+
+export function categoriesKeyboard(
+  categories: NluCategoryOption[],
+  opts: { limit?: number } = {},
+): InlineKeyboardMarkup {
+  const limit = opts.limit ?? 10;
+  const slice = categories.slice(0, limit);
+  const rows: InlineKeyboardMarkup["inline_keyboard"] = [];
+  for (let i = 0; i < slice.length; i += 2) {
+    const row = slice.slice(i, i + 2).map((c) => ({
+      text: c.name,
+      callback_data: `${CALLBACK.CATEGORY_PREFIX}${c.slug}`,
+    }));
+    rows.push(row);
+  }
+  rows.push([{ text: "⬅️ Volver", callback_data: CALLBACK.BACK }]);
+  return { inline_keyboard: rows };
+}

--- a/src/lib/telegram/keyboard.ts
+++ b/src/lib/telegram/keyboard.ts
@@ -29,10 +29,13 @@ export function confirmKeyboard(): InlineKeyboardMarkup {
 export function accountsKeyboard(accounts: NluAccountOption[]): InlineKeyboardMarkup {
   const rows: InlineKeyboardMarkup["inline_keyboard"] = [];
   for (const a of accounts) {
-    const last4 = a.last4s?.[0] ? ` *${a.last4s[0]}` : "";
+    // Only append the last4 if the account name doesn't already carry it
+    // (most accounts embed "*1234" in the name; avoid showing "Visa *1234 *1234").
+    const l4 = a.last4s?.[0];
+    const last4Part = l4 && !a.name.includes(`*${l4}`) ? ` *${l4}` : "";
     rows.push([
       {
-        text: `${a.name}${last4} (${a.currency})`,
+        text: `${a.name}${last4Part} (${a.currency})`,
         callback_data: `${CALLBACK.ACCOUNT_PREFIX}${a.id}`,
       },
     ]);

--- a/src/lib/telegram/poll-worker.ts
+++ b/src/lib/telegram/poll-worker.ts
@@ -62,11 +62,22 @@ export async function runPollWorker(opts: PollWorkerOptions): Promise<void> {
     now: opts.deps?.now,
   };
 
+  // If no external signal is provided, own the shutdown lifecycle. This keeps
+  // `process.once` out of `instrumentation.ts` (which Next.js analyzes for
+  // Edge runtime compatibility) and limits it to this Node-only module.
+  const ownedAbort = opts.signal ? null : new AbortController();
+  const signal = opts.signal ?? ownedAbort!.signal;
+  const shutdown = () => ownedAbort?.abort();
+  if (ownedAbort) {
+    process.once("SIGTERM", shutdown);
+    process.once("SIGINT", shutdown);
+  }
+
   let offset = await getOffset();
   let backoff = BACKOFF_MIN_MS;
   console.log(`[telegram] long-poll worker started (offset=${offset})`);
 
-  while (!opts.signal?.aborted) {
+  while (!signal.aborted) {
     try {
       const updates = await client.getUpdates({
         offset: offset + 1,
@@ -86,12 +97,26 @@ export async function runPollWorker(opts: PollWorkerOptions): Promise<void> {
         }
       }
     } catch (err) {
-      (opts.onError ?? ((e) => console.error("[telegram] poll error:", e)))(err);
-      await delay(backoff, opts.signal);
+      const reason = describePollError(err);
+      (opts.onError ?? ((e) => console.error(`[telegram] poll error (${reason}):`, e)))(err);
+      await delay(backoff, signal);
       backoff = Math.min(backoff * 2, BACKOFF_MAX_MS);
     }
   }
   console.log("[telegram] long-poll worker stopped");
+}
+
+function describePollError(err: unknown): string {
+  if (err instanceof Error) {
+    const cause = (err as Error & { cause?: { code?: string } }).cause;
+    if (cause?.code === "ETIMEDOUT")
+      return "network timeout reaching api.telegram.org — check connectivity";
+    if (cause?.code === "ENOTFOUND") return "DNS lookup failed for api.telegram.org";
+    if (cause?.code === "ECONNREFUSED") return "connection refused by api.telegram.org";
+    if (err.message.includes("401")) return "invalid TELEGRAM_BOT_TOKEN";
+    return err.message;
+  }
+  return String(err);
 }
 
 function delay(ms: number, signal?: AbortSignal): Promise<void> {

--- a/src/lib/telegram/poll-worker.ts
+++ b/src/lib/telegram/poll-worker.ts
@@ -1,5 +1,14 @@
+import { setDefaultResultOrder } from "node:dns";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
+
+// Force IPv4-first DNS resolution for the Node.js process. Some hosting
+// networks (including ia-server's ISP) have broken IPv6 egress. Node's
+// undici fetch does Happy Eyeballs, but long-polling (~30s) waits long
+// enough that the IPv6 connection attempt can dominate and time out before
+// the IPv4 fallback kicks in. This flag affects all outbound fetch from
+// this process (Telegram, Anthropic, TRM, etc.) — which is what we want.
+setDefaultResultOrder("ipv4first");
 import { telegramPollState } from "@/lib/db/schema";
 import { createTelegramClient, type TelegramClient } from "@/lib/telegram/client";
 import { handleUpdate, type RouterDeps } from "@/lib/telegram/router";

--- a/src/lib/telegram/poll-worker.ts
+++ b/src/lib/telegram/poll-worker.ts
@@ -1,0 +1,109 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { telegramPollState } from "@/lib/db/schema";
+import { createTelegramClient, type TelegramClient } from "@/lib/telegram/client";
+import { handleUpdate, type RouterDeps } from "@/lib/telegram/router";
+import { parseAllowlist } from "@/lib/telegram/allowlist";
+import { parseTransactionMessage } from "@/lib/ai/transaction-nlu";
+import { listAccountsDetailed } from "@/lib/accounts/queries";
+import { listCategories } from "@/lib/transactions/queries";
+
+const POLL_STATE_ROW_ID = 1;
+const LONG_POLL_TIMEOUT_SECONDS = 30;
+const BACKOFF_MIN_MS = 1_000;
+const BACKOFF_MAX_MS = 60_000;
+
+async function getOffset(): Promise<number> {
+  const rows = await db
+    .select({ lastUpdateId: telegramPollState.lastUpdateId })
+    .from(telegramPollState)
+    .where(eq(telegramPollState.id, POLL_STATE_ROW_ID))
+    .limit(1);
+  if (rows.length === 0) {
+    await db.insert(telegramPollState).values({
+      id: POLL_STATE_ROW_ID,
+      lastUpdateId: BigInt(0),
+      updatedAt: new Date(),
+    });
+    return 0;
+  }
+  return Number(rows[0].lastUpdateId);
+}
+
+async function setOffset(updateId: number): Promise<void> {
+  await db
+    .update(telegramPollState)
+    .set({ lastUpdateId: BigInt(updateId), updatedAt: new Date() })
+    .where(eq(telegramPollState.id, POLL_STATE_ROW_ID));
+}
+
+export type PollWorkerOptions = {
+  token: string;
+  allowedUserIds: string | undefined;
+  client?: TelegramClient;
+  deps?: Partial<RouterDeps>;
+  signal?: AbortSignal;
+  onError?: (err: unknown) => void;
+};
+
+export async function runPollWorker(opts: PollWorkerOptions): Promise<void> {
+  const client = opts.client ?? createTelegramClient({ token: opts.token });
+  const allowlist = parseAllowlist(opts.allowedUserIds);
+  if (allowlist.size === 0) {
+    console.warn("[telegram] allowlist is empty — bot will reject everyone");
+  }
+
+  const routerDeps: RouterDeps = {
+    allowlist,
+    listAccounts: opts.deps?.listAccounts ?? listAccountsDetailed,
+    listCategories: opts.deps?.listCategories ?? listCategories,
+    parseNlu:
+      opts.deps?.parseNlu ?? ((p) => parseTransactionMessage({ text: p.text, context: p.context })),
+    now: opts.deps?.now,
+  };
+
+  let offset = await getOffset();
+  let backoff = BACKOFF_MIN_MS;
+  console.log(`[telegram] long-poll worker started (offset=${offset})`);
+
+  while (!opts.signal?.aborted) {
+    try {
+      const updates = await client.getUpdates({
+        offset: offset + 1,
+        timeout: LONG_POLL_TIMEOUT_SECONDS,
+      });
+      backoff = BACKOFF_MIN_MS;
+
+      for (const update of updates) {
+        try {
+          await handleUpdate(update, client, routerDeps);
+        } catch (err) {
+          (opts.onError ?? ((e) => console.error("[telegram] handler error:", e)))(err);
+        }
+        if (update.update_id > offset) {
+          offset = update.update_id;
+          await setOffset(offset);
+        }
+      }
+    } catch (err) {
+      (opts.onError ?? ((e) => console.error("[telegram] poll error:", e)))(err);
+      await delay(backoff, opts.signal);
+      backoff = Math.min(backoff * 2, BACKOFF_MAX_MS);
+    }
+  }
+  console.log("[telegram] long-poll worker stopped");
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(t);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}

--- a/src/lib/telegram/router.test.ts
+++ b/src/lib/telegram/router.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { parseAmountFromText } from "./router";
+
+describe("parseAmountFromText", () => {
+  it("parses '45k' as 45000 pesos (cents = 4500000)", () => {
+    expect(parseAmountFromText("45k")).toBe("4500000");
+  });
+
+  it("parses '45K' case-insensitive", () => {
+    expect(parseAmountFromText("45K")).toBe("4500000");
+  });
+
+  it("parses '45 mil' as 45000", () => {
+    expect(parseAmountFromText("45 mil")).toBe("4500000");
+  });
+
+  it("parses '2 millones' as 2000000", () => {
+    expect(parseAmountFromText("2 millones")).toBe("200000000");
+  });
+
+  it("parses '2M' as 2000000", () => {
+    expect(parseAmountFromText("2M")).toBe("200000000");
+  });
+
+  it("parses Colombian thousand separator '123.450'", () => {
+    expect(parseAmountFromText("123.450")).toBe("12345000");
+  });
+
+  it("parses decimal with comma '12,50'", () => {
+    expect(parseAmountFromText("12,50")).toBe("1250");
+  });
+
+  it("strips dollar sign", () => {
+    expect(parseAmountFromText("$45000")).toBe("4500000");
+  });
+
+  it("parses plain integer", () => {
+    expect(parseAmountFromText("45000")).toBe("4500000");
+  });
+
+  it("returns null for non-numeric input", () => {
+    expect(parseAmountFromText("hola")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseAmountFromText("")).toBeNull();
+  });
+});

--- a/src/lib/telegram/router.ts
+++ b/src/lib/telegram/router.ts
@@ -1,0 +1,362 @@
+import type { TelegramClient } from "@/lib/telegram/client";
+import type { TelegramUpdate, TelegramMessage, TelegramCallbackQuery } from "@/lib/telegram/types";
+import type { AccountDetail } from "@/lib/accounts/queries";
+import type { NluAccountOption, NluCategoryOption, NluResult } from "@/lib/ai/transaction-nlu";
+import type { TelegramDraft, TelegramSessionState } from "@/lib/db/schema";
+import { isAllowed } from "@/lib/telegram/allowlist";
+import { handleCommand, parseCommand } from "@/lib/telegram/commands";
+import { clearSession, getSession, mergeDraft, upsertSession } from "@/lib/telegram/session";
+import {
+  accountsKeyboard,
+  categoriesKeyboard,
+  CALLBACK,
+  confirmKeyboard,
+} from "@/lib/telegram/keyboard";
+import {
+  renderAskAccount,
+  renderAskAmount,
+  renderAskCategory,
+  renderCanceled,
+  renderConfirmCard,
+  renderError,
+  renderInserted,
+  renderUnauthorized,
+} from "@/lib/telegram/formatter";
+import { insertFromDraft, isDraftComplete } from "@/lib/telegram/confirm";
+
+export type RouterDeps = {
+  allowlist: Set<number>;
+  listAccounts: () => Promise<AccountDetail[]>;
+  listCategories: () => Promise<NluCategoryOption[]>;
+  parseNlu: (opts: {
+    text: string;
+    context: { now: Date; accounts: NluAccountOption[]; categories: NluCategoryOption[] };
+  }) => Promise<NluResult>;
+  now?: () => Date;
+};
+
+function accountsToNluOptions(accounts: AccountDetail[]): NluAccountOption[] {
+  return accounts
+    .filter((a) => a.active)
+    .map((a) => ({
+      id: a.id,
+      name: a.name,
+      institution: a.institution,
+      currency: a.currency,
+      last4s: a.metadata?.last4s,
+    }));
+}
+
+export function parseAmountFromText(text: string): string | null {
+  const trimmed = text.trim().replace(/\$/g, "").replace(/\s+/g, " ");
+
+  const kMatch = trimmed.match(/^(\d+(?:[,.]\d+)?)\s*[kK]$/);
+  if (kMatch) {
+    const val = parseFloat(kMatch[1].replace(",", "."));
+    if (Number.isFinite(val)) return String(BigInt(Math.round(val * 1000 * 100)));
+  }
+
+  const milMatch = trimmed.match(/^(\d+(?:[,.]\d+)?)\s*mil$/i);
+  if (milMatch) {
+    const val = parseFloat(milMatch[1].replace(",", "."));
+    if (Number.isFinite(val)) return String(BigInt(Math.round(val * 1000 * 100)));
+  }
+
+  const mMatch = trimmed.match(/^(\d+(?:[,.]\d+)?)\s*(?:millones?|m|M)$/);
+  if (mMatch) {
+    const val = parseFloat(mMatch[1].replace(",", "."));
+    if (Number.isFinite(val)) return String(BigInt(Math.round(val * 1_000_000 * 100)));
+  }
+
+  // Plain number (es-CO): dots are thousand separators, comma is decimal.
+  if (/^\d{1,3}(\.\d{3})+(,\d+)?$/.test(trimmed)) {
+    const normalized = trimmed.replace(/\./g, "").replace(",", ".");
+    const val = parseFloat(normalized);
+    if (Number.isFinite(val)) return String(BigInt(Math.round(val * 100)));
+  }
+  if (/^\d+(,\d+)?$/.test(trimmed)) {
+    const normalized = trimmed.replace(",", ".");
+    const val = parseFloat(normalized);
+    if (Number.isFinite(val)) return String(BigInt(Math.round(val * 100)));
+  }
+  if (/^\d+(\.\d+)?$/.test(trimmed)) {
+    const val = parseFloat(trimmed);
+    if (Number.isFinite(val)) return String(BigInt(Math.round(val * 100)));
+  }
+
+  return null;
+}
+
+function pickDefaultCurrency(accounts: NluAccountOption[], accountId?: number): "COP" | "USD" {
+  if (typeof accountId === "number") {
+    const acc = accounts.find((a) => a.id === accountId);
+    if (acc) return acc.currency;
+  }
+  return "COP";
+}
+
+async function advanceFlow(opts: {
+  chatId: number;
+  userId: number;
+  state: TelegramSessionState;
+  accounts: NluAccountOption[];
+  categories: NluCategoryOption[];
+  client: TelegramClient;
+}): Promise<void> {
+  const { chatId, userId, state, accounts, categories, client } = opts;
+  const draft = state.draft;
+
+  if (!draft.amountCents) {
+    const next: TelegramSessionState = { ...state, step: "awaiting_amount" };
+    await upsertSession({ chatId, userId, state: next });
+    await client.sendMessage({ chat_id: chatId, text: renderAskAmount() });
+    return;
+  }
+
+  if (typeof draft.accountId !== "number") {
+    const next: TelegramSessionState = { ...state, step: "awaiting_account" };
+    await upsertSession({ chatId, userId, state: next });
+    await client.sendMessage({
+      chat_id: chatId,
+      text: renderAskAccount(),
+      reply_markup: accountsKeyboard(accounts),
+    });
+    return;
+  }
+
+  const next: TelegramSessionState = { ...state, step: "awaiting_confirm" };
+  const sent = await client.sendMessage({
+    chat_id: chatId,
+    text: renderConfirmCard({ draft, accounts, categories }),
+    reply_markup: confirmKeyboard(),
+  });
+  next.promptMessageId = sent.message_id;
+  await upsertSession({ chatId, userId, state: next });
+}
+
+async function handleText(
+  message: TelegramMessage,
+  client: TelegramClient,
+  deps: RouterDeps,
+): Promise<void> {
+  const text = message.text ?? "";
+  const chatId = message.chat.id;
+  const userId = message.from?.id ?? 0;
+
+  const command = parseCommand(text);
+  if (command) {
+    await handleCommand({ command, chatId, client });
+    return;
+  }
+
+  const existing = await getSession(chatId);
+
+  // awaiting_amount: treat text as amount first, fall back to full re-parse.
+  if (existing?.step === "awaiting_amount") {
+    const amountCents = parseAmountFromText(text);
+    if (amountCents) {
+      const patched = mergeDraft(existing, { amountCents });
+      const accounts = accountsToNluOptions(await deps.listAccounts());
+      const categories = await deps.listCategories();
+      await advanceFlow({ chatId, userId, state: patched, accounts, categories, client });
+      return;
+    }
+  }
+
+  // Otherwise: re-parse the whole message with NLU (starts a fresh draft).
+  const accountsFull = await deps.listAccounts();
+  const accounts = accountsToNluOptions(accountsFull);
+  const categories = await deps.listCategories();
+  const now = (deps.now ?? (() => new Date()))();
+
+  let nlu: NluResult;
+  try {
+    nlu = await deps.parseNlu({ text, context: { now, accounts, categories } });
+  } catch (err) {
+    await client.sendMessage({
+      chat_id: chatId,
+      text: renderError(
+        `No pude procesar el mensaje (${err instanceof Error ? err.message : "error"}).`,
+      ),
+    });
+    return;
+  }
+
+  const draft: TelegramDraft = {
+    amountCents: nlu.draft.amountCents ?? undefined,
+    currency: nlu.draft.currency ?? pickDefaultCurrency(accounts, nlu.draft.accountId ?? undefined),
+    direction: nlu.draft.direction ?? "expense",
+    merchant: nlu.draft.merchant ?? undefined,
+    description: nlu.draft.description ?? undefined,
+    occurredOn: nlu.draft.occurredOn ?? undefined,
+    accountId: nlu.draft.accountId ?? undefined,
+    categorySlug: nlu.draft.categorySlug ?? undefined,
+    notes: nlu.draft.notes,
+  };
+
+  // Auto-pick the account when there's exactly one active account in that currency.
+  if (typeof draft.accountId !== "number") {
+    const matches = accounts.filter((a) => a.currency === draft.currency);
+    if (matches.length === 1) draft.accountId = matches[0].id;
+  }
+
+  const state: TelegramSessionState = {
+    step: "idle",
+    draft,
+    sourceChatId: chatId,
+    sourceMessageId: message.message_id,
+  };
+
+  await advanceFlow({ chatId, userId, state, accounts, categories, client });
+}
+
+async function handleCallback(
+  cb: TelegramCallbackQuery,
+  client: TelegramClient,
+  deps: RouterDeps,
+): Promise<void> {
+  const data = cb.data ?? "";
+  const chatId = cb.message?.chat.id;
+  const userId = cb.from.id;
+  if (typeof chatId !== "number") {
+    await client.answerCallbackQuery({ callback_query_id: cb.id });
+    return;
+  }
+
+  const session = await getSession(chatId);
+  if (!session) {
+    await client.answerCallbackQuery({ callback_query_id: cb.id, text: "Sesión expirada" });
+    await client.sendMessage({
+      chat_id: chatId,
+      text: "La sesión expiró. Mandame el mensaje de nuevo.",
+    });
+    return;
+  }
+
+  const accountsFull = await deps.listAccounts();
+  const accounts = accountsToNluOptions(accountsFull);
+  const categories = await deps.listCategories();
+
+  if (data === CALLBACK.CONFIRM) {
+    if (!isDraftComplete(session.draft)) {
+      await client.answerCallbackQuery({ callback_query_id: cb.id, text: "Faltan datos" });
+      await advanceFlow({ chatId, userId, state: session, accounts, categories, client });
+      return;
+    }
+    const result = await insertFromDraft({
+      draft: session.draft,
+      chatId,
+      sourceMessageId: session.sourceMessageId,
+    });
+    await client.answerCallbackQuery({ callback_query_id: cb.id });
+    if (result.status === "inserted") {
+      await client.sendMessage({ chat_id: chatId, text: renderInserted(result.txId) });
+      await clearSession(chatId);
+    } else if (result.status === "duplicated") {
+      await client.sendMessage({
+        chat_id: chatId,
+        text: renderError("Ya había una transacción con el mismo origen."),
+      });
+      await clearSession(chatId);
+    } else {
+      await client.sendMessage({ chat_id: chatId, text: renderError(`Error: ${result.reason}`) });
+    }
+    return;
+  }
+
+  if (data === CALLBACK.CANCEL) {
+    await clearSession(chatId);
+    await client.answerCallbackQuery({ callback_query_id: cb.id });
+    await client.sendMessage({ chat_id: chatId, text: renderCanceled() });
+    return;
+  }
+
+  if (data === CALLBACK.EDIT_ACCOUNT) {
+    const next: TelegramSessionState = { ...session, step: "awaiting_account" };
+    await upsertSession({ chatId, userId, state: next });
+    await client.answerCallbackQuery({ callback_query_id: cb.id });
+    await client.sendMessage({
+      chat_id: chatId,
+      text: renderAskAccount(),
+      reply_markup: accountsKeyboard(accounts),
+    });
+    return;
+  }
+
+  if (data === CALLBACK.EDIT_CATEGORY) {
+    const next: TelegramSessionState = { ...session, step: "awaiting_category" };
+    await upsertSession({ chatId, userId, state: next });
+    await client.answerCallbackQuery({ callback_query_id: cb.id });
+    await client.sendMessage({
+      chat_id: chatId,
+      text: renderAskCategory(),
+      reply_markup: categoriesKeyboard(categories),
+    });
+    return;
+  }
+
+  if (data === CALLBACK.BACK) {
+    await client.answerCallbackQuery({ callback_query_id: cb.id });
+    await advanceFlow({ chatId, userId, state: session, accounts, categories, client });
+    return;
+  }
+
+  if (data.startsWith(CALLBACK.ACCOUNT_PREFIX)) {
+    const id = Number(data.slice(CALLBACK.ACCOUNT_PREFIX.length));
+    if (!Number.isInteger(id) || !accounts.some((a) => a.id === id)) {
+      await client.answerCallbackQuery({ callback_query_id: cb.id, text: "Cuenta inválida" });
+      return;
+    }
+    const picked = accounts.find((a) => a.id === id)!;
+    const patched = mergeDraft(session, {
+      accountId: id,
+      currency: picked.currency,
+    });
+    await client.answerCallbackQuery({ callback_query_id: cb.id });
+    await advanceFlow({ chatId, userId, state: patched, accounts, categories, client });
+    return;
+  }
+
+  if (data.startsWith(CALLBACK.CATEGORY_PREFIX)) {
+    const slug = data.slice(CALLBACK.CATEGORY_PREFIX.length);
+    if (!categories.some((c) => c.slug === slug)) {
+      await client.answerCallbackQuery({ callback_query_id: cb.id, text: "Categoría inválida" });
+      return;
+    }
+    const patched = mergeDraft(session, { categorySlug: slug });
+    await client.answerCallbackQuery({ callback_query_id: cb.id });
+    await advanceFlow({ chatId, userId, state: patched, accounts, categories, client });
+    return;
+  }
+
+  await client.answerCallbackQuery({ callback_query_id: cb.id });
+}
+
+export async function handleUpdate(
+  update: TelegramUpdate,
+  client: TelegramClient,
+  deps: RouterDeps,
+): Promise<void> {
+  if (update.message) {
+    const msg = update.message;
+    if (!isAllowed(msg.from?.id, deps.allowlist)) {
+      if (msg.from?.id) {
+        await client.sendMessage({ chat_id: msg.chat.id, text: renderUnauthorized() });
+      }
+      return;
+    }
+    if (typeof msg.text === "string") {
+      await handleText(msg, client, deps);
+    }
+    return;
+  }
+
+  if (update.callback_query) {
+    const cb = update.callback_query;
+    if (!isAllowed(cb.from.id, deps.allowlist)) {
+      await client.answerCallbackQuery({ callback_query_id: cb.id, text: "No autorizado" });
+      return;
+    }
+    await handleCallback(cb, client, deps);
+  }
+}

--- a/src/lib/telegram/session.ts
+++ b/src/lib/telegram/session.ts
@@ -1,0 +1,74 @@
+import { eq, lt } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { telegramSessions, type TelegramSessionState, type TelegramDraft } from "@/lib/db/schema";
+
+const SESSION_TTL_MS = 30 * 60 * 1000;
+
+export function emptyState(chatId: number, sourceMessageId?: number): TelegramSessionState {
+  return {
+    step: "idle",
+    draft: {},
+    sourceChatId: chatId,
+    sourceMessageId,
+  };
+}
+
+export async function getSession(chatId: number): Promise<TelegramSessionState | null> {
+  const rows = await db
+    .select()
+    .from(telegramSessions)
+    .where(eq(telegramSessions.chatId, BigInt(chatId)))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  if (row.expiresAt.getTime() < Date.now()) {
+    await db.delete(telegramSessions).where(eq(telegramSessions.chatId, BigInt(chatId)));
+    return null;
+  }
+  return row.state;
+}
+
+export async function upsertSession(opts: {
+  chatId: number;
+  userId: number;
+  state: TelegramSessionState;
+}): Promise<void> {
+  const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
+  await db
+    .insert(telegramSessions)
+    .values({
+      chatId: BigInt(opts.chatId),
+      userId: BigInt(opts.userId),
+      state: opts.state,
+      updatedAt: new Date(),
+      expiresAt,
+    })
+    .onConflictDoUpdate({
+      target: telegramSessions.chatId,
+      set: {
+        userId: BigInt(opts.userId),
+        state: opts.state,
+        updatedAt: new Date(),
+        expiresAt,
+      },
+    });
+}
+
+export async function clearSession(chatId: number): Promise<void> {
+  await db.delete(telegramSessions).where(eq(telegramSessions.chatId, BigInt(chatId)));
+}
+
+export async function sweepExpiredSessions(): Promise<number> {
+  const result = await db
+    .delete(telegramSessions)
+    .where(lt(telegramSessions.expiresAt, new Date()))
+    .returning({ chatId: telegramSessions.chatId });
+  return result.length;
+}
+
+export function mergeDraft(
+  state: TelegramSessionState,
+  patch: Partial<TelegramDraft>,
+): TelegramSessionState {
+  return { ...state, draft: { ...state.draft, ...patch } };
+}

--- a/src/lib/telegram/types.ts
+++ b/src/lib/telegram/types.ts
@@ -1,0 +1,65 @@
+export type TelegramUser = {
+  id: number;
+  is_bot: boolean;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+  language_code?: string;
+};
+
+export type TelegramChat = {
+  id: number;
+  type: "private" | "group" | "supergroup" | "channel";
+  title?: string;
+  username?: string;
+};
+
+export type TelegramMessage = {
+  message_id: number;
+  date: number;
+  chat: TelegramChat;
+  from?: TelegramUser;
+  text?: string;
+  entities?: Array<{ type: string; offset: number; length: number }>;
+};
+
+export type TelegramCallbackQuery = {
+  id: string;
+  from: TelegramUser;
+  message?: TelegramMessage;
+  data?: string;
+  chat_instance: string;
+};
+
+export type TelegramUpdate = {
+  update_id: number;
+  message?: TelegramMessage;
+  edited_message?: TelegramMessage;
+  callback_query?: TelegramCallbackQuery;
+};
+
+export type InlineKeyboardButton = {
+  text: string;
+  callback_data?: string;
+  url?: string;
+};
+
+export type InlineKeyboardMarkup = {
+  inline_keyboard: InlineKeyboardButton[][];
+};
+
+export type SendMessageOptions = {
+  chat_id: number;
+  text: string;
+  parse_mode?: "Markdown" | "MarkdownV2" | "HTML";
+  reply_markup?: InlineKeyboardMarkup;
+  reply_to_message_id?: number;
+};
+
+export type EditMessageOptions = {
+  chat_id: number;
+  message_id: number;
+  text: string;
+  parse_mode?: "Markdown" | "MarkdownV2" | "HTML";
+  reply_markup?: InlineKeyboardMarkup;
+};


### PR DESCRIPTION
## Summary

Fase 1 del bot de Telegram (#67): **texto libre → NLU Claude Haiku → confirmación con inline keyboard → inserción**. Foto/OCR + SMS forwardeado van en #169, nota de voz en #170.

- Long-poll desde `src/instrumentation.ts` (mismo patrón que el cron de recurring-gap). Cero infra nueva. Toggle: `FINDASH_DISABLE_TELEGRAM=1`.
- NLU con Claude Haiku + zod validation (raw fetch, mismo patrón de `classification/ai.ts`).
- Schema: `tx_source += 'telegram'`, nueva tabla `telegram_sessions` (chatId PK, JSONB state, TTL 30 min), singleton `telegram_poll_state` con offset de long-poll.
- Allowlist hardcoded vía `TELEGRAM_ALLOWED_USER_IDS`. Usuarios fuera reciben "No autorizado".

## Flow

Usuario manda `pagué 45k en el restaurante` →

1. Router parsea con NLU → draft
2. Si falta monto o cuenta, el bot pregunta (plain text o inline keyboard)
3. Card de confirmación: `💸 Gasto · 45.000 COP / 🏪 Restaurante / 💳 Visa *2575 / 📅 Hoy / 🏷️ restaurantes` con botones `[✅] [❌] [✏️ Cuenta] [✏️ Categoría]`
4. Al confirmar: insert con `source='telegram'`, `externalId='tg:<chatId>:<msgId>'` (dedup), `classifyByRule` rellena categoría si el NLU no la resolvió, emit `transaction:created` (dashboard SSE refresca)

## Acceptance checklist

- [x] `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_USER_IDS` documentados en `.env.example`
- [x] Texto libre → NLU → confirmación → tx creada (flow implementado)
- [x] `/start`, `/help`, `/cancel` — comandos básicos
- [x] Usuario no whitelisted recibe "No autorizado"
- [x] `lint` + `typecheck` + `format:check` pasan
- [x] Tests: 10 casos del NLU parser (inputs reales con `k`, `mil`, `millones`, decimales coma, `ayer`, `ingresé`, slug inválido, account inválida, JSON roto, API error) + 9 de allowlist + 11 de `parseAmountFromText`
- [ ] Smoke test end-to-end con bot real (pendiente — necesita `TELEGRAM_BOT_TOKEN` en `.env.local`)

## Test plan

- [ ] Crear bot con @BotFather, pegar token en `.env.local`
- [ ] Setear `TELEGRAM_ALLOWED_USER_IDS` con mi user ID
- [ ] `bun run dev` — verificar log `[telegram] long-poll worker started (offset=0)`
- [ ] Enviar `/start` → verificar bienvenida
- [ ] Enviar `pagué 45k en el restaurante con la visa *2575` → confirmar → tx aparece en dashboard
- [ ] Enviar `mercado 123.450` → bot pregunta cuenta → elegir → confirmar → tx creada
- [ ] Enviar `ingresé 2 millones del sueldo` → verificar direction=income, amount positivo
- [ ] `/cancel` durante un draft → descarta
- [ ] Usuario fuera de allowlist envía mensaje → responde "No autorizado"

## Out of scope (issues hijos)

- #169 Fase 2: foto (OCR) + SMS Bancolombia forwardeado
- #170 Fase 3: nota de voz (STT)

Closes #67 (Fase 1 ship; sub-issues quedan abiertos).