### PR TITLE
fix(telegram): accept null for NLU optional fields + friendlier error (#172)

### DIFF
--- a/src/lib/ai/transaction-nlu.test.ts
+++ b/src/lib/ai/transaction-nlu.test.ts
@@ -249,6 +249,34 @@ describe("parseTransactionMessage", () => {
     expect(result.draft.accountId).toBeNull();
   });
 
+  it("accepts null for optional fields (model routinely returns null instead of omitting)", async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse({
+        amountCents: null,
+        currency: null,
+        direction: null,
+        merchant: null,
+        description: null,
+        occurredOn: null,
+        accountId: null,
+        categorySlug: null,
+        confidence: 10,
+        notes: null,
+      }),
+    );
+
+    const result = await parseTransactionMessage({
+      text: "algo sin sentido",
+      context: { now: FIXED_NOW, accounts: ACCOUNTS, categories: CATEGORIES },
+      apiKey: "test-key",
+      fetchImpl,
+    });
+
+    expect(result.draft.amountCents).toBeNull();
+    expect(result.draft.notes).toBeUndefined();
+    expect(result.draft.confidence).toBe(10);
+  });
+
   it("throws on invalid JSON from model", async () => {
     const fetchImpl: typeof fetch = async () =>
       new Response(

--- a/src/lib/ai/transaction-nlu.ts
+++ b/src/lib/ai/transaction-nlu.ts
@@ -41,20 +41,24 @@ export type NluResult = {
 
 const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
 
+// All optional fields use `.nullish()` (accepts null OR undefined) because
+// Claude routinely returns explicit `"field": null` for absent values instead
+// of omitting the key. Being strict here would crash the parser on perfectly
+// valid model output.
 const nluResponseSchema = z.object({
-  amountCents: z.string().regex(/^\d+$/).nullable(),
-  currency: z.enum(["COP", "USD"]).nullable(),
-  direction: z.enum(["expense", "income"]).nullable(),
-  merchant: z.string().max(200).nullable(),
-  description: z.string().max(500).nullable(),
+  amountCents: z.string().regex(/^\d+$/).nullish(),
+  currency: z.enum(["COP", "USD"]).nullish(),
+  direction: z.enum(["expense", "income"]).nullish(),
+  merchant: z.string().max(200).nullish(),
+  description: z.string().max(500).nullish(),
   occurredOn: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullable(),
-  accountId: z.number().int().nullable(),
-  categorySlug: z.string().max(60).nullable(),
+    .nullish(),
+  accountId: z.number().int().nullish(),
+  categorySlug: z.string().max(60).nullish(),
   confidence: z.number().int().min(0).max(100),
-  notes: z.string().max(200).optional(),
+  notes: z.string().max(200).nullish(),
 });
 
 function formatBogotaDate(now: Date): string {
@@ -180,13 +184,22 @@ export async function parseTransactionMessage(opts: {
 
   const validAccountIds = new Set(opts.context.accounts.map((a) => a.id));
   const validCategorySlugs = new Set(opts.context.categories.map((c) => c.slug));
+  // Normalize `undefined` to `null` so downstream consumers only handle one
+  // "absent" shape. The schema accepts both because models return either.
   const draft: NluDraft = {
-    ...parsed,
+    amountCents: parsed.amountCents ?? null,
+    currency: parsed.currency ?? null,
+    direction: parsed.direction ?? null,
+    merchant: parsed.merchant ?? null,
+    description: parsed.description ?? null,
+    occurredOn: parsed.occurredOn ?? null,
     accountId: parsed.accountId && validAccountIds.has(parsed.accountId) ? parsed.accountId : null,
     categorySlug:
       parsed.categorySlug && validCategorySlugs.has(parsed.categorySlug)
         ? parsed.categorySlug
         : null,
+    confidence: parsed.confidence,
+    notes: parsed.notes ?? undefined,
   };
 
   return {

--- a/src/lib/telegram/router.ts
+++ b/src/lib/telegram/router.ts
@@ -173,10 +173,11 @@ async function handleText(
   try {
     nlu = await deps.parseNlu({ text, context: { now, accounts, categories } });
   } catch (err) {
+    console.error("[telegram] NLU parse failed:", err);
     await client.sendMessage({
       chat_id: chatId,
       text: renderError(
-        `No pude procesar el mensaje (${err instanceof Error ? err.message : "error"}).`,
+        "No pude entender el mensaje. Probá reformularlo con monto y descripción más claras (ej: 'pagué 45k en el restaurante').",
       ),
     });
     return;


### PR DESCRIPTION
## Summary

Hotfix for the NLU parser that crashed on perfectly valid model output and dumped the raw zod error to the user (observed in the Telegram UI after merging #171).

- **Root cause**: Claude Haiku routinely returns \`"field": null\` for absent optional values instead of omitting the key. My schema declared \`notes: z.string().max(200).optional()\` which accepts \`undefined\` but NOT \`null\` — so any response with \`notes: null\` blew up zod.
- **Fix**: swap all optional fields to \`.nullish()\` (accepts null OR undefined). Normalize undefined → null in the draft so downstream consumers handle one "absent" shape.
- **Bonus**: catch NLU errors in the router and show "No pude entender el mensaje. Probá reformularlo..." instead of zod's JSON dump. Full stack still logged to console.error.

Added a regression test: \`parseTransactionMessage\` with every field nullable explicitly set to \`null\`.

Closes #172.

## Test plan

- [x] \`bun run test\` — 218/218 green (was 217, +1 null-fields test)
- [x] \`bun run typecheck\` + \`bun run lint\` clean
- [ ] User reforwards the Bancolombia SMS (\`Compraste COP18.000,00 en DL*DIDI FOOD CO...\`) → bot shows confirm card, no zod error