### PR TITLE
feat(db): add user_id to tenant tables with DEFAULT 1 (#183)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
       # NextAuth requires AUTH_SECRET at build/runtime. CI uses a dummy value;
       # real secrets live in production env files.
       AUTH_SECRET: ci-dummy-secret-not-used-in-production
+      # Seeds the bootstrap user (id=1) that every tenant table's user_id
+      # column defaults to. Without it the FK in #183's migrations fails.
+      BOOTSTRAP_USER_EMAIL: ci@findash.local
+      BOOTSTRAP_USER_NAME: CI Bootstrap
 
     steps:
       - uses: actions/checkout@v6

--- a/drizzle/0012_broad_mercury.sql
+++ b/drizzle/0012_broad_mercury.sql
@@ -1,0 +1,34 @@
+-- Multi-tenancy phase 1 (#183): add user_id to every tenant-scoped table.
+-- Strategy: NOT NULL DEFAULT 1 backfills existing rows with the bootstrap
+-- user's id (= 1) in-place, eliminating the NULL window. The temporary
+-- default is dropped in PR 3 once every INSERT supplies an explicit user_id.
+--
+-- telegram_sessions.user_id (bigint, the Telegram API's user id) is renamed
+-- to telegram_user_id; a new user_id integer FK is added alongside it.
+-- RENAME preserves data that a DATA TYPE cast would risk truncating.
+
+ALTER TABLE "telegram_sessions" RENAME COLUMN "user_id" TO "telegram_user_id";--> statement-breakpoint
+ALTER TABLE "telegram_sessions" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "account_snapshots" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "accounts" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "budgets" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "classification_rules" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "counterparties" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "counterparty_aliases" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "ingestion_logs" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "insights_reports" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "recurring_gaps" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "recurring_transactions" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "user_id" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "account_snapshots" ADD CONSTRAINT "account_snapshots_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "budgets" ADD CONSTRAINT "budgets_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "classification_rules" ADD CONSTRAINT "classification_rules_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "counterparties" ADD CONSTRAINT "counterparties_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "counterparty_aliases" ADD CONSTRAINT "counterparty_aliases_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ingestion_logs" ADD CONSTRAINT "ingestion_logs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "insights_reports" ADD CONSTRAINT "insights_reports_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recurring_gaps" ADD CONSTRAINT "recurring_gaps_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recurring_transactions" ADD CONSTRAINT "recurring_transactions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "telegram_sessions" ADD CONSTRAINT "telegram_sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "transactions" ADD CONSTRAINT "transactions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "7eb49b72-90a7-4e58-97d1-989707242204",
-  "prevId": "e055cec0-f26c-442c-a396-91653f89a51b",
+  "id": "02c4b9a4-b818-4d53-8e98-9d6da2a417b3",
+  "prevId": "7eb49b72-90a7-4e58-97d1-989707242204",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -13,6 +13,13 @@
           "type": "serial",
           "primaryKey": true,
           "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
         },
         "account_id": {
           "name": "account_id",
@@ -64,6 +71,19 @@
         }
       },
       "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
         "account_snapshots_account_id_accounts_id_fk": {
           "name": "account_snapshots_account_id_accounts_id_fk",
           "tableFrom": "account_snapshots",
@@ -93,6 +113,13 @@
           "type": "serial",
           "primaryKey": true,
           "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
         },
         "name": {
           "name": "name",
@@ -157,7 +184,21 @@
         }
       },
       "indexes": {},
-      "foreignKeys": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
@@ -173,6 +214,13 @@
           "type": "serial",
           "primaryKey": true,
           "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
         },
         "category_slug": {
           "name": "category_slug",
@@ -223,6 +271,19 @@
       },
       "indexes": {},
       "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
         "budgets_category_slug_categories_slug_fk": {
           "name": "budgets_category_slug_categories_slug_fk",
           "tableFrom": "budgets",
@@ -397,6 +458,13 @@
           "primaryKey": true,
           "notNull": true
         },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
         "pattern": {
           "name": "pattern",
           "type": "text",
@@ -462,6 +530,19 @@
         }
       },
       "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
         "classification_rules_category_slug_categories_slug_fk": {
           "name": "classification_rules_category_slug_categories_slug_fk",
           "tableFrom": "classification_rules",
@@ -491,6 +572,13 @@
           "type": "serial",
           "primaryKey": true,
           "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
         },
         "display_name": {
           "name": "display_name",
@@ -548,6 +636,19 @@
       },
       "indexes": {},
       "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
         "counterparties_default_category_slug_categories_slug_fk": {
           "name": "counterparties_default_category_slug_categories_slug_fk",
           "tableFrom": "counterparties",
@@ -577,6 +678,13 @@
           "type": "serial",
           "primaryKey": true,
           "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
         },
         "counterparty_id": {
           "name": "counterparty_id",
@@ -644,6 +752,19 @@
         }
       },
       "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
         "counterparty_aliases_counterparty_id_counterparties_id_fk": {
           "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
           "tableFrom": "counterparty_aliases",
@@ -785,6 +906,13 @@
           "primaryKey": true,
           "notNull": true
         },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
         "source": {
           "name": "source",
           "type": "tx_source",
@@ -846,7 +974,21 @@
         }
       },
       "indexes": {},
-      "foreignKeys": {},
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
@@ -862,6 +1004,13 @@
           "type": "serial",
           "primaryKey": true,
           "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
         },
         "year_month": {
           "name": "year_month",
@@ -910,7 +1059,21 @@
         }
       },
       "indexes": {},
-      "foreignKeys": {},
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "insights_reports_year_month_unique": {
@@ -1006,6 +1169,13 @@
           "primaryKey": true,
           "notNull": true
         },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
         "recurring_id": {
           "name": "recurring_id",
           "type": "integer",
@@ -1065,6 +1235,19 @@
         }
       },
       "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
         "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
           "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
           "tableFrom": "recurring_gaps",
@@ -1094,6 +1277,13 @@
           "type": "serial",
           "primaryKey": true,
           "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
         },
         "account_id": {
           "name": "account_id",
@@ -1168,6 +1358,19 @@
       },
       "indexes": {},
       "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
         "recurring_transactions_account_id_accounts_id_fk": {
           "name": "recurring_transactions_account_id_accounts_id_fk",
           "tableFrom": "recurring_transactions",
@@ -1246,6 +1449,13 @@
         },
         "user_id": {
           "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
           "type": "bigint",
           "primaryKey": false,
           "notNull": true
@@ -1271,7 +1481,21 @@
         }
       },
       "indexes": {},
-      "foreignKeys": {},
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
@@ -1287,6 +1511,13 @@
           "type": "serial",
           "primaryKey": true,
           "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
         },
         "account_id": {
           "name": "account_id",
@@ -1523,6 +1754,19 @@
         }
       },
       "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
         "transactions_account_id_accounts_id_fk": {
           "name": "transactions_account_id_accounts_id_fk",
           "tableFrom": "transactions",

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1776567600000,
       "tag": "0011_aldous_clean_slate",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1776567700000,
+      "tag": "0012_broad_mercury",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -75,6 +75,10 @@ export const counterpartyKeyKind = pgEnum("counterparty_key_kind", [
 
 export const accounts = pgTable("accounts", {
   id: serial("id").primaryKey(),
+  userId: integer("user_id")
+    .notNull()
+    .default(1)
+    .references(() => users.id, { onDelete: "cascade" }),
   name: varchar("name", { length: 100 }).notNull(),
   institution: varchar("institution", { length: 50 }).notNull(),
   type: accountType("type").notNull(),
@@ -125,6 +129,10 @@ export const categories = pgTable("categories", {
 
 export const counterparties = pgTable("counterparties", {
   id: serial("id").primaryKey(),
+  userId: integer("user_id")
+    .notNull()
+    .default(1)
+    .references(() => users.id, { onDelete: "cascade" }),
   displayName: varchar("display_name", { length: 120 }).notNull(),
   type: counterpartyType("type").notNull().default("unknown"),
   defaultCategorySlug: varchar("default_category_slug", { length: 60 }).references(
@@ -142,6 +150,10 @@ export const counterpartyAliases = pgTable(
   "counterparty_aliases",
   {
     id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .default(1)
+      .references(() => users.id, { onDelete: "cascade" }),
     counterpartyId: integer("counterparty_id")
       .notNull()
       .references(() => counterparties.id, { onDelete: "cascade" }),
@@ -159,6 +171,10 @@ export const transactions = pgTable(
   "transactions",
   {
     id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .default(1)
+      .references(() => users.id, { onDelete: "cascade" }),
     accountId: integer("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "restrict" }),
@@ -207,6 +223,10 @@ export const classificationRules = pgTable(
   "classification_rules",
   {
     id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .default(1)
+      .references(() => users.id, { onDelete: "cascade" }),
     pattern: text("pattern").notNull(),
     categorySlug: varchar("category_slug", { length: 60 })
       .notNull()
@@ -232,6 +252,10 @@ export const classificationRuleSeeds = pgTable("classification_rule_seeds", {
 
 export const budgets = pgTable("budgets", {
   id: serial("id").primaryKey(),
+  userId: integer("user_id")
+    .notNull()
+    .default(1)
+    .references(() => users.id, { onDelete: "cascade" }),
   categorySlug: varchar("category_slug", { length: 60 })
     .notNull()
     .references(() => categories.slug, { onDelete: "cascade" }),
@@ -245,6 +269,10 @@ export const budgets = pgTable("budgets", {
 
 export const recurringTransactions = pgTable("recurring_transactions", {
   id: serial("id").primaryKey(),
+  userId: integer("user_id")
+    .notNull()
+    .default(1)
+    .references(() => users.id, { onDelete: "cascade" }),
   accountId: integer("account_id")
     .notNull()
     .references(() => accounts.id, { onDelete: "cascade" }),
@@ -266,6 +294,10 @@ export const recurringGaps = pgTable(
   "recurring_gaps",
   {
     id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .default(1)
+      .references(() => users.id, { onDelete: "cascade" }),
     recurringId: integer("recurring_id")
       .notNull()
       .references(() => recurringTransactions.id, { onDelete: "cascade" }),
@@ -280,6 +312,10 @@ export const recurringGaps = pgTable(
 
 export const ingestionLogs = pgTable("ingestion_logs", {
   id: serial("id").primaryKey(),
+  userId: integer("user_id")
+    .notNull()
+    .default(1)
+    .references(() => users.id, { onDelete: "cascade" }),
   source: txSource("source").notNull(),
   status: varchar("status", { length: 20 }).notNull(),
   itemsReceived: integer("items_received").notNull().default(0),
@@ -293,6 +329,10 @@ export const ingestionLogs = pgTable("ingestion_logs", {
 
 export const insightsReports = pgTable("insights_reports", {
   id: serial("id").primaryKey(),
+  userId: integer("user_id")
+    .notNull()
+    .default(1)
+    .references(() => users.id, { onDelete: "cascade" }),
   yearMonth: varchar("year_month", { length: 7 }).notNull().unique(),
   generatedAt: timestamp("generated_at", { withTimezone: true }).notNull().defaultNow(),
   inputHash: varchar("input_hash", { length: 64 }).notNull(),
@@ -323,6 +363,10 @@ export const accountSnapshots = pgTable(
   "account_snapshots",
   {
     id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .default(1)
+      .references(() => users.id, { onDelete: "cascade" }),
     accountId: integer("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
@@ -372,7 +416,11 @@ export type TelegramSessionState = {
 
 export const telegramSessions = pgTable("telegram_sessions", {
   chatId: bigint("chat_id", { mode: "bigint" }).primaryKey(),
-  userId: bigint("user_id", { mode: "bigint" }).notNull(),
+  userId: integer("user_id")
+    .notNull()
+    .default(1)
+    .references(() => users.id, { onDelete: "cascade" }),
+  telegramUserId: bigint("telegram_user_id", { mode: "bigint" }).notNull(),
   state: jsonb("state").$type<TelegramSessionState>().notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),

--- a/src/lib/telegram/router.ts
+++ b/src/lib/telegram/router.ts
@@ -133,14 +133,14 @@ async function advanceFlow(opts: {
 
   if (!draft.amountCents) {
     const next: TelegramSessionState = { ...state, step: "awaiting_amount" };
-    await upsertSession({ chatId, userId, state: next });
+    await upsertSession({ chatId, telegramUserId: userId, state: next });
     await client.sendMessage({ chat_id: chatId, text: renderAskAmount() });
     return;
   }
 
   if (typeof draft.accountId !== "number") {
     const next: TelegramSessionState = { ...state, step: "awaiting_account" };
-    await upsertSession({ chatId, userId, state: next });
+    await upsertSession({ chatId, telegramUserId: userId, state: next });
     await client.sendMessage({
       chat_id: chatId,
       text: renderAskAccount(),
@@ -156,7 +156,7 @@ async function advanceFlow(opts: {
     reply_markup: confirmKeyboard(),
   });
   next.promptMessageId = sent.message_id;
-  await upsertSession({ chatId, userId, state: next });
+  await upsertSession({ chatId, telegramUserId: userId, state: next });
 }
 
 async function handlePhoto(
@@ -183,7 +183,7 @@ async function handlePhoto(
     sourceMessageId: message.message_id,
     photoFileId: largest.file_id,
   };
-  await upsertSession({ chatId, userId, state });
+  await upsertSession({ chatId, telegramUserId: userId, state });
 
   await client.sendMessage({
     chat_id: chatId,
@@ -263,7 +263,7 @@ async function runOcrAndAdvance(opts: {
     reply_markup: batchConfirmKeyboard(batch.length),
   });
   next.promptMessageId = sent.message_id;
-  await upsertSession({ chatId, userId, state: next });
+  await upsertSession({ chatId, telegramUserId: userId, state: next });
 }
 
 function mediaTypeFromPath(filePath: string): OcrMediaType {
@@ -526,7 +526,7 @@ async function handleCallback(
 
   if (data === CALLBACK.EDIT_ACCOUNT) {
     const next: TelegramSessionState = { ...session, step: "awaiting_account" };
-    await upsertSession({ chatId, userId, state: next });
+    await upsertSession({ chatId, telegramUserId: userId, state: next });
     await client.answerCallbackQuery({ callback_query_id: cb.id });
     await client.sendMessage({
       chat_id: chatId,
@@ -538,7 +538,7 @@ async function handleCallback(
 
   if (data === CALLBACK.EDIT_CATEGORY) {
     const next: TelegramSessionState = { ...session, step: "awaiting_category" };
-    await upsertSession({ chatId, userId, state: next });
+    await upsertSession({ chatId, telegramUserId: userId, state: next });
     await client.answerCallbackQuery({ callback_query_id: cb.id });
     await client.sendMessage({
       chat_id: chatId,

--- a/src/lib/telegram/session.ts
+++ b/src/lib/telegram/session.ts
@@ -30,7 +30,7 @@ export async function getSession(chatId: number): Promise<TelegramSessionState |
 
 export async function upsertSession(opts: {
   chatId: number;
-  userId: number;
+  telegramUserId: number;
   state: TelegramSessionState;
 }): Promise<void> {
   const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
@@ -38,7 +38,7 @@ export async function upsertSession(opts: {
     .insert(telegramSessions)
     .values({
       chatId: BigInt(opts.chatId),
-      userId: BigInt(opts.userId),
+      telegramUserId: BigInt(opts.telegramUserId),
       state: opts.state,
       updatedAt: new Date(),
       expiresAt,
@@ -46,7 +46,7 @@ export async function upsertSession(opts: {
     .onConflictDoUpdate({
       target: telegramSessions.chatId,
       set: {
-        userId: BigInt(opts.userId),
+        telegramUserId: BigInt(opts.telegramUserId),
         state: opts.state,
         updatedAt: new Date(),
         expiresAt,


### PR DESCRIPTION
## Summary

PR 1 of the #183 chain (multi-tenancy migration).

- Adds `user_id integer NOT NULL DEFAULT 1 REFERENCES users(id) ON DELETE CASCADE` to 12 tenant-scoped tables (see list below).
- `telegram_sessions.user_id` (bigint, the Telegram API user id) is renamed to `telegram_user_id` via `ALTER TABLE ... RENAME COLUMN` (preserves the existing value). A fresh integer `user_id` FK column is added alongside it.
- Fixes the `drizzle/meta/0011_snapshot.json` id/prevId chain that PR 0 (#190) left in a collision state with 0010.

## Why DEFAULT 1 instead of nullable → backfill → NOT NULL

The doc (`docs/multi-user-plan.md` §4) prescribes the three-phase sequence assuming the schema change + query rewrite ship together. Since we are splitting #183 into 4 smaller PRs, a window exists between the schema migration and the query rewrite (PR 3) where INSERTs do not supply `user_id`. Without `DEFAULT 1` those inserts would either fail (strict NOT NULL) or leak NULL rows (nullable). `DEFAULT 1` lets existing code keep working during the window, with every row scoped to the bootstrap user. PR 3 will drop the default once every INSERT supplies an explicit `user_id`.

## Tables touched

`accounts`, `transactions`, `classification_rules`, `counterparties`, `counterparty_aliases`, `budgets`, `recurring_transactions`, `recurring_gaps`, `account_snapshots`, `ingestion_logs`, `insights_reports`, `telegram_sessions` (+ rename).

## Code changes

- `src/lib/db/schema.ts` — adds `userId` to all 12 tables, adds `telegramUserId` on `telegram_sessions`.
- `src/lib/telegram/session.ts` — renames the `upsertSession` param `userId` → `telegramUserId` to reflect the new column semantics. The new integer `user_id` column is backfilled by `DEFAULT 1` and is not explicitly set here (PR 3 will do that).
- `src/lib/telegram/router.ts` — updates 7 `upsertSession` call sites to pass `telegramUserId: userId`.

## Test plan

- [x] Fresh `findash_test`: `dropdb && createdb && bun run db:migrate:test && bun run db:seed:test` — all 13 migrations applied, seed inserts 7 accounts, 41 classification rules, 41 seed rules.
- [x] Dev DB (`findash`) post-migration: `accounts`, `transactions`, `classification_rules`, `counterparties`, `ingestion_logs`, `telegram_sessions` — 100% rows have `user_id = 1`.
- [x] Telegram session row preserved: chat_id kept, old bigint `user_id = 315043990` moved to `telegram_user_id`, new integer `user_id = 1`.
- [x] `bun run lint` — clean.
- [x] `bunx tsc --noEmit` — clean.
- [x] `bunx prettier --check` on touched files — clean.
- [x] `bun run test` — 259 / 259 pass against fresh test DB.

## Next in chain

- PR 2: composite indexes per doc §5 (critical: unique `(user_id, kind, value)` on `counterparty_aliases`).
- PR 3: `getSessionUser()` helper, query rewrite across all tenant-table reads/writes, drop the `DEFAULT 1`, add integration tests.
- PR 4: NextAuth signup callback copies `classification_rule_seeds` → `classification_rules` with the new `user_id`. Closes #183.

Refs #183