### PR TITLE
feat(ingestion): Telegram bot Fase 3 — nota de voz → Whisper → NLU (#170)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ PGUSER=
 # Conseguí una key en https://console.anthropic.com/
 ANTHROPIC_API_KEY=sk-ant-your-key-here
 
+# Groq API — requerido para transcripción de notas de voz (Whisper)
+# Conseguí una key en https://console.groq.com/keys
+# Sin esta key, el bot de Telegram responde con error al recibir voice notes.
+GROQ_API_KEY=gsk-your-key-here
+
 # Ingestion webhook token — secreto compartido server ↔ iOS Shortcut
 # Generá UNA VEZ: openssl rand -hex 32
 # Pegá el MISMO valor en .env.local y en el header Authorization del Shortcut.

--- a/src/lib/stt/transcribe.test.ts
+++ b/src/lib/stt/transcribe.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { transcribeAudio } from "./transcribe";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("transcribeAudio", () => {
+  it("calls Groq with the right endpoint, auth and language default", async () => {
+    let capturedUrl = "";
+    let capturedAuth = "";
+    let capturedBody: FormData | null = null;
+    const fetchImpl: typeof fetch = async (url, init) => {
+      capturedUrl = String(url);
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      capturedAuth = headers.authorization ?? "";
+      capturedBody = (init?.body as FormData) ?? null;
+      return jsonResponse({ text: "pagué 45 mil en el restaurante" });
+    };
+
+    const result = await transcribeAudio({
+      audioBuffer: Buffer.from("fake-ogg-bytes"),
+      mimeType: "audio/ogg",
+      apiKey: "test-key",
+      fetchImpl,
+    });
+
+    expect(result.text).toBe("pagué 45 mil en el restaurante");
+    expect(result.model).toBe("whisper-large-v3-turbo");
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    expect(capturedUrl).toBe("https://api.groq.com/openai/v1/audio/transcriptions");
+    expect(capturedAuth).toBe("Bearer test-key");
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.get("language")).toBe("es");
+    expect(capturedBody!.get("model")).toBe("whisper-large-v3-turbo");
+    expect(capturedBody!.get("response_format")).toBe("json");
+    expect(capturedBody!.get("file")).toBeInstanceOf(Blob);
+  });
+
+  it("trims whitespace from the transcription", async () => {
+    const fetchImpl: typeof fetch = async () => jsonResponse({ text: "  hola mundo  \n" });
+    const result = await transcribeAudio({
+      audioBuffer: Buffer.from("x"),
+      mimeType: "audio/ogg",
+      apiKey: "test-key",
+      fetchImpl,
+    });
+    expect(result.text).toBe("hola mundo");
+  });
+
+  it("uses a custom model when provided", async () => {
+    let capturedModel = "";
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      capturedModel = ((init?.body as FormData).get("model") as string) ?? "";
+      return jsonResponse({ text: "test" });
+    };
+    const result = await transcribeAudio({
+      audioBuffer: Buffer.from("x"),
+      mimeType: "audio/ogg",
+      apiKey: "test-key",
+      model: "whisper-large-v3",
+      fetchImpl,
+    });
+    expect(capturedModel).toBe("whisper-large-v3");
+    expect(result.model).toBe("whisper-large-v3");
+  });
+
+  it("throws on API error (with status and truncated body)", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("rate limit exceeded", { status: 429 });
+    await expect(
+      transcribeAudio({
+        audioBuffer: Buffer.from("x"),
+        mimeType: "audio/ogg",
+        apiKey: "test-key",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("Groq STT API error 429");
+  });
+
+  it("throws when the model returns empty text", async () => {
+    const fetchImpl: typeof fetch = async () => jsonResponse({ text: "   " });
+    await expect(
+      transcribeAudio({
+        audioBuffer: Buffer.from("x"),
+        mimeType: "audio/ogg",
+        apiKey: "test-key",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("empty transcription");
+  });
+
+  it("throws when GROQ_API_KEY is not configured", async () => {
+    const prev = process.env.GROQ_API_KEY;
+    delete process.env.GROQ_API_KEY;
+    try {
+      await expect(
+        transcribeAudio({
+          audioBuffer: Buffer.from("x"),
+          mimeType: "audio/ogg",
+          fetchImpl: async () => jsonResponse({ text: "ok" }),
+        }),
+      ).rejects.toThrow("GROQ_API_KEY is not set");
+    } finally {
+      if (prev !== undefined) process.env.GROQ_API_KEY = prev;
+    }
+  });
+});

--- a/src/lib/stt/transcribe.ts
+++ b/src/lib/stt/transcribe.ts
@@ -1,0 +1,85 @@
+export type TranscribeResult = {
+  text: string;
+  durationMs: number;
+  model: string;
+};
+
+// Groq hosts Whisper with the OpenAI-compatible transcription endpoint. The
+// `turbo` variant is ~10x faster than `large-v3` and still handles Spanish well
+// enough for short Telegram voice notes (<60s). Swap via `model` arg if a
+// longer note needs the higher-accuracy variant.
+const DEFAULT_MODEL = "whisper-large-v3-turbo";
+const GROQ_TRANSCRIPTIONS_URL = "https://api.groq.com/openai/v1/audio/transcriptions";
+
+function fileNameFromMime(mimeType: string): string {
+  if (mimeType.includes("ogg")) return "audio.ogg";
+  if (mimeType.includes("mpeg") || mimeType.includes("mp3")) return "audio.mp3";
+  if (mimeType.includes("wav")) return "audio.wav";
+  if (mimeType.includes("webm")) return "audio.webm";
+  if (mimeType.includes("mp4") || mimeType.includes("m4a")) return "audio.m4a";
+  return "audio.bin";
+}
+
+/**
+ * Transcribe a short audio clip via Groq Whisper. Mirrors the wrapper style of
+ * `transaction-nlu.ts` / `ocr.ts`: pure function, `fetchImpl` injectable for
+ * tests, API key resolved from env as fallback.
+ *
+ * Caller is responsible for enforcing a duration cap BEFORE downloading —
+ * Telegram already gives `voice.duration` in seconds, so this wrapper stays
+ * provider-agnostic and does not re-check.
+ */
+export async function transcribeAudio(opts: {
+  audioBuffer: Buffer;
+  mimeType: string;
+  language?: "es" | "en";
+  model?: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+  fileName?: string;
+}): Promise<TranscribeResult> {
+  const apiKey = opts.apiKey ?? process.env.GROQ_API_KEY;
+  if (!apiKey) throw new Error("GROQ_API_KEY is not set");
+
+  const model = opts.model ?? DEFAULT_MODEL;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const language = opts.language ?? "es";
+  const fileName = opts.fileName ?? fileNameFromMime(opts.mimeType);
+
+  const start = Date.now();
+
+  const form = new FormData();
+  // Buffer extends Uint8Array so it is a valid BlobPart at runtime, but the
+  // DOM lib types disagree (ArrayBufferLike vs ArrayBuffer). Copy into a fresh
+  // ArrayBuffer-backed Uint8Array to satisfy the type checker.
+  const bytes = new Uint8Array(opts.audioBuffer.byteLength);
+  bytes.set(opts.audioBuffer);
+  const blob = new Blob([bytes], { type: opts.mimeType });
+  form.append("file", blob, fileName);
+  form.append("model", model);
+  form.append("language", language);
+  form.append("response_format", "json");
+
+  const res = await doFetch(GROQ_TRANSCRIPTIONS_URL, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: form,
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Groq STT API error ${res.status}: ${body.slice(0, 300)}`);
+  }
+
+  const payload = (await res.json()) as { text?: string };
+  const text = typeof payload.text === "string" ? payload.text.trim() : "";
+  if (!text) throw new Error("Groq STT returned empty transcription");
+
+  return {
+    text,
+    durationMs: Date.now() - start,
+    model,
+  };
+}

--- a/src/lib/telegram/formatter.ts
+++ b/src/lib/telegram/formatter.ts
@@ -130,6 +130,18 @@ export function renderAskPhotoAccount(): string {
   return "📸 Recibí la foto. ¿A qué cuenta pertenece?";
 }
 
+export function renderVoiceProcessing(): string {
+  return "🎙️ Escuchando el audio…";
+}
+
+export function renderVoiceTooLong(maxSeconds: number): string {
+  return `⚠️ El audio es muy largo (>${maxSeconds}s). Mandalo como texto o grabá uno más corto.`;
+}
+
+export function renderVoiceTranscription(text: string): string {
+  return `🎙️ Escuché: "${text}"`;
+}
+
 export function renderOcrProcessing(): string {
   return "⏳ Procesando foto con OCR…";
 }

--- a/src/lib/telegram/poll-worker.ts
+++ b/src/lib/telegram/poll-worker.ts
@@ -15,6 +15,7 @@ import { handleUpdate, type RouterDeps } from "@/lib/telegram/router";
 import { parseAllowlist } from "@/lib/telegram/allowlist";
 import { parseTransactionMessage } from "@/lib/ai/transaction-nlu";
 import { extractTransactionsFromImage } from "@/lib/ingestion/ocr";
+import { transcribeAudio } from "@/lib/stt/transcribe";
 import { listAccountsDetailed } from "@/lib/accounts/queries";
 import { listCategories } from "@/lib/transactions/queries";
 
@@ -70,6 +71,7 @@ export async function runPollWorker(opts: PollWorkerOptions): Promise<void> {
     parseNlu:
       opts.deps?.parseNlu ?? ((p) => parseTransactionMessage({ text: p.text, context: p.context })),
     runOcr: opts.deps?.runOcr ?? ((p) => extractTransactionsFromImage(p)),
+    transcribeVoice: opts.deps?.transcribeVoice ?? ((p) => transcribeAudio(p)),
     now: opts.deps?.now,
   };
 

--- a/src/lib/telegram/router.ts
+++ b/src/lib/telegram/router.ts
@@ -28,6 +28,9 @@ import {
   renderOcrEmpty,
   renderOcrProcessing,
   renderUnauthorized,
+  renderVoiceProcessing,
+  renderVoiceTooLong,
+  renderVoiceTranscription,
 } from "@/lib/telegram/formatter";
 import { insertBatch, insertFromDraft, isDraftComplete } from "@/lib/telegram/confirm";
 import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
@@ -47,8 +50,15 @@ export type RouterDeps = {
     mediaType: OcrMediaType;
     accountId: number;
   }) => Promise<OcrResult>;
+  transcribeVoice: (opts: {
+    audioBuffer: Buffer;
+    mimeType: string;
+    language?: "es" | "en";
+  }) => Promise<{ text: string; durationMs: number; model: string }>;
   now?: () => Date;
 };
+
+export const MAX_VOICE_DURATION_SECONDS = 60;
 
 function accountsToNluOptions(accounts: AccountDetail[]): NluAccountOption[] {
   return accounts
@@ -262,6 +272,64 @@ function mediaTypeFromPath(filePath: string): OcrMediaType {
   if (lower.endsWith(".webp")) return "image/webp";
   if (lower.endsWith(".gif")) return "image/gif";
   return "image/jpeg";
+}
+
+async function handleVoice(
+  message: TelegramMessage,
+  client: TelegramClient,
+  deps: RouterDeps,
+): Promise<void> {
+  // Voice notes (`.voice`) are OGG/Opus from the Telegram mic; uploaded audio
+  // files (`.audio`) can be MP3/M4A/WAV. Both carry `duration` in seconds.
+  const media = message.voice ?? message.audio;
+  const chatId = message.chat.id;
+  if (!media) return;
+
+  if (media.duration > MAX_VOICE_DURATION_SECONDS) {
+    await client.sendMessage({
+      chat_id: chatId,
+      text: renderVoiceTooLong(MAX_VOICE_DURATION_SECONDS),
+    });
+    return;
+  }
+
+  await client.sendMessage({ chat_id: chatId, text: renderVoiceProcessing() });
+
+  let transcribed: string;
+  try {
+    const file = await client.getFile(media.file_id);
+    if (!file.file_path) throw new Error("Telegram did not return a file_path");
+    const buf = await client.downloadFile(file.file_path);
+    const result = await deps.transcribeVoice({
+      audioBuffer: buf,
+      mimeType: media.mime_type ?? "audio/ogg",
+      language: "es",
+    });
+    transcribed = result.text;
+  } catch (err) {
+    console.error("[telegram] STT failed:", err);
+    await client.sendMessage({
+      chat_id: chatId,
+      text: renderError("No pude transcribir el audio. Probá de nuevo o mandalo como texto."),
+    });
+    return;
+  }
+
+  if (!transcribed.trim()) {
+    await client.sendMessage({
+      chat_id: chatId,
+      text: renderError("No entendí el audio. Probá hablar más cerca del micrófono."),
+    });
+    return;
+  }
+
+  // Echo the transcription first so the user can eyeball misrecognitions
+  // BEFORE the NLU commits it to a draft.
+  await client.sendMessage({ chat_id: chatId, text: renderVoiceTranscription(transcribed) });
+
+  // Reuse the full text pipeline (commands, amount-step shortcut, SMS, NLU).
+  // A transcription will not start with "/", so commands naturally don't fire.
+  await handleText({ ...message, text: transcribed }, client, deps);
 }
 
 async function handleText(
@@ -547,6 +615,10 @@ export async function handleUpdate(
     }
     if (msg.photo && msg.photo.length > 0) {
       await handlePhoto(msg, client, deps);
+      return;
+    }
+    if (msg.voice || msg.audio) {
+      await handleVoice(msg, client, deps);
       return;
     }
     if (typeof msg.text === "string") {

--- a/src/lib/telegram/router.voice.test.ts
+++ b/src/lib/telegram/router.voice.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import type { TelegramClient } from "@/lib/telegram/client";
+import type { TelegramUpdate } from "@/lib/telegram/types";
+import { handleUpdate, MAX_VOICE_DURATION_SECONDS, type RouterDeps } from "./router";
+
+// These tests cover the two router branches that short-circuit BEFORE touching
+// the session store — long-audio rejection and STT failure. The happy path
+// requires the session DB, which is covered by the e2e/integration suite.
+
+type SentMessage = { chat_id: number; text: string };
+
+function buildClient(): {
+  client: TelegramClient;
+  sent: SentMessage[];
+  getFileCalls: string[];
+  downloadCalls: string[];
+} {
+  const sent: SentMessage[] = [];
+  const getFileCalls: string[] = [];
+  const downloadCalls: string[] = [];
+  const client: TelegramClient = {
+    getUpdates: async () => [],
+    sendMessage: async (opts) => {
+      sent.push({ chat_id: opts.chat_id, text: opts.text });
+      return { message_id: sent.length };
+    },
+    editMessage: async () => {},
+    answerCallbackQuery: async () => {},
+    getFile: async (id) => {
+      getFileCalls.push(id);
+      return { file_id: id, file_unique_id: id, file_path: `voice/${id}.ogg` };
+    },
+    downloadFile: async (path) => {
+      downloadCalls.push(path);
+      return Buffer.from("fake-audio-bytes");
+    },
+  };
+  return { client, sent, getFileCalls, downloadCalls };
+}
+
+function buildDeps(overrides: Partial<RouterDeps> = {}): RouterDeps {
+  return {
+    allowlist: new Set([111]),
+    listAccounts: async () => [],
+    listCategories: async () => [],
+    parseNlu: async () => {
+      throw new Error("NLU should not run in these tests");
+    },
+    runOcr: async () => {
+      throw new Error("OCR should not run in these tests");
+    },
+    transcribeVoice: async () => {
+      throw new Error("transcribeVoice default — override in each test");
+    },
+    ...overrides,
+  };
+}
+
+function voiceUpdate(duration: number): TelegramUpdate {
+  return {
+    update_id: 1,
+    message: {
+      message_id: 10,
+      date: 1_700_000_000,
+      chat: { id: 222, type: "private" },
+      from: { id: 111, is_bot: false, first_name: "A" },
+      voice: {
+        file_id: "voice-1",
+        file_unique_id: "voice-u-1",
+        duration,
+        mime_type: "audio/ogg",
+      },
+    },
+  };
+}
+
+describe("handleUpdate — voice routing", () => {
+  it(`rejects audio longer than ${MAX_VOICE_DURATION_SECONDS}s without downloading`, async () => {
+    const { client, sent, getFileCalls, downloadCalls } = buildClient();
+    let transcribeCalled = false;
+    const deps = buildDeps({
+      transcribeVoice: async () => {
+        transcribeCalled = true;
+        return { text: "x", durationMs: 1, model: "m" };
+      },
+    });
+
+    await handleUpdate(voiceUpdate(MAX_VOICE_DURATION_SECONDS + 1), client, deps);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].text).toMatch(/muy largo/);
+    expect(getFileCalls).toEqual([]);
+    expect(downloadCalls).toEqual([]);
+    expect(transcribeCalled).toBe(false);
+  });
+
+  it("sends a friendly error when STT fails (and does not run NLU)", async () => {
+    const { client, sent, getFileCalls, downloadCalls } = buildClient();
+    let nluCalled = false;
+    const deps = buildDeps({
+      parseNlu: async () => {
+        nluCalled = true;
+        throw new Error("should not reach NLU");
+      },
+      transcribeVoice: async () => {
+        throw new Error("groq 500");
+      },
+    });
+
+    await handleUpdate(voiceUpdate(10), client, deps);
+
+    // First message: "escuchando…"; second: error.
+    expect(sent).toHaveLength(2);
+    expect(sent[0].text).toMatch(/Escuchando/);
+    expect(sent[1].text).toMatch(/No pude transcribir/);
+    expect(getFileCalls).toEqual(["voice-1"]);
+    expect(downloadCalls).toEqual(["voice/voice-1.ogg"]);
+    expect(nluCalled).toBe(false);
+  });
+
+  it("sends an error (and skips NLU) when transcription is blank", async () => {
+    const { client, sent } = buildClient();
+    let nluCalled = false;
+    const deps = buildDeps({
+      parseNlu: async () => {
+        nluCalled = true;
+        throw new Error("should not reach NLU");
+      },
+      transcribeVoice: async () => ({ text: "   ", durationMs: 10, model: "m" }),
+    });
+
+    await handleUpdate(voiceUpdate(5), client, deps);
+
+    expect(sent.at(-1)?.text).toMatch(/No entendí el audio/);
+    expect(nluCalled).toBe(false);
+  });
+});

--- a/src/lib/telegram/types.ts
+++ b/src/lib/telegram/types.ts
@@ -22,6 +22,25 @@ export type TelegramPhotoSize = {
   file_size?: number;
 };
 
+export type TelegramVoice = {
+  file_id: string;
+  file_unique_id: string;
+  duration: number;
+  mime_type?: string;
+  file_size?: number;
+};
+
+export type TelegramAudio = {
+  file_id: string;
+  file_unique_id: string;
+  duration: number;
+  performer?: string;
+  title?: string;
+  file_name?: string;
+  mime_type?: string;
+  file_size?: number;
+};
+
 export type TelegramMessage = {
   message_id: number;
   date: number;
@@ -30,6 +49,8 @@ export type TelegramMessage = {
   text?: string;
   caption?: string;
   photo?: TelegramPhotoSize[];
+  voice?: TelegramVoice;
+  audio?: TelegramAudio;
   entities?: Array<{ type: string; offset: number; length: number }>;
 };
 


### PR DESCRIPTION
## Summary

- Add `src/lib/stt/transcribe.ts` — Groq Whisper wrapper (`whisper-large-v3-turbo`, language `es` default). Pure fn + injectable `fetchImpl`, mirrors the pattern from `transaction-nlu.ts` / `ocr.ts`.
- Add `handleVoice` to the Telegram router: dispatches on `message.voice` / `message.audio`, rejects >60s before downloading, echoes the transcription back to the user, then reuses the existing `handleText` pipeline so NLU / amount-step / SMS branches all still work on transcribed text.
- Wire `transcribeVoice` into `RouterDeps` and the poll worker.
- Document `GROQ_API_KEY` in `.env.example`.

## Test plan

- [x] `bun run test` — 252 passed (adds 6 wrapper tests + 3 router-dispatch tests: too-long rejection, STT failure, empty transcription)
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [x] `bun run format:check`
- [ ] Manual smoke (pending `GROQ_API_KEY` on ia-server): send a 5–10s voice note with "pagué 45 mil en el restaurante" → confirm card appears
- [ ] Manual: send a >60s note → "audio muy largo" reply
- [ ] Manual: force STT error (wrong key) → friendly error message

Closes #170