### PR TITLE
feat(telegram): detect forwarded Bancolombia SMS and dedupe with sms-ingest (#169)

### DIFF
--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -322,6 +322,7 @@ export type TelegramSessionState = {
   sourceChatId: number;
   sourceMessageId?: number;
   promptMessageId?: number;
+  externalIdOverride?: string;
 };
 
 export const telegramSessions = pgTable("telegram_sessions", {

--- a/src/lib/telegram/confirm.ts
+++ b/src/lib/telegram/confirm.ts
@@ -23,8 +23,9 @@ export async function insertFromDraft(opts: {
   draft: TelegramDraft;
   chatId: number;
   sourceMessageId?: number;
+  externalIdOverride?: string;
 }): Promise<ConfirmResult> {
-  const { draft, chatId, sourceMessageId } = opts;
+  const { draft, chatId, sourceMessageId, externalIdOverride } = opts;
 
   if (!isDraftComplete(draft)) {
     return { status: "error", reason: "draft is incomplete" };
@@ -54,7 +55,8 @@ export async function insertFromDraft(opts: {
     }
   }
 
-  const externalId = sourceMessageId ? `tg:${chatId}:${sourceMessageId}` : null;
+  const externalId =
+    externalIdOverride ?? (sourceMessageId ? `tg:${chatId}:${sourceMessageId}` : null);
 
   try {
     const result = await db

--- a/src/lib/telegram/router.ts
+++ b/src/lib/telegram/router.ts
@@ -23,6 +23,8 @@ import {
   renderUnauthorized,
 } from "@/lib/telegram/formatter";
 import { insertFromDraft, isDraftComplete } from "@/lib/telegram/confirm";
+import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
+import { buildDraftFromParsedSms } from "@/lib/telegram/sms-draft";
 
 export type RouterDeps = {
   allowlist: Set<number>;
@@ -163,8 +165,39 @@ async function handleText(
     }
   }
 
-  // Otherwise: re-parse the whole message with NLU (starts a fresh draft).
   const accountsFull = await deps.listAccounts();
+
+  // Forwarded Bancolombia SMS branch: deterministic parser first, NLU fallback.
+  // Calling the parser unconditionally is safe — its regexes are tight enough
+  // that normal freeform text returns skip:"unknown" and falls through.
+  const smsParsed = parseSmsBancolombia(text);
+  if (smsParsed.kind !== "skip") {
+    const { draft, externalId } = buildDraftFromParsedSms(smsParsed, accountsFull);
+    const categories = await deps.listCategories();
+    const state: TelegramSessionState = {
+      step: "idle",
+      draft,
+      sourceChatId: chatId,
+      sourceMessageId: message.message_id,
+      externalIdOverride: externalId,
+    };
+    const accounts = accountsToNluOptions(accountsFull);
+    await advanceFlow({ chatId, userId, state, accounts, categories, client });
+    return;
+  }
+  if (smsParsed.reason === "failed" || smsParsed.reason === "non_transactional") {
+    await client.sendMessage({
+      chat_id: chatId,
+      text: renderError(
+        smsParsed.reason === "failed"
+          ? "Ese SMS indica una transacción fallida — no lo ingreso."
+          : "Ese SMS no es una transacción — no lo ingreso.",
+      ),
+    });
+    return;
+  }
+
+  // Otherwise: re-parse the whole message with NLU (starts a fresh draft).
   const accounts = accountsToNluOptions(accountsFull);
   const categories = await deps.listCategories();
   const now = (deps.now ?? (() => new Date()))();
@@ -248,6 +281,7 @@ async function handleCallback(
       draft: session.draft,
       chatId,
       sourceMessageId: session.sourceMessageId,
+      externalIdOverride: session.externalIdOverride,
     });
     await client.answerCallbackQuery({ callback_query_id: cb.id });
     if (result.status === "inserted") {

--- a/src/lib/telegram/sms-draft.test.ts
+++ b/src/lib/telegram/sms-draft.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import type { AccountDetail } from "@/lib/accounts/queries";
+import { parseSmsBancolombia, type ParsedSms } from "@/lib/ingestion/sms-bancolombia";
+import { buildDraftFromParsedSms } from "./sms-draft";
+
+const ACCOUNTS: AccountDetail[] = [
+  {
+    id: 1,
+    name: "Ahorros",
+    institution: "Bancolombia",
+    type: "savings",
+    currency: "COP",
+    balanceCents: BigInt(0),
+    active: true,
+    metadata: { last4s: ["1234"] },
+  },
+  {
+    id: 2,
+    name: "Visa",
+    institution: "Bancolombia",
+    type: "credit_card",
+    currency: "COP",
+    balanceCents: BigInt(0),
+    active: true,
+    metadata: { last4s: ["2575"] },
+  },
+  {
+    id: 3,
+    name: "Visa USD",
+    institution: "Bancolombia",
+    type: "credit_card",
+    currency: "USD",
+    balanceCents: BigInt(0),
+    active: true,
+    metadata: { last4s: ["2575"] },
+  },
+  {
+    id: 4,
+    name: "Inactive",
+    institution: "Bancolombia",
+    type: "savings",
+    currency: "COP",
+    balanceCents: BigInt(0),
+    active: false,
+    metadata: { last4s: ["9999"] },
+  },
+];
+
+function parseOrThrow(body: string): ParsedSms {
+  const parsed = parseSmsBancolombia(body);
+  if (parsed.kind === "skip") throw new Error(`expected parse, got skip: ${parsed.reason}`);
+  return parsed;
+}
+
+describe("buildDraftFromParsedSms", () => {
+  it("maps a purchase to an expense draft with merchant and resolved account", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: Compraste $45.000,00 en RAPPI con tu T.Cred *2575, el 15/04/2026 a las 19:30",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.direction).toBe("expense");
+    expect(result.draft.currency).toBe("COP");
+    expect(result.draft.amountCents).toBe("4500000");
+    expect(result.draft.merchant).toBe("RAPPI");
+    expect(result.draft.description).toBe("RAPPI");
+    expect(result.draft.accountId).toBe(2);
+    expect(result.draft.occurredOn).toBe("2026-04-15");
+    expect(result.draft.categorySlug).toBeUndefined();
+    expect(result.externalId).toBe(parsed.externalId);
+    expect(result.externalId.startsWith("bcol-sms:")).toBe(true);
+  });
+
+  it("routes a USD purchase to the USD account when same last4 exists in two currencies", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: Compraste USD195,26 en AMAZON con tu T.Cred *2575, el 15/04/2026 a las 19:30",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.currency).toBe("USD");
+    expect(result.draft.accountId).toBe(3);
+  });
+
+  it("leaves accountId undefined when no account matches the last4", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: Compraste $10.000,00 en FOO con tu T.Cred *9876, el 15/04/2026 a las 19:30",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.accountId).toBeUndefined();
+    expect(result.draft.direction).toBe("expense");
+  });
+
+  it("ignores inactive accounts when resolving by last4", () => {
+    // last4 '9999' matches an INACTIVE account — should not resolve.
+    const parsed = parseOrThrow(
+      "Bancolombia: Compraste $10.000,00 en FOO con tu T.Cred *9999, el 15/04/2026 a las 19:30",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.accountId).toBeUndefined();
+  });
+
+  it("maps a transfer_sent to expense with 'transferencias' category", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: Transferiste $100.000,00 desde tu cuenta *1234 a la cuenta *9988, el 15/04/2026 a las 10:00",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.direction).toBe("expense");
+    expect(result.draft.categorySlug).toBe("transferencias");
+    expect(result.draft.accountId).toBe(1);
+    expect(result.draft.description).toContain("*9988");
+  });
+
+  it("maps a QR transfer with isQR=true", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: Transferiste $50.000,00 por QR desde tu cuenta *1234 a la cuenta *5566, el 15/04/2026 a las 10:00",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.description).toContain("QR");
+  });
+
+  it("maps a transfer_received to income with 'ingresos' category", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: Alejandro, recibiste una transferencia de PEPITO PEREZ por $200.000,00 en tu cuenta *1234 conectada a la llave 3150 el 15/04/2026 a las 10:00",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.direction).toBe("income");
+    expect(result.draft.categorySlug).toBe("ingresos");
+    expect(result.draft.merchant).toBe("PEPITO PEREZ");
+    expect(result.draft.accountId).toBe(1);
+  });
+
+  it("maps tc_payment to expense with 'pago-tc' category", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: Pagaste $500.000,00 en la tarjeta de credito *2575 desde la cuenta *1234, el 15/04/2026 a las 10:00",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.direction).toBe("expense");
+    expect(result.draft.categorySlug).toBe("pago-tc");
+    expect(result.draft.accountId).toBe(1);
+  });
+
+  it("maps atm_withdrawal with resolved account but no category", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: Retiraste $100.000,00 en 43AVENIDA de tu T.Deb *1234 el 15/04/2026 a las 10:00",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.direction).toBe("expense");
+    expect(result.draft.accountId).toBe(1);
+    expect(result.draft.categorySlug).toBeUndefined();
+    expect(result.draft.description).toContain("43AVENIDA");
+  });
+
+  it("maps qr_payment to expense without category (rule engine handles it)", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: Alejandro pagaste $30.000,00 por codigo QR desde tu cuenta *1234 a la llave 3150 el 15/04/2026 a las 10:00",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.direction).toBe("expense");
+    expect(result.draft.accountId).toBe(1);
+    expect(result.draft.categorySlug).toBeUndefined();
+    expect(result.draft.description).toContain("llave 3150");
+  });
+
+  it("routes provider_payment to the Bancolombia savings account of matching currency", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: Recibiste un pago PROVEEDOR de EMPRESA XYZ por $1.000.000,00 en tu cuenta de Ahorros el 15/04/2026 a las 10:00",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.direction).toBe("income");
+    expect(result.draft.accountId).toBe(1);
+    expect(result.draft.categorySlug).toBe("ingresos");
+  });
+
+  it("preserves externalId so SMS-forward dedupes against regular SMS ingest", () => {
+    const body =
+      "Bancolombia: Compraste $45.000,00 en RAPPI con tu T.Cred *2575, el 15/04/2026 a las 19:30";
+    const fromTelegram = buildDraftFromParsedSms(parseOrThrow(body), ACCOUNTS).externalId;
+    const fromPhoneIngest = parseOrThrow(body).externalId;
+    expect(fromTelegram).toBe(fromPhoneIngest);
+  });
+});

--- a/src/lib/telegram/sms-draft.ts
+++ b/src/lib/telegram/sms-draft.ts
@@ -1,0 +1,159 @@
+import type { AccountDetail } from "@/lib/accounts/queries";
+import type { TelegramDraft } from "@/lib/db/schema";
+import {
+  resolveAccountFromLast4,
+  type ParsedSms,
+  type RoutableAccount,
+} from "@/lib/ingestion/sms-bancolombia";
+
+export type SmsDraftResult = {
+  draft: TelegramDraft;
+  externalId: string;
+  occurredOn: string;
+  raw: string;
+  kind: ParsedSms["kind"];
+};
+
+function toRoutable(accounts: AccountDetail[]): Array<RoutableAccount & { institution: string }> {
+  return accounts
+    .filter((a) => a.active)
+    .map((a) => ({
+      id: a.id,
+      currency: a.currency,
+      metadata: a.metadata,
+      institution: a.institution,
+    }));
+}
+
+function resolveAccountId(parsed: ParsedSms, accounts: AccountDetail[]): number | undefined {
+  const routable = toRoutable(accounts);
+  let last4: string | null = null;
+  switch (parsed.kind) {
+    case "purchase":
+      last4 = parsed.cardLast4;
+      break;
+    case "transfer_sent":
+    case "qr_payment":
+    case "tc_payment":
+    case "provider_payment_sent":
+    case "atm_withdrawal":
+    case "bre_b_transfer":
+      last4 = parsed.fromLast4;
+      break;
+    case "transfer_received":
+      last4 = parsed.toLast4;
+      break;
+    case "tc_credit_received":
+      last4 = parsed.toCardLast4;
+      break;
+    case "provider_payment": {
+      // SMS says "en tu cuenta de Ahorros" with no last4 — pick the single
+      // Bancolombia savings account in the matching currency.
+      const match = routable.find(
+        (a) => a.institution === "Bancolombia" && a.currency === parsed.currency,
+      );
+      return match?.id;
+    }
+  }
+  if (!last4) return undefined;
+  const match = resolveAccountFromLast4(last4, parsed.currency, routable);
+  return match?.id;
+}
+
+function describe(parsed: ParsedSms): {
+  merchant?: string;
+  description: string;
+  direction: "expense" | "income";
+  categorySlug?: string;
+} {
+  switch (parsed.kind) {
+    case "purchase":
+      return {
+        merchant: parsed.merchant,
+        description: parsed.merchant,
+        direction: "expense",
+      };
+    case "transfer_sent":
+      return {
+        description: `Transferencia${parsed.isQR ? " QR" : ""} a cuenta *${parsed.toAccount}`,
+        direction: "expense",
+        categorySlug: "transferencias",
+      };
+    case "qr_payment":
+      return {
+        description: `Pago QR a llave ${parsed.toKey}`,
+        direction: "expense",
+      };
+    case "tc_payment":
+      return {
+        description: `Pago TC *${parsed.toCardLast4}`,
+        direction: "expense",
+        categorySlug: "pago-tc",
+      };
+    case "transfer_received":
+      return {
+        merchant: parsed.senderName,
+        description: `Transferencia recibida de ${parsed.senderName}`,
+        direction: "income",
+        categorySlug: "ingresos",
+      };
+    case "provider_payment":
+      return {
+        merchant: parsed.senderName,
+        description: `Pago PROVEEDOR de ${parsed.senderName}`,
+        direction: "income",
+        categorySlug: "ingresos",
+      };
+    case "provider_payment_sent":
+      return {
+        merchant: parsed.providerName,
+        description: `Pago a ${parsed.providerName}`,
+        direction: "expense",
+      };
+    case "atm_withdrawal":
+      return {
+        description: `Retiro ATM ${parsed.atmCode}`,
+        direction: "expense",
+      };
+    case "tc_credit_received":
+      return {
+        merchant: parsed.senderName,
+        description: `Abono de ${parsed.senderName} a TC *${parsed.toCardLast4}`,
+        direction: "income",
+        categorySlug: "pago-tc",
+      };
+    case "bre_b_transfer":
+      return {
+        merchant: parsed.recipientName,
+        description: `Transferencia Bre-b a ${parsed.recipientName}`,
+        direction: "expense",
+      };
+  }
+}
+
+export function buildDraftFromParsedSms(
+  parsed: ParsedSms,
+  accounts: AccountDetail[],
+): SmsDraftResult {
+  const accountId = resolveAccountId(parsed, accounts);
+  const { merchant, description, direction, categorySlug } = describe(parsed);
+
+  const draft: TelegramDraft = {
+    amountCents: parsed.amountCents.toString(),
+    currency: parsed.currency,
+    direction,
+    merchant,
+    description,
+    occurredOn: parsed.occurredOn,
+    accountId,
+    categorySlug,
+  };
+
+  return {
+    draft,
+    externalId: parsed.externalId,
+    occurredOn: parsed.occurredOn,
+    raw: parsed.raw,
+    kind: parsed.kind,
+  };
+}


### PR DESCRIPTION
## Summary

Partial implementation of #169 — **SMS forwardeado branch**. Photo/OCR path follows in a separate PR.

When the user forwards a Bancolombia SMS to the bot, `router.handleText` now runs the deterministic `parseSmsBancolombia` parser **before** hitting the NLU. If it returns a `ParsedSms`, the draft is built directly from it with account resolution by `last4 + currency` — no Claude Haiku call, no token spend.

Key decisions:
- **Unconditional parse**: SMS regexes are tight enough that normal NLU text returns `skip:"unknown"` and falls through. No sniff heuristic needed.
- **`skip` with `reason=failed|non_transactional`**: bot politely declines instead of falling to NLU (e.g. a failed-transaction SMS).
- **Dedup with `/api/ingest/sms`**: the Telegram branch reuses the SMS parser's `externalId` (`bcol-sms:<hash>`) instead of the default `tg:<chatId>:<msgId>`. If the same SMS arrived through both paths, the second insert hits `ON CONFLICT DO NOTHING`.
- **Reuse existing pipelines**: account routing goes through `resolveAccountFromLast4`; category hints (`transferencias`, `pago-tc`, `ingresos`) mirror `buildTxFields` in the ingest route. Rule engine still runs at insert time for kinds without a hardcoded category.

## Files
- `src/lib/telegram/sms-draft.ts` (new) — `buildDraftFromParsedSms(parsed, accounts)` maps all 10 `ParsedSms` kinds to a `TelegramDraft` + `externalId`.
- `src/lib/telegram/sms-draft.test.ts` (new) — 12 tests: purchase, transfer sent/received, QR, TC payment, ATM, provider payment, plus inactive-account gate and externalId dedup.
- `src/lib/telegram/router.ts` — new SMS branch in `handleText` before NLU; passes `externalIdOverride` through the session state.
- `src/lib/telegram/confirm.ts` — accepts `externalIdOverride` in `insertFromDraft`.
- `src/lib/db/schema.ts` — `TelegramSessionState.externalIdOverride?: string`.

## Out of scope (follow-up PR for #169)
- Photo/OCR branch — Telegram `photo` update → `getFile` → `extractTransactionsFromImage`.

Closes nothing yet (#169 stays open until the photo/OCR branch ships).

## Test plan
- [x] `bun run test` — 230 passing (12 new in `sms-draft.test.ts`)
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` + `bun run format:check` — clean
- [ ] Smoke test: forward a real Bancolombia SMS to the bot → confirmation card appears with merchant, amount, account auto-resolved by last4
- [ ] Forward a "no fue exitosa" SMS → bot replies "Ese SMS indica una transacción fallida"
- [ ] Send freeform text ("pagué 45k en el restaurante") → still goes through NLU (regression check)