### PR TITLE
fix(ocr): echo sign_token so Haiku can't flip direction on Bancolombia lists (#176)

### DIFF
--- a/src/lib/ingestion/ocr.test.ts
+++ b/src/lib/ingestion/ocr.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { extractTransactionsFromImage } from "./ocr";
+
+function anthropicResponse(transactions: unknown[]): unknown {
+  return {
+    content: [{ type: "text", text: JSON.stringify({ transactions }) }],
+    usage: { input_tokens: 10, output_tokens: 20 },
+  };
+}
+
+function mockFetch(responseJson: unknown): typeof fetch {
+  const impl: typeof fetch = async () =>
+    new Response(JSON.stringify(responseJson), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  return impl;
+}
+
+const commonOpts = {
+  imageBase64: "ZmFrZQ==",
+  mediaType: "image/png" as const,
+  accountId: 42,
+  apiKey: "test-key",
+};
+
+describe("extractTransactionsFromImage — sign_token post-processing", () => {
+  it("uses sign_token as source of truth even when amount sign agrees", async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse([
+        { date: "2026-04-16", description: "PAGO QR", amount: -28000, sign_token: "-$" },
+      ]),
+    );
+    const r = await extractTransactionsFromImage({ ...commonOpts, fetchImpl });
+    expect(r.rows[0].amountCents).toBe(BigInt(-2800000));
+  });
+
+  it("fixes a flipped sign when sign_token disagrees with amount", async () => {
+    // Model wrote amount=-100 (negative) but the literal token it saw was "$"
+    // (income). sign_token should win — row becomes +100.
+    const fetchImpl = mockFetch(
+      anthropicResponse([
+        {
+          date: "2026-04-16",
+          description: "TRANSFERENCIA CTA SUC VIRTUAL",
+          amount: -100,
+          sign_token: "$",
+        },
+      ]),
+    );
+    const r = await extractTransactionsFromImage({ ...commonOpts, fetchImpl });
+    expect(r.rows[0].amountCents).toBe(BigInt(10000));
+  });
+
+  it("fixes a mirrored flip (positive amount + '-$' token → negative)", async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse([
+        {
+          date: "2026-04-16",
+          description: "TRANSFERENCIA CTA SUC VIRTUAL",
+          amount: 100,
+          sign_token: "-$",
+        },
+      ]),
+    );
+    const r = await extractTransactionsFromImage({ ...commonOpts, fetchImpl });
+    expect(r.rows[0].amountCents).toBe(BigInt(-10000));
+  });
+
+  it("falls back to raw amount sign when sign_token is missing (backwards compat)", async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse([{ date: "2026-04-16", description: "PAYU*CINEMARK", amount: -25.54 }]),
+    );
+    const r = await extractTransactionsFromImage({ ...commonOpts, fetchImpl });
+    expect(r.rows[0].amountCents).toBe(BigInt(-2554));
+  });
+
+  it("handles the Bancolombia mixed-sign batch correctly end-to-end", async () => {
+    // Reproduces issue #176 — 4 rows with mixed direction. With sign_token
+    // echoed correctly by the model, all 4 land with correct signs.
+    const fetchImpl = mockFetch(
+      anthropicResponse([
+        {
+          date: "2026-04-16",
+          description: "TRANSFERENCIA CTA SUC VIRTUAL",
+          amount: 101,
+          sign_token: "$",
+        },
+        {
+          date: "2026-04-16",
+          description: "TRANSFERENCIA CTA SUC VIRTUAL",
+          amount: -100,
+          sign_token: "-$",
+        },
+        {
+          date: "2026-04-16",
+          description: "PAGO QR LA MARQUESA M",
+          amount: -28000,
+          sign_token: "-$",
+        },
+        {
+          date: "2026-04-16",
+          description: "TRANSFERENCIA CTA SUC VIRTUAL",
+          amount: 100,
+          sign_token: "$",
+        },
+      ]),
+    );
+    const r = await extractTransactionsFromImage({ ...commonOpts, fetchImpl });
+    expect(r.rows.map((row) => row.amountCents)).toEqual([
+      BigInt(10100),
+      BigInt(-10000),
+      BigInt(-2800000),
+      BigInt(10000),
+    ]);
+  });
+
+  it("skips rows with zero amount", async () => {
+    const fetchImpl = mockFetch(
+      anthropicResponse([{ date: "2026-04-16", description: "FOO", amount: 0, sign_token: "$" }]),
+    );
+    const r = await extractTransactionsFromImage({ ...commonOpts, fetchImpl });
+    expect(r.rows).toHaveLength(0);
+    expect(r.skipped).toHaveLength(1);
+  });
+
+  it("generates distinct externalIds when same (date, amount, description) repeats", async () => {
+    // Two identical transfers on the same day — same amount, same desc, same sign.
+    // Dedup inside a single OCR call is handled via positionInDay in the hash.
+    const fetchImpl = mockFetch(
+      anthropicResponse([
+        {
+          date: "2026-04-16",
+          description: "TRANSFERENCIA CTA SUC VIRTUAL",
+          amount: 100,
+          sign_token: "$",
+        },
+        {
+          date: "2026-04-16",
+          description: "TRANSFERENCIA CTA SUC VIRTUAL",
+          amount: 100,
+          sign_token: "$",
+        },
+      ]),
+    );
+    const r = await extractTransactionsFromImage({ ...commonOpts, fetchImpl });
+    expect(r.rows).toHaveLength(2);
+    expect(r.rows[0].externalId).not.toBe(r.rows[1].externalId);
+  });
+});

--- a/src/lib/ingestion/ocr.ts
+++ b/src/lib/ingestion/ocr.ts
@@ -24,6 +24,14 @@ const responseSchema = z.object({
       date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
       description: z.string().min(1).max(500),
       amount: z.number().finite(),
+      // Optional echo of the literal sign token the model saw ("$" with no
+      // minus = income, "-$" = expense). When present, this is the source of
+      // truth for the sign; we only use the magnitude of `amount`. Dense
+      // Colombian bank screenshots (Bancolombia movimientos) pack rows tightly
+      // with both + and - rows, and vision models drop the minus or flip it
+      // under token pressure. The echo forces the model to commit to what it
+      // actually saw rather than inferring from description heuristics.
+      sign_token: z.enum(["$", "-$"]).optional(),
     }),
   ),
 });
@@ -35,7 +43,7 @@ const PROMPT = `You extract transactions from a bank or fintech app screenshot.
 Return ONLY valid JSON matching this shape (no prose, no markdown):
 {
   "transactions": [
-    { "date": "YYYY-MM-DD", "description": "string", "amount": number }
+    { "date": "YYYY-MM-DD", "description": "string", "amount": number, "sign_token": "$" | "-$" }
   ]
 }
 
@@ -45,7 +53,11 @@ The screenshot may be EITHER:
 
 Rules:
 - "amount" is a JSON number (JSON uses "." as decimal separator). The screenshot may use "," as the decimal separator (e.g. Colombian/European locale): "25,54" = 25.54, NOT 2554. Thousands separators may be "." or "," — infer from context (two digits after the last separator = decimals).
-- NEGATIVE for debits/expenses/withdrawals/payments (usually shown with a minus sign or red/outgoing indicator). POSITIVE for credits/deposits/refunds/incoming.
+- "sign_token" is THE SINGLE SOURCE OF TRUTH FOR DIRECTION. Look at the literal character(s) prefixing the amount in the screenshot and copy what you see:
+  * "-$" → money leaving the account (expense, debit, payment, withdrawal, transfer sent)
+  * "$" → money entering the account (income, credit, refund, transfer received)
+  DO NOT infer sign from the description text. "TRANSFERENCIA" and "PAGO" can be EITHER direction depending on the sign token. A row labeled "TRANSFERENCIA" with "$ 101,00" (no minus) is INCOME; the same description with "-$ 100,00" is EXPENSE. The minus character is the only signal. Color (green = income, red = expense) is a confirmation cue but is NOT reliable under compression — always defer to the literal token.
+- "amount" should match the sign_token: NEGATIVE when sign_token is "-$", POSITIVE when sign_token is "$". If sign_token and amount sign disagree, sign_token wins downstream — but you MUST set them consistent.
 - Use the account's PRIMARY currency shown on the transaction (e.g. for ARQ use the USDc/USD amount, NOT the informational "Local amount" in COP). Treat USDc as USD.
 - "date" in ISO YYYY-MM-DD. Parse dates like "13 Apr 2026" or "13 abr 2026" into "2026-04-13". Ignore the time of day. If only day+month are shown, use the most likely year from context; if truly ambiguous, use the current year.
 - "description" = merchant name (+ short reference if visible). Prefer the merchant field (e.g. "PAYU*CINEMARK") over the app's category label (e.g. "Entertainment"). Keep it concise, no emojis, no card-mask strings like "··1356".
@@ -54,6 +66,28 @@ Rules:
 
 function toCents(amount: number): bigint {
   return BigInt(Math.round(amount * 100));
+}
+
+/**
+ * Resolves the signed cents amount using sign_token as source of truth.
+ * - If sign_token is present, magnitude of `amount` is paired with the sign
+ *   implied by the token ("-$" → negative, "$" → positive). Any disagreement
+ *   between `amount`'s sign and `sign_token` is logged and the token wins.
+ * - If sign_token is absent (older responses), fall back to the raw `amount`.
+ */
+function resolveSignedCents(
+  amount: number,
+  signToken: "$" | "-$" | undefined,
+): { cents: bigint; mismatch: boolean } {
+  if (!signToken) {
+    return { cents: toCents(amount), mismatch: false };
+  }
+  const magnitude = toCents(Math.abs(amount));
+  const expectedNegative = signToken === "-$";
+  const actualNegative = amount < 0;
+  const mismatch = expectedNegative !== actualNegative;
+  const cents = expectedNegative ? -magnitude : magnitude;
+  return { cents, mismatch };
 }
 
 function buildExternalId(
@@ -152,10 +186,15 @@ export async function extractTransactionsFromImage(opts: {
       skipped.push({ rowIndex: i, reason: "Missing description" });
       return;
     }
-    const amountCents = toCents(t.amount);
+    const { cents: amountCents, mismatch } = resolveSignedCents(t.amount, t.sign_token);
     if (amountCents === BigInt(0)) {
       skipped.push({ rowIndex: i, reason: "Zero amount" });
       return;
+    }
+    if (mismatch) {
+      console.warn(
+        `[ocr] row ${i} sign_token/amount mismatch — sign_token="${t.sign_token}" amount=${t.amount} → trusting sign_token`,
+      );
     }
 
     const dayKey = `${t.date}|${amountCents.toString()}|${description}`;


### PR DESCRIPTION
## Summary

Closes #176. OCR was flipping the direction sign on 3 of 4 rows in a dense Bancolombia movements screenshot — treating income as expense and vice versa, because Claude Haiku dropped the minus character under token pressure and let description heuristics ("TRANSFERENCIA", "PAGO") take over.

## Fix

Two-layer defense. Neither by itself is bulletproof; together they eliminate the class.

1. **Sign_token echo (schema + prompt)**: the model must return a literal \`sign_token: "$" | "-$"\` copy of the token it saw in the screenshot. Forces the model to commit to what's in the image rather than inferring from the description. The prompt now says explicitly: "DO NOT infer sign from the description text. TRANSFERENCIA and PAGO can be EITHER direction. The minus character is the only signal."
2. **Post-processing override**: when \`sign_token\` is present, it is the source of truth for the sign. The magnitude of \`amount\` is used, but the sign comes from the token. If the model returns an inconsistent pair (e.g. \`amount: -100\` with \`sign_token: "$"\`), the token wins and we log a warning server-side.

\`sign_token\` is \`.optional()\` in the zod schema → older model responses still parse (they just fall back to the raw \`amount\` sign as before).

## Files
- \`src/lib/ingestion/ocr.ts\` — schema + prompt + \`resolveSignedCents\` helper.
- \`src/lib/ingestion/ocr.test.ts\` (new, 7 tests) — covers both-agree, flipped, mirrored-flip, missing-token fallback, the issue #176 4-row reproduction, zero-amount skip, and dup externalId disambiguation.

## Test plan
- [x] \`bun run test\` — 243 passing (7 new in \`ocr.test.ts\`)
- [x] \`bunx tsc --noEmit\` clean
- [x] format/lint clean
- [ ] Smoke (post-deploy): re-send the Bancolombia Nómina screenshot from #176 → all 4 rows should land with correct signs in the batch summary (💰 for the two +\$ rows, 💸 for the two -\$ rows)