### PR TITLE
feat(db): drop DEFAULT 1 on user_id + two-user isolation test (#183)

### DIFF
--- a/drizzle/0015_mighty_sheva_callister.sql
+++ b/drizzle/0015_mighty_sheva_callister.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "account_snapshots" ALTER COLUMN "user_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "accounts" ALTER COLUMN "user_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "budgets" ALTER COLUMN "user_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "classification_rules" ALTER COLUMN "user_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "counterparties" ALTER COLUMN "user_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "counterparty_aliases" ALTER COLUMN "user_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "ingestion_logs" ALTER COLUMN "user_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "insights_reports" ALTER COLUMN "user_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "recurring_gaps" ALTER COLUMN "user_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "recurring_transactions" ALTER COLUMN "user_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "telegram_sessions" ALTER COLUMN "user_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "transactions" ALTER COLUMN "user_id" DROP DEFAULT;

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,2301 @@
+{
+  "id": "77c22e38-5974-4b31-9ff3-ab6cf095d76d",
+  "prevId": "1cf197b7-223d-4a40-86c3-992f596d7cd8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_category_slug_categories_slug_fk": {
+          "name": "budgets_category_slug_categories_slug_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_slug_categories_slug_fk": {
+          "name": "categories_parent_slug_categories_slug_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_categories_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_category_slug_categories_slug_fk": {
+          "name": "classification_rules_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_default_category_slug_categories_slug_fk": {
+          "name": "counterparties_default_category_slug_categories_slug_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_category_slug_categories_slug_fk": {
+          "name": "recurring_transactions_category_slug_categories_slug_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_poll_state": {
+      "name": "telegram_poll_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_update_id": {
+          "name": "last_update_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_category_slug_categories_slug_fk": {
+          "name": "transactions_category_slug_categories_slug_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "ai",
+        "manual",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1776567900000,
       "tag": "0014_fuzzy_zzzax",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1776568000000,
+      "tag": "0015_mighty_sheva_callister",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-recurring-gaps.ts
+++ b/scripts/backfill-recurring-gaps.ts
@@ -54,7 +54,9 @@ async function main() {
   let totalGapsCreated = 0;
   let totalAutoLinked = 0;
   for (const ym of months) {
-    const result = await detectGapsForMonth(ym);
+    // Backfill script runs against the single-user dev DB pre-multi-tenancy
+    // data, so user_id=1 is the right scope.
+    const result = await detectGapsForMonth(1, ym);
     totalGapsCreated += result.gapsCreated;
     totalAutoLinked += result.autoLinked;
     console.log(`  ${ym}: ${JSON.stringify(result)}`);

--- a/src/app/(app)/transactions/actions.test.ts
+++ b/src/app/(app)/transactions/actions.test.ts
@@ -57,6 +57,8 @@ async function cleanup() {
   `);
 }
 
+const TEST_USER_ID = 1;
+
 async function seedCounterparty(args: {
   key: string;
   kind?: CounterpartyKind;
@@ -64,8 +66,9 @@ async function seedCounterparty(args: {
   defaultCategory?: string | null;
 }): Promise<number> {
   const rows = await db.execute<{ id: number }>(sql`
-    INSERT INTO counterparties (display_name, type, default_category_slug)
+    INSERT INTO counterparties (user_id, display_name, type, default_category_slug)
     VALUES (
+      ${TEST_USER_ID},
       ${args.displayName ?? args.key},
       'unknown',
       ${args.defaultCategory ?? null}
@@ -73,8 +76,9 @@ async function seedCounterparty(args: {
     RETURNING id
   `);
   await db.execute(sql`
-    INSERT INTO counterparty_aliases (counterparty_id, kind, value)
+    INSERT INTO counterparty_aliases (user_id, counterparty_id, kind, value)
     VALUES (
+      ${TEST_USER_ID},
       ${rows[0].id},
       ${args.kind ?? "qr"}::counterparty_key_kind,
       ${args.key}
@@ -96,10 +100,10 @@ async function seedTx(args: {
   const rawData = args.smsBody ? JSON.stringify({ kind: "sms", sms: args.smsBody }) : "{}";
   const rows = await db.execute<{ id: number }>(sql`
     INSERT INTO transactions (
-      account_id, occurred_at, amount_cents, currency, description_raw,
+      user_id, account_id, occurred_at, amount_cents, currency, description_raw,
       counterparty_id, category_slug, classification_method, source, external_id, raw_data
     ) VALUES (
-      ${acc.id}, now(), -5000, 'COP', 'test',
+      ${TEST_USER_ID}, ${acc.id}, now(), -5000, 'COP', 'test',
       ${args.counterpartyId},
       ${args.categorySlug ?? null},
       ${args.method ?? "unclassified"}::classification_method,
@@ -118,8 +122,9 @@ async function seedAlias(args: {
   value: string;
 }): Promise<number> {
   const rows = await db.execute<{ id: number }>(sql`
-    INSERT INTO counterparty_aliases (counterparty_id, kind, value)
+    INSERT INTO counterparty_aliases (user_id, counterparty_id, kind, value)
     VALUES (
+      ${TEST_USER_ID},
       ${args.counterpartyId},
       ${args.kind}::counterparty_key_kind,
       ${args.value}
@@ -136,8 +141,9 @@ async function seedBareCounterparty(args: {
   defaultCategory?: string | null;
 }): Promise<number> {
   const rows = await db.execute<{ id: number }>(sql`
-    INSERT INTO counterparties (display_name, type, default_category_slug)
+    INSERT INTO counterparties (user_id, display_name, type, default_category_slug)
     VALUES (
+      ${TEST_USER_ID},
       ${args.displayName},
       'unknown',
       ${args.defaultCategory ?? null}
@@ -744,10 +750,10 @@ describe("classifySingleWithAi", () => {
     `);
     const rows = await db.execute<{ id: number }>(sql`
       INSERT INTO transactions (
-        account_id, occurred_at, amount_cents, currency, description_raw,
+        user_id, account_id, occurred_at, amount_cents, currency, description_raw,
         classification_method, source, external_id
       ) VALUES (
-        ${acc.id}, now(), -42000, 'COP', 'NETFLIX',
+        ${TEST_USER_ID}, ${acc.id}, now(), -42000, 'COP', 'NETFLIX',
         'unclassified'::classification_method, 'sms', ${externalId}
       )
       RETURNING id
@@ -761,10 +767,10 @@ describe("classifySingleWithAi", () => {
     `);
     const rows = await db.execute<{ id: number }>(sql`
       INSERT INTO transactions (
-        account_id, occurred_at, amount_cents, currency, description_raw,
+        user_id, account_id, occurred_at, amount_cents, currency, description_raw,
         category_slug, classification_method, source, external_id
       ) VALUES (
-        ${acc.id}, now(), -5000, 'COP', 'manual already',
+        ${TEST_USER_ID}, ${acc.id}, now(), -5000, 'COP', 'manual already',
         'alimentacion', 'manual'::classification_method, 'sms', ${externalId}
       )
       RETURNING id

--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -68,8 +68,9 @@ async function createCounterpartyWithAlias(args: {
   defaultCategorySlug?: string | null;
 }) {
   const rows = await db.execute<{ id: number }>(sql`
-    INSERT INTO counterparties (display_name, type, default_category_slug)
+    INSERT INTO counterparties (user_id, display_name, type, default_category_slug)
     VALUES (
+      ${TEST_USER_ID},
       ${args.displayName},
       ${args.type ?? "unknown"}::counterparty_type,
       ${args.defaultCategorySlug ?? null}
@@ -77,8 +78,8 @@ async function createCounterpartyWithAlias(args: {
     RETURNING id
   `);
   await db.execute(sql`
-    INSERT INTO counterparty_aliases (counterparty_id, kind, value)
-    VALUES (${rows[0].id}, ${args.kind}::counterparty_key_kind, ${args.value})
+    INSERT INTO counterparty_aliases (user_id, counterparty_id, kind, value)
+    VALUES (${TEST_USER_ID}, ${rows[0].id}, ${args.kind}::counterparty_key_kind, ${args.value})
   `);
   return rows[0].id;
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -24,11 +24,14 @@ export async function register() {
 
   // Day 5 of each month at 06:00 America/Bogota — gives a 4-day grace window
   // for late-posting SMS/Apple Pay events before we finalize gaps.
+  // NOTE: scopes to user 1 pending #185 (multi-user bot + webhook migration).
+  // Once that lands, iterate over every active user and run the detector per
+  // user id.
   cron.schedule(
     "0 6 5 * *",
     async () => {
       try {
-        const result = await closePreviousMonth();
+        const result = await closePreviousMonth(1);
         console.log(
           `[findash] recurring-gap detector closed ${result.yearMonth}:`,
           JSON.stringify(result),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -102,7 +102,6 @@ export const accounts = pgTable(
     id: serial("id").primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     name: varchar("name", { length: 100 }).notNull(),
     institution: varchar("institution", { length: 50 }).notNull(),
@@ -160,7 +159,6 @@ export const counterparties = pgTable(
     id: serial("id").primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     displayName: varchar("display_name", { length: 120 }).notNull(),
     type: counterpartyType("type").notNull().default("unknown"),
@@ -183,7 +181,6 @@ export const counterpartyAliases = pgTable(
     id: serial("id").primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     counterpartyId: integer("counterparty_id")
       .notNull()
@@ -204,7 +201,6 @@ export const transactions = pgTable(
     id: serial("id").primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     accountId: integer("account_id")
       .notNull()
@@ -256,7 +252,6 @@ export const classificationRules = pgTable(
     id: serial("id").primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     pattern: text("pattern").notNull(),
     categorySlug: varchar("category_slug", { length: 60 })
@@ -290,7 +285,6 @@ export const budgets = pgTable(
     id: serial("id").primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     categorySlug: varchar("category_slug", { length: 60 })
       .notNull()
@@ -311,7 +305,6 @@ export const recurringTransactions = pgTable(
     id: serial("id").primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     accountId: integer("account_id")
       .notNull()
@@ -338,7 +331,6 @@ export const recurringGaps = pgTable(
     id: serial("id").primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     recurringId: integer("recurring_id")
       .notNull()
@@ -359,7 +351,6 @@ export const ingestionLogs = pgTable(
     id: serial("id").primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     source: txSource("source").notNull(),
     status: varchar("status", { length: 20 }).notNull(),
@@ -380,7 +371,6 @@ export const insightsReports = pgTable(
     id: serial("id").primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     yearMonth: varchar("year_month", { length: 7 }).notNull(),
     generatedAt: timestamp("generated_at", { withTimezone: true }).notNull().defaultNow(),
@@ -416,7 +406,6 @@ export const accountSnapshots = pgTable(
     id: serial("id").primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     accountId: integer("account_id")
       .notNull()
@@ -471,7 +460,6 @@ export const telegramSessions = pgTable(
     chatId: bigint("chat_id", { mode: "bigint" }).primaryKey(),
     userId: integer("user_id")
       .notNull()
-      .default(1)
       .references(() => users.id, { onDelete: "cascade" }),
     telegramUserId: bigint("telegram_user_id", { mode: "bigint" }).notNull(),
     state: jsonb("state").$type<TelegramSessionState>().notNull(),

--- a/src/lib/db/seed-transactions.ts
+++ b/src/lib/db/seed-transactions.ts
@@ -252,6 +252,7 @@ async function main() {
     const daysAgo = Math.floor(Math.random() * 60);
     const occurredAt = new Date(now - daysAgo * dayMs - Math.floor(Math.random() * dayMs));
     return {
+      userId: acc.userId,
       accountId: acc.id,
       occurredAt,
       amountCents: BigInt(s.cents),

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -1,4 +1,4 @@
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { db } from "./index";
 import {
   accounts,
@@ -183,26 +183,33 @@ const seedRules: Array<{ pattern: string; categorySlug: string; priority?: numbe
   { pattern: "%Pago QR a llave%", categorySlug: "transferencias", priority: 50 },
 ];
 
-async function seedBootstrapUser() {
+async function seedBootstrapUser(): Promise<number | null> {
   const email = process.env.BOOTSTRAP_USER_EMAIL?.trim();
   const name = process.env.BOOTSTRAP_USER_NAME?.trim() || email;
   if (!email) {
     console.log("  BOOTSTRAP_USER_EMAIL not set — skipping bootstrap user");
-    return;
+    return null;
   }
   await db
     .insert(users)
     .values({ email, name: name ?? email })
     .onConflictDoNothing({ target: users.email });
-  console.log(`  bootstrap user ensured for ${email}`);
+  const [row] = await db.select({ id: users.id }).from(users).where(eq(users.email, email));
+  console.log(`  bootstrap user ensured for ${email} (id=${row?.id ?? "?"})`);
+  return row?.id ?? null;
 }
 
 export async function runSeed() {
   console.log("seeding bootstrap user...");
-  await seedBootstrapUser();
+  const bootstrapUserId = await seedBootstrapUser();
 
   console.log("seeding categories...");
   await db.insert(categories).values(seedCategories).onConflictDoNothing();
+
+  if (bootstrapUserId === null) {
+    console.log("  skipping accounts + rules seed — no bootstrap user to attribute them to");
+    return;
+  }
 
   console.log("seeding accounts...");
   const existing = await db
@@ -217,7 +224,7 @@ export async function runSeed() {
   const existingNames = new Set(existing.map((e) => e.name));
   const toInsert = seedAccounts.filter((a) => !existingNames.has(a.name));
   if (toInsert.length > 0) {
-    await db.insert(accounts).values(toInsert);
+    await db.insert(accounts).values(toInsert.map((a) => ({ ...a, userId: bootstrapUserId })));
     console.log(`  inserted ${toInsert.length} new accounts`);
   } else {
     console.log("  all accounts already exist");
@@ -226,7 +233,9 @@ export async function runSeed() {
   console.log("seeding classification rules...");
   const existingRuleCount = await db.$count(classificationRules);
   if (existingRuleCount === 0) {
-    await db.insert(classificationRules).values(seedRules);
+    await db
+      .insert(classificationRules)
+      .values(seedRules.map((r) => ({ ...r, userId: bootstrapUserId })));
     console.log(`  inserted ${seedRules.length} classification rules`);
   } else {
     console.log(`  ${existingRuleCount} classification rules already present — skipping`);

--- a/src/lib/ingestion/sms-health.test.ts
+++ b/src/lib/ingestion/sms-health.test.ts
@@ -92,6 +92,7 @@ describe("getSmsHealthHistory (integration)", () => {
 
     await db.insert(ingestionLogs).values([
       {
+        userId: TEST_USER_ID,
         source: "sms",
         status: "inserted",
         itemsReceived: 1,
@@ -100,6 +101,7 @@ describe("getSmsHealthHistory (integration)", () => {
         finishedAt: base,
       },
       {
+        userId: TEST_USER_ID,
         source: "sms",
         status: "inserted",
         itemsReceived: 1,
@@ -108,6 +110,7 @@ describe("getSmsHealthHistory (integration)", () => {
         finishedAt: later,
       },
       {
+        userId: TEST_USER_ID,
         source: "sms",
         status: "skipped",
         itemsReceived: 1,
@@ -133,6 +136,7 @@ describe("getSmsHealthHistory (integration)", () => {
 
   it("ignores logs from non-sms sources", async () => {
     await db.insert(ingestionLogs).values({
+      userId: TEST_USER_ID,
       source: "manual",
       status: "inserted",
       itemsReceived: 1,
@@ -165,6 +169,7 @@ describe("getSmsHealthSnapshot (integration)", () => {
     for (let d = 10; d <= 16; d += 1) {
       const ts = new Date(Date.UTC(2026, 3, d, 18, 0, 0)); // 13:00 COP that day
       values.push({
+        userId: TEST_USER_ID,
         source: "sms",
         status: "inserted",
         itemsReceived: 1,

--- a/src/lib/recurring/auto-link.test.ts
+++ b/src/lib/recurring/auto-link.test.ts
@@ -15,10 +15,13 @@ async function cleanup() {
   await db.execute(sql`DELETE FROM accounts WHERE name = ${TEST_ACCOUNT}`);
 }
 
+const TEST_USER_ID = 1;
+
 async function seedAccount() {
   const [a] = await db
     .insert(accounts)
     .values({
+      userId: TEST_USER_ID,
       name: TEST_ACCOUNT,
       institution: "Test",
       type: "savings",
@@ -35,6 +38,7 @@ async function seedRecurringWithGap(
   const [r] = await db
     .insert(recurringTransactions)
     .values({
+      userId: TEST_USER_ID,
       accountId,
       label: opts.label,
       amountCents: opts.amountCents,
@@ -46,7 +50,7 @@ async function seedRecurringWithGap(
 
   const [g] = await db
     .insert(recurringGaps)
-    .values({ recurringId: r.id, yearMonth: opts.yearMonth })
+    .values({ userId: TEST_USER_ID, recurringId: r.id, yearMonth: opts.yearMonth })
     .returning({ id: recurringGaps.id });
 
   return { recurringId: r.id, gapId: g.id };
@@ -65,6 +69,7 @@ async function seedTx(
   const [t] = await db
     .insert(transactions)
     .values({
+      userId: TEST_USER_ID,
       accountId,
       occurredAt: new Date(`${opts.occurredOn}T12:00:00-05:00`),
       amountCents: opts.amountCents,

--- a/src/lib/recurring/gap-detector.test.ts
+++ b/src/lib/recurring/gap-detector.test.ts
@@ -15,10 +15,13 @@ async function cleanup() {
   await db.execute(sql`DELETE FROM accounts WHERE name = ${TEST_ACCOUNT}`);
 }
 
+const TEST_USER_ID = 1;
+
 async function seedAccount() {
   const [a] = await db
     .insert(accounts)
     .values({
+      userId: TEST_USER_ID,
       name: TEST_ACCOUNT,
       institution: "Test",
       type: "savings",
@@ -40,6 +43,7 @@ async function seedRecurring(
   const [r] = await db
     .insert(recurringTransactions)
     .values({
+      userId: TEST_USER_ID,
       accountId,
       label: opts.label,
       amountCents: opts.amountCents,
@@ -65,6 +69,7 @@ async function seedTx(
   const [t] = await db
     .insert(transactions)
     .values({
+      userId: TEST_USER_ID,
       accountId,
       occurredAt: new Date(`${opts.occurredOn}T12:00:00-05:00`),
       amountCents: opts.amountCents,
@@ -90,7 +95,7 @@ describe("detectGapsForMonth (integration)", () => {
   afterEach(cleanup);
 
   it("returns empty result when no active recurrings exist", async () => {
-    const result = await detectGapsForMonth("2026-04");
+    const result = await detectGapsForMonth(TEST_USER_ID, "2026-04");
     expect(result.checkedRecurrings).toBe(0);
     expect(result.gapsCreated).toBe(0);
   });
@@ -103,7 +108,7 @@ describe("detectGapsForMonth (integration)", () => {
       dayOfMonth: 1,
     });
 
-    const result = await detectGapsForMonth("2026-04");
+    const result = await detectGapsForMonth(TEST_USER_ID, "2026-04");
     expect(result.gapsCreated).toBe(1);
     expect(result.autoLinked).toBe(0);
     expect(result.existingLinks).toBe(0);
@@ -126,7 +131,7 @@ describe("detectGapsForMonth (integration)", () => {
       amountCents: BigInt(-2500000),
     });
 
-    const result = await detectGapsForMonth("2026-04");
+    const result = await detectGapsForMonth(TEST_USER_ID, "2026-04");
     expect(result.autoLinked).toBe(1);
     expect(result.gapsCreated).toBe(0);
 
@@ -155,7 +160,7 @@ describe("detectGapsForMonth (integration)", () => {
       recurringYearMonth: "2026-04",
     });
 
-    await detectGapsForMonth("2026-04");
+    await detectGapsForMonth(TEST_USER_ID, "2026-04");
 
     // No gap should exist for this specific recurring
     const gaps = await db
@@ -174,7 +179,7 @@ describe("detectGapsForMonth (integration)", () => {
       skippedMonths: ["2026-04"],
     });
 
-    await detectGapsForMonth("2026-04");
+    await detectGapsForMonth(TEST_USER_ID, "2026-04");
 
     const gaps = await db
       .select({ id: recurringGaps.id })
@@ -203,7 +208,7 @@ describe("detectGapsForMonth (integration)", () => {
       recurringYearMonth: "2026-04",
     });
 
-    const result = await detectGapsForMonth("2026-04");
+    const result = await detectGapsForMonth(TEST_USER_ID, "2026-04");
     expect(result.existingLinks).toBe(1);
     expect(result.gapsCreated).toBe(1); // recB has no match → gap
   });
@@ -221,7 +226,7 @@ describe("detectGapsForMonth (integration)", () => {
       amountCents: BigInt(-100000),
     });
 
-    const result = await detectGapsForMonth("2026-04");
+    const result = await detectGapsForMonth(TEST_USER_ID, "2026-04");
     expect(result.autoLinked).toBe(1);
   });
 
@@ -238,7 +243,7 @@ describe("detectGapsForMonth (integration)", () => {
       amountCents: BigInt(-100000),
     });
 
-    const result = await detectGapsForMonth("2026-04");
+    const result = await detectGapsForMonth(TEST_USER_ID, "2026-04");
     expect(result.autoLinked).toBe(0);
     expect(result.gapsCreated).toBe(1);
   });
@@ -251,10 +256,10 @@ describe("detectGapsForMonth (integration)", () => {
       dayOfMonth: 1,
     });
 
-    const first = await detectGapsForMonth("2026-04");
+    const first = await detectGapsForMonth(TEST_USER_ID, "2026-04");
     expect(first.gapsCreated).toBe(1);
 
-    const second = await detectGapsForMonth("2026-04");
+    const second = await detectGapsForMonth(TEST_USER_ID, "2026-04");
     expect(second.gapsCreated).toBe(0);
     expect(second.gapsAlreadyOpen).toBe(1);
 
@@ -278,7 +283,7 @@ describe("detectGapsForMonth (integration)", () => {
       amountCents: BigInt(-100000),
     });
 
-    const result = await detectGapsForMonth("2026-02");
+    const result = await detectGapsForMonth(TEST_USER_ID, "2026-02");
     expect(result.autoLinked).toBe(1);
   });
 
@@ -294,7 +299,7 @@ describe("detectGapsForMonth (integration)", () => {
       amountCents: BigInt(-347000), // variable — different amount
     });
 
-    const result = await detectGapsForMonth("2026-04");
+    const result = await detectGapsForMonth(TEST_USER_ID, "2026-04");
     expect(result.autoLinked).toBe(0);
     expect(result.gapsCreated).toBe(1);
   });

--- a/src/lib/recurring/gap-detector.ts
+++ b/src/lib/recurring/gap-detector.ts
@@ -55,6 +55,7 @@ export function previousYearMonth(today: Date): string {
  * and the unique link index on transactions.
  */
 export async function detectGapsForMonth(
+  userId: number,
   yearMonth: string,
   database: DB = defaultDb,
   opts: DetectOptions = {},
@@ -74,7 +75,7 @@ export async function detectGapsForMonth(
       skippedMonths: recurringTransactions.skippedMonths,
     })
     .from(recurringTransactions)
-    .where(eq(recurringTransactions.active, true));
+    .where(and(eq(recurringTransactions.userId, userId), eq(recurringTransactions.active, true)));
 
   const result: DetectResult = {
     yearMonth,
@@ -95,6 +96,7 @@ export async function detectGapsForMonth(
     .from(transactions)
     .where(
       and(
+        eq(transactions.userId, userId),
         inArray(transactions.recurringId, recurringIds),
         eq(transactions.recurringYearMonth, yearMonth),
       ),
@@ -122,6 +124,7 @@ export async function detectGapsForMonth(
       .from(transactions)
       .where(
         and(
+          eq(transactions.userId, userId),
           eq(transactions.accountId, r.accountId),
           eq(transactions.amountCents, r.amountCents),
           isNull(transactions.recurringId),
@@ -139,7 +142,7 @@ export async function detectGapsForMonth(
           recurringYearMonth: yearMonth,
           updatedAt: new Date(),
         })
-        .where(eq(transactions.id, candidates[0].id));
+        .where(and(eq(transactions.userId, userId), eq(transactions.id, candidates[0].id)));
       result.autoLinked += 1;
       continue;
     }
@@ -147,6 +150,7 @@ export async function detectGapsForMonth(
     const inserted = await database
       .insert(recurringGaps)
       .values({
+        userId,
         recurringId: r.id,
         yearMonth,
       })
@@ -171,10 +175,11 @@ export async function detectGapsForMonth(
  * finalize gaps.
  */
 export async function closePreviousMonth(
+  userId: number,
   today: Date = new Date(),
   database: DB = defaultDb,
 ): Promise<DetectResult> {
-  return detectGapsForMonth(previousYearMonth(today), database);
+  return detectGapsForMonth(userId, previousYearMonth(today), database);
 }
 
 export { DEFAULT_WINDOW_BEFORE_DAYS, DEFAULT_WINDOW_AFTER_DAYS };

--- a/src/lib/telegram/session.ts
+++ b/src/lib/telegram/session.ts
@@ -34,9 +34,13 @@ export async function upsertSession(opts: {
   state: TelegramSessionState;
 }): Promise<void> {
   const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
+  // Single-bot poll worker scopes every session to user 1; #185 will resolve
+  // the Telegram chat → Findash user via telegram_bots + webhooks.
+  const userId = 1;
   await db
     .insert(telegramSessions)
     .values({
+      userId,
       chatId: BigInt(opts.chatId),
       telegramUserId: BigInt(opts.telegramUserId),
       state: opts.state,
@@ -46,6 +50,7 @@ export async function upsertSession(opts: {
     .onConflictDoUpdate({
       target: telegramSessions.chatId,
       set: {
+        userId,
         telegramUserId: BigInt(opts.telegramUserId),
         state: opts.state,
         updatedAt: new Date(),

--- a/src/lib/tenant-isolation.test.ts
+++ b/src/lib/tenant-isolation.test.ts
@@ -1,0 +1,417 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  budgets,
+  classificationRules,
+  counterparties,
+  counterpartyAliases,
+  ingestionLogs,
+  insightsReports,
+  recurringGaps,
+  recurringTransactions,
+  transactions,
+  users,
+} from "@/lib/db/schema";
+import { classifyByRule } from "@/lib/classification/rules";
+import {
+  getAccountStatuses,
+  getCategoryBreakdown,
+  getMonthlyFlow,
+  getNetWorth,
+  getTopExpenses,
+} from "@/lib/dashboard/queries";
+import { listAccountsDetailed } from "@/lib/accounts/queries";
+import { getOpenGaps, getLinkCandidates } from "@/lib/recurring/gap-queries";
+import { getUpcomingForMonth } from "@/lib/recurring/upcoming";
+import { getSmsHealthHistory } from "@/lib/ingestion/sms-health";
+import {
+  countTotal,
+  countUnclassified,
+  listAccounts,
+  listCounterparties,
+  listTransactions,
+} from "@/lib/transactions/queries";
+
+// Integration test for #183 tenant isolation. Creates two parallel users with
+// disjoint data and asserts every read path scoped to userA never returns
+// userB's rows. Also verifies that INSERTs without user_id now fail (drop
+// DEFAULT 1 migration applied).
+
+const TAG = "ISOLATION_TEST";
+
+async function createUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  return row.id;
+}
+
+async function createAccount(userId: number, name: string): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name,
+      institution: TAG,
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createTransaction(
+  userId: number,
+  accountId: number,
+  amountCents: bigint,
+  occurredAt: Date,
+  externalId: string,
+): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt,
+      amountCents,
+      currency: "COP",
+      descriptionRaw: `${TAG} ${externalId}`,
+      categorySlug: "otros",
+      classificationMethod: "manual",
+      source: "manual",
+      externalId,
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function createCounterparty(userId: number, displayName: string): Promise<number> {
+  const [row] = await db
+    .insert(counterparties)
+    .values({ userId, displayName, type: "unknown" })
+    .returning({ id: counterparties.id });
+  return row.id;
+}
+
+async function createAlias(userId: number, counterpartyId: number, value: string): Promise<void> {
+  await db.insert(counterpartyAliases).values({
+    userId,
+    counterpartyId,
+    kind: "name",
+    value,
+  });
+}
+
+async function createRule(userId: number, pattern: string): Promise<void> {
+  await db.insert(classificationRules).values({
+    userId,
+    pattern,
+    categorySlug: "otros",
+    priority: 1,
+    active: true,
+  });
+}
+
+async function createRecurring(userId: number, accountId: number, label: string): Promise<number> {
+  const [row] = await db
+    .insert(recurringTransactions)
+    .values({
+      userId,
+      accountId,
+      label,
+      amountCents: BigInt(-100_000),
+      currency: "COP",
+      categorySlug: "otros",
+      dayOfMonth: 15,
+    })
+    .returning({ id: recurringTransactions.id });
+  return row.id;
+}
+
+async function createGap(userId: number, recurringId: number, yearMonth: string): Promise<number> {
+  const [row] = await db
+    .insert(recurringGaps)
+    .values({ userId, recurringId, yearMonth })
+    .returning({ id: recurringGaps.id });
+  return row.id;
+}
+
+async function createBudget(userId: number): Promise<void> {
+  await db.insert(budgets).values({
+    userId,
+    categorySlug: "otros",
+    amountCents: BigInt(500_000),
+    currency: "COP",
+    periodStart: "2026-04-01",
+    periodEnd: "2026-04-30",
+    active: true,
+  });
+}
+
+async function createIngestionLog(userId: number): Promise<void> {
+  await db.insert(ingestionLogs).values({
+    userId,
+    source: "sms",
+    status: "inserted",
+    itemsReceived: 1,
+    itemsInserted: 1,
+    startedAt: new Date(),
+    finishedAt: new Date(),
+  });
+}
+
+async function createInsight(userId: number, yearMonth: string): Promise<void> {
+  await db.insert(insightsReports).values({
+    userId,
+    yearMonth,
+    inputHash: "x".repeat(64),
+    markdown: TAG,
+    model: "test",
+    inputTokens: 0,
+    outputTokens: 0,
+  });
+}
+
+let userA: number;
+let userB: number;
+let accountA: number;
+let accountB: number;
+let cpA: number;
+let cpB: number;
+let recurringA: number;
+let recurringB: number;
+
+async function cleanup() {
+  // ON DELETE CASCADE on user_id handles downstream rows in tenant tables.
+  await db.delete(users).where(sql`email LIKE ${TAG + "%"}`);
+}
+
+describe("#183 tenant isolation", () => {
+  beforeAll(async () => {
+    await cleanup();
+    userA = await createUser(`${TAG}-A@test.local`);
+    userB = await createUser(`${TAG}-B@test.local`);
+
+    accountA = await createAccount(userA, `${TAG}-A acct`);
+    accountB = await createAccount(userB, `${TAG}-B acct`);
+
+    await createTransaction(userA, accountA, BigInt(-1000), new Date("2026-04-10"), `${TAG}-A-tx1`);
+    await createTransaction(userA, accountA, BigInt(-2000), new Date("2026-04-12"), `${TAG}-A-tx2`);
+    await createTransaction(userB, accountB, BigInt(-3000), new Date("2026-04-10"), `${TAG}-B-tx1`);
+
+    cpA = await createCounterparty(userA, `${TAG}-A cp`);
+    cpB = await createCounterparty(userB, `${TAG}-B cp`);
+    await createAlias(userA, cpA, `${TAG}-A alias`);
+    await createAlias(userB, cpB, `${TAG}-B alias`);
+
+    await createRule(userA, `%${TAG}-A pattern%`);
+    await createRule(userB, `%${TAG}-B pattern%`);
+
+    recurringA = await createRecurring(userA, accountA, `${TAG}-A recurring`);
+    recurringB = await createRecurring(userB, accountB, `${TAG}-B recurring`);
+
+    await createGap(userA, recurringA, "2026-04");
+    await createGap(userB, recurringB, "2026-04");
+
+    await createBudget(userA);
+    await createBudget(userB);
+
+    await createIngestionLog(userA);
+    await createIngestionLog(userB);
+
+    await createInsight(userA, "2026-04");
+    await createInsight(userB, "2026-04");
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await db.$client.end({ timeout: 1 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Read-path isolation
+  // ---------------------------------------------------------------------------
+
+  describe("listTransactions", () => {
+    it("returns only userA's transactions", async () => {
+      const { rows } = await listTransactions(userA, {});
+      const ours = rows.filter((r) => r.descriptionRaw.includes(TAG));
+      expect(ours).toHaveLength(2);
+      expect(ours.every((r) => r.descriptionRaw.includes(`${TAG}-A`))).toBe(true);
+    });
+
+    it("returns only userB's transactions", async () => {
+      const { rows } = await listTransactions(userB, {});
+      const ours = rows.filter((r) => r.descriptionRaw.includes(TAG));
+      expect(ours).toHaveLength(1);
+      expect(ours[0].descriptionRaw).toContain(`${TAG}-B`);
+    });
+  });
+
+  it("countTotal and countUnclassified are scoped per user", async () => {
+    const totalA = await countTotal(userA, {});
+    const totalB = await countTotal(userB, {});
+    const rows = await db.execute<{ c: number }>(sql`
+      SELECT COUNT(*)::int AS c FROM transactions WHERE user_id = ${userA}
+    `);
+    expect(totalA).toBe(rows[0].c);
+    expect(totalB).toBeGreaterThan(0);
+    expect(totalA).not.toBe(totalB);
+    // userA has no unclassified fixtures; userB has none either. Both just
+    // need to not read each other's rows — the SQL COUNT with no user predicate
+    // would have yielded A+B.
+    const unclassifiedA = await countUnclassified(userA);
+    const unclassifiedB = await countUnclassified(userB);
+    expect(unclassifiedA).toBe(0);
+    expect(unclassifiedB).toBe(0);
+  });
+
+  it("listAccounts + listAccountsDetailed are scoped per user", async () => {
+    const accsA = await listAccounts(userA);
+    const accsB = await listAccounts(userB);
+    expect(accsA.map((a) => a.id)).toEqual([accountA]);
+    expect(accsB.map((a) => a.id)).toEqual([accountB]);
+
+    const detailedA = await listAccountsDetailed(userA);
+    expect(detailedA.every((a) => a.institution === TAG)).toBe(true);
+    expect(detailedA).toHaveLength(1);
+  });
+
+  it("listCounterparties is scoped per user", async () => {
+    const cpsA = await listCounterparties(userA);
+    const cpsB = await listCounterparties(userB);
+    const ourA = cpsA.filter((c) => c.displayName.includes(TAG));
+    const ourB = cpsB.filter((c) => c.displayName.includes(TAG));
+    expect(ourA.map((c) => c.id)).toEqual([cpA]);
+    expect(ourB.map((c) => c.id)).toEqual([cpB]);
+  });
+
+  it("dashboard queries are scoped per user", async () => {
+    const [nwA, nwB] = await Promise.all([getNetWorth(userA, 4000), getNetWorth(userB, 4000)]);
+    // Distinct values because userA and userB touch disjoint accounts (all are
+    // empty; balances stay at 0 but the SQL paths are exercised).
+    expect(nwA.totalCopCents).toBe(BigInt(0));
+    expect(nwB.totalCopCents).toBe(BigInt(0));
+
+    const statusesA = await getAccountStatuses(userA);
+    expect(statusesA).toHaveLength(1);
+    expect(statusesA[0].id).toBe(accountA);
+
+    const flowA = await getMonthlyFlow(userA, 4000, new Date("2026-04-15"));
+    // Sum of -1000 + -2000 = -3000 for userA, so expense=3000.
+    expect(flowA.expenseCopCents).toBe(BigInt(3000));
+
+    const flowB = await getMonthlyFlow(userB, 4000, new Date("2026-04-15"));
+    expect(flowB.expenseCopCents).toBe(BigInt(3000));
+
+    const catA = await getCategoryBreakdown(userA, 4000, new Date("2026-04-15"));
+    expect(catA.every((c) => c.amountCopCents >= BigInt(0))).toBe(true);
+
+    const topA = await getTopExpenses(userA, 4000, new Date("2026-04-15"), 10);
+    expect(topA.every((t) => t.descriptionRaw.includes(`${TAG}-A`))).toBe(true);
+  });
+
+  it("classifyByRule only sees the calling user's rules", async () => {
+    const hitA = await classifyByRule(userA, { descriptionRaw: `${TAG}-A pattern match` });
+    expect(hitA).not.toBeNull();
+
+    // userB has a different pattern; userA's scope must not match it.
+    const crossMiss = await classifyByRule(userA, { descriptionRaw: `${TAG}-B pattern match` });
+    expect(crossMiss).toBeNull();
+
+    const hitB = await classifyByRule(userB, { descriptionRaw: `${TAG}-B pattern match` });
+    expect(hitB).not.toBeNull();
+  });
+
+  it("getOpenGaps + getLinkCandidates are scoped per user", async () => {
+    const gapsA = await getOpenGaps(userA);
+    const gapsB = await getOpenGaps(userB);
+    expect(gapsA.every((g) => g.label.includes(`${TAG}-A`))).toBe(true);
+    expect(gapsB.every((g) => g.label.includes(`${TAG}-B`))).toBe(true);
+
+    // Cross-tenant gapId lookup must return empty (even though the gap row
+    // exists for userB, userA's scope hides it).
+    const gapBId = gapsB[0]!.gapId;
+    const crossCandidates = await getLinkCandidates(userA, gapBId);
+    expect(crossCandidates).toEqual([]);
+  });
+
+  it("getUpcomingForMonth is scoped per user", async () => {
+    const upA = await getUpcomingForMonth({ userId: userA, year: 2026, month: 4 });
+    const upB = await getUpcomingForMonth({ userId: userB, year: 2026, month: 4 });
+    expect(upA.every((u) => u.label.includes(`${TAG}-A`))).toBe(true);
+    expect(upB.every((u) => u.label.includes(`${TAG}-B`))).toBe(true);
+  });
+
+  it("getSmsHealthHistory is scoped per user", async () => {
+    const historyA = await getSmsHealthHistory(userA, 30);
+    const historyB = await getSmsHealthHistory(userB, 30);
+    // Each user inserted exactly one 'inserted' sms log.
+    const countA = historyA.reduce((s, d) => s + d.inserted, 0);
+    const countB = historyB.reduce((s, d) => s + d.inserted, 0);
+    expect(countA).toBe(1);
+    expect(countB).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // DEFAULT 1 is gone — raw INSERTs without user_id must fail now.
+  // Verifies the #183 PR 3b migration.
+  // ---------------------------------------------------------------------------
+
+  it("INSERT into accounts without user_id fails (DEFAULT 1 dropped)", async () => {
+    await expect(
+      db.execute(
+        sql`INSERT INTO accounts (name, institution, type, currency) VALUES (${TAG + " fail"}, ${TAG}, 'savings', 'COP')`,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("INSERT into transactions without user_id fails (DEFAULT 1 dropped)", async () => {
+    await expect(
+      db.execute(sql`
+        INSERT INTO transactions (account_id, occurred_at, amount_cents, currency, description_raw, classification_method, source)
+        VALUES (${accountA}, now(), 0, 'COP', ${TAG + " fail"}, 'manual', 'manual')
+      `),
+    ).rejects.toThrow();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Counterparty + alias uniqueness is now per-user
+  // (classification_rules unique + counterparty_aliases unique both landed in
+  //  PR 2 / #183). Same (kind, value) across different users must coexist.
+  // ---------------------------------------------------------------------------
+
+  it("two users can hold the same counterparty alias (user_id, kind, value)", async () => {
+    const [cpA2] = await db
+      .insert(counterparties)
+      .values({ userId: userA, displayName: `${TAG}-A cp2`, type: "unknown" })
+      .returning({ id: counterparties.id });
+    const [cpB2] = await db
+      .insert(counterparties)
+      .values({ userId: userB, displayName: `${TAG}-B cp2`, type: "unknown" })
+      .returning({ id: counterparties.id });
+
+    const sharedValue = `${TAG}-shared`;
+    await db
+      .insert(counterpartyAliases)
+      .values({ userId: userA, counterpartyId: cpA2.id, kind: "name", value: sharedValue });
+    await db
+      .insert(counterpartyAliases)
+      .values({ userId: userB, counterpartyId: cpB2.id, kind: "name", value: sharedValue });
+
+    const rowsA = await db
+      .select({ id: counterpartyAliases.id })
+      .from(counterpartyAliases)
+      .where(
+        and(eq(counterpartyAliases.userId, userA), eq(counterpartyAliases.value, sharedValue)),
+      );
+    const rowsB = await db
+      .select({ id: counterpartyAliases.id })
+      .from(counterpartyAliases)
+      .where(
+        and(eq(counterpartyAliases.userId, userB), eq(counterpartyAliases.value, sharedValue)),
+      );
+    expect(rowsA).toHaveLength(1);
+    expect(rowsB).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

PR 3b of the #183 chain. Completes multi-tenancy hardening.

1. **Migration 0015** drops \`DEFAULT 1\` from every tenant table's \`user_id\` column. INSERTs that don't supply \`userId\` now fail with a NOT NULL violation at the DB layer.
2. **\`src/lib/tenant-isolation.test.ts\`** creates two parallel users with disjoint data across every tenant table and asserts every read path scoped to userA never returns userB's rows. Also verifies that raw INSERTs without \`user_id\` are rejected.

## What changed

### Migration 0015
\`\`\`sql
ALTER TABLE "account_snapshots" ALTER COLUMN "user_id" DROP DEFAULT;
ALTER TABLE "accounts"          ALTER COLUMN "user_id" DROP DEFAULT;
ALTER TABLE "budgets"           ALTER COLUMN "user_id" DROP DEFAULT;
ALTER TABLE "classification_rules" ALTER COLUMN "user_id" DROP DEFAULT;
ALTER TABLE "counterparties"    ALTER COLUMN "user_id" DROP DEFAULT;
ALTER TABLE "counterparty_aliases" ALTER COLUMN "user_id" DROP DEFAULT;
ALTER TABLE "ingestion_logs"    ALTER COLUMN "user_id" DROP DEFAULT;
ALTER TABLE "insights_reports"  ALTER COLUMN "user_id" DROP DEFAULT;
ALTER TABLE "recurring_gaps"    ALTER COLUMN "user_id" DROP DEFAULT;
ALTER TABLE "recurring_transactions" ALTER COLUMN "user_id" DROP DEFAULT;
ALTER TABLE "telegram_sessions" ALTER COLUMN "user_id" DROP DEFAULT;
ALTER TABLE "transactions"      ALTER COLUMN "user_id" DROP DEFAULT;
\`\`\`

### Code that caught a missing explicit userId after the drop

- \`src/lib/telegram/session.ts\` — upsertSession now sets \`userId: 1\` (single-bot pin until #185 per-user bots).
- \`src/lib/recurring/gap-detector.ts\` — \`detectGapsForMonth(userId, …)\` + \`closePreviousMonth(userId, …)\`.
- \`src/instrumentation.ts\` — cron calls \`closePreviousMonth(1)\` with a comment pointing at #185.
- \`src/lib/db/seed.ts\` — attributes accounts + classification_rules to the bootstrap user id.
- \`src/lib/db/seed-transactions.ts\` — reads userId from the account row and copies it into the transaction.
- \`scripts/backfill-recurring-gaps.ts\` — pins to user 1.

### Tests

- New \`src/lib/tenant-isolation.test.ts\` — 13 integration tests covering \`listTransactions\`, \`countTotal/Unclassified\`, \`listAccounts\`, \`listAccountsDetailed\`, \`listCounterparties\`, dashboard queries, \`classifyByRule\`, \`getOpenGaps\`, \`getLinkCandidates\`, \`getUpcomingForMonth\`, \`getSmsHealthHistory\`, and the DROP DEFAULT enforcement + composite unique on \`counterparty_aliases (user_id, kind, value)\`.
- Existing test fixtures updated to thread \`TEST_USER_ID = 1\` into every raw INSERT against a tenant table.

## Test plan

- [x] Fresh test DB: \`dropdb findash_test && createdb findash_test && bun run db:migrate:test && bun run db:seed:test\` — clean.
- [x] \`bun run lint\` — clean.
- [x] \`bunx tsc --noEmit\` — clean.
- [x] \`bun run test\` — **278 / 278 pass** (265 existing + 13 new isolation tests).
- [x] Verified \`SELECT column_name, column_default FROM information_schema.columns WHERE column_name = 'user_id'\` in dev DB — all 12 tenant columns show \`column_default = null\`.

## What remains to close #183

- **PR 4**: NextAuth signup callback copies \`classification_rule_seeds\` → \`classification_rules\` with the new user's id.

## Telegram single-bot pin

The plan doc (\`docs/multi-user-plan.md\` §2.7) already defers multi-bot to #185 (webhook migration). Until that lands, the poll worker, router, and cron pin to user 1. The inline code comments flag this explicitly.

Refs #183