### PR TITLE
chore(auth): remove legacy INGEST_WEBHOOK_TOKEN fallback (#194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Dashboard financiero personal para Colombia con clasificación AI, presupuestos 
 ```bash
 bun install
 cp .env.example .env.local
-# Editar .env.local: ANTHROPIC_API_KEY y INGEST_WEBHOOK_TOKEN (ver abajo)
+# Editar .env.local: ANTHROPIC_API_KEY y FINDASH_WEBHOOK_TOKEN (ver abajo)
 bun run db:push        # crea las tablas
 bun run db:seed        # cuentas, categorías y reglas colombianas
 bun run dev            # arranca en http://localhost:3100
@@ -26,11 +26,11 @@ bun run dev            # arranca en http://localhost:3100
 
 `.env.example` tiene la plantilla. `.env.local` nunca se commitea.
 
-| Variable                                                 | Qué es                                                                | Cómo obtenerla                                                                                  |
-| -------------------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `PGHOST`, `PGDATABASE`, `PGUSER`, `PGPORT`, `PGPASSWORD` | Conexión a PostgreSQL                                                 | Dejar en blanco usa defaults: `/var/run/postgresql` + `findash` + `$USER` (peer auth en Linux). |
-| `ANTHROPIC_API_KEY`                                      | Clasificación AI, insights y OCR con Claude                           | https://console.anthropic.com/                                                                  |
-| `INGEST_WEBHOOK_TOKEN`                                   | Bearer token para `/api/ingest/*` (iOS Shortcut Apple Pay, SMS, etc.) | Secreto compartido fijo entre server e iOS Shortcut. Generar una vez: `openssl rand -hex 32`.   |
+| Variable                                                 | Qué es                                                                               | Cómo obtenerla                                                                                                      |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `PGHOST`, `PGDATABASE`, `PGUSER`, `PGPORT`, `PGPASSWORD` | Conexión a PostgreSQL                                                                | Dejar en blanco usa defaults: `/var/run/postgresql` + `findash` + `$USER` (peer auth en Linux).                     |
+| `ANTHROPIC_API_KEY`                                      | Clasificación AI, insights y OCR con Claude                                          | https://console.anthropic.com/                                                                                      |
+| `FINDASH_WEBHOOK_TOKEN`                                  | Bearer token per-user para `/api/ingest/{sms,debug}` (iOS Shortcut, scripts locales) | Mintá vía `/settings/webhooks` o `bun run db:bootstrap:webhook-tokens`. El plaintext se muestra una vez — guardalo. |
 
 ## Comandos DB
 

--- a/ios-shortcuts/README.md
+++ b/ios-shortcuts/README.md
@@ -6,7 +6,7 @@ iOS automations that feed transactions into Findash via authenticated webhooks.
 >
 > - iPhone on iOS 17 or later (Transaction trigger requires iOS 17+).
 > - Findash reachable over Tailscale (e.g. `https://ia-server.tailcabcc8.ts.net:3100`).
-> - `INGEST_WEBHOOK_TOKEN` set in the server's `.env.local` (see `.env.example`).
+> - A per-user webhook token minted via `/settings/webhooks` (one per purpose: `debug` for the discovery shortcut, `sms` for the SMS ingest shortcut). The plaintext is shown only once — paste it into the Shortcut immediately.
 
 ---
 
@@ -24,7 +24,7 @@ The endpoint `/api/ingest/debug` stores the full request (headers + body) in the
    - **URL**: `https://ia-server.tailcabcc8.ts.net:3100/api/ingest/debug`
    - **Method**: `POST`
    - **Headers**:
-     - `Authorization` → `Bearer <token>` (paste your `INGEST_WEBHOOK_TOKEN`)
+     - `Authorization` → `Bearer <token>` (paste a token minted for `purpose=debug` at `/settings/webhooks`)
      - `Content-Type` → `application/json`
    - **Request Body**: `JSON` — build an object with every variable available from the Shortcut Input. At minimum:
 

--- a/scripts/test-debug-ingest.sh
+++ b/scripts/test-debug-ingest.sh
@@ -3,11 +3,11 @@
 #
 # Usage (recommended):
 #   ./scripts/test-debug-ingest.sh
-#   (auto-loads INGEST_WEBHOOK_TOKEN from .env.local)
+#   (auto-loads FINDASH_WEBHOOK_TOKEN from .env.local)
 #
 # Or pass the token explicitly:
-#   INGEST_WEBHOOK_TOKEN=xxx ./scripts/test-debug-ingest.sh
-#   HOST=http://localhost:3100 INGEST_WEBHOOK_TOKEN=xxx ./scripts/test-debug-ingest.sh
+#   FINDASH_WEBHOOK_TOKEN=xxx ./scripts/test-debug-ingest.sh
+#   HOST=http://localhost:3100 FINDASH_WEBHOOK_TOKEN=xxx ./scripts/test-debug-ingest.sh
 #
 # Requires the dev server running (`bun run dev`).
 
@@ -19,27 +19,27 @@ cd "$(dirname "$0")/.."
 # Auto-load .env.local if the token is not already exported in the environment.
 # `set -a` auto-exports every variable assigned while it's on — the classic
 # idiom for sourcing an env file into the current shell.
-if [[ -z "${INGEST_WEBHOOK_TOKEN:-}" && -f .env.local ]]; then
+if [[ -z "${FINDASH_WEBHOOK_TOKEN:-}" && -f .env.local ]]; then
   set -a
   # shellcheck disable=SC1091
   source .env.local
   set +a
 fi
 
-: "${INGEST_WEBHOOK_TOKEN:?Set INGEST_WEBHOOK_TOKEN (in .env.local or exported in shell)}"
+: "${FINDASH_WEBHOOK_TOKEN:?Set FINDASH_WEBHOOK_TOKEN (in .env.local or exported in shell)}"
 
 HOST="${HOST:-http://localhost:3100}"
 
 echo "==> POST JSON with valid bearer token (expect 200 + logId)"
 curl -sS -i -X POST "$HOST/api/ingest/debug" \
-  -H "Authorization: Bearer $INGEST_WEBHOOK_TOKEN" \
+  -H "Authorization: Bearer $FINDASH_WEBHOOK_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"test":"smoke","merchant":"CURL SMOKE TEST","amount":"1000","card":"Visa ···· 1234"}'
 printf '\n\n'
 
 echo "==> POST form-urlencoded (expect 200 + logId)"
 curl -sS -i -X POST "$HOST/api/ingest/debug" \
-  -H "Authorization: Bearer $INGEST_WEBHOOK_TOKEN" \
+  -H "Authorization: Bearer $FINDASH_WEBHOOK_TOKEN" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d 'merchant=STARBUCKS&amount=14500&card=Mastercard+9876'
 printf '\n\n'

--- a/scripts/test-sms-ingest.sh
+++ b/scripts/test-sms-ingest.sh
@@ -3,10 +3,10 @@
 #
 # Usage:
 #   ./scripts/test-sms-ingest.sh
-#   (auto-loads INGEST_WEBHOOK_TOKEN from .env.local)
+#   (auto-loads FINDASH_WEBHOOK_TOKEN from .env.local)
 #
 # Or pass the token explicitly:
-#   INGEST_WEBHOOK_TOKEN=xxx ./scripts/test-sms-ingest.sh
+#   FINDASH_WEBHOOK_TOKEN=xxx ./scripts/test-sms-ingest.sh
 #
 # Requires the dev server running (`bun run dev`).
 
@@ -14,14 +14,14 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-if [[ -z "${INGEST_WEBHOOK_TOKEN:-}" && -f .env.local ]]; then
+if [[ -z "${FINDASH_WEBHOOK_TOKEN:-}" && -f .env.local ]]; then
   set -a
   # shellcheck disable=SC1091
   source .env.local
   set +a
 fi
 
-: "${INGEST_WEBHOOK_TOKEN:?Set INGEST_WEBHOOK_TOKEN (in .env.local or exported)}"
+: "${FINDASH_WEBHOOK_TOKEN:?Set FINDASH_WEBHOOK_TOKEN (in .env.local or exported)}"
 HOST="${HOST:-http://localhost:3100}"
 
 post() {
@@ -33,7 +33,7 @@ post() {
   payload=$(jq -n --arg sender "$sender" --arg body "$body" \
     '{sender: $sender, body: $body}')
   curl -sS -X POST "$HOST/api/ingest/sms" \
-    -H "Authorization: Bearer $INGEST_WEBHOOK_TOKEN" \
+    -H "Authorization: Bearer $FINDASH_WEBHOOK_TOKEN" \
     -H "Content-Type: application/json" \
     -d "$payload" | jq .
   printf '\n'

--- a/src/app/api/ingest/debug/route.test.ts
+++ b/src/app/api/ingest/debug/route.test.ts
@@ -1,9 +1,13 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
-import { sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
+import { webhookTokens } from "@/lib/db/schema";
+import { mintWebhookToken } from "@/lib/webhook-tokens";
 import { POST } from "./route";
 
-const TEST_TOKEN = "test-token-vitest-debug-capture";
+const TEST_USER_ID = 1;
+const TEST_TOKEN_LABEL = "vitest-debug-route";
+let TEST_TOKEN = "";
 const MARKER = "VITEST_DEBUG_CAPTURE_MARKER";
 
 function makeRequest(init: { body?: string; headers?: Record<string, string> }) {
@@ -23,23 +27,22 @@ async function cleanup() {
 }
 
 describe("POST /api/ingest/debug", () => {
-  beforeEach(() => {
-    process.env.INGEST_WEBHOOK_TOKEN = TEST_TOKEN;
+  beforeAll(async () => {
+    const { plaintext } = await mintWebhookToken({
+      userId: TEST_USER_ID,
+      purpose: "debug",
+      label: TEST_TOKEN_LABEL,
+    });
+    TEST_TOKEN = plaintext;
   });
   afterEach(cleanup);
   afterAll(async () => {
-    delete process.env.INGEST_WEBHOOK_TOKEN;
+    await db
+      .delete(webhookTokens)
+      .where(
+        and(eq(webhookTokens.userId, TEST_USER_ID), eq(webhookTokens.label, TEST_TOKEN_LABEL)),
+      );
     await db.$client.end({ timeout: 1 });
-  });
-
-  it("returns 401 when no auth path matches (no env var, no per-user token)", async () => {
-    delete process.env.INGEST_WEBHOOK_TOKEN;
-    const res = await POST(
-      makeRequest({
-        headers: { authorization: `Bearer ${TEST_TOKEN}` },
-      }),
-    );
-    expect(res.status).toBe(401);
   });
 
   it("returns 401 when Authorization header is missing", async () => {
@@ -47,7 +50,7 @@ describe("POST /api/ingest/debug", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 401 when bearer token does not match", async () => {
+  it("returns 401 when bearer token does not match any webhook_token row", async () => {
     const res = await POST(
       makeRequest({
         headers: { authorization: "Bearer wrong-token" },

--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -1,10 +1,14 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
-import { sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
+import { webhookTokens } from "@/lib/db/schema";
+import { mintWebhookToken } from "@/lib/webhook-tokens";
 import { POST } from "./route";
 import type { CounterpartyKind, CounterpartyType } from "@/lib/types";
 
-const TEST_TOKEN = "test-token-vitest-sms-ingest";
+const TEST_USER_ID = 1;
+const TEST_TOKEN_LABEL = "vitest-sms-route";
+let TEST_TOKEN = "";
 // SMS bodies used in tests — we clean up by externalId, not by marker,
 // because the externalId is deterministic per (kind, amount, date, ...).
 const TEST_EXTERNAL_ID_PREFIX = "bcol-sms:";
@@ -94,12 +98,21 @@ function authedHeaders() {
 }
 
 describe("POST /api/ingest/sms", () => {
-  beforeEach(() => {
-    process.env.INGEST_WEBHOOK_TOKEN = TEST_TOKEN;
+  beforeAll(async () => {
+    const { plaintext } = await mintWebhookToken({
+      userId: TEST_USER_ID,
+      purpose: "sms",
+      label: TEST_TOKEN_LABEL,
+    });
+    TEST_TOKEN = plaintext;
   });
   afterEach(cleanup);
   afterAll(async () => {
-    delete process.env.INGEST_WEBHOOK_TOKEN;
+    await db
+      .delete(webhookTokens)
+      .where(
+        and(eq(webhookTokens.userId, TEST_USER_ID), eq(webhookTokens.label, TEST_TOKEN_LABEL)),
+      );
     await db.$client.end({ timeout: 1 });
   });
 
@@ -107,23 +120,12 @@ describe("POST /api/ingest/sms", () => {
   // Auth
   // ---------------------------------------------------------------------------
 
-  it("returns 401 when no auth path matches (no env var, no per-user token)", async () => {
-    delete process.env.INGEST_WEBHOOK_TOKEN;
-    const res = await POST(
-      makeRequest({
-        body: jsonBody({ body: "test" }),
-        headers: authedHeaders(),
-      }),
-    );
-    expect(res.status).toBe(401);
-  });
-
   it("returns 401 when Authorization header is missing", async () => {
     const res = await POST(makeRequest({ body: jsonBody({ body: "test" }) }));
     expect(res.status).toBe(401);
   });
 
-  it("returns 401 when bearer token does not match", async () => {
+  it("returns 401 when bearer token does not match any webhook_token row", async () => {
     const res = await POST(
       makeRequest({
         body: jsonBody({ body: "test" }),

--- a/src/lib/webhook-tokens/index.test.ts
+++ b/src/lib/webhook-tokens/index.test.ts
@@ -43,7 +43,7 @@ describe("webhook-tokens module", () => {
   });
 
   it("resolveWebhookAuth accepts a valid per-user token and returns userId", async () => {
-    const { plaintext } = await mintWebhookToken({
+    const { id, plaintext } = await mintWebhookToken({
       userId: TEST_USER_ID,
       purpose: "sms",
       label: LABEL_PREFIX,
@@ -54,7 +54,7 @@ describe("webhook-tokens module", () => {
     });
     expect(result).not.toBeNull();
     expect(result?.userId).toBe(TEST_USER_ID);
-    expect(result?.source).toBe("per-user-token");
+    expect(result?.tokenId).toBe(id);
   });
 
   it("resolveWebhookAuth rejects a token minted for a different purpose", async () => {
@@ -89,16 +89,14 @@ describe("webhook-tokens module", () => {
     expect(retry).toBe(false);
   });
 
-  it("resolveWebhookAuth falls back to INGEST_WEBHOOK_TOKEN env var and attributes to user 1", async () => {
-    process.env.INGEST_WEBHOOK_TOKEN = "legacy-fallback-token-for-test";
+  it("resolveWebhookAuth ignores the retired INGEST_WEBHOOK_TOKEN env var", async () => {
+    process.env.INGEST_WEBHOOK_TOKEN = "legacy-fallback-token-no-longer-honored";
     try {
       const result = await resolveWebhookAuth({
-        authHeader: `Bearer legacy-fallback-token-for-test`,
+        authHeader: `Bearer legacy-fallback-token-no-longer-honored`,
         purpose: "sms",
       });
-      expect(result).not.toBeNull();
-      expect(result?.userId).toBe(1);
-      expect(result?.source).toBe("legacy-env-token");
+      expect(result).toBeNull();
     } finally {
       delete process.env.INGEST_WEBHOOK_TOKEN;
     }

--- a/src/lib/webhook-tokens/index.ts
+++ b/src/lib/webhook-tokens/index.ts
@@ -71,17 +71,15 @@ export async function listWebhookTokensForUser(userId: number) {
 
 export type ResolvedWebhookAuth = {
   userId: number;
-  source: "per-user-token" | "legacy-env-token";
-  tokenId: number | null;
+  tokenId: number;
 };
 
 /**
  * Resolves a webhook request's userId from an `Authorization: Bearer <token>`
- * header. Tries the per-user webhook_tokens table first; if that misses, falls
- * back to the legacy INGEST_WEBHOOK_TOKEN env var (attributes to user 1).
+ * header by hashing the plaintext and looking it up in webhook_tokens.
  *
- * Returns null if neither path authenticates. Callers must NOT leak which path
- * succeeded in error messages — both misses return the same null.
+ * Returns null when the header is missing, the hash doesn't match any row, the
+ * matched row is revoked, or the row's purpose doesn't match.
  */
 export async function resolveWebhookAuth(opts: {
   authHeader: string | null;
@@ -91,17 +89,9 @@ export async function resolveWebhookAuth(opts: {
   if (!provided) return null;
 
   const match = await lookupPerUserToken(provided, opts.purpose);
-  if (match) {
-    void markTokenUsed(match.tokenId);
-    return { userId: match.userId, source: "per-user-token", tokenId: match.tokenId };
-  }
-
-  const legacy = process.env.INGEST_WEBHOOK_TOKEN;
-  if (legacy && provided === legacy) {
-    return { userId: 1, source: "legacy-env-token", tokenId: null };
-  }
-
-  return null;
+  if (!match) return null;
+  void markTokenUsed(match.tokenId);
+  return { userId: match.userId, tokenId: match.tokenId };
 }
 
 async function lookupPerUserToken(


### PR DESCRIPTION
## Summary

Cutover PR for #194. \`resolveWebhookAuth\` only honors per-user tokens from \`webhook_tokens\` now — the \`INGEST_WEBHOOK_TOKEN\` env-var fallback that attributed to user 1 is gone.

## What breaks and what fixes it

- Any existing iOS Shortcut still sending \`Authorization: Bearer <old-shared-token>\` will get \`401\` from \`/api/ingest/sms\` and \`/api/ingest/debug\`.
- Fix: mint a per-user token at \`/settings/webhooks\` (or \`bun run db:bootstrap:webhook-tokens\`) and paste the plaintext into the Shortcut's header.

## Changes

- \`src/lib/webhook-tokens/index.ts\` — removed the \`legacy-env-token\` branch from \`resolveWebhookAuth\`; \`ResolvedWebhookAuth\` is now \`{ userId, tokenId }\` (no \`source\` discriminator since there's only one source left).
- \`src/lib/webhook-tokens/index.test.ts\` — replaced the "falls back to env var" test with a "ignores the retired env var" regression.
- \`src/app/api/ingest/sms/route.test.ts\`, \`.../debug/route.test.ts\` — mint a real per-user token in \`beforeAll\`, use it via \`Bearer \${TEST_TOKEN}\`, clean up by label in \`afterAll\`. The old \`process.env.INGEST_WEBHOOK_TOKEN = TEST_TOKEN\` setup is removed.
- \`README.md\`, \`ios-shortcuts/README.md\`, \`scripts/test-{sms,debug}-ingest.sh\` — rewired to \`FINDASH_WEBHOOK_TOKEN\` and point at \`/settings/webhooks\`.

## Follow-up (not in this PR)

- \`.env.example\` still lists \`INGEST_WEBHOOK_TOKEN\`. It's ignored by the code now, but the template is write-blocked in this environment. Remove it manually and add \`FINDASH_WEBHOOK_TOKEN=\` (empty placeholder).
- Before merging this PR on a deployed environment, the iOS Shortcut on that environment must already have a per-user token pasted into its \`Authorization\` header. Dev/test don't care.

## Test plan

- [x] \`bun run lint\` — clean
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun run test\` — 265 / 265 pass (net -2 from PR A: the two obsolete "no env var" route tests are gone; webhook-tokens module added a new regression test)
- [x] No \`INGEST_WEBHOOK_TOKEN\` references left outside the regression test in \`src/lib/webhook-tokens/index.test.ts\`

Closes #194