### PR TITLE
feat(auth): per-user webhook token auth (#194)

### DIFF
--- a/drizzle/0014_fuzzy_zzzax.sql
+++ b/drizzle/0014_fuzzy_zzzax.sql
@@ -1,0 +1,15 @@
+CREATE TYPE "public"."webhook_purpose" AS ENUM('sms', 'debug');--> statement-breakpoint
+CREATE TABLE "webhook_tokens" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"purpose" "webhook_purpose" NOT NULL,
+	"token_hash" varchar(64) NOT NULL,
+	"label" varchar(120),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_used_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	CONSTRAINT "webhook_tokens_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "webhook_tokens" ADD CONSTRAINT "webhook_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "webhook_tokens_user_purpose_active_idx" ON "webhook_tokens" USING btree ("user_id","purpose") WHERE "webhook_tokens"."revoked_at" IS NULL;

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2313 @@
+{
+  "id": "1cf197b7-223d-4a40-86c3-992f596d7cd8",
+  "prevId": "9ddeb772-50a5-4b6d-9107-81ff53044f72",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_category_slug_categories_slug_fk": {
+          "name": "budgets_category_slug_categories_slug_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_slug_categories_slug_fk": {
+          "name": "categories_parent_slug_categories_slug_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_categories_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_category_slug_categories_slug_fk": {
+          "name": "classification_rules_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_default_category_slug_categories_slug_fk": {
+          "name": "counterparties_default_category_slug_categories_slug_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_category_slug_categories_slug_fk": {
+          "name": "recurring_transactions_category_slug_categories_slug_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_poll_state": {
+      "name": "telegram_poll_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_update_id": {
+          "name": "last_update_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_category_slug_categories_slug_fk": {
+          "name": "transactions_category_slug_categories_slug_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "ai",
+        "manual",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1776567800000,
       "tag": "0013_mature_jackpot",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1776567900000,
+      "tag": "0014_fuzzy_zzzax",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:migrate:test": "PGDATABASE=findash_test drizzle-kit migrate",
     "db:seed:test": "PGDATABASE=findash_test bun run src/lib/db/seed.ts",
     "db:bootstrap:invites": "bun run scripts/bootstrap-invites.ts",
+    "db:bootstrap:webhook-tokens": "bun run scripts/bootstrap-webhook-tokens.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",

--- a/scripts/bootstrap-webhook-tokens.ts
+++ b/scripts/bootstrap-webhook-tokens.ts
@@ -1,0 +1,83 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { users, webhookTokens } from "@/lib/db/schema";
+import { mintWebhookToken, type WebhookPurpose } from "@/lib/webhook-tokens";
+
+const PURPOSES: readonly WebhookPurpose[] = ["sms", "debug"] as const;
+
+async function resolveBootstrapUser(): Promise<{ id: number; email: string }> {
+  const email = process.env.BOOTSTRAP_USER_EMAIL?.trim();
+  if (!email) {
+    throw new Error("BOOTSTRAP_USER_EMAIL is not set");
+  }
+  const name = process.env.BOOTSTRAP_USER_NAME?.trim() || email;
+  await db.insert(users).values({ email, name }).onConflictDoNothing({ target: users.email });
+  const [row] = await db
+    .select({ id: users.id, email: users.email })
+    .from(users)
+    .where(eq(users.email, email));
+  if (!row) {
+    throw new Error(`Failed to ensure bootstrap user for ${email}`);
+  }
+  return row;
+}
+
+async function hasActiveToken(userId: number, purpose: WebhookPurpose): Promise<boolean> {
+  const [existing] = await db
+    .select({ id: webhookTokens.id })
+    .from(webhookTokens)
+    .where(
+      and(
+        eq(webhookTokens.userId, userId),
+        eq(webhookTokens.purpose, purpose),
+        isNull(webhookTokens.revokedAt),
+      ),
+    )
+    .limit(1);
+  return Boolean(existing);
+}
+
+export async function bootstrapWebhookTokens(): Promise<
+  Array<{ purpose: WebhookPurpose; plaintext: string | null; skipped: boolean }>
+> {
+  const bootstrap = await resolveBootstrapUser();
+  console.log(`bootstrap user: ${bootstrap.email} (id=${bootstrap.id})`);
+
+  const results: Array<{ purpose: WebhookPurpose; plaintext: string | null; skipped: boolean }> =
+    [];
+  for (const purpose of PURPOSES) {
+    if (await hasActiveToken(bootstrap.id, purpose)) {
+      console.log(`  ${purpose}: active token already exists — skipping`);
+      results.push({ purpose, plaintext: null, skipped: true });
+      continue;
+    }
+    const { plaintext } = await mintWebhookToken({
+      userId: bootstrap.id,
+      purpose,
+      label: "bootstrap",
+    });
+    results.push({ purpose, plaintext, skipped: false });
+  }
+  return results;
+}
+
+if (import.meta.main) {
+  bootstrapWebhookTokens()
+    .then((results) => {
+      const minted = results.filter((r) => !r.skipped);
+      if (minted.length === 0) {
+        console.log("\nnothing minted — revoke any existing token first to re-issue.");
+      } else {
+        console.log(`\nminted ${minted.length} tokens:`);
+        for (const r of minted) {
+          console.log(`  ${r.purpose}: ${r.plaintext}`);
+        }
+        console.log("\nstore each — the plaintext will not be retrievable again.");
+      }
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -19,6 +19,12 @@ const LINKS = [
     description:
       "Salud de la ingestión por SMS: últimos 30 días, detección de drift y regla activa.",
   },
+  {
+    href: "/settings/webhooks",
+    title: "Webhook tokens",
+    description:
+      "Per-user bearer tokens for the SMS and debug ingest endpoints. Mint, copy once, revoke when needed.",
+  },
 ];
 
 export default function SettingsPage() {

--- a/src/app/(app)/settings/webhooks/actions.ts
+++ b/src/app/(app)/settings/webhooks/actions.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { getSessionUser } from "@/lib/auth/session";
+import {
+  WEBHOOK_PURPOSES,
+  mintWebhookToken,
+  revokeWebhookToken,
+  type WebhookPurpose,
+} from "@/lib/webhook-tokens";
+
+const mintSchema = z.object({
+  purpose: z.enum(WEBHOOK_PURPOSES as unknown as [WebhookPurpose, ...WebhookPurpose[]]),
+  label: z.string().trim().max(120).optional(),
+});
+
+export type MintActionState =
+  | { status: "idle" }
+  | { status: "error"; message: string }
+  | { status: "success"; id: number; purpose: WebhookPurpose; plaintext: string };
+
+export async function mintWebhookTokenAction(
+  _prev: MintActionState,
+  formData: FormData,
+): Promise<MintActionState> {
+  const session = await getSessionUser();
+  const parsed = mintSchema.safeParse({
+    purpose: formData.get("purpose"),
+    label: formData.get("label") ?? undefined,
+  });
+  if (!parsed.success) {
+    return { status: "error", message: "Invalid input." };
+  }
+  const { id, plaintext } = await mintWebhookToken({
+    userId: session.id,
+    purpose: parsed.data.purpose,
+    label: parsed.data.label ?? null,
+  });
+  revalidatePath("/settings/webhooks");
+  return { status: "success", id, purpose: parsed.data.purpose, plaintext };
+}
+
+const revokeSchema = z.object({
+  tokenId: z.coerce.number().int().positive(),
+});
+
+export async function revokeWebhookTokenAction(input: z.input<typeof revokeSchema>) {
+  const session = await getSessionUser();
+  const { tokenId } = revokeSchema.parse(input);
+  const ok = await revokeWebhookToken({ userId: session.id, tokenId });
+  if (!ok) {
+    throw new Error("Token not found, already revoked, or not yours.");
+  }
+  revalidatePath("/settings/webhooks");
+}

--- a/src/app/(app)/settings/webhooks/page.tsx
+++ b/src/app/(app)/settings/webhooks/page.tsx
@@ -1,0 +1,35 @@
+import { getSessionUser } from "@/lib/auth/session";
+import { listWebhookTokensForUser } from "@/lib/webhook-tokens";
+import { WebhookTokensManager } from "./webhook-tokens-manager";
+
+export const dynamic = "force-dynamic";
+
+export default async function WebhooksPage() {
+  const session = await getSessionUser();
+  const tokens = await listWebhookTokensForUser(session.id);
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-h1">Webhook tokens</h1>
+        <p className="text-body text-muted-foreground">
+          Per-user bearer tokens for the ingest webhooks ({" "}
+          <code className="font-mono">/api/ingest/sms</code>,{" "}
+          <code className="font-mono">/api/ingest/debug</code>). Mint one per device or automation
+          (the iPhone Shortcut, a debug client, etc.). The plaintext value is shown{" "}
+          <strong>once</strong> at mint time — store it before leaving the page.
+        </p>
+      </header>
+      <WebhookTokensManager
+        tokens={tokens.map((t) => ({
+          id: t.id,
+          purpose: t.purpose,
+          label: t.label,
+          createdAt: t.createdAt.toISOString(),
+          lastUsedAt: t.lastUsedAt ? t.lastUsedAt.toISOString() : null,
+          revokedAt: t.revokedAt ? t.revokedAt.toISOString() : null,
+        }))}
+      />
+    </main>
+  );
+}

--- a/src/app/(app)/settings/webhooks/webhook-tokens-manager.tsx
+++ b/src/app/(app)/settings/webhooks/webhook-tokens-manager.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useActionState, useTransition } from "react";
+import { ClipboardCopyIcon, Trash2Icon } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import type { WebhookPurpose } from "@/lib/webhook-tokens";
+import { mintWebhookTokenAction, revokeWebhookTokenAction, type MintActionState } from "./actions";
+
+type TokenRow = {
+  id: number;
+  purpose: WebhookPurpose;
+  label: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+};
+
+const INITIAL_STATE: MintActionState = { status: "idle" };
+
+const PURPOSE_LABELS: Record<WebhookPurpose, string> = {
+  sms: "SMS ingest",
+  debug: "Debug capture",
+};
+
+export function WebhookTokensManager({ tokens }: { tokens: TokenRow[] }) {
+  const [state, formAction, pending] = useActionState(mintWebhookTokenAction, INITIAL_STATE);
+  const [revoking, startRevoke] = useTransition();
+
+  function onRevoke(row: TokenRow) {
+    if (!confirm(`Revoke ${PURPOSE_LABELS[row.purpose]} token "${row.label ?? "(no label)"}"?`)) {
+      return;
+    }
+    startRevoke(async () => {
+      try {
+        await revokeWebhookTokenAction({ tokenId: row.id });
+        toast.success("Revoked");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed");
+      }
+    });
+  }
+
+  async function copyPlaintext(plaintext: string) {
+    try {
+      await navigator.clipboard.writeText(plaintext);
+      toast.success("Copied");
+    } catch {
+      toast.error("Copy failed — select and copy manually");
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Mint a new token</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form action={formAction} className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="purpose">Purpose</Label>
+                <select
+                  id="purpose"
+                  name="purpose"
+                  defaultValue="sms"
+                  className="border-input bg-background h-9 rounded-md border px-3 text-sm"
+                >
+                  <option value="sms">SMS ingest</option>
+                  <option value="debug">Debug capture</option>
+                </select>
+              </div>
+              <div className="flex flex-col gap-2 sm:col-span-2">
+                <Label htmlFor="label">Label (optional)</Label>
+                <Input
+                  id="label"
+                  name="label"
+                  placeholder="iPhone Shortcut, Postman, etc."
+                  maxLength={120}
+                />
+              </div>
+            </div>
+            <div>
+              <Button type="submit" disabled={pending}>
+                {pending ? "Minting..." : "Mint token"}
+              </Button>
+            </div>
+          </form>
+          {state.status === "error" && (
+            <p className="text-destructive mt-3 text-sm">{state.message}</p>
+          )}
+          {state.status === "success" && (
+            <div className="bg-muted/50 mt-4 rounded-md border p-4">
+              <p className="text-body font-medium">
+                Token minted for {PURPOSE_LABELS[state.purpose]}. This is your only chance to copy
+                the plaintext — store it now.
+              </p>
+              <div className="mt-3 flex items-center gap-2">
+                <code className="bg-background flex-1 truncate rounded border px-2 py-1 font-mono text-sm">
+                  {state.plaintext}
+                </code>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => copyPlaintext(state.plaintext)}
+                >
+                  <ClipboardCopyIcon className="size-4" />
+                  Copy
+                </Button>
+              </div>
+              <p className="text-muted-foreground mt-2 text-xs">
+                Send as <code className="font-mono">Authorization: Bearer {"<token>"}</code>.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Your tokens</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {tokens.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No tokens yet. Mint one above.</p>
+          ) : (
+            <ul className="divide-y">
+              {tokens.map((t) => (
+                <li
+                  key={t.id}
+                  className={cn(
+                    "flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between",
+                    t.revokedAt && "opacity-60",
+                  )}
+                >
+                  <div className="flex flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="outline">{PURPOSE_LABELS[t.purpose]}</Badge>
+                      <span className="text-body font-medium">{t.label ?? "(no label)"}</span>
+                      {t.revokedAt && <Badge variant="destructive">Revoked</Badge>}
+                    </div>
+                    <p className="text-muted-foreground text-xs">
+                      Created {new Date(t.createdAt).toLocaleString()} · Last used{" "}
+                      {t.lastUsedAt ? new Date(t.lastUsedAt).toLocaleString() : "never"}
+                      {t.revokedAt && ` · Revoked ${new Date(t.revokedAt).toLocaleString()}`}
+                    </p>
+                  </div>
+                  {!t.revokedAt && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      disabled={revoking}
+                      onClick={() => onRevoke(t)}
+                    >
+                      <Trash2Icon className="size-4" />
+                      Revoke
+                    </Button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/api/ingest/debug/route.test.ts
+++ b/src/app/api/ingest/debug/route.test.ts
@@ -32,14 +32,14 @@ describe("POST /api/ingest/debug", () => {
     await db.$client.end({ timeout: 1 });
   });
 
-  it("returns 503 when INGEST_WEBHOOK_TOKEN is not configured", async () => {
+  it("returns 401 when no auth path matches (no env var, no per-user token)", async () => {
     delete process.env.INGEST_WEBHOOK_TOKEN;
     const res = await POST(
       makeRequest({
         headers: { authorization: `Bearer ${TEST_TOKEN}` },
       }),
     );
-    expect(res.status).toBe(503);
+    expect(res.status).toBe(401);
   });
 
   it("returns 401 when Authorization header is missing", async () => {

--- a/src/app/api/ingest/debug/route.ts
+++ b/src/app/api/ingest/debug/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { ingestionLogs } from "@/lib/db/schema";
+import { resolveWebhookAuth } from "@/lib/webhook-tokens";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -10,14 +11,11 @@ const MAX_BODY_BYTES = 50 * 1024;
 export async function POST(req: Request) {
   const startedAt = new Date();
 
-  const expectedToken = process.env.INGEST_WEBHOOK_TOKEN;
-  if (!expectedToken) {
-    return NextResponse.json({ error: "INGEST_WEBHOOK_TOKEN not configured" }, { status: 503 });
-  }
-
-  const authHeader = req.headers.get("authorization") ?? "";
-  const providedToken = authHeader.replace(/^Bearer\s+/i, "").trim();
-  if (!providedToken || providedToken !== expectedToken) {
+  const auth = await resolveWebhookAuth({
+    authHeader: req.headers.get("authorization"),
+    purpose: "debug",
+  });
+  if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -89,6 +87,6 @@ export async function POST(req: Request) {
 export async function GET() {
   return NextResponse.json({
     ok: true,
-    hint: "POST any payload with Authorization: Bearer <INGEST_WEBHOOK_TOKEN>",
+    hint: "POST any payload with Authorization: Bearer <per-user token from /settings/webhooks>",
   });
 }

--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -107,7 +107,7 @@ describe("POST /api/ingest/sms", () => {
   // Auth
   // ---------------------------------------------------------------------------
 
-  it("returns 503 when INGEST_WEBHOOK_TOKEN is not configured", async () => {
+  it("returns 401 when no auth path matches (no env var, no per-user token)", async () => {
     delete process.env.INGEST_WEBHOOK_TOKEN;
     const res = await POST(
       makeRequest({
@@ -115,7 +115,7 @@ describe("POST /api/ingest/sms", () => {
         headers: authedHeaders(),
       }),
     );
-    expect(res.status).toBe(503);
+    expect(res.status).toBe(401);
   });
 
   it("returns 401 when Authorization header is missing", async () => {

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -13,6 +13,7 @@ import {
   type RoutableAccount,
 } from "@/lib/ingestion/sms-bancolombia";
 import { keyForParsed } from "@/lib/counterparties/alias-key";
+import { resolveWebhookAuth } from "@/lib/webhook-tokens";
 import type { ClassificationMethod } from "@/lib/types";
 
 export const runtime = "nodejs";
@@ -32,14 +33,11 @@ type IngestOutcome =
 export async function POST(req: Request) {
   const startedAt = new Date();
 
-  const expectedToken = process.env.INGEST_WEBHOOK_TOKEN;
-  if (!expectedToken) {
-    return NextResponse.json({ error: "INGEST_WEBHOOK_TOKEN not configured" }, { status: 503 });
-  }
-
-  const authHeader = req.headers.get("authorization") ?? "";
-  const providedToken = authHeader.replace(/^Bearer\s+/i, "").trim();
-  if (!providedToken || providedToken !== expectedToken) {
+  const auth = await resolveWebhookAuth({
+    authHeader: req.headers.get("authorization"),
+    purpose: "sms",
+  });
+  if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -94,7 +92,7 @@ export async function POST(req: Request) {
 export async function GET() {
   return NextResponse.json({
     ok: true,
-    hint: "POST { sender, body, receivedAt? } with Authorization: Bearer <INGEST_WEBHOOK_TOKEN>",
+    hint: "POST { sender, body, receivedAt? } with Authorization: Bearer <per-user token from /settings/webhooks>",
   });
 }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -43,6 +43,29 @@ export const inviteCodes = pgTable(
   (t) => [check("invite_codes_uses_count_check", sql`${t.usesCount} <= ${t.maxUses}`)],
 );
 
+export const webhookPurpose = pgEnum("webhook_purpose", ["sms", "debug"]);
+
+export const webhookTokens = pgTable(
+  "webhook_tokens",
+  {
+    id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    purpose: webhookPurpose("purpose").notNull(),
+    tokenHash: varchar("token_hash", { length: 64 }).notNull().unique(),
+    label: varchar("label", { length: 120 }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+  },
+  (t) => [
+    index("webhook_tokens_user_purpose_active_idx")
+      .on(t.userId, t.purpose)
+      .where(sql`${t.revokedAt} IS NULL`),
+  ],
+);
+
 export const accountType = pgEnum("account_type", ["savings", "credit_card", "loan"]);
 
 export const currency = pgEnum("currency", ["COP", "USD"]);

--- a/src/lib/webhook-tokens/index.test.ts
+++ b/src/lib/webhook-tokens/index.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { webhookTokens } from "@/lib/db/schema";
+import {
+  hashWebhookToken,
+  listWebhookTokensForUser,
+  mintWebhookToken,
+  resolveWebhookAuth,
+  revokeWebhookToken,
+} from ".";
+
+const TEST_USER_ID = 1;
+const LABEL_PREFIX = "vitest-webhook-tokens";
+
+async function cleanup() {
+  await db
+    .delete(webhookTokens)
+    .where(and(eq(webhookTokens.userId, TEST_USER_ID), eq(webhookTokens.label, LABEL_PREFIX)));
+}
+
+describe("webhook-tokens module", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+  afterAll(async () => {
+    delete process.env.INGEST_WEBHOOK_TOKEN;
+    await db.$client.end({ timeout: 1 });
+  });
+
+  it("mintWebhookToken stores the hash and never the plaintext", async () => {
+    const { id, plaintext } = await mintWebhookToken({
+      userId: TEST_USER_ID,
+      purpose: "sms",
+      label: LABEL_PREFIX,
+    });
+    expect(plaintext).toMatch(/^[0-9a-f]{64}$/);
+    const [row] = await db
+      .select({ tokenHash: webhookTokens.tokenHash })
+      .from(webhookTokens)
+      .where(eq(webhookTokens.id, id));
+    expect(row.tokenHash).toBe(hashWebhookToken(plaintext));
+    expect(row.tokenHash).not.toBe(plaintext);
+  });
+
+  it("resolveWebhookAuth accepts a valid per-user token and returns userId", async () => {
+    const { plaintext } = await mintWebhookToken({
+      userId: TEST_USER_ID,
+      purpose: "sms",
+      label: LABEL_PREFIX,
+    });
+    const result = await resolveWebhookAuth({
+      authHeader: `Bearer ${plaintext}`,
+      purpose: "sms",
+    });
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe(TEST_USER_ID);
+    expect(result?.source).toBe("per-user-token");
+  });
+
+  it("resolveWebhookAuth rejects a token minted for a different purpose", async () => {
+    const { plaintext } = await mintWebhookToken({
+      userId: TEST_USER_ID,
+      purpose: "sms",
+      label: LABEL_PREFIX,
+    });
+    const result = await resolveWebhookAuth({
+      authHeader: `Bearer ${plaintext}`,
+      purpose: "debug",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("revokeWebhookToken disables a token and resolveWebhookAuth stops accepting it", async () => {
+    const { id, plaintext } = await mintWebhookToken({
+      userId: TEST_USER_ID,
+      purpose: "sms",
+      label: LABEL_PREFIX,
+    });
+    const revoked = await revokeWebhookToken({ userId: TEST_USER_ID, tokenId: id });
+    expect(revoked).toBe(true);
+
+    const result = await resolveWebhookAuth({
+      authHeader: `Bearer ${plaintext}`,
+      purpose: "sms",
+    });
+    expect(result).toBeNull();
+
+    const retry = await revokeWebhookToken({ userId: TEST_USER_ID, tokenId: id });
+    expect(retry).toBe(false);
+  });
+
+  it("resolveWebhookAuth falls back to INGEST_WEBHOOK_TOKEN env var and attributes to user 1", async () => {
+    process.env.INGEST_WEBHOOK_TOKEN = "legacy-fallback-token-for-test";
+    try {
+      const result = await resolveWebhookAuth({
+        authHeader: `Bearer legacy-fallback-token-for-test`,
+        purpose: "sms",
+      });
+      expect(result).not.toBeNull();
+      expect(result?.userId).toBe(1);
+      expect(result?.source).toBe("legacy-env-token");
+    } finally {
+      delete process.env.INGEST_WEBHOOK_TOKEN;
+    }
+  });
+
+  it("resolveWebhookAuth returns null for missing header", async () => {
+    const result = await resolveWebhookAuth({ authHeader: null, purpose: "sms" });
+    expect(result).toBeNull();
+  });
+
+  it("listWebhookTokensForUser returns rows ordered newest first", async () => {
+    const a = await mintWebhookToken({
+      userId: TEST_USER_ID,
+      purpose: "sms",
+      label: LABEL_PREFIX,
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    const b = await mintWebhookToken({
+      userId: TEST_USER_ID,
+      purpose: "debug",
+      label: LABEL_PREFIX,
+    });
+    const rows = await listWebhookTokensForUser(TEST_USER_ID);
+    const ourRows = rows.filter((r) => r.label === LABEL_PREFIX);
+    expect(ourRows.map((r) => r.id)).toEqual([b.id, a.id]);
+  });
+
+  it("resolveWebhookAuth updates last_used_at on successful match", async () => {
+    const { id, plaintext } = await mintWebhookToken({
+      userId: TEST_USER_ID,
+      purpose: "sms",
+      label: LABEL_PREFIX,
+    });
+    const before = await db
+      .select({ lastUsedAt: webhookTokens.lastUsedAt })
+      .from(webhookTokens)
+      .where(eq(webhookTokens.id, id));
+    expect(before[0].lastUsedAt).toBeNull();
+
+    await resolveWebhookAuth({ authHeader: `Bearer ${plaintext}`, purpose: "sms" });
+    // fire-and-forget — give it a moment to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    const after = await db
+      .select({ lastUsedAt: webhookTokens.lastUsedAt })
+      .from(webhookTokens)
+      .where(and(eq(webhookTokens.id, id), isNull(webhookTokens.revokedAt)));
+    expect(after[0].lastUsedAt).not.toBeNull();
+  });
+});

--- a/src/lib/webhook-tokens/index.ts
+++ b/src/lib/webhook-tokens/index.ts
@@ -1,0 +1,154 @@
+import { randomBytes, createHash } from "node:crypto";
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { webhookTokens } from "@/lib/db/schema";
+
+export type WebhookPurpose = "sms" | "debug";
+
+export const WEBHOOK_PURPOSES: readonly WebhookPurpose[] = ["sms", "debug"] as const;
+
+export function hashWebhookToken(plaintext: string): string {
+  return createHash("sha256").update(plaintext, "utf8").digest("hex");
+}
+
+function generatePlaintext(): string {
+  // 32 bytes → 64 hex chars. Fits the token_hash varchar(64) one-to-one with
+  // the SHA-256 digest, avoids ambiguous URL characters.
+  return randomBytes(32).toString("hex");
+}
+
+export async function mintWebhookToken(opts: {
+  userId: number;
+  purpose: WebhookPurpose;
+  label?: string | null;
+}): Promise<{ id: number; plaintext: string }> {
+  const plaintext = generatePlaintext();
+  const tokenHash = hashWebhookToken(plaintext);
+  const [row] = await db
+    .insert(webhookTokens)
+    .values({
+      userId: opts.userId,
+      purpose: opts.purpose,
+      tokenHash,
+      label: opts.label?.trim() || null,
+    })
+    .returning({ id: webhookTokens.id });
+  return { id: row.id, plaintext };
+}
+
+export async function revokeWebhookToken(opts: {
+  userId: number;
+  tokenId: number;
+}): Promise<boolean> {
+  const result = await db
+    .update(webhookTokens)
+    .set({ revokedAt: new Date() })
+    .where(
+      and(
+        eq(webhookTokens.id, opts.tokenId),
+        eq(webhookTokens.userId, opts.userId),
+        isNull(webhookTokens.revokedAt),
+      ),
+    )
+    .returning({ id: webhookTokens.id });
+  return result.length > 0;
+}
+
+export async function listWebhookTokensForUser(userId: number) {
+  return db
+    .select({
+      id: webhookTokens.id,
+      purpose: webhookTokens.purpose,
+      label: webhookTokens.label,
+      createdAt: webhookTokens.createdAt,
+      lastUsedAt: webhookTokens.lastUsedAt,
+      revokedAt: webhookTokens.revokedAt,
+    })
+    .from(webhookTokens)
+    .where(eq(webhookTokens.userId, userId))
+    .orderBy(desc(webhookTokens.createdAt));
+}
+
+export type ResolvedWebhookAuth = {
+  userId: number;
+  source: "per-user-token" | "legacy-env-token";
+  tokenId: number | null;
+};
+
+/**
+ * Resolves a webhook request's userId from an `Authorization: Bearer <token>`
+ * header. Tries the per-user webhook_tokens table first; if that misses, falls
+ * back to the legacy INGEST_WEBHOOK_TOKEN env var (attributes to user 1).
+ *
+ * Returns null if neither path authenticates. Callers must NOT leak which path
+ * succeeded in error messages — both misses return the same null.
+ */
+export async function resolveWebhookAuth(opts: {
+  authHeader: string | null;
+  purpose: WebhookPurpose;
+}): Promise<ResolvedWebhookAuth | null> {
+  const provided = (opts.authHeader ?? "").replace(/^Bearer\s+/i, "").trim();
+  if (!provided) return null;
+
+  const match = await lookupPerUserToken(provided, opts.purpose);
+  if (match) {
+    void markTokenUsed(match.tokenId);
+    return { userId: match.userId, source: "per-user-token", tokenId: match.tokenId };
+  }
+
+  const legacy = process.env.INGEST_WEBHOOK_TOKEN;
+  if (legacy && provided === legacy) {
+    return { userId: 1, source: "legacy-env-token", tokenId: null };
+  }
+
+  return null;
+}
+
+async function lookupPerUserToken(
+  plaintext: string,
+  purpose: WebhookPurpose,
+): Promise<{ userId: number; tokenId: number } | null> {
+  const tokenHash = hashWebhookToken(plaintext);
+  const [row] = await db
+    .select({ id: webhookTokens.id, userId: webhookTokens.userId })
+    .from(webhookTokens)
+    .where(
+      and(
+        eq(webhookTokens.tokenHash, tokenHash),
+        eq(webhookTokens.purpose, purpose),
+        isNull(webhookTokens.revokedAt),
+      ),
+    )
+    .limit(1);
+  if (!row) return null;
+  return { userId: row.userId, tokenId: row.id };
+}
+
+async function markTokenUsed(tokenId: number): Promise<void> {
+  try {
+    await db
+      .update(webhookTokens)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(webhookTokens.id, tokenId));
+  } catch {
+    // Fire-and-forget: a failed last_used_at update must not fail ingestion.
+  }
+}
+
+export async function countActiveTokensByPurpose(
+  userId: number,
+): Promise<Record<WebhookPurpose, number>> {
+  const rows = await db
+    .select({
+      purpose: webhookTokens.purpose,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(webhookTokens)
+    .where(and(eq(webhookTokens.userId, userId), isNull(webhookTokens.revokedAt)))
+    .groupBy(webhookTokens.purpose);
+  const result: Record<WebhookPurpose, number> = { sms: 0, debug: 0 };
+  for (const row of rows) {
+    result[row.purpose as WebhookPurpose] = row.count;
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

PR A of #194 — feature PR. Introduces per-user bearer token auth for the ingest webhooks (SMS, debug). OCR is session-backed (not a webhook) so it's out of scope.

## Shape

New table \`webhook_tokens\`:

| col | type | notes |
|---|---|---|
| \`id\` | serial PK | |
| \`user_id\` | int NOT NULL FK users(id) ON DELETE CASCADE | |
| \`purpose\` | enum('sms','debug') | extendable later |
| \`token_hash\` | varchar(64) UNIQUE | SHA-256 hex of plaintext |
| \`label\` | varchar(120) | optional human label |
| \`created_at\`, \`last_used_at\`, \`revoked_at\` | timestamptz | |

Index: \`(user_id, purpose) WHERE revoked_at IS NULL\`.

Plaintext is shown once at mint time; only \`sha256(plaintext)\` is stored. If the DB leaks, tokens are unusable without reversing SHA-256.

## Auth flow

Request: \`Authorization: Bearer <plaintext>\`.

1. \`resolveWebhookAuth({ authHeader, purpose })\` hashes the plaintext, looks up \`webhook_tokens\` scoped by \`purpose\` and \`revoked_at IS NULL\`.
2. Match → \`{ userId, source: 'per-user-token' }\`. \`last_used_at\` update fires async.
3. Miss → fall back to legacy \`INGEST_WEBHOOK_TOKEN\` env var (attributes to user 1).
4. Both miss → \`null\` → route returns 401.

Legacy fallback is intentional: the iPhone Shortcut keeps working until user 1 mints and adopts a new per-user token. The cutover PR (#194 PR B) drops it.

## UI

\`/settings/webhooks\` (server component + server actions):
- Mint form: purpose (sms/debug) + optional label. On success, plaintext is shown **once** with a Copy button.
- List: tokens grouped by creation date, shows last_used_at, revoke button.
- Linked from \`/settings\` landing card.

## Bootstrap

\`bun run db:bootstrap:webhook-tokens\` (env-gated on \`BOOTSTRAP_USER_EMAIL\`) mints one \`sms\` + one \`debug\` token for user 1 and prints the plaintext once. Idempotent: if active tokens already exist for a purpose, it skips that purpose and prints a notice.

## Changes

- \`drizzle/0014_fuzzy_zzzax.sql\` — \`webhook_purpose\` enum + \`webhook_tokens\` table + index
- \`src/lib/db/schema.ts\` — \`webhookPurpose\`, \`webhookTokens\`
- \`src/lib/webhook-tokens/\` — \`mintWebhookToken\`, \`revokeWebhookToken\`, \`listWebhookTokensForUser\`, \`resolveWebhookAuth\`, \`hashWebhookToken\`
- \`src/app/api/ingest/sms/route.ts\` + \`.test.ts\` — delegates auth to \`resolveWebhookAuth\`; outdated 503 test replaced with 401
- \`src/app/api/ingest/debug/route.ts\` + \`.test.ts\` — same
- \`src/app/(app)/settings/webhooks/{page,actions,webhook-tokens-manager}\` — mint/revoke UI
- \`src/app/(app)/settings/page.tsx\` — new link
- \`scripts/bootstrap-webhook-tokens.ts\` + \`package.json\` script
- Route GET helper hints updated to point at /settings/webhooks

## Test plan

- [x] Unit tests: hash, mint, revoke, resolve (valid + wrong purpose + revoked + legacy fallback + missing header + last_used_at update) — 8 new tests
- [x] Route tests: legacy env-var path + 401 on no-match (existing tests kept passing against the new code path)
- [x] \`bun run db:migrate\` + \`db:migrate:test\` — applies cleanly
- [x] \`bun run db:bootstrap:webhook-tokens\` — mints 2 tokens for user 1 in dev, idempotent on re-run
- [x] \`bun run lint\` — clean
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun run test\` — 267 / 267 pass (up from 259)

## Next

- PR B — remove the legacy \`INGEST_WEBHOOK_TOKEN\` env-var fallback after the iPhone Shortcut is updated with the new token.
- Then resume #183 PR 3 (query rewrite + drop DEFAULT 1).

Closes part of #194