### PR TITLE
feat(telegram): photo → OCR ingest with account-first prompt and batch confirm (#169)

### DIFF
--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -302,7 +302,14 @@ export type TelegramSessionStep =
   | "awaiting_account"
   | "awaiting_amount"
   | "awaiting_category"
-  | "awaiting_confirm";
+  | "awaiting_confirm"
+  | "awaiting_photo_account"
+  | "awaiting_batch_confirm";
+
+export type TelegramBatchItem = {
+  draft: TelegramDraft;
+  externalId: string;
+};
 
 export type TelegramDraft = {
   amountCents?: string;
@@ -323,6 +330,8 @@ export type TelegramSessionState = {
   sourceMessageId?: number;
   promptMessageId?: number;
   externalIdOverride?: string;
+  photoFileId?: string;
+  batch?: TelegramBatchItem[];
 };
 
 export const telegramSessions = pgTable("telegram_sessions", {

--- a/src/lib/telegram/client.ts
+++ b/src/lib/telegram/client.ts
@@ -1,5 +1,10 @@
 import { request, type RequestOptions } from "node:https";
-import type { EditMessageOptions, SendMessageOptions, TelegramUpdate } from "@/lib/telegram/types";
+import type {
+  EditMessageOptions,
+  SendMessageOptions,
+  TelegramFile,
+  TelegramUpdate,
+} from "@/lib/telegram/types";
 
 const TELEGRAM_HOST = "api.telegram.org";
 
@@ -14,6 +19,8 @@ export type TelegramClient = {
   sendMessage: (opts: SendMessageOptions) => Promise<{ message_id: number }>;
   editMessage: (opts: EditMessageOptions) => Promise<void>;
   answerCallbackQuery: (opts: { callback_query_id: string; text?: string }) => Promise<void>;
+  getFile: (fileId: string) => Promise<TelegramFile>;
+  downloadFile: (filePath: string) => Promise<Buffer>;
 };
 
 // Built on node:https (not fetch) because undici's default fetch in Node 20+
@@ -23,6 +30,34 @@ export type TelegramClient = {
 // falling back to IPv4. node:https.request respects `dns.setDefaultResultOrder`
 // and lets us pin `family: 4`, which bypasses the issue entirely.
 type RawResponse = { status: number; body: string };
+
+function httpsBinary(opts: { path: string; timeoutMs: number }): Promise<Buffer> {
+  const reqOpts: RequestOptions = {
+    host: TELEGRAM_HOST,
+    port: 443,
+    path: opts.path,
+    method: "GET",
+    family: 4,
+  };
+  return new Promise((resolve, reject) => {
+    const req = request(reqOpts, (res) => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`Telegram file download failed: status ${res.statusCode}`));
+        res.resume();
+        return;
+      }
+      const chunks: Buffer[] = [];
+      res.on("data", (c: Buffer) => chunks.push(c));
+      res.on("end", () => resolve(Buffer.concat(chunks)));
+      res.on("error", reject);
+    });
+    req.setTimeout(opts.timeoutMs, () => {
+      req.destroy(new Error(`Telegram download timed out after ${opts.timeoutMs}ms`));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
 
 function httpsJson(opts: {
   method: string;
@@ -109,6 +144,15 @@ export function createTelegramClient(opts: { token: string }): TelegramClient {
         { callback_query_id: opts.callback_query_id, text: opts.text },
         10_000,
       );
+    },
+    async getFile(fileId) {
+      return call<TelegramFile>("getFile", { file_id: fileId }, 10_000);
+    },
+    async downloadFile(filePath) {
+      return httpsBinary({
+        path: `/file/bot${opts.token}/${filePath}`,
+        timeoutMs: 30_000,
+      });
     },
   };
 }

--- a/src/lib/telegram/confirm.ts
+++ b/src/lib/telegram/confirm.ts
@@ -1,6 +1,6 @@
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { transactions, type TelegramDraft } from "@/lib/db/schema";
+import { transactions, type TelegramBatchItem, type TelegramDraft } from "@/lib/db/schema";
 import { classifyByRule } from "@/lib/classification/rules";
 import { emit } from "@/lib/events/bus";
 
@@ -100,4 +100,31 @@ export async function insertFromDraft(opts: {
   } catch (err) {
     return { status: "error", reason: err instanceof Error ? err.message : String(err) };
   }
+}
+
+export type BatchResult = {
+  inserted: number[];
+  duplicated: number;
+  errors: string[];
+};
+
+export async function insertBatch(opts: {
+  items: TelegramBatchItem[];
+  chatId: number;
+}): Promise<BatchResult> {
+  const { items, chatId } = opts;
+  const result: BatchResult = { inserted: [], duplicated: 0, errors: [] };
+
+  for (const item of items) {
+    const outcome = await insertFromDraft({
+      draft: item.draft,
+      chatId,
+      externalIdOverride: item.externalId,
+    });
+    if (outcome.status === "inserted") result.inserted.push(outcome.txId);
+    else if (outcome.status === "duplicated") result.duplicated += 1;
+    else result.errors.push(outcome.reason);
+  }
+
+  return result;
 }

--- a/src/lib/telegram/formatter.ts
+++ b/src/lib/telegram/formatter.ts
@@ -1,4 +1,4 @@
-import type { TelegramDraft } from "@/lib/db/schema";
+import type { TelegramBatchItem, TelegramDraft } from "@/lib/db/schema";
 import type { NluAccountOption, NluCategoryOption } from "@/lib/ai/transaction-nlu";
 
 function formatAmount(amountCentsStr: string, currency: "COP" | "USD"): string {
@@ -87,6 +87,10 @@ export function renderStart(): string {
     "• `ayer gasté 123.450 en el mercado con la visa`",
     "• `ingresé 2 millones del sueldo`",
     "",
+    "También podés:",
+    "• Reenviarme un SMS de Bancolombia (lo parseo automático).",
+    "• Mandarme una foto de un comprobante o lista de transacciones (OCR).",
+    "",
     "Comandos:",
     "/help — ayuda",
     "/cancel — descartar el draft actual",
@@ -120,4 +124,47 @@ export function renderInserted(txId: number): string {
 
 export function renderError(msg: string): string {
   return `⚠️ ${msg}`;
+}
+
+export function renderAskPhotoAccount(): string {
+  return "📸 Recibí la foto. ¿A qué cuenta pertenece?";
+}
+
+export function renderOcrProcessing(): string {
+  return "⏳ Procesando foto con OCR…";
+}
+
+export function renderOcrEmpty(): string {
+  return "🤔 No pude extraer ninguna transacción de la foto. Probá con otra imagen más clara.";
+}
+
+export function renderBatchSummary(items: TelegramBatchItem[]): string {
+  const lines: string[] = [`📋 Encontré ${items.length} transacciones:\n`];
+  for (const item of items) {
+    const { draft } = item;
+    const emoji = draft.direction === "income" ? "💰" : "💸";
+    const amount =
+      draft.amountCents && draft.currency
+        ? formatAmount(draft.amountCents, draft.currency)
+        : "(sin monto)";
+    const desc = draft.merchant ?? draft.description ?? "(sin descripción)";
+    const date = draft.occurredOn ?? "hoy";
+    lines.push(`${emoji} ${amount} · ${desc} · ${date}`);
+  }
+  lines.push("\n¿Confirmar todas?");
+  return lines.join("\n");
+}
+
+export function renderBatchInserted(opts: {
+  inserted: number[];
+  duplicated: number;
+  errors: number;
+}): string {
+  const parts: string[] = [];
+  if (opts.inserted.length > 0) {
+    parts.push(`✅ Guardadas ${opts.inserted.length}`);
+  }
+  if (opts.duplicated > 0) parts.push(`🔁 ${opts.duplicated} duplicadas`);
+  if (opts.errors > 0) parts.push(`⚠️ ${opts.errors} con error`);
+  return parts.join(" · ") || "Sin cambios.";
 }

--- a/src/lib/telegram/keyboard.ts
+++ b/src/lib/telegram/keyboard.ts
@@ -9,6 +9,7 @@ export const CALLBACK = {
   ACCOUNT_PREFIX: "a:",
   CATEGORY_PREFIX: "k:",
   BACK: "b",
+  BATCH_CONFIRM: "bc",
 } as const;
 
 export function confirmKeyboard(): InlineKeyboardMarkup {
@@ -42,6 +43,17 @@ export function accountsKeyboard(accounts: NluAccountOption[]): InlineKeyboardMa
   }
   rows.push([{ text: "⬅️ Volver", callback_data: CALLBACK.BACK }]);
   return { inline_keyboard: rows };
+}
+
+export function batchConfirmKeyboard(count: number): InlineKeyboardMarkup {
+  return {
+    inline_keyboard: [
+      [
+        { text: `✅ Confirmar (${count})`, callback_data: CALLBACK.BATCH_CONFIRM },
+        { text: "❌ Cancelar", callback_data: CALLBACK.CANCEL },
+      ],
+    ],
+  };
 }
 
 export function categoriesKeyboard(

--- a/src/lib/telegram/ocr-draft.test.ts
+++ b/src/lib/telegram/ocr-draft.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { AccountDetail } from "@/lib/accounts/queries";
+import type { OcrParsedRow } from "@/lib/ingestion/ocr";
+import { buildDraftFromOcrRow } from "./ocr-draft";
+
+const ACCOUNT: AccountDetail = {
+  id: 7,
+  name: "ARQ",
+  institution: "ARQ",
+  type: "savings",
+  currency: "USD",
+  balanceCents: BigInt(0),
+  active: true,
+  metadata: {},
+};
+
+function row(overrides: Partial<OcrParsedRow> = {}): OcrParsedRow {
+  return {
+    rowIndex: 0,
+    occurredOn: "2026-04-15",
+    description: "COFFEE SHOP",
+    amountCents: BigInt(-325),
+    externalId: "ocr:7:abc123",
+    ...overrides,
+  };
+}
+
+describe("buildDraftFromOcrRow", () => {
+  it("maps a negative amount to an expense with absolute value", () => {
+    const result = buildDraftFromOcrRow(row({ amountCents: BigInt(-325) }), ACCOUNT);
+    expect(result.draft.direction).toBe("expense");
+    expect(result.draft.amountCents).toBe("325");
+    expect(result.draft.currency).toBe("USD");
+    expect(result.draft.accountId).toBe(7);
+  });
+
+  it("maps a positive amount to income", () => {
+    const result = buildDraftFromOcrRow(row({ amountCents: BigInt(50000) }), ACCOUNT);
+    expect(result.draft.direction).toBe("income");
+    expect(result.draft.amountCents).toBe("50000");
+  });
+
+  it("preserves description as both merchant and description", () => {
+    const result = buildDraftFromOcrRow(row({ description: "PAYU*CINEMARK" }), ACCOUNT);
+    expect(result.draft.merchant).toBe("PAYU*CINEMARK");
+    expect(result.draft.description).toBe("PAYU*CINEMARK");
+  });
+
+  it("uses the account's currency (OCR doesn't know currency)", () => {
+    const copAcc: AccountDetail = { ...ACCOUNT, id: 2, currency: "COP" };
+    const result = buildDraftFromOcrRow(row(), copAcc);
+    expect(result.draft.currency).toBe("COP");
+  });
+
+  it("passes occurredOn through unchanged", () => {
+    const result = buildDraftFromOcrRow(row({ occurredOn: "2026-03-02" }), ACCOUNT);
+    expect(result.draft.occurredOn).toBe("2026-03-02");
+  });
+
+  it("preserves externalId for dedup against OCR-via-import path", () => {
+    const result = buildDraftFromOcrRow(row({ externalId: "ocr:7:deadbeef" }), ACCOUNT);
+    expect(result.externalId).toBe("ocr:7:deadbeef");
+  });
+});

--- a/src/lib/telegram/ocr-draft.ts
+++ b/src/lib/telegram/ocr-draft.ts
@@ -1,0 +1,28 @@
+import type { AccountDetail } from "@/lib/accounts/queries";
+import type { TelegramBatchItem, TelegramDraft } from "@/lib/db/schema";
+import type { OcrParsedRow } from "@/lib/ingestion/ocr";
+
+/**
+ * Maps an OCR-extracted row to a TelegramDraft ready for the confirm flow.
+ * OCR returns signed amounts (positive=income, negative=expense); we strip
+ * the sign and set `direction` accordingly. Currency follows the account.
+ */
+export function buildDraftFromOcrRow(row: OcrParsedRow, account: AccountDetail): TelegramBatchItem {
+  const direction: "expense" | "income" = row.amountCents < BigInt(0) ? "expense" : "income";
+  const magnitude = row.amountCents < BigInt(0) ? -row.amountCents : row.amountCents;
+
+  const draft: TelegramDraft = {
+    amountCents: magnitude.toString(),
+    currency: account.currency,
+    direction,
+    merchant: row.description,
+    description: row.description,
+    occurredOn: row.occurredOn,
+    accountId: account.id,
+  };
+
+  return {
+    draft,
+    externalId: row.externalId,
+  };
+}

--- a/src/lib/telegram/poll-worker.ts
+++ b/src/lib/telegram/poll-worker.ts
@@ -14,6 +14,7 @@ import { createTelegramClient, type TelegramClient } from "@/lib/telegram/client
 import { handleUpdate, type RouterDeps } from "@/lib/telegram/router";
 import { parseAllowlist } from "@/lib/telegram/allowlist";
 import { parseTransactionMessage } from "@/lib/ai/transaction-nlu";
+import { extractTransactionsFromImage } from "@/lib/ingestion/ocr";
 import { listAccountsDetailed } from "@/lib/accounts/queries";
 import { listCategories } from "@/lib/transactions/queries";
 
@@ -68,6 +69,7 @@ export async function runPollWorker(opts: PollWorkerOptions): Promise<void> {
     listCategories: opts.deps?.listCategories ?? listCategories,
     parseNlu:
       opts.deps?.parseNlu ?? ((p) => parseTransactionMessage({ text: p.text, context: p.context })),
+    runOcr: opts.deps?.runOcr ?? ((p) => extractTransactionsFromImage(p)),
     now: opts.deps?.now,
   };
 

--- a/src/lib/telegram/router.ts
+++ b/src/lib/telegram/router.ts
@@ -2,12 +2,14 @@ import type { TelegramClient } from "@/lib/telegram/client";
 import type { TelegramUpdate, TelegramMessage, TelegramCallbackQuery } from "@/lib/telegram/types";
 import type { AccountDetail } from "@/lib/accounts/queries";
 import type { NluAccountOption, NluCategoryOption, NluResult } from "@/lib/ai/transaction-nlu";
-import type { TelegramDraft, TelegramSessionState } from "@/lib/db/schema";
+import type { TelegramBatchItem, TelegramDraft, TelegramSessionState } from "@/lib/db/schema";
+import type { OcrMediaType, OcrResult } from "@/lib/ingestion/ocr";
 import { isAllowed } from "@/lib/telegram/allowlist";
 import { handleCommand, parseCommand } from "@/lib/telegram/commands";
 import { clearSession, getSession, mergeDraft, upsertSession } from "@/lib/telegram/session";
 import {
   accountsKeyboard,
+  batchConfirmKeyboard,
   categoriesKeyboard,
   CALLBACK,
   confirmKeyboard,
@@ -16,15 +18,21 @@ import {
   renderAskAccount,
   renderAskAmount,
   renderAskCategory,
+  renderAskPhotoAccount,
+  renderBatchInserted,
+  renderBatchSummary,
   renderCanceled,
   renderConfirmCard,
   renderError,
   renderInserted,
+  renderOcrEmpty,
+  renderOcrProcessing,
   renderUnauthorized,
 } from "@/lib/telegram/formatter";
-import { insertFromDraft, isDraftComplete } from "@/lib/telegram/confirm";
+import { insertBatch, insertFromDraft, isDraftComplete } from "@/lib/telegram/confirm";
 import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
 import { buildDraftFromParsedSms } from "@/lib/telegram/sms-draft";
+import { buildDraftFromOcrRow } from "@/lib/telegram/ocr-draft";
 
 export type RouterDeps = {
   allowlist: Set<number>;
@@ -34,6 +42,11 @@ export type RouterDeps = {
     text: string;
     context: { now: Date; accounts: NluAccountOption[]; categories: NluCategoryOption[] };
   }) => Promise<NluResult>;
+  runOcr: (opts: {
+    imageBase64: string;
+    mediaType: OcrMediaType;
+    accountId: number;
+  }) => Promise<OcrResult>;
   now?: () => Date;
 };
 
@@ -134,6 +147,121 @@ async function advanceFlow(opts: {
   });
   next.promptMessageId = sent.message_id;
   await upsertSession({ chatId, userId, state: next });
+}
+
+async function handlePhoto(
+  message: TelegramMessage,
+  client: TelegramClient,
+  deps: RouterDeps,
+): Promise<void> {
+  const photos = message.photo;
+  const chatId = message.chat.id;
+  const userId = message.from?.id ?? 0;
+  if (!photos || photos.length === 0) return;
+
+  // Telegram sends an array of PhotoSize (varying resolutions); the largest
+  // is always the last. OCR benefits from max resolution.
+  const largest = photos[photos.length - 1];
+
+  const accountsFull = await deps.listAccounts();
+  const accounts = accountsToNluOptions(accountsFull);
+
+  const state: TelegramSessionState = {
+    step: "awaiting_photo_account",
+    draft: {},
+    sourceChatId: chatId,
+    sourceMessageId: message.message_id,
+    photoFileId: largest.file_id,
+  };
+  await upsertSession({ chatId, userId, state });
+
+  await client.sendMessage({
+    chat_id: chatId,
+    text: renderAskPhotoAccount(),
+    reply_markup: accountsKeyboard(accounts),
+  });
+}
+
+async function runOcrAndAdvance(opts: {
+  chatId: number;
+  userId: number;
+  session: TelegramSessionState;
+  account: AccountDetail;
+  accounts: NluAccountOption[];
+  categories: NluCategoryOption[];
+  client: TelegramClient;
+  deps: RouterDeps;
+}): Promise<void> {
+  const { chatId, userId, session, account, accounts, categories, client, deps } = opts;
+  const fileId = session.photoFileId;
+  if (!fileId) {
+    await client.sendMessage({ chat_id: chatId, text: renderError("Foto no encontrada.") });
+    await clearSession(chatId);
+    return;
+  }
+
+  await client.sendMessage({ chat_id: chatId, text: renderOcrProcessing() });
+
+  let ocr: OcrResult;
+  try {
+    const file = await client.getFile(fileId);
+    if (!file.file_path) throw new Error("Telegram did not return a file_path");
+    const buf = await client.downloadFile(file.file_path);
+    const imageBase64 = buf.toString("base64");
+    const mediaType = mediaTypeFromPath(file.file_path);
+    ocr = await deps.runOcr({ imageBase64, mediaType, accountId: account.id });
+  } catch (err) {
+    console.error("[telegram] OCR failed:", err);
+    await client.sendMessage({
+      chat_id: chatId,
+      text: renderError("No pude procesar la foto. Probá con otra imagen."),
+    });
+    await clearSession(chatId);
+    return;
+  }
+
+  if (ocr.rows.length === 0) {
+    await client.sendMessage({ chat_id: chatId, text: renderOcrEmpty() });
+    await clearSession(chatId);
+    return;
+  }
+
+  if (ocr.rows.length === 1) {
+    const { draft, externalId } = buildDraftFromOcrRow(ocr.rows[0], account);
+    const next: TelegramSessionState = {
+      step: "idle",
+      draft,
+      sourceChatId: chatId,
+      sourceMessageId: session.sourceMessageId,
+      externalIdOverride: externalId,
+    };
+    await advanceFlow({ chatId, userId, state: next, accounts, categories, client });
+    return;
+  }
+
+  const batch: TelegramBatchItem[] = ocr.rows.map((row) => buildDraftFromOcrRow(row, account));
+  const next: TelegramSessionState = {
+    step: "awaiting_batch_confirm",
+    draft: {},
+    sourceChatId: chatId,
+    sourceMessageId: session.sourceMessageId,
+    batch,
+  };
+  const sent = await client.sendMessage({
+    chat_id: chatId,
+    text: renderBatchSummary(batch),
+    reply_markup: batchConfirmKeyboard(batch.length),
+  });
+  next.promptMessageId = sent.message_id;
+  await upsertSession({ chatId, userId, state: next });
+}
+
+function mediaTypeFromPath(filePath: string): OcrMediaType {
+  const lower = filePath.toLowerCase();
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".webp")) return "image/webp";
+  if (lower.endsWith(".gif")) return "image/gif";
+  return "image/jpeg";
 }
 
 async function handleText(
@@ -271,6 +399,28 @@ async function handleCallback(
   const accounts = accountsToNluOptions(accountsFull);
   const categories = await deps.listCategories();
 
+  if (data === CALLBACK.BATCH_CONFIRM) {
+    if (!session.batch || session.batch.length === 0) {
+      await client.answerCallbackQuery({ callback_query_id: cb.id, text: "Sin datos" });
+      return;
+    }
+    await client.answerCallbackQuery({ callback_query_id: cb.id });
+    const result = await insertBatch({ items: session.batch, chatId });
+    await client.sendMessage({
+      chat_id: chatId,
+      text: renderBatchInserted({
+        inserted: result.inserted,
+        duplicated: result.duplicated,
+        errors: result.errors.length,
+      }),
+    });
+    if (result.errors.length > 0) {
+      console.error("[telegram] batch insert errors:", result.errors);
+    }
+    await clearSession(chatId);
+    return;
+  }
+
   if (data === CALLBACK.CONFIRM) {
     if (!isDraftComplete(session.draft)) {
       await client.answerCallbackQuery({ callback_query_id: cb.id, text: "Faltan datos" });
@@ -342,6 +492,21 @@ async function handleCallback(
       await client.answerCallbackQuery({ callback_query_id: cb.id, text: "Cuenta inválida" });
       return;
     }
+    if (session.step === "awaiting_photo_account") {
+      const accountDetail = accountsFull.find((a) => a.id === id)!;
+      await client.answerCallbackQuery({ callback_query_id: cb.id });
+      await runOcrAndAdvance({
+        chatId,
+        userId,
+        session,
+        account: accountDetail,
+        accounts,
+        categories,
+        client,
+        deps,
+      });
+      return;
+    }
     const picked = accounts.find((a) => a.id === id)!;
     const patched = mergeDraft(session, {
       accountId: id,
@@ -378,6 +543,10 @@ export async function handleUpdate(
       if (msg.from?.id) {
         await client.sendMessage({ chat_id: msg.chat.id, text: renderUnauthorized() });
       }
+      return;
+    }
+    if (msg.photo && msg.photo.length > 0) {
+      await handlePhoto(msg, client, deps);
       return;
     }
     if (typeof msg.text === "string") {

--- a/src/lib/telegram/types.ts
+++ b/src/lib/telegram/types.ts
@@ -14,13 +14,30 @@ export type TelegramChat = {
   username?: string;
 };
 
+export type TelegramPhotoSize = {
+  file_id: string;
+  file_unique_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+};
+
 export type TelegramMessage = {
   message_id: number;
   date: number;
   chat: TelegramChat;
   from?: TelegramUser;
   text?: string;
+  caption?: string;
+  photo?: TelegramPhotoSize[];
   entities?: Array<{ type: string; offset: number; length: number }>;
+};
+
+export type TelegramFile = {
+  file_id: string;
+  file_unique_id: string;
+  file_size?: number;
+  file_path?: string;
 };
 
 export type TelegramCallbackQuery = {


### PR DESCRIPTION
## Summary

Closes #169. Completes Fase 2 of the Telegram bot — photos/OCR path on top of the SMS-forwarded branch shipped in #174.

**Flow:**
1. User sends a photo (receipt, ARQ screenshot, Bancolombia tx list).
2. Bot replies "📸 Recibí la foto. ¿A qué cuenta pertenece?" + account keyboard.
3. User taps an account → bot sends "⏳ Procesando foto…" then calls `extractTransactionsFromImage` (Claude Haiku vision).
4. If OCR returns **1 row** → normal single-tx confirm card (✅ / ✏️ Cuenta / ✏️ Categoría / ❌).
5. If OCR returns **N rows** → batch summary with one ✅ Confirmar(N) / ❌ Cancelar button pair. Inserts all rows atomically per-row via `insertBatch`.
6. Empty result → friendly "probá otra imagen" message + session clear.

## Design decisions
- **Account-first, OCR-second**: OCR can't know which account a screenshot belongs to (ARQ vs Visa vs Ahorros). Asking first means Claude already has the accountId baked into the externalId hash, so dedup works at insert time.
- **Largest PhotoSize**: Telegram sends multiple resolutions; we always pick the last (largest) for OCR fidelity.
- **IPv4-pinned download**: reuses the same `node:https` + `family: 4` path from #171 for both `getFile` and the `/file/bot<token>/<file_path>` binary download. Works on ia-server's broken-IPv6 ISP.
- **Out of scope per #169**: per-row edit of multi-row results. Confirm-all or cancel-all only — user can always re-send the photo or enter rows manually.
- **runOcr as injected dep**: `RouterDeps.runOcr` is mockable for tests; default implementation wired in `poll-worker.ts`.
- **Batch dedup**: each OCR row already produces its own externalId (`ocr:<accountId>:<hash>`) via `extractTransactionsFromImage`. `insertBatch` threads that through `insertFromDraft` via `externalIdOverride`, so duplicates from re-sending the same photo no-op.

## Files
- `src/lib/telegram/ocr-draft.ts` (new) + `ocr-draft.test.ts` (6 tests) — maps `OcrParsedRow` → `TelegramBatchItem` with sign-based direction and account-derived currency.
- `src/lib/telegram/types.ts` — `TelegramPhotoSize`, `TelegramFile`, and `photo`/`caption` fields on `TelegramMessage`.
- `src/lib/telegram/client.ts` — `getFile()` + `downloadFile()` via `node:https` (IPv4-pinned).
- `src/lib/telegram/router.ts` — `handlePhoto`, `runOcrAndAdvance`, `BATCH_CONFIRM` callback branch, photo-flow dispatch in `handleUpdate`.
- `src/lib/telegram/confirm.ts` — `insertBatch` helper.
- `src/lib/telegram/formatter.ts` — `renderAskPhotoAccount`, `renderOcrProcessing`, `renderOcrEmpty`, `renderBatchSummary`, `renderBatchInserted`. `renderStart` now mentions photos + SMS forwarding.
- `src/lib/telegram/keyboard.ts` — `batchConfirmKeyboard`, `CALLBACK.BATCH_CONFIRM`.
- `src/lib/telegram/poll-worker.ts` — wires `runOcr` default via `extractTransactionsFromImage`.
- `src/lib/db/schema.ts` — extends `TelegramSessionStep` with `awaiting_photo_account` + `awaiting_batch_confirm`, adds `photoFileId` + `batch` to session state.

Closes #169

## Test plan
- [x] `bun run test` — 236 passing (6 new in `ocr-draft.test.ts`)
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` + `bun run format:check` clean
- [ ] Smoke: send a photo of an ARQ tx → pick account → single confirm card appears with merchant + amount + date populated
- [ ] Smoke: send a photo of a Bancolombia tx list (N rows) → pick account → batch summary appears → confirm → all rows inserted
- [ ] Smoke: re-send the same photo → all rows hit `duplicated` (externalId dedup)
- [ ] Regression: text messages still route to SMS parser or NLU; no behaviour changes on existing paths