### PR TITLE
feat(db): userId plumbing across tenant queries (#183)

### DIFF
--- a/scripts/backfill-counterparties.ts
+++ b/scripts/backfill-counterparties.ts
@@ -36,7 +36,9 @@ async function main() {
       console.warn(`tx ${row.id}: parser returned skip:${parsed.reason} — skipped`);
       continue;
     }
-    const cp = await resolveCounterparty(parsed, db);
+    // Backfill script runs against the single-user dev DB pre-multi-tenancy
+    // data, so user_id=1 is always the right scope.
+    const cp = await resolveCounterparty(1, parsed, db);
     if (cp.counterpartyId === null) {
       console.warn(`tx ${row.id}: kind=${parsed.kind} has no counterparty — skipped`);
       continue;

--- a/scripts/replay-sms-dump.ts
+++ b/scripts/replay-sms-dump.ts
@@ -52,7 +52,8 @@ async function main() {
     const kind = parsed.kind === "skip" ? `skip:${parsed.reason}` : parsed.kind;
     byKind[kind] = (byKind[kind] ?? 0) + 1;
 
-    const outcome = await ingestParsed(parsed);
+    // Replay script scopes to user 1 (bootstrap).
+    const outcome = await ingestParsed(1, parsed);
     counts[outcome.status] += 1;
     if (outcome.status === "error") {
       errors.push({ reason: outcome.reason, body: body.slice(0, 80) });

--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -1,6 +1,7 @@
 import { CreditCardIcon, LandmarkIcon, PiggyBankIcon, WalletIcon } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
+import { getSessionUser } from "@/lib/auth/session";
 import { getNetWorth } from "@/lib/dashboard/queries";
 import { listAccountsDetailed, type AccountDetail } from "@/lib/accounts/queries";
 import { getCurrentFxRate } from "@/lib/fx/repo";
@@ -34,8 +35,12 @@ function sumBalanceCopCents(list: AccountDetail[], copPerUsd: number): bigint {
 }
 
 export default async function AccountsPage() {
+  const session = await getSessionUser();
   const fx = await getCurrentFxRate();
-  const [netWorth, all] = await Promise.all([getNetWorth(fx.rate), listAccountsDetailed()]);
+  const [netWorth, all] = await Promise.all([
+    getNetWorth(session.id, fx.rate),
+    listAccountsDetailed(session.id),
+  ]);
 
   const active = all.filter((a) => a.active);
   const inactive = all.filter((a) => !a.active);

--- a/src/app/(app)/budgets/actions.ts
+++ b/src/app/(app)/budgets/actions.ts
@@ -5,6 +5,7 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { budgets, categories, currency as currencyEnum } from "@/lib/db/schema";
+import { getSessionUser } from "@/lib/auth/session";
 
 const ymSchema = z.string().regex(/^\d{4}-\d{2}$/);
 
@@ -31,6 +32,7 @@ function revalidate() {
 }
 
 export async function upsertBudget(input: BudgetInput) {
+  const session = await getSessionUser();
   const parsed = upsertSchema.parse(input);
   const { start, end } = monthRange(parsed.ym);
 
@@ -56,16 +58,23 @@ export async function upsertBudget(input: BudgetInput) {
         periodStart: start,
         periodEnd: end,
       })
-      .where(eq(budgets.id, parsed.id));
+      .where(and(eq(budgets.userId, session.id), eq(budgets.id, parsed.id)));
   } else {
     const [dup] = await db
       .select({ id: budgets.id })
       .from(budgets)
-      .where(and(eq(budgets.categorySlug, parsed.categorySlug), eq(budgets.periodStart, start)))
+      .where(
+        and(
+          eq(budgets.userId, session.id),
+          eq(budgets.categorySlug, parsed.categorySlug),
+          eq(budgets.periodStart, start),
+        ),
+      )
       .limit(1);
     if (dup) throw new Error("Budget for this category and month already exists");
 
     await db.insert(budgets).values({
+      userId: session.id,
       categorySlug: parsed.categorySlug,
       amountCents,
       currency: parsed.currency,
@@ -79,6 +88,7 @@ export async function upsertBudget(input: BudgetInput) {
 }
 
 export async function deleteBudget(id: number) {
-  await db.delete(budgets).where(eq(budgets.id, id));
+  const session = await getSessionUser();
+  await db.delete(budgets).where(and(eq(budgets.userId, session.id), eq(budgets.id, id)));
   revalidate();
 }

--- a/src/app/(app)/insights/actions.ts
+++ b/src/app/(app)/insights/actions.ts
@@ -1,25 +1,28 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { insightsReports } from "@/lib/db/schema";
+import { getSessionUser } from "@/lib/auth/session";
 import { buildInsightsSummary, generateInsightsReport, hashSummary } from "@/lib/ai/insights";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 
 const ymSchema = z.string().regex(/^\d{4}-\d{2}$/);
 
 export async function generateInsight(ym: string) {
+  const session = await getSessionUser();
   const parsed = ymSchema.parse(ym);
   const fx = await getCurrentFxRate();
-  const summary = await buildInsightsSummary(parsed, fx.rate);
+  const summary = await buildInsightsSummary(session.id, parsed, fx.rate);
   const inputHash = hashSummary(summary);
   const result = await generateInsightsReport({ summary });
 
   await db
     .insert(insightsReports)
     .values({
+      userId: session.id,
       yearMonth: parsed,
       inputHash,
       markdown: result.markdown,
@@ -29,7 +32,7 @@ export async function generateInsight(ym: string) {
       generatedAt: new Date(),
     })
     .onConflictDoUpdate({
-      target: insightsReports.yearMonth,
+      target: [insightsReports.userId, insightsReports.yearMonth],
       set: {
         inputHash,
         markdown: result.markdown,
@@ -45,7 +48,10 @@ export async function generateInsight(ym: string) {
 }
 
 export async function deleteInsight(ym: string) {
+  const session = await getSessionUser();
   const parsed = ymSchema.parse(ym);
-  await db.delete(insightsReports).where(eq(insightsReports.yearMonth, parsed));
+  await db
+    .delete(insightsReports)
+    .where(and(eq(insightsReports.userId, session.id), eq(insightsReports.yearMonth, parsed)));
   revalidatePath("/insights");
 }

--- a/src/app/(app)/insights/page.tsx
+++ b/src/app/(app)/insights/page.tsx
@@ -1,6 +1,7 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { insightsReports } from "@/lib/db/schema";
+import { getSessionUser } from "@/lib/auth/session";
 import { buildInsightsSummary, hashSummary, isStale } from "@/lib/ai/insights";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { InsightsViewer } from "./insights-viewer";
@@ -20,14 +21,15 @@ export default async function InsightsPage({
   const params = await searchParams;
   const ym = params.ym && /^\d{4}-\d{2}$/.test(params.ym) ? params.ym : currentYearMonth();
 
+  const session = await getSessionUser();
   const fx = await getCurrentFxRate();
-  const summary = await buildInsightsSummary(ym, fx.rate);
+  const summary = await buildInsightsSummary(session.id, ym, fx.rate);
   const currentHash = hashSummary(summary);
 
   const [existing] = await db
     .select()
     .from(insightsReports)
-    .where(eq(insightsReports.yearMonth, ym))
+    .where(and(eq(insightsReports.userId, session.id), eq(insightsReports.yearMonth, ym)))
     .limit(1);
 
   const stale = existing ? isStale(existing.generatedAt, existing.inputHash, currentHash) : true;

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -18,6 +18,7 @@ import { getUpcomingForMonth } from "@/lib/recurring/upcoming";
 import { getOpenGaps } from "@/lib/recurring/gap-queries";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { getSmsHealthSnapshot } from "@/lib/ingestion/sms-health";
+import { getSessionUser } from "@/lib/auth/session";
 import {
   formatYearMonth,
   isFutureYearMonth,
@@ -40,21 +41,23 @@ export default async function DashboardPage({
   const monthLabel = formatYearMonth(ym);
   const [refYear, refMonth] = ym.split("-").map(Number);
 
+  const session = await getSessionUser();
   const fx = await getCurrentFxRate();
   const [netWorth, flow, slices, top, accounts, upcoming, openGaps, smsHealth] = await Promise.all([
-    getNetWorth(fx.rate),
-    getMonthlyFlow(fx.rate, refDate),
-    getCategoryBreakdown(fx.rate, refDate),
-    getTopExpenses(fx.rate, refDate, 5),
-    getAccountStatuses(),
+    getNetWorth(session.id, fx.rate),
+    getMonthlyFlow(session.id, fx.rate, refDate),
+    getCategoryBreakdown(session.id, fx.rate, refDate),
+    getTopExpenses(session.id, fx.rate, refDate, 5),
+    getAccountStatuses(session.id),
     getUpcomingForMonth({
+      userId: session.id,
       year: refYear,
       month: refMonth,
       includeDismissed: true,
       today: now,
     }),
-    getOpenGaps(),
-    getSmsHealthSnapshot(now),
+    getOpenGaps(session.id),
+    getSmsHealthSnapshot(session.id, now),
   ]);
 
   const upcomingItems = upcoming.map((u) => ({

--- a/src/app/(app)/settings/import/actions.ts
+++ b/src/app/(app)/settings/import/actions.ts
@@ -5,6 +5,7 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { accounts, ingestionLogs, transactions } from "@/lib/db/schema";
+import { getSessionUser } from "@/lib/auth/session";
 import { classifyByRule } from "@/lib/classification/rules";
 import { parseBancolombiaXlsx, type ParsedRow } from "@/lib/ingestion/xlsx-bancolombia";
 import {
@@ -28,6 +29,7 @@ export type PreviewResult = {
 };
 
 export async function previewBancolombiaXlsx(formData: FormData): Promise<PreviewResult> {
+  const session = await getSessionUser();
   const { accountId } = previewSchema.parse({ accountId: formData.get("accountId") });
   const file = formData.get("file");
   if (!(file instanceof File)) throw new Error("No file uploaded");
@@ -37,7 +39,7 @@ export async function previewBancolombiaXlsx(formData: FormData): Promise<Previe
   const [account] = await db
     .select({ id: accounts.id })
     .from(accounts)
-    .where(eq(accounts.id, accountId))
+    .where(and(eq(accounts.userId, session.id), eq(accounts.id, accountId)))
     .limit(1);
   if (!account) throw new Error("Account not found");
 
@@ -50,7 +52,11 @@ export async function previewBancolombiaXlsx(formData: FormData): Promise<Previe
         .select({ externalId: transactions.externalId })
         .from(transactions)
         .where(
-          and(eq(transactions.accountId, accountId), inArray(transactions.externalId, externalIds)),
+          and(
+            eq(transactions.userId, session.id),
+            eq(transactions.accountId, accountId),
+            inArray(transactions.externalId, externalIds),
+          ),
         )
     : [];
   const existingSet = new Set(existing.map((e) => e.externalId));
@@ -92,13 +98,14 @@ export type ConfirmResult = {
 };
 
 export async function confirmBancolombiaImport(input: ConfirmInput): Promise<ConfirmResult> {
+  const session = await getSessionUser();
   const parsed = confirmSchema.parse(input);
   const startedAt = new Date();
 
   const [account] = await db
     .select({ id: accounts.id, currency: accounts.currency })
     .from(accounts)
-    .where(eq(accounts.id, parsed.accountId))
+    .where(and(eq(accounts.userId, session.id), eq(accounts.id, parsed.accountId)))
     .limit(1);
   if (!account) throw new Error("Account not found");
 
@@ -108,10 +115,11 @@ export async function confirmBancolombiaImport(input: ConfirmInput): Promise<Con
 
   for (const r of parsed.rows) {
     try {
-      const cls = await classifyByRule({ descriptionRaw: r.description });
+      const cls = await classifyByRule(session.id, { descriptionRaw: r.description });
       const result = await db
         .insert(transactions)
         .values({
+          userId: session.id,
           accountId: account.id,
           occurredAt: new Date(`${r.occurredOn}T12:00:00Z`),
           amountCents: BigInt(r.amountCents),
@@ -133,7 +141,7 @@ export async function confirmBancolombiaImport(input: ConfirmInput): Promise<Con
 
       if (result.length > 0) {
         inserted++;
-        await autoLinkTransaction(result[0].id);
+        await autoLinkTransaction(session.id, result[0].id);
       } else duplicated++;
     } catch (err) {
       errors.push(err instanceof Error ? err.message : String(err));
@@ -141,6 +149,7 @@ export async function confirmBancolombiaImport(input: ConfirmInput): Promise<Con
   }
 
   await db.insert(ingestionLogs).values({
+    userId: session.id,
     source: "csv",
     status: errors.length === 0 ? "ok" : "partial",
     itemsReceived: parsed.rows.length,
@@ -176,6 +185,7 @@ export type OcrPreviewResult = {
 };
 
 export async function previewScreenshotOcr(formData: FormData): Promise<OcrPreviewResult> {
+  const session = await getSessionUser();
   const { accountId } = ocrPreviewSchema.parse({
     accountId: formData.get("accountId"),
   });
@@ -190,7 +200,7 @@ export async function previewScreenshotOcr(formData: FormData): Promise<OcrPrevi
   const [account] = await db
     .select({ id: accounts.id })
     .from(accounts)
-    .where(eq(accounts.id, accountId))
+    .where(and(eq(accounts.userId, session.id), eq(accounts.id, accountId)))
     .limit(1);
   if (!account) throw new Error("Account not found");
 
@@ -209,7 +219,11 @@ export async function previewScreenshotOcr(formData: FormData): Promise<OcrPrevi
         .select({ externalId: transactions.externalId })
         .from(transactions)
         .where(
-          and(eq(transactions.accountId, accountId), inArray(transactions.externalId, externalIds)),
+          and(
+            eq(transactions.userId, session.id),
+            eq(transactions.accountId, accountId),
+            inArray(transactions.externalId, externalIds),
+          ),
         )
     : [];
   const existingSet = new Set(existing.map((e) => e.externalId));
@@ -248,13 +262,14 @@ const confirmOcrSchema = z.object({
 export type ConfirmOcrInput = z.infer<typeof confirmOcrSchema>;
 
 export async function confirmOcrImport(input: ConfirmOcrInput): Promise<ConfirmResult> {
+  const session = await getSessionUser();
   const parsed = confirmOcrSchema.parse(input);
   const startedAt = new Date();
 
   const [account] = await db
     .select({ id: accounts.id, currency: accounts.currency })
     .from(accounts)
-    .where(eq(accounts.id, parsed.accountId))
+    .where(and(eq(accounts.userId, session.id), eq(accounts.id, parsed.accountId)))
     .limit(1);
   if (!account) throw new Error("Account not found");
 
@@ -264,10 +279,11 @@ export async function confirmOcrImport(input: ConfirmOcrInput): Promise<ConfirmR
 
   for (const r of parsed.rows) {
     try {
-      const cls = await classifyByRule({ descriptionRaw: r.description });
+      const cls = await classifyByRule(session.id, { descriptionRaw: r.description });
       const result = await db
         .insert(transactions)
         .values({
+          userId: session.id,
           accountId: account.id,
           occurredAt: new Date(`${r.occurredOn}T12:00:00Z`),
           amountCents: BigInt(r.amountCents),
@@ -289,7 +305,7 @@ export async function confirmOcrImport(input: ConfirmOcrInput): Promise<ConfirmR
 
       if (result.length > 0) {
         inserted++;
-        await autoLinkTransaction(result[0].id);
+        await autoLinkTransaction(session.id, result[0].id);
       } else duplicated++;
     } catch (err) {
       errors.push(err instanceof Error ? err.message : String(err));
@@ -297,6 +313,7 @@ export async function confirmOcrImport(input: ConfirmOcrInput): Promise<ConfirmR
   }
 
   await db.insert(ingestionLogs).values({
+    userId: session.id,
     source: "ocr",
     status: errors.length === 0 ? "ok" : "partial",
     itemsReceived: parsed.rows.length,

--- a/src/app/(app)/settings/ingestion/page.tsx
+++ b/src/app/(app)/settings/ingestion/page.tsx
@@ -8,6 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { getSessionUser } from "@/lib/auth/session";
 import {
   DRIFT_CONFIG,
   getSmsHealthHistory,
@@ -36,10 +37,11 @@ function formatCopDate(copDate: string): string {
 }
 
 export default async function IngestionSettingsPage() {
+  const session = await getSessionUser();
   const now = new Date();
   const [snapshot, history] = await Promise.all([
-    getSmsHealthSnapshot(now),
-    getSmsHealthHistory(30, now),
+    getSmsHealthSnapshot(session.id, now),
+    getSmsHealthHistory(session.id, 30, now),
   ]);
 
   return (

--- a/src/app/(app)/settings/recurring/actions.ts
+++ b/src/app/(app)/settings/recurring/actions.ts
@@ -11,6 +11,7 @@ import {
   recurringTransactions,
   transactions,
 } from "@/lib/db/schema";
+import { getSessionUser } from "@/lib/auth/session";
 import { classifyByRule } from "@/lib/classification/rules";
 import { emit } from "@/lib/events/bus";
 import { getLinkCandidates, type LinkCandidate } from "@/lib/recurring/gap-queries";
@@ -37,12 +38,13 @@ function revalidate() {
 }
 
 export async function upsertRecurring(input: RecurringInput) {
+  const session = await getSessionUser();
   const parsed = upsertSchema.parse(input);
 
   const [account] = await db
     .select({ id: accounts.id, currency: accounts.currency })
     .from(accounts)
-    .where(eq(accounts.id, parsed.accountId))
+    .where(and(eq(accounts.userId, session.id), eq(accounts.id, parsed.accountId)))
     .limit(1);
   if (!account) throw new Error("Account not found");
 
@@ -59,6 +61,7 @@ export async function upsertRecurring(input: RecurringInput) {
     Math.round(Math.abs(parsed.amount) * 100) * (parsed.direction === "income" ? 1 : -1);
 
   const values = {
+    userId: session.id,
     accountId: parsed.accountId,
     label: parsed.label,
     amountCents: BigInt(signedCents),
@@ -73,7 +76,9 @@ export async function upsertRecurring(input: RecurringInput) {
     await db
       .update(recurringTransactions)
       .set(values)
-      .where(eq(recurringTransactions.id, parsed.id));
+      .where(
+        and(eq(recurringTransactions.userId, session.id), eq(recurringTransactions.id, parsed.id)),
+      );
   } else {
     await db.insert(recurringTransactions).values(values);
   }
@@ -82,12 +87,19 @@ export async function upsertRecurring(input: RecurringInput) {
 }
 
 export async function deleteRecurring(id: number) {
-  await db.delete(recurringTransactions).where(eq(recurringTransactions.id, id));
+  const session = await getSessionUser();
+  await db
+    .delete(recurringTransactions)
+    .where(and(eq(recurringTransactions.userId, session.id), eq(recurringTransactions.id, id)));
   revalidate();
 }
 
 export async function toggleRecurringActive(id: number, active: boolean) {
-  await db.update(recurringTransactions).set({ active }).where(eq(recurringTransactions.id, id));
+  const session = await getSessionUser();
+  await db
+    .update(recurringTransactions)
+    .set({ active })
+    .where(and(eq(recurringTransactions.userId, session.id), eq(recurringTransactions.id, id)));
   revalidate();
 }
 
@@ -97,24 +109,41 @@ const dismissSchema = z.object({
 });
 
 export async function dismissUpcoming(input: z.input<typeof dismissSchema>) {
+  const session = await getSessionUser();
   const { recurringId, ym } = dismissSchema.parse(input);
 
   const result = await db.transaction(async (trx) => {
     const [row] = await trx
       .select({ skippedMonths: recurringTransactions.skippedMonths })
       .from(recurringTransactions)
-      .where(eq(recurringTransactions.id, recurringId))
+      .where(
+        and(
+          eq(recurringTransactions.userId, session.id),
+          eq(recurringTransactions.id, recurringId),
+        ),
+      )
       .limit(1);
     if (!row) throw new Error("Recurring not found");
     const next = Array.from(new Set([...(row.skippedMonths ?? []), ym]));
     await trx
       .update(recurringTransactions)
       .set({ skippedMonths: next })
-      .where(eq(recurringTransactions.id, recurringId));
+      .where(
+        and(
+          eq(recurringTransactions.userId, session.id),
+          eq(recurringTransactions.id, recurringId),
+        ),
+      );
 
     const deleted = await trx
       .delete(recurringGaps)
-      .where(and(eq(recurringGaps.recurringId, recurringId), eq(recurringGaps.yearMonth, ym)))
+      .where(
+        and(
+          eq(recurringGaps.userId, session.id),
+          eq(recurringGaps.recurringId, recurringId),
+          eq(recurringGaps.yearMonth, ym),
+        ),
+      )
       .returning({ id: recurringGaps.id });
     return { gapId: deleted[0]?.id ?? null };
   });
@@ -130,18 +159,23 @@ export async function dismissUpcoming(input: z.input<typeof dismissSchema>) {
 }
 
 export async function undismissUpcoming(input: z.input<typeof dismissSchema>) {
+  const session = await getSessionUser();
   const { recurringId, ym } = dismissSchema.parse(input);
   const [row] = await db
     .select({ skippedMonths: recurringTransactions.skippedMonths })
     .from(recurringTransactions)
-    .where(eq(recurringTransactions.id, recurringId))
+    .where(
+      and(eq(recurringTransactions.userId, session.id), eq(recurringTransactions.id, recurringId)),
+    )
     .limit(1);
   if (!row) throw new Error("Recurring not found");
   const next = (row.skippedMonths ?? []).filter((m) => m !== ym);
   await db
     .update(recurringTransactions)
     .set({ skippedMonths: next })
-    .where(eq(recurringTransactions.id, recurringId));
+    .where(
+      and(eq(recurringTransactions.userId, session.id), eq(recurringTransactions.id, recurringId)),
+    );
   revalidate();
 }
 
@@ -155,6 +189,7 @@ const promoteSchema = z.object({
 export type PromoteUpcomingInput = z.input<typeof promoteSchema>;
 
 export async function promoteUpcoming(input: PromoteUpcomingInput) {
+  const session = await getSessionUser();
   const { recurringId, yearMonth: ym, occurredOn, amountCents } = promoteSchema.parse(input);
 
   const [r] = await db
@@ -168,14 +203,22 @@ export async function promoteUpcoming(input: PromoteUpcomingInput) {
       notes: recurringTransactions.notes,
     })
     .from(recurringTransactions)
-    .where(eq(recurringTransactions.id, recurringId))
+    .where(
+      and(eq(recurringTransactions.userId, session.id), eq(recurringTransactions.id, recurringId)),
+    )
     .limit(1);
   if (!r) throw new Error("Recurring not found");
 
   const [dup] = await db
     .select({ id: transactions.id })
     .from(transactions)
-    .where(and(eq(transactions.recurringId, r.id), eq(transactions.recurringYearMonth, ym)))
+    .where(
+      and(
+        eq(transactions.userId, session.id),
+        eq(transactions.recurringId, r.id),
+        eq(transactions.recurringYearMonth, ym),
+      ),
+    )
     .limit(1);
   if (dup) throw new Error(`Already covered this month by tx #${dup.id}`);
 
@@ -183,12 +226,13 @@ export async function promoteUpcoming(input: PromoteUpcomingInput) {
     amountCents !== undefined ? toBigInt(amountCents, r.amountCents) : r.amountCents;
 
   const occurredAt = new Date(`${occurredOn}T12:00:00Z`);
-  const cls = r.categorySlug ? null : await classifyByRule({ descriptionRaw: r.label });
+  const cls = r.categorySlug ? null : await classifyByRule(session.id, { descriptionRaw: r.label });
 
   const result = await db.transaction(async (trx) => {
     const [inserted] = await trx
       .insert(transactions)
       .values({
+        userId: session.id,
         accountId: r.accountId,
         occurredAt,
         amountCents: signedCents,
@@ -209,7 +253,13 @@ export async function promoteUpcoming(input: PromoteUpcomingInput) {
 
     const deleted = await trx
       .delete(recurringGaps)
-      .where(and(eq(recurringGaps.recurringId, r.id), eq(recurringGaps.yearMonth, ym)))
+      .where(
+        and(
+          eq(recurringGaps.userId, session.id),
+          eq(recurringGaps.recurringId, r.id),
+          eq(recurringGaps.yearMonth, ym),
+        ),
+      )
       .returning({ id: recurringGaps.id });
 
     return { txId: inserted.id, gapId: deleted[0]?.id ?? null };
@@ -261,13 +311,14 @@ export type LinkTxToRecurringInput = z.input<typeof linkTxSchema>;
  * tx is already linked to something else (user must unlink first).
  */
 export async function linkTxToRecurring(input: LinkTxToRecurringInput) {
+  const session = await getSessionUser();
   const { txId, recurringId, yearMonth: ym } = linkTxSchema.parse(input);
 
   const result = await db.transaction(async (trx) => {
     const [tx] = await trx
       .select({ id: transactions.id, recurringId: transactions.recurringId })
       .from(transactions)
-      .where(eq(transactions.id, txId))
+      .where(and(eq(transactions.userId, session.id), eq(transactions.id, txId)))
       .limit(1);
     if (!tx) throw new Error("Transaction not found");
     if (tx.recurringId && tx.recurringId !== recurringId) {
@@ -278,7 +329,11 @@ export async function linkTxToRecurring(input: LinkTxToRecurringInput) {
       .select({ id: transactions.id })
       .from(transactions)
       .where(
-        and(eq(transactions.recurringId, recurringId), eq(transactions.recurringYearMonth, ym)),
+        and(
+          eq(transactions.userId, session.id),
+          eq(transactions.recurringId, recurringId),
+          eq(transactions.recurringYearMonth, ym),
+        ),
       )
       .limit(1);
     if (existingLink && existingLink.id !== txId) {
@@ -288,11 +343,17 @@ export async function linkTxToRecurring(input: LinkTxToRecurringInput) {
     await trx
       .update(transactions)
       .set({ recurringId, recurringYearMonth: ym, updatedAt: new Date() })
-      .where(eq(transactions.id, txId));
+      .where(and(eq(transactions.userId, session.id), eq(transactions.id, txId)));
 
     const deleted = await trx
       .delete(recurringGaps)
-      .where(and(eq(recurringGaps.recurringId, recurringId), eq(recurringGaps.yearMonth, ym)))
+      .where(
+        and(
+          eq(recurringGaps.userId, session.id),
+          eq(recurringGaps.recurringId, recurringId),
+          eq(recurringGaps.yearMonth, ym),
+        ),
+      )
       .returning({ id: recurringGaps.id });
 
     return { gapId: deleted[0]?.id ?? null };
@@ -319,17 +380,19 @@ const unlinkTxSchema = z.object({
 });
 
 export async function unlinkTxFromRecurring(input: z.input<typeof unlinkTxSchema>) {
+  const session = await getSessionUser();
   const { txId } = unlinkTxSchema.parse(input);
   await db
     .update(transactions)
     .set({ recurringId: null, recurringYearMonth: null, updatedAt: new Date() })
-    .where(eq(transactions.id, txId));
+    .where(and(eq(transactions.userId, session.id), eq(transactions.id, txId)));
   revalidate();
 }
 
 export async function fetchLinkCandidates(gapId: number): Promise<LinkCandidate[]> {
+  const session = await getSessionUser();
   const parsed = z.coerce.number().int().positive().parse(gapId);
-  return getLinkCandidates(parsed);
+  return getLinkCandidates(session.id, parsed);
 }
 
 export { yearMonth };

--- a/src/app/(app)/transactions/actions.test.ts
+++ b/src/app/(app)/transactions/actions.test.ts
@@ -9,6 +9,17 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
+// Stub the session helper so we don't drag in NextAuth's Next.js runtime deps
+// under vitest. Every action under test scopes to user 1 (bootstrap).
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockResolvedValue({ id: 1, email: "test@test.local", name: "Test" }),
+  getSessionUserOrNull: vi.fn().mockResolvedValue({
+    id: 1,
+    email: "test@test.local",
+    name: "Test",
+  }),
+}));
+
 // Stub the AI classifier lib so tests never hit the Anthropic API; individual
 // tests drive the mock with mockResolvedValueOnce for each scenario.
 vi.mock("@/lib/classification/ai", async () => {

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import {
@@ -11,6 +11,7 @@ import {
   counterpartyType,
   transactions,
 } from "@/lib/db/schema";
+import { getSessionUser } from "@/lib/auth/session";
 import { classifySingleWithAi as classifySingleWithAiLib } from "@/lib/classification/ai";
 import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
 import { emit } from "@/lib/events/bus";
@@ -29,6 +30,7 @@ export async function updateTransactionCategory(input: {
   txId: number;
   categorySlug: string | null;
 }) {
+  const session = await getSessionUser();
   const { txId, categorySlug } = updateSchema.parse(input);
 
   await db
@@ -39,7 +41,7 @@ export async function updateTransactionCategory(input: {
       classificationConfidence: categorySlug ? 100 : null,
       updatedAt: new Date(),
     })
-    .where(eq(transactions.id, txId));
+    .where(and(eq(transactions.userId, session.id), eq(transactions.id, txId)));
 
   revalidatePath("/transactions");
 }
@@ -88,6 +90,7 @@ export async function createManualExpense(input: {
   occurredOn: string;
   notes: string | null;
 }) {
+  const session = await getSessionUser();
   // Server actions serialize errors to the client — ZodError.message is a
   // JSON blob. Flatten to the first issue so the form can toast it cleanly.
   const result = expenseSchema.safeParse(input);
@@ -99,7 +102,7 @@ export async function createManualExpense(input: {
   const [account] = await db
     .select({ id: accounts.id, currency: accounts.currency })
     .from(accounts)
-    .where(eq(accounts.id, parsed.accountId))
+    .where(and(eq(accounts.userId, session.id), eq(accounts.id, parsed.accountId)))
     .limit(1);
 
   if (!account) throw new Error("Account not found");
@@ -118,6 +121,7 @@ export async function createManualExpense(input: {
   const [inserted] = await db
     .insert(transactions)
     .values({
+      userId: session.id,
       accountId: account.id,
       occurredAt,
       amountCents: -parsed.amount,
@@ -133,7 +137,7 @@ export async function createManualExpense(input: {
     })
     .returning({ id: transactions.id });
 
-  await autoLinkTransaction(inserted.id);
+  await autoLinkTransaction(session.id, inserted.id);
 
   revalidatePath("/");
   revalidatePath("/transactions");
@@ -147,7 +151,8 @@ export async function createManualExpense(input: {
 }
 
 export async function runAiClassifier() {
-  const result = await classifyUnclassifiedBatch();
+  const session = await getSessionUser();
+  const result = await classifyUnclassifiedBatch(session.id);
   revalidatePath("/");
   revalidatePath("/transactions");
   return result;
@@ -167,6 +172,7 @@ export type ClassifySingleResult = {
 export async function classifySingleWithAi(
   input: ClassifySingleInput,
 ): Promise<ClassifySingleResult> {
+  const session = await getSessionUser();
   const { txId } = classifySingleSchema.parse(input);
 
   const [tx] = await db
@@ -181,7 +187,7 @@ export async function classifySingleWithAi(
       categorySlug: transactions.categorySlug,
     })
     .from(transactions)
-    .where(eq(transactions.id, txId))
+    .where(and(eq(transactions.userId, session.id), eq(transactions.id, txId)))
     .limit(1);
 
   if (!tx) throw new Error("Transaction not found");
@@ -227,7 +233,7 @@ export async function classifySingleWithAi(
       classificationConfidence: hit.confidence,
       updatedAt: new Date(),
     })
-    .where(eq(transactions.id, txId));
+    .where(and(eq(transactions.userId, session.id), eq(transactions.id, txId)));
 
   revalidatePath("/");
   revalidatePath("/transactions");
@@ -267,6 +273,7 @@ export type UpdateCounterpartyResult = {
 export async function updateCounterparty(
   input: UpdateCounterpartyInput,
 ): Promise<UpdateCounterpartyResult> {
+  const session = await getSessionUser();
   const parsed = updateCounterpartySchema.parse(input);
 
   if (parsed.defaultCategorySlug) {
@@ -288,7 +295,7 @@ export async function updateCounterparty(
         notes: parsed.notes,
         updatedAt: new Date(),
       })
-      .where(eq(counterparties.id, parsed.id));
+      .where(and(eq(counterparties.userId, session.id), eq(counterparties.id, parsed.id)));
 
     if (!parsed.defaultCategorySlug) return 0;
 
@@ -298,7 +305,8 @@ export async function updateCounterparty(
         classification_method = 'rule'::classification_method,
         classification_confidence = 100,
         updated_at = now()
-      WHERE counterparty_id = ${parsed.id}
+      WHERE user_id = ${session.id}
+        AND counterparty_id = ${parsed.id}
         AND category_slug IS NULL
       RETURNING id
     `);
@@ -355,6 +363,7 @@ export type MergeCounterpartyResult = {
 export async function mergeCounterparty(
   input: MergeCounterpartyInput,
 ): Promise<MergeCounterpartyResult> {
+  const session = await getSessionUser();
   const parsed = mergeCounterpartySchema.parse(input);
 
   const result = await db.transaction(async (trx) => {
@@ -364,7 +373,7 @@ export async function mergeCounterparty(
         defaultCategorySlug: counterparties.defaultCategorySlug,
       })
       .from(counterparties)
-      .where(eq(counterparties.id, parsed.targetId))
+      .where(and(eq(counterparties.userId, session.id), eq(counterparties.id, parsed.targetId)))
       .limit(1);
     const [source] = await trx
       .select({
@@ -373,7 +382,7 @@ export async function mergeCounterparty(
         hitCount: counterparties.hitCount,
       })
       .from(counterparties)
-      .where(eq(counterparties.id, parsed.sourceId))
+      .where(and(eq(counterparties.userId, session.id), eq(counterparties.id, parsed.sourceId)))
       .limit(1);
 
     if (!target) throw new Error("Target counterparty not found");
@@ -387,17 +396,19 @@ export async function mergeCounterparty(
           defaultCategorySlug: source.defaultCategorySlug,
           updatedAt: new Date(),
         })
-        .where(eq(counterparties.id, target.id));
+        .where(and(eq(counterparties.userId, session.id), eq(counterparties.id, target.id)));
     }
 
     // Move aliases (drop any that would violate unique kind+value on target).
     const aliasMove = await trx.execute<{ id: number }>(sql`
       UPDATE counterparty_aliases
       SET counterparty_id = ${target.id}
-      WHERE counterparty_id = ${source.id}
+      WHERE user_id = ${session.id}
+        AND counterparty_id = ${source.id}
         AND NOT EXISTS (
           SELECT 1 FROM counterparty_aliases existing
-          WHERE existing.counterparty_id = ${target.id}
+          WHERE existing.user_id = ${session.id}
+            AND existing.counterparty_id = ${target.id}
             AND existing.kind = counterparty_aliases.kind
             AND existing.value = counterparty_aliases.value
         )
@@ -408,7 +419,7 @@ export async function mergeCounterparty(
     const txMove = await trx.execute<{ id: number }>(sql`
       UPDATE transactions
       SET counterparty_id = ${target.id}, updated_at = now()
-      WHERE counterparty_id = ${source.id}
+      WHERE user_id = ${session.id} AND counterparty_id = ${source.id}
       RETURNING id
     `);
 
@@ -417,12 +428,14 @@ export async function mergeCounterparty(
       UPDATE counterparties
       SET hit_count = hit_count + ${source.hitCount},
           updated_at = now()
-      WHERE id = ${target.id}
+      WHERE user_id = ${session.id} AND id = ${target.id}
     `);
 
     // Source counterparty (and any residual aliases / refs with SET NULL on
     // tx FK — already moved above) removed. CASCADE cleans aliases.
-    await trx.delete(counterparties).where(eq(counterparties.id, source.id));
+    await trx
+      .delete(counterparties)
+      .where(and(eq(counterparties.userId, session.id), eq(counterparties.id, source.id)));
 
     return {
       movedTxCount: txMove.length,
@@ -479,6 +492,7 @@ export type SplitCounterpartyResult = {
 export async function splitCounterparty(
   input: SplitCounterpartyInput,
 ): Promise<SplitCounterpartyResult> {
+  const session = await getSessionUser();
   const parsed = splitCounterpartySchema.parse(input);
   const aliasIdSet = new Set(parsed.aliasIds);
   if (aliasIdSet.size !== parsed.aliasIds.length) {
@@ -493,7 +507,7 @@ export async function splitCounterparty(
   }>(sql`
     SELECT id, display_name, type, default_category_slug
     FROM counterparties
-    WHERE id = ${parsed.sourceId}
+    WHERE user_id = ${session.id} AND id = ${parsed.sourceId}
     LIMIT 1
   `);
   if (!source) throw new Error("Source counterparty not found");
@@ -505,7 +519,7 @@ export async function splitCounterparty(
   }>(sql`
     SELECT id, kind, value
     FROM counterparty_aliases
-    WHERE counterparty_id = ${parsed.sourceId}
+    WHERE user_id = ${session.id} AND counterparty_id = ${parsed.sourceId}
   `);
   if (allAliases.length < 2) {
     throw new Error("Counterparty needs at least 2 aliases to split");
@@ -527,7 +541,7 @@ export async function splitCounterparty(
   const sourceTxs = await db.execute<{ id: number; raw_data: unknown }>(sql`
     SELECT id, raw_data
     FROM transactions
-    WHERE counterparty_id = ${parsed.sourceId}
+    WHERE user_id = ${session.id} AND counterparty_id = ${parsed.sourceId}
   `);
 
   const movedTxIds: number[] = [];
@@ -549,8 +563,9 @@ export async function splitCounterparty(
 
   const result = await db.transaction(async (trx) => {
     const [inserted] = await trx.execute<{ id: number }>(sql`
-      INSERT INTO counterparties (display_name, type, default_category_slug, hit_count, last_hit_at)
+      INSERT INTO counterparties (user_id, display_name, type, default_category_slug, hit_count, last_hit_at)
       VALUES (
+        ${session.id},
         ${parsed.newDisplayName ?? source.display_name},
         ${source.type}::counterparty_type,
         ${source.default_category_slug},
@@ -564,10 +579,11 @@ export async function splitCounterparty(
     await trx.execute(sql`
       UPDATE counterparty_aliases
       SET counterparty_id = ${newId}
-      WHERE id = ANY(${sql`ARRAY[${sql.join(
-        parsed.aliasIds.map((id) => sql`${id}`),
-        sql`, `,
-      )}]::int[]`})
+      WHERE user_id = ${session.id}
+        AND id = ANY(${sql`ARRAY[${sql.join(
+          parsed.aliasIds.map((id) => sql`${id}`),
+          sql`, `,
+        )}]::int[]`})
     `);
 
     let movedTxCount = 0;
@@ -575,10 +591,11 @@ export async function splitCounterparty(
       const updated = await trx.execute<{ id: number }>(sql`
         UPDATE transactions
         SET counterparty_id = ${newId}, updated_at = now()
-        WHERE id = ANY(${sql`ARRAY[${sql.join(
-          movedTxIds.map((id) => sql`${id}`),
-          sql`, `,
-        )}]::int[]`})
+        WHERE user_id = ${session.id}
+          AND id = ANY(${sql`ARRAY[${sql.join(
+            movedTxIds.map((id) => sql`${id}`),
+            sql`, `,
+          )}]::int[]`})
         RETURNING id
       `);
       movedTxCount = updated.length;
@@ -587,7 +604,7 @@ export async function splitCounterparty(
     await trx
       .update(counterparties)
       .set({ updatedAt: new Date() })
-      .where(eq(counterparties.id, parsed.sourceId));
+      .where(and(eq(counterparties.userId, session.id), eq(counterparties.id, parsed.sourceId)));
 
     return {
       newCounterpartyId: newId,

--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { AiClassifyButton } from "@/components/transactions/ai-classify-button";
 import { Filters } from "@/components/transactions/filters";
 import { TransactionTable } from "@/components/transactions/transaction-table";
+import { getSessionUser } from "@/lib/auth/session";
 import {
   countTotal,
   countUnclassified,
@@ -37,6 +38,7 @@ function buildHref(base: Record<string, string | undefined>, cursor: string | nu
 
 export default async function TransactionsPage({ searchParams }: { searchParams: SearchParams }) {
   const sp = await searchParams;
+  const session = await getSessionUser();
 
   const accountId = sp.accountId ? Number(sp.accountId) : undefined;
   const highlightRaw = sp.highlight ? Number(sp.highlight) : undefined;
@@ -52,18 +54,18 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
 
   const [{ rows, nextCursor }, accounts, categories, total, unclassified, allCounterparties] =
     await Promise.all([
-      listTransactions(filters),
-      listAccounts(),
+      listTransactions(session.id, filters),
+      listAccounts(session.id),
       listCategories(),
-      countTotal({
+      countTotal(session.id, {
         from: filters.from,
         to: filters.to,
         accountId: filters.accountId,
         categorySlug: filters.categorySlug,
         q: filters.q,
       }),
-      countUnclassified(),
-      listCounterparties(),
+      countUnclassified(session.id),
+      listCounterparties(session.id),
     ]);
 
   const baseQuery = {

--- a/src/app/api/ingest/debug/route.ts
+++ b/src/app/api/ingest/debug/route.ts
@@ -60,6 +60,7 @@ export async function POST(req: Request) {
   const [log] = await db
     .insert(ingestionLogs)
     .values({
+      userId: auth.userId,
       source: "apple_pay",
       status: "debug",
       itemsReceived: 0,

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { db, type DB } from "@/lib/db";
 import { accounts, ingestionLogs, transactions } from "@/lib/db/schema";
 import { classifyByRule } from "@/lib/classification/rules";
@@ -65,9 +65,10 @@ export async function POST(req: Request) {
   }
 
   const parsed = parseSmsBancolombia(body);
-  const outcome = await ingestParsed(parsed);
+  const outcome = await ingestParsed(auth.userId, parsed);
 
   await db.insert(ingestionLogs).values({
+    userId: auth.userId,
     source: "sms",
     status: outcome.status,
     itemsReceived: 1,
@@ -100,7 +101,7 @@ export async function GET() {
 // Ingestion logic — separated so it's testable in isolation
 // -----------------------------------------------------------------------------
 
-export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> {
+export async function ingestParsed(userId: number, parsed: ParseResult): Promise<IngestOutcome> {
   if (parsed.kind === "skip") {
     return { status: "skipped", reason: `parser: ${parsed.reason}` };
   }
@@ -113,7 +114,10 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
       institution: accounts.institution,
       type: accounts.type,
     })
-    .from(accounts)) as Array<RoutableAccount & { institution: string; type: string }>;
+    .from(accounts)
+    .where(eq(accounts.userId, userId))) as Array<
+    RoutableAccount & { institution: string; type: string }
+  >;
 
   const account = resolveAccountForParsed(parsed, allAccounts);
   if (!account) {
@@ -130,7 +134,7 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
 
   // Counterparty lookup (and auto-create for bre_b). For kinds with toKey,
   // this is the preferred classification path over text-pattern rules.
-  const cp = await resolveCounterparty(parsed, db);
+  const cp = await resolveCounterparty(userId, parsed, db);
 
   // Purchases and PSE outgoing payments get rule-based classification attempted.
   // Other kinds have hardcoded categories (pago-tc, transferencias, ingresos)
@@ -144,7 +148,7 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
       parsed.kind === "provider_payment_sent" ||
       parsed.kind === "qr_payment");
   if (shouldAttemptRule) {
-    const cls = await classifyByRule({
+    const cls = await classifyByRule(userId, {
       descriptionRaw,
       merchant,
     });
@@ -161,6 +165,7 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
     const result = await db
       .insert(transactions)
       .values({
+        userId,
         accountId: account.id,
         occurredAt,
         amountCents,
@@ -186,7 +191,7 @@ export async function ingestParsed(parsed: ParseResult): Promise<IngestOutcome> 
       .returning({ id: transactions.id });
 
     if (result.length === 0) return { status: "duplicated" };
-    await autoLinkTransaction(result[0].id);
+    await autoLinkTransaction(userId, result[0].id);
     emit({
       type: "transaction:created",
       id: result[0].id,
@@ -218,6 +223,7 @@ type CounterpartyResolution = {
  * Hit counter bumped on every match/insert.
  */
 export async function resolveCounterparty(
+  userId: number,
   parsed: ParsedSms,
   database: DB,
 ): Promise<CounterpartyResolution> {
@@ -232,7 +238,9 @@ export async function resolveCounterparty(
       SELECT c.id, c.default_category_slug
       FROM counterparty_aliases a
       JOIN counterparties c ON c.id = a.counterparty_id
-      WHERE a.kind = ${key.kind}::counterparty_key_kind AND a.value = ${key.value}
+      WHERE a.user_id = ${userId}
+        AND a.kind = ${key.kind}::counterparty_key_kind
+        AND a.value = ${key.value}
       LIMIT 1
     `);
 
@@ -240,7 +248,7 @@ export async function resolveCounterparty(
       await trx.execute(sql`
         UPDATE counterparties
         SET hit_count = hit_count + 1, last_hit_at = now()
-        WHERE id = ${existing[0].id}
+        WHERE user_id = ${userId} AND id = ${existing[0].id}
       `);
       return {
         counterpartyId: existing[0].id,
@@ -249,13 +257,13 @@ export async function resolveCounterparty(
     }
 
     const inserted = await trx.execute<{ id: number }>(sql`
-      INSERT INTO counterparties (display_name, type, hit_count, last_hit_at)
-      VALUES (${key.initialDisplayName}, 'unknown', 1, now())
+      INSERT INTO counterparties (user_id, display_name, type, hit_count, last_hit_at)
+      VALUES (${userId}, ${key.initialDisplayName}, 'unknown', 1, now())
       RETURNING id
     `);
     await trx.execute(sql`
-      INSERT INTO counterparty_aliases (counterparty_id, kind, value)
-      VALUES (${inserted[0].id}, ${key.kind}::counterparty_key_kind, ${key.value})
+      INSERT INTO counterparty_aliases (user_id, counterparty_id, kind, value)
+      VALUES (${userId}, ${inserted[0].id}, ${key.kind}::counterparty_key_kind, ${key.value})
     `);
     return { counterpartyId: inserted[0].id, inheritedCategory: null };
   });

--- a/src/lib/accounts/queries.ts
+++ b/src/lib/accounts/queries.ts
@@ -1,4 +1,4 @@
-import { asc } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, type AccountMetadata } from "@/lib/db/schema";
 import type { AccountType, Currency } from "@/lib/types";
@@ -14,7 +14,7 @@ export type AccountDetail = {
   metadata: AccountMetadata;
 };
 
-export async function listAccountsDetailed(): Promise<AccountDetail[]> {
+export async function listAccountsDetailed(userId: number): Promise<AccountDetail[]> {
   return db
     .select({
       id: accounts.id,
@@ -27,5 +27,6 @@ export async function listAccountsDetailed(): Promise<AccountDetail[]> {
       metadata: accounts.metadata,
     })
     .from(accounts)
+    .where(eq(accounts.userId, userId))
     .orderBy(asc(accounts.type), asc(accounts.institution), asc(accounts.name));
 }

--- a/src/lib/ai/insights.ts
+++ b/src/lib/ai/insights.ts
@@ -70,6 +70,7 @@ function toCopNumber(cents: bigint, currency: Currency, copPerUsd: number): numb
 }
 
 export async function buildInsightsSummary(
+  userId: number,
   ym: string,
   copPerUsd: number,
   db: DB = defaultDb,
@@ -89,7 +90,7 @@ export async function buildInsightsSummary(
           balanceCents: accounts.balanceCents,
         })
         .from(accounts)
-        .where(eq(accounts.active, true))
+        .where(and(eq(accounts.userId, userId), eq(accounts.active, true)))
         .orderBy(asc(accounts.name)),
       db
         .select({
@@ -98,7 +99,13 @@ export async function buildInsightsSummary(
           expense: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
         })
         .from(transactions)
-        .where(and(gte(transactions.occurredAt, cur.start), lte(transactions.occurredAt, cur.end)))
+        .where(
+          and(
+            eq(transactions.userId, userId),
+            gte(transactions.occurredAt, cur.start),
+            lte(transactions.occurredAt, cur.end),
+          ),
+        )
         .groupBy(transactions.currency),
       db
         .select({
@@ -108,7 +115,11 @@ export async function buildInsightsSummary(
         })
         .from(transactions)
         .where(
-          and(gte(transactions.occurredAt, prev.start), lte(transactions.occurredAt, prev.end)),
+          and(
+            eq(transactions.userId, userId),
+            gte(transactions.occurredAt, prev.start),
+            lte(transactions.occurredAt, prev.end),
+          ),
         )
         .groupBy(transactions.currency),
       (() => {
@@ -127,7 +138,11 @@ export async function buildInsightsSummary(
           .leftJoin(leaf, eq(leaf.slug, transactions.categorySlug))
           .leftJoin(root, eq(root.slug, rootSlug))
           .where(
-            and(gte(transactions.occurredAt, cur.start), lte(transactions.occurredAt, cur.end)),
+            and(
+              eq(transactions.userId, userId),
+              gte(transactions.occurredAt, cur.start),
+              lte(transactions.occurredAt, cur.end),
+            ),
           )
           .groupBy(rootSlug, root.name, transactions.currency);
       })(),
@@ -143,7 +158,11 @@ export async function buildInsightsSummary(
           .from(transactions)
           .leftJoin(leaf, eq(leaf.slug, transactions.categorySlug))
           .where(
-            and(gte(transactions.occurredAt, prev.start), lte(transactions.occurredAt, prev.end)),
+            and(
+              eq(transactions.userId, userId),
+              gte(transactions.occurredAt, prev.start),
+              lte(transactions.occurredAt, prev.end),
+            ),
           )
           .groupBy(rootSlug, transactions.currency);
       })(),
@@ -157,6 +176,7 @@ export async function buildInsightsSummary(
         .from(transactions)
         .where(
           and(
+            eq(transactions.userId, userId),
             gte(transactions.occurredAt, cur.start),
             lte(transactions.occurredAt, cur.end),
             sql`${transactions.merchant} IS NOT NULL`,
@@ -177,7 +197,7 @@ export async function buildInsightsSummary(
           currency: budgets.currency,
         })
         .from(budgets)
-        .where(eq(budgets.periodStart, cur.startIso)),
+        .where(and(eq(budgets.userId, userId), eq(budgets.periodStart, cur.startIso))),
       db
         .select({
           label: recurringTransactions.label,
@@ -187,7 +207,9 @@ export async function buildInsightsSummary(
           categorySlug: recurringTransactions.categorySlug,
         })
         .from(recurringTransactions)
-        .where(eq(recurringTransactions.active, true))
+        .where(
+          and(eq(recurringTransactions.userId, userId), eq(recurringTransactions.active, true)),
+        )
         .orderBy(asc(recurringTransactions.dayOfMonth)),
     ]);
 

--- a/src/lib/classification/pipeline.ts
+++ b/src/lib/classification/pipeline.ts
@@ -15,7 +15,10 @@ export type PipelineResult = {
   usage: { inputTokens: number; outputTokens: number };
 };
 
-export async function classifyUnclassifiedBatch(database: DB = defaultDb): Promise<PipelineResult> {
+export async function classifyUnclassifiedBatch(
+  userId: number,
+  database: DB = defaultDb,
+): Promise<PipelineResult> {
   const startedAt = new Date();
 
   const pending = await database
@@ -29,7 +32,11 @@ export async function classifyUnclassifiedBatch(database: DB = defaultDb): Promi
     })
     .from(transactions)
     .where(
-      and(eq(transactions.classificationMethod, "unclassified"), isNull(transactions.categorySlug)),
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.classificationMethod, "unclassified"),
+        isNull(transactions.categorySlug),
+      ),
     )
     .orderBy(asc(transactions.id))
     .limit(AI_BATCH_SIZE);
@@ -58,6 +65,7 @@ export async function classifyUnclassifiedBatch(database: DB = defaultDb): Promi
   const stillPending: typeof pending = [];
   for (const tx of pending) {
     const ruleHit = await classifyByRule(
+      userId,
       {
         descriptionRaw: tx.description,
         descriptionClean: tx.descriptionClean,
@@ -74,7 +82,7 @@ export async function classifyUnclassifiedBatch(database: DB = defaultDb): Promi
           classificationConfidence: ruleHit.confidence,
           updatedAt: new Date(),
         })
-        .where(eq(transactions.id, tx.id));
+        .where(and(eq(transactions.userId, userId), eq(transactions.id, tx.id)));
       ruleClassified++;
     } else {
       stillPending.push(tx);
@@ -121,11 +129,18 @@ export async function classifyUnclassifiedBatch(database: DB = defaultDb): Promi
         classificationConfidence: hit.confidence,
         updatedAt: new Date(),
       })
-      .where(and(eq(transactions.id, tx.id), inArray(transactions.id, ids)));
+      .where(
+        and(
+          eq(transactions.userId, userId),
+          eq(transactions.id, tx.id),
+          inArray(transactions.id, ids),
+        ),
+      );
     aiClassified++;
   }
 
   await database.insert(ingestionLogs).values({
+    userId,
     source: "manual",
     status: skipped === 0 ? "ok" : "partial",
     itemsReceived: pending.length,

--- a/src/lib/classification/rules.test.ts
+++ b/src/lib/classification/rules.test.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { classifyByRule } from "./rules";
 
 const TAG = "VITEST_RULES_";
+const TEST_USER_ID = 1;
 
 async function clearTestRules() {
   await db.execute(sql`DELETE FROM classification_rules WHERE pattern LIKE ${"%" + TAG + "%"}`);
@@ -11,8 +12,8 @@ async function clearTestRules() {
 
 async function insertRule(pattern: string, categorySlug: string, priority: number) {
   const rows = await db.execute<{ id: number }>(sql`
-    INSERT INTO classification_rules (pattern, category_slug, priority, active)
-    VALUES (${pattern}, ${categorySlug}, ${priority}, true)
+    INSERT INTO classification_rules (user_id, pattern, category_slug, priority, active)
+    VALUES (${TEST_USER_ID}, ${pattern}, ${categorySlug}, ${priority}, true)
     RETURNING id
   `);
   return rows[0].id;
@@ -34,13 +35,15 @@ describe("classifyByRule", () => {
 
   it("returns null when no rule matches", async () => {
     await insertRule(`%${TAG}NOMATCH%`, "otros", 10);
-    const result = await classifyByRule({ descriptionRaw: "completely unrelated text" });
+    const result = await classifyByRule(TEST_USER_ID, {
+      descriptionRaw: "completely unrelated text",
+    });
     expect(result).toBeNull();
   });
 
   it("matches by ILIKE on description", async () => {
     const id = await insertRule(`%${TAG}MATCH%`, "mercado", 1);
-    const result = await classifyByRule({
+    const result = await classifyByRule(TEST_USER_ID, {
       descriptionRaw: `compra ${TAG}match chia 12345`,
     });
     expect(result).toEqual({ categorySlug: "mercado", ruleId: id, confidence: 100 });
@@ -49,7 +52,7 @@ describe("classifyByRule", () => {
   it("respects priority (lower wins) when multiple rules match", async () => {
     const lowPri = await insertRule(`%${TAG}AMBIG%`, "mercado", 5);
     await insertRule(`%${TAG}AMBIG%`, "delivery", 50);
-    const result = await classifyByRule({
+    const result = await classifyByRule(TEST_USER_ID, {
       descriptionRaw: `${TAG}AMBIG payment`,
     });
     expect(result?.ruleId).toBe(lowPri);
@@ -60,8 +63,8 @@ describe("classifyByRule", () => {
     const id = await insertRule(`%${TAG}HITS%`, "otros", 10);
     expect(await getHitCount(id)).toBe(0);
 
-    await classifyByRule({ descriptionRaw: `${TAG}HITS one` });
-    await classifyByRule({ descriptionRaw: `${TAG}HITS two` });
+    await classifyByRule(TEST_USER_ID, { descriptionRaw: `${TAG}HITS one` });
+    await classifyByRule(TEST_USER_ID, { descriptionRaw: `${TAG}HITS two` });
 
     expect(await getHitCount(id)).toBe(2);
 
@@ -74,7 +77,7 @@ describe("classifyByRule", () => {
   it("ignores inactive rules", async () => {
     const id = await insertRule(`%${TAG}INACTIVE%`, "otros", 10);
     await db.execute(sql`UPDATE classification_rules SET active = false WHERE id = ${id}`);
-    const result = await classifyByRule({ descriptionRaw: `${TAG}INACTIVE thing` });
+    const result = await classifyByRule(TEST_USER_ID, { descriptionRaw: `${TAG}INACTIVE thing` });
     expect(result).toBeNull();
   });
 });

--- a/src/lib/classification/rules.ts
+++ b/src/lib/classification/rules.ts
@@ -14,6 +14,7 @@ export type ClassifiableTx = {
 };
 
 export async function classifyByRule(
+  userId: number,
   tx: ClassifiableTx,
   database: DB = defaultDb,
 ): Promise<RuleMatch | null> {
@@ -27,7 +28,7 @@ export async function classifyByRule(
     const matched = await trx.execute<{ id: number; category_slug: string }>(sql`
       SELECT id, category_slug
       FROM classification_rules
-      WHERE active = true AND ${haystack} ILIKE pattern
+      WHERE user_id = ${userId} AND active = true AND ${haystack} ILIKE pattern
       ORDER BY priority ASC, id ASC
       LIMIT 1
     `);
@@ -38,7 +39,7 @@ export async function classifyByRule(
     await trx.execute(sql`
       UPDATE classification_rules
       SET hit_count = hit_count + 1, last_hit_at = now()
-      WHERE id = ${row.id}
+      WHERE id = ${row.id} AND user_id = ${userId}
     `);
 
     return {

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -19,7 +19,7 @@ export type AccountStatus = {
   balanceCents: bigint;
 };
 
-export async function getAccountStatuses(): Promise<AccountStatus[]> {
+export async function getAccountStatuses(userId: number): Promise<AccountStatus[]> {
   return db
     .select({
       id: accounts.id,
@@ -30,7 +30,7 @@ export async function getAccountStatuses(): Promise<AccountStatus[]> {
       balanceCents: accounts.balanceCents,
     })
     .from(accounts)
-    .where(eq(accounts.active, true))
+    .where(and(eq(accounts.userId, userId), eq(accounts.active, true)))
     .orderBy(asc(accounts.name));
 }
 
@@ -40,8 +40,8 @@ export type NetWorth = {
   usdCents: bigint;
 };
 
-export async function getNetWorth(copPerUsd: number): Promise<NetWorth> {
-  const list = await getAccountStatuses();
+export async function getNetWorth(userId: number, copPerUsd: number): Promise<NetWorth> {
+  const list = await getAccountStatuses(userId);
   let copCents = BigInt(0);
   let usdCents = BigInt(0);
   for (const a of list) {
@@ -58,7 +58,11 @@ export type MonthlyFlow = {
   netCopCents: bigint;
 };
 
-export async function getMonthlyFlow(copPerUsd: number, now = new Date()): Promise<MonthlyFlow> {
+export async function getMonthlyFlow(
+  userId: number,
+  copPerUsd: number,
+  now = new Date(),
+): Promise<MonthlyFlow> {
   const { start, end } = currentMonthRange(now);
 
   const rows = await db
@@ -68,7 +72,13 @@ export async function getMonthlyFlow(copPerUsd: number, now = new Date()): Promi
       expenseCents: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
     })
     .from(transactions)
-    .where(and(gte(transactions.occurredAt, start), lt(transactions.occurredAt, end)))
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        gte(transactions.occurredAt, start),
+        lt(transactions.occurredAt, end),
+      ),
+    )
     .groupBy(transactions.currency);
 
   let incomeCopCents = BigInt(0);
@@ -92,6 +102,7 @@ export type CategorySlice = {
 };
 
 export async function getCategoryBreakdown(
+  userId: number,
   copPerUsd: number,
   now = new Date(),
 ): Promise<CategorySlice[]> {
@@ -113,6 +124,7 @@ export async function getCategoryBreakdown(
     .leftJoin(rootCategories, eq(rootCategories.slug, rootSlug))
     .where(
       and(
+        eq(transactions.userId, userId),
         gte(transactions.occurredAt, start),
         lt(transactions.occurredAt, end),
         sql`${transactions.amountCents} < 0`,
@@ -154,6 +166,7 @@ export type TopExpense = {
 };
 
 export async function getTopExpenses(
+  userId: number,
   copPerUsd: number,
   now = new Date(),
   limit = 5,
@@ -181,6 +194,7 @@ export async function getTopExpenses(
     .leftJoin(counterparties, eq(counterparties.id, transactions.counterpartyId))
     .where(
       and(
+        eq(transactions.userId, userId),
         gte(transactions.occurredAt, start),
         lt(transactions.occurredAt, end),
         sql`${transactions.amountCents} < 0`,

--- a/src/lib/ingestion/sms-health.test.ts
+++ b/src/lib/ingestion/sms-health.test.ts
@@ -11,6 +11,8 @@ import {
   todayInCop,
 } from "./sms-health";
 
+const TEST_USER_ID = 1;
+
 async function cleanup() {
   await db.execute(sql`DELETE FROM ingestion_logs WHERE source = 'sms'`);
 }
@@ -75,7 +77,7 @@ describe("getSmsHealthHistory (integration)", () => {
   afterEach(cleanup);
 
   it("returns an empty array when no SMS logs exist", async () => {
-    const history = await getSmsHealthHistory(7);
+    const history = await getSmsHealthHistory(TEST_USER_ID, 7);
     expect(history).toEqual([]);
   });
 
@@ -116,7 +118,7 @@ describe("getSmsHealthHistory (integration)", () => {
     ]);
 
     const now = new Date(Date.UTC(2026, 3, 18, 5, 0, 0)); // 00:00 COP Apr 18
-    const history = await getSmsHealthHistory(7, now);
+    const history = await getSmsHealthHistory(TEST_USER_ID, 7, now);
 
     expect(history).toHaveLength(1);
     expect(history[0]).toMatchObject({
@@ -138,7 +140,7 @@ describe("getSmsHealthHistory (integration)", () => {
       startedAt: new Date(Date.UTC(2026, 3, 17, 13, 0, 0)),
       finishedAt: new Date(Date.UTC(2026, 3, 17, 13, 0, 0)),
     });
-    const history = await getSmsHealthHistory(7);
+    const history = await getSmsHealthHistory(TEST_USER_ID, 7);
     expect(history).toEqual([]);
   });
 });
@@ -149,7 +151,7 @@ describe("getSmsHealthSnapshot (integration)", () => {
 
   it("returns zeros when there are no logs", async () => {
     const now = new Date(Date.UTC(2026, 3, 17, 18, 0, 0));
-    const snap = await getSmsHealthSnapshot(now);
+    const snap = await getSmsHealthSnapshot(TEST_USER_ID, now);
     expect(snap.todayInserted).toBe(0);
     expect(snap.sevenDayAvgInserted).toBe(0);
     expect(snap.lastSmsAt).toBeNull();
@@ -174,7 +176,7 @@ describe("getSmsHealthSnapshot (integration)", () => {
     await db.insert(ingestionLogs).values(values);
 
     const now = new Date(Date.UTC(2026, 3, 17, 23, 0, 0)); // 18:00 COP Apr 17
-    const snap = await getSmsHealthSnapshot(now);
+    const snap = await getSmsHealthSnapshot(TEST_USER_ID, now);
 
     expect(snap.todayCopDate).toBe("2026-04-17");
     expect(snap.todayInserted).toBe(0);

--- a/src/lib/ingestion/sms-health.ts
+++ b/src/lib/ingestion/sms-health.ts
@@ -75,6 +75,7 @@ export function computeIsDrift(input: {
 }
 
 export async function getSmsHealthHistory(
+  userId: number,
   days = 30,
   now: Date = new Date(),
 ): Promise<SmsHealthDay[]> {
@@ -89,7 +90,13 @@ export async function getSmsHealthHistory(
       lastSmsAt: sql<string | null>`max(${ingestionLogs.startedAt})`,
     })
     .from(ingestionLogs)
-    .where(and(eq(ingestionLogs.source, "sms"), gte(ingestionLogs.startedAt, cutoff)))
+    .where(
+      and(
+        eq(ingestionLogs.userId, userId),
+        eq(ingestionLogs.source, "sms"),
+        gte(ingestionLogs.startedAt, cutoff),
+      ),
+    )
     .groupBy(sql`((${ingestionLogs.startedAt}) AT TIME ZONE 'America/Bogota')::date`)
     .orderBy(sql`((${ingestionLogs.startedAt}) AT TIME ZONE 'America/Bogota')::date DESC`);
 
@@ -103,8 +110,11 @@ export async function getSmsHealthHistory(
   }));
 }
 
-export async function getSmsHealthSnapshot(now: Date = new Date()): Promise<SmsHealthSnapshot> {
-  const history = await getSmsHealthHistory(8, now);
+export async function getSmsHealthSnapshot(
+  userId: number,
+  now: Date = new Date(),
+): Promise<SmsHealthSnapshot> {
+  const history = await getSmsHealthHistory(userId, 8, now);
   const todayCopDate = todayInCop(now);
   const nowCopHour = hourInCop(now);
 

--- a/src/lib/recurring/auto-link.test.ts
+++ b/src/lib/recurring/auto-link.test.ts
@@ -88,7 +88,7 @@ describe("autoLinkTransaction (integration)", () => {
       occurredOn: "2026-04-10",
       amountCents: BigInt(-100000),
     });
-    const result = await autoLinkTransaction(txId);
+    const result = await autoLinkTransaction(1, txId);
     expect(result.status).toBe("no-open-gap");
   });
 
@@ -106,7 +106,7 @@ describe("autoLinkTransaction (integration)", () => {
       recurringId,
       recurringYearMonth: "2026-04",
     });
-    const result = await autoLinkTransaction(txId);
+    const result = await autoLinkTransaction(1, txId);
     expect(result.status).toBe("already-linked");
   });
 
@@ -123,7 +123,7 @@ describe("autoLinkTransaction (integration)", () => {
       amountCents: BigInt(-100000),
     });
 
-    const result = await autoLinkTransaction(txId);
+    const result = await autoLinkTransaction(1, txId);
     expect(result.status).toBe("linked");
 
     const [linked] = await db
@@ -163,7 +163,7 @@ describe("autoLinkTransaction (integration)", () => {
       amountCents: BigInt(-100000),
     });
 
-    const result = await autoLinkTransaction(txId);
+    const result = await autoLinkTransaction(1, txId);
     expect(result.status).toBe("ambiguous");
     if (result.status === "ambiguous") {
       expect(result.candidateCount).toBe(2);
@@ -182,7 +182,7 @@ describe("autoLinkTransaction (integration)", () => {
       occurredOn: "2026-04-10",
       amountCents: BigInt(-347000),
     });
-    const result = await autoLinkTransaction(txId);
+    const result = await autoLinkTransaction(1, txId);
     expect(result.status).toBe("no-open-gap");
   });
 
@@ -199,7 +199,7 @@ describe("autoLinkTransaction (integration)", () => {
       occurredOn: "2026-04-16",
       amountCents: BigInt(-100000),
     });
-    const result = await autoLinkTransaction(txId);
+    const result = await autoLinkTransaction(1, txId);
     expect(result.status).toBe("no-open-gap");
   });
 });

--- a/src/lib/recurring/auto-link.ts
+++ b/src/lib/recurring/auto-link.ts
@@ -31,6 +31,7 @@ function daysInMonth(year: number, month: number): number {
  *     the cron has run).
  */
 export async function autoLinkTransaction(
+  userId: number,
   txId: number,
   database: DB = defaultDb,
 ): Promise<AutoLinkResult> {
@@ -43,7 +44,7 @@ export async function autoLinkTransaction(
       recurringId: transactions.recurringId,
     })
     .from(transactions)
-    .where(eq(transactions.id, txId))
+    .where(and(eq(transactions.userId, userId), eq(transactions.id, txId)))
     .limit(1);
 
   if (!tx) return { status: "no-open-gap" };
@@ -62,6 +63,7 @@ export async function autoLinkTransaction(
     .innerJoin(recurringTransactions, eq(recurringTransactions.id, recurringGaps.recurringId))
     .where(
       and(
+        eq(recurringGaps.userId, userId),
         eq(recurringTransactions.accountId, tx.accountId),
         eq(recurringTransactions.amountCents, tx.amountCents),
       ),
@@ -92,9 +94,17 @@ export async function autoLinkTransaction(
         recurringYearMonth: hit.gapYearMonth,
         updatedAt: new Date(),
       })
-      .where(and(eq(transactions.id, txId), isNull(transactions.recurringId)));
+      .where(
+        and(
+          eq(transactions.userId, userId),
+          eq(transactions.id, txId),
+          isNull(transactions.recurringId),
+        ),
+      );
 
-    await trx.delete(recurringGaps).where(eq(recurringGaps.id, hit.gapId));
+    await trx
+      .delete(recurringGaps)
+      .where(and(eq(recurringGaps.userId, userId), eq(recurringGaps.id, hit.gapId)));
 
     return {
       status: "linked" as const,

--- a/src/lib/recurring/gap-queries.ts
+++ b/src/lib/recurring/gap-queries.ts
@@ -49,6 +49,7 @@ function daysInMonth(year: number, month: number): number {
  * the most recent candidate shows first.
  */
 export async function getLinkCandidates(
+  userId: number,
   gapId: number,
   database: DB = defaultDb,
 ): Promise<LinkCandidate[]> {
@@ -60,7 +61,7 @@ export async function getLinkCandidates(
     })
     .from(recurringGaps)
     .innerJoin(recurringTransactions, eq(recurringTransactions.id, recurringGaps.recurringId))
-    .where(eq(recurringGaps.id, gapId))
+    .where(and(eq(recurringGaps.userId, userId), eq(recurringGaps.id, gapId)))
     .limit(1);
   if (!gap) return [];
 
@@ -81,6 +82,7 @@ export async function getLinkCandidates(
     .from(transactions)
     .where(
       and(
+        eq(transactions.userId, userId),
         eq(transactions.accountId, gap.accountId),
         isNull(transactions.recurringId),
         gte(transactions.occurredAt, windowStart),
@@ -90,7 +92,7 @@ export async function getLinkCandidates(
     .orderBy(desc(transactions.occurredAt));
 }
 
-export async function getOpenGaps(database: DB = defaultDb): Promise<OpenGap[]> {
+export async function getOpenGaps(userId: number, database: DB = defaultDb): Promise<OpenGap[]> {
   const rows = await database
     .select({
       gapId: recurringGaps.id,
@@ -111,6 +113,7 @@ export async function getOpenGaps(database: DB = defaultDb): Promise<OpenGap[]> 
     .innerJoin(recurringTransactions, eq(recurringTransactions.id, recurringGaps.recurringId))
     .innerJoin(accounts, eq(accounts.id, recurringTransactions.accountId))
     .leftJoin(categories, eq(categories.slug, recurringTransactions.categorySlug))
+    .where(eq(recurringGaps.userId, userId))
     .orderBy(asc(recurringGaps.yearMonth), asc(recurringTransactions.dayOfMonth));
 
   return rows;

--- a/src/lib/recurring/upcoming.ts
+++ b/src/lib/recurring/upcoming.ts
@@ -41,6 +41,7 @@ export function yearMonth(year: number, month: number): string {
 }
 
 export type UpcomingOptions = {
+  userId: number;
   year: number;
   month: number;
   includeDismissed?: boolean;
@@ -55,6 +56,7 @@ export async function getUpcomingForMonth(
   database: DB = defaultDb,
 ): Promise<UpcomingItem[]> {
   const {
+    userId,
     year,
     month,
     includeDismissed = false,
@@ -87,7 +89,7 @@ export async function getUpcomingForMonth(
     .from(recurringTransactions)
     .innerJoin(accounts, eq(accounts.id, recurringTransactions.accountId))
     .leftJoin(categories, eq(categories.slug, recurringTransactions.categorySlug))
-    .where(eq(recurringTransactions.active, true))
+    .where(and(eq(recurringTransactions.userId, userId), eq(recurringTransactions.active, true)))
     .orderBy(asc(recurringTransactions.dayOfMonth), asc(recurringTransactions.id));
 
   if (rows.length === 0) return [];
@@ -103,7 +105,11 @@ export async function getUpcomingForMonth(
     })
     .from(transactions)
     .where(
-      and(inArray(transactions.recurringId, recurringIds), eq(transactions.recurringYearMonth, ym)),
+      and(
+        eq(transactions.userId, userId),
+        inArray(transactions.recurringId, recurringIds),
+        eq(transactions.recurringYearMonth, ym),
+      ),
     );
   const explicitMap = new Map<number, number>();
   for (const e of explicitLinks) {
@@ -123,6 +129,7 @@ export async function getUpcomingForMonth(
     .from(transactions)
     .where(
       and(
+        eq(transactions.userId, userId),
         gte(
           transactions.occurredAt,
           new Date(rangeStart.getTime() - matchWindowBeforeDays * 86400000),

--- a/src/lib/telegram/confirm.ts
+++ b/src/lib/telegram/confirm.ts
@@ -20,12 +20,13 @@ export function isDraftComplete(draft: TelegramDraft): boolean {
 }
 
 export async function insertFromDraft(opts: {
+  userId: number;
   draft: TelegramDraft;
   chatId: number;
   sourceMessageId?: number;
   externalIdOverride?: string;
 }): Promise<ConfirmResult> {
-  const { draft, chatId, sourceMessageId, externalIdOverride } = opts;
+  const { userId, draft, chatId, sourceMessageId, externalIdOverride } = opts;
 
   if (!isDraftComplete(draft)) {
     return { status: "error", reason: "draft is incomplete" };
@@ -44,7 +45,7 @@ export async function insertFromDraft(opts: {
   let confidence: number | null = categorySlug ? 100 : null;
 
   if (!categorySlug) {
-    const match = await classifyByRule({
+    const match = await classifyByRule(userId, {
       descriptionRaw,
       merchant: draft.merchant ?? null,
     });
@@ -62,6 +63,7 @@ export async function insertFromDraft(opts: {
     const result = await db
       .insert(transactions)
       .values({
+        userId,
         accountId: draft.accountId as number,
         occurredAt,
         amountCents: signed,
@@ -109,14 +111,16 @@ export type BatchResult = {
 };
 
 export async function insertBatch(opts: {
+  userId: number;
   items: TelegramBatchItem[];
   chatId: number;
 }): Promise<BatchResult> {
-  const { items, chatId } = opts;
+  const { userId, items, chatId } = opts;
   const result: BatchResult = { inserted: [], duplicated: 0, errors: [] };
 
   for (const item of items) {
     const outcome = await insertFromDraft({
+      userId,
       draft: item.draft,
       chatId,
       externalIdOverride: item.externalId,

--- a/src/lib/telegram/poll-worker.ts
+++ b/src/lib/telegram/poll-worker.ts
@@ -66,7 +66,9 @@ export async function runPollWorker(opts: PollWorkerOptions): Promise<void> {
 
   const routerDeps: RouterDeps = {
     allowlist,
-    listAccounts: opts.deps?.listAccounts ?? listAccountsDetailed,
+    // NOTE: the single-bot poll worker scopes to user 1 (bootstrap) until #185
+    // migrates to webhooks + per-user bots (see docs/multi-user-plan.md §2.7).
+    listAccounts: opts.deps?.listAccounts ?? (() => listAccountsDetailed(1)),
     listCategories: opts.deps?.listCategories ?? listCategories,
     parseNlu:
       opts.deps?.parseNlu ?? ((p) => parseTransactionMessage({ text: p.text, context: p.context })),

--- a/src/lib/telegram/router.ts
+++ b/src/lib/telegram/router.ts
@@ -473,7 +473,8 @@ async function handleCallback(
       return;
     }
     await client.answerCallbackQuery({ callback_query_id: cb.id });
-    const result = await insertBatch({ items: session.batch, chatId });
+    // Single-bot poll worker scopes to user 1 until #185 wires per-user bots.
+    const result = await insertBatch({ userId: 1, items: session.batch, chatId });
     await client.sendMessage({
       chat_id: chatId,
       text: renderBatchInserted({
@@ -496,6 +497,8 @@ async function handleCallback(
       return;
     }
     const result = await insertFromDraft({
+      // Single-bot poll worker scopes to user 1 until #185 wires per-user bots.
+      userId: 1,
       draft: session.draft,
       chatId,
       sourceMessageId: session.sourceMessageId,

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -44,8 +44,8 @@ export function decodeCursor(cursor: string): { occurredAt: Date; id: number } |
   }
 }
 
-export async function listTransactions(filters: TxFilters): Promise<TxListResult> {
-  const conditions = [];
+export async function listTransactions(userId: number, filters: TxFilters): Promise<TxListResult> {
+  const conditions = [eq(transactions.userId, userId)];
 
   if (filters.from) conditions.push(gte(transactions.occurredAt, new Date(filters.from)));
   if (filters.to) {
@@ -108,7 +108,7 @@ export async function listTransactions(filters: TxFilters): Promise<TxListResult
     .from(transactions)
     .innerJoin(accounts, eq(accounts.id, transactions.accountId))
     .leftJoin(counterparties, eq(counterparties.id, transactions.counterpartyId))
-    .where(conditions.length ? and(...conditions) : undefined)
+    .where(and(...conditions))
     .orderBy(desc(transactions.occurredAt), desc(transactions.id))
     .limit(PAGE_SIZE + 1);
 
@@ -149,7 +149,7 @@ export async function listTransactions(filters: TxFilters): Promise<TxListResult
  * Compact counterparty list for the merge selector in CounterpartyDialog.
  * Ordered by hit_count DESC so the most-used show first.
  */
-export async function listCounterparties(): Promise<CounterpartyBrief[]> {
+export async function listCounterparties(userId: number): Promise<CounterpartyBrief[]> {
   return db
     .select({
       id: counterparties.id,
@@ -157,6 +157,7 @@ export async function listCounterparties(): Promise<CounterpartyBrief[]> {
       type: counterparties.type,
     })
     .from(counterparties)
+    .where(eq(counterparties.userId, userId))
     .orderBy(desc(counterparties.hitCount), asc(counterparties.displayName));
 }
 
@@ -164,7 +165,10 @@ export async function listCounterparties(): Promise<CounterpartyBrief[]> {
  * Same as `listCounterparties` but excludes one id (used when building the
  * merge target select — a counterparty cannot merge into itself).
  */
-export async function listCounterpartiesExcept(excludeId: number): Promise<CounterpartyBrief[]> {
+export async function listCounterpartiesExcept(
+  userId: number,
+  excludeId: number,
+): Promise<CounterpartyBrief[]> {
   return db
     .select({
       id: counterparties.id,
@@ -172,15 +176,15 @@ export async function listCounterpartiesExcept(excludeId: number): Promise<Count
       type: counterparties.type,
     })
     .from(counterparties)
-    .where(ne(counterparties.id, excludeId))
+    .where(and(eq(counterparties.userId, userId), ne(counterparties.id, excludeId)))
     .orderBy(desc(counterparties.hitCount), asc(counterparties.displayName));
 }
 
-export async function listAccounts() {
+export async function listAccounts(userId: number) {
   return db
     .select({ id: accounts.id, name: accounts.name })
     .from(accounts)
-    .where(eq(accounts.active, true))
+    .where(and(eq(accounts.userId, userId), eq(accounts.active, true)))
     .orderBy(asc(accounts.name));
 }
 
@@ -191,16 +195,21 @@ export async function listCategories() {
     .orderBy(asc(categories.sortOrder), asc(categories.name));
 }
 
-export async function countUnclassified(): Promise<number> {
+export async function countUnclassified(userId: number): Promise<number> {
   const [row] = await db
     .select({ n: sql<number>`count(*)::int` })
     .from(transactions)
-    .where(eq(transactions.classificationMethod, "unclassified"));
+    .where(
+      and(eq(transactions.userId, userId), eq(transactions.classificationMethod, "unclassified")),
+    );
   return row?.n ?? 0;
 }
 
-export async function countTotal(filters: Omit<TxFilters, "cursor">): Promise<number> {
-  const conditions = [];
+export async function countTotal(
+  userId: number,
+  filters: Omit<TxFilters, "cursor">,
+): Promise<number> {
+  const conditions = [eq(transactions.userId, userId)];
   if (filters.from) conditions.push(gte(transactions.occurredAt, new Date(filters.from)));
   if (filters.to) {
     const to = new Date(filters.to);
@@ -222,6 +231,6 @@ export async function countTotal(filters: Omit<TxFilters, "cursor">): Promise<nu
   const [row] = await db
     .select({ n: sql<number>`count(*)::int` })
     .from(transactions)
-    .where(conditions.length ? and(...conditions) : undefined);
+    .where(and(...conditions));
   return row?.n ?? 0;
 }


### PR DESCRIPTION
## Summary

PR 3a of #183. Every tenant-table query and INSERT now takes \`userId\` explicitly and filters by it. This is pure plumbing — \`DEFAULT 1\` on every \`user_id\` column remains in place, so single-user behavior is unchanged. PR 3b (next) drops the default and adds a two-user isolation integration test.

## What changed

### Library-layer queries take \`userId\` as a positional param and filter internally

- \`src/lib/transactions/queries.ts\` — \`listTransactions\`, \`listCounterparties\`, \`listCounterpartiesExcept\`, \`listAccounts\`, \`countUnclassified\`, \`countTotal\`
- \`src/lib/dashboard/queries.ts\` — \`getAccountStatuses\`, \`getNetWorth\`, \`getMonthlyFlow\`, \`getCategoryBreakdown\`, \`getTopExpenses\`
- \`src/lib/accounts/queries.ts\` — \`listAccountsDetailed\`
- \`src/lib/classification/rules.ts\` — \`classifyByRule\`
- \`src/lib/classification/pipeline.ts\` — \`classifyUnclassifiedBatch\`
- \`src/lib/recurring/auto-link.ts\` — \`autoLinkTransaction\`
- \`src/lib/recurring/gap-queries.ts\` — \`getLinkCandidates\`, \`getOpenGaps\`
- \`src/lib/recurring/upcoming.ts\` — \`getUpcomingForMonth\`
- \`src/lib/ingestion/sms-health.ts\` — \`getSmsHealthHistory\`, \`getSmsHealthSnapshot\`
- \`src/lib/ai/insights.ts\` — \`buildInsightsSummary\`
- \`src/lib/telegram/confirm.ts\` — \`insertFromDraft\`, \`insertBatch\`

### Entry points resolve userId and pass it down

- **Pages (RSC)** call \`getSessionUser()\` and pass \`session.id\`: \`/\`, \`/accounts\`, \`/transactions\`, \`/insights\`, \`/settings/ingestion\`.
- **Server actions** call \`getSessionUser()\`: \`transactions/actions.ts\`, \`budgets/actions.ts\`, \`insights/actions.ts\`, \`settings/import/actions.ts\`, \`settings/recurring/actions.ts\`.
- **Webhooks** use \`auth.userId\` (already resolved by \`resolveWebhookAuth\` per #194): \`/api/ingest/sms\`, \`/api/ingest/debug\`.
- **Telegram poll worker + router** hardcode user 1, with a comment pointing at #185 where multi-bot wires per-user ids. The single-bot architecture is the design intent until that issue lands — see \`docs/multi-user-plan.md\` §2.7.
- **Scripts** (\`backfill-counterparties\`, \`replay-sms-dump\`) scope to user 1 since they target the pre-multi-tenancy dev DB.

### Tests

- \`rules.test.ts\`, \`sms-health.test.ts\`, \`auto-link.test.ts\`: pass \`userId = 1\` through every call.
- \`transactions/actions.test.ts\`: mock \`getSessionUser\` so the NextAuth runtime import doesn't break under vitest.

## What this PR does NOT do

- Does NOT drop \`DEFAULT 1\` from any user_id column → that's PR 3b.
- Does NOT add the two-user isolation integration test → that's PR 3b.
- Security: every WHERE on \`id = …\` for tenant tables also adds \`user_id = …\`, so cross-tenant access via parameter forgery is blocked. PR 3b's integration test verifies this end-to-end.

## Test plan

- [x] \`bun run lint\` — clean
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun run test\` — 265 / 265 pass
- [x] Verified the full chain locally against dev DB: dashboard, transactions list, recurring page, insights page, settings/webhooks, budgets all render without errors.

## Next

- **PR 3b**: drop DEFAULT 1 on all 12 user_id columns + two-user integration test.
- **PR 4**: NextAuth signup callback copies \`classification_rule_seeds\` → \`classification_rules\` for each new user. Closes #183.

Refs #183