### PR TITLE
feat(auth): signup copies classification_rule_seeds into user rules (#183)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,6 +4,7 @@ import Google from "next-auth/providers/google";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
+import { copyRuleSeedsToUser } from "@/lib/auth/signup";
 
 declare module "next-auth" {
   interface Session {
@@ -53,8 +54,17 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           .update(users)
           .set({ googleSub: sub, name, pictureUrl, updatedAt: new Date() })
           .where(eq(users.id, row.id));
+        // Bootstrap users predate the seeds table — top up any missing rules
+        // so every user ends up with the full template regardless of signup
+        // timing. The unique index + ON CONFLICT makes this a cheap no-op once
+        // a user already owns the full set.
+        await copyRuleSeedsToUser(row.id);
       } else {
-        await db.insert(users).values({ googleSub: sub, email, name, pictureUrl });
+        const [inserted] = await db
+          .insert(users)
+          .values({ googleSub: sub, email, name, pictureUrl })
+          .returning({ id: users.id });
+        await copyRuleSeedsToUser(inserted.id);
       }
       return true;
     },

--- a/src/lib/auth/signup.test.ts
+++ b/src/lib/auth/signup.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { classificationRuleSeeds, classificationRules, users } from "@/lib/db/schema";
+import { copyRuleSeedsToUser } from "./signup";
+
+// Integration test for the signup → rules copy flow (PR 4 of #183).
+// Creates an isolated user, copies the seeds, and verifies:
+//   - every seed row became a classification_rules row with user_id set
+//   - the call is idempotent (ON CONFLICT on the (user_id, pattern, category_slug)
+//     unique constraint swallows reruns)
+
+const EMAIL_PREFIX = "signup-test-";
+
+async function cleanup() {
+  await db.delete(users).where(sql`email LIKE ${EMAIL_PREFIX + "%"}`);
+}
+
+async function createTestUser(tag: string): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `${EMAIL_PREFIX}${tag}@test.local`, name: tag })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+describe("copyRuleSeedsToUser", () => {
+  let seedCount = 0;
+
+  beforeAll(async () => {
+    await cleanup();
+    const [row] = await db.select({ n: sql<number>`count(*)::int` }).from(classificationRuleSeeds);
+    seedCount = row.n;
+    expect(seedCount).toBeGreaterThan(0);
+  });
+
+  afterEach(cleanup);
+  afterAll(async () => {
+    await db.$client.end({ timeout: 1 });
+  });
+
+  it("copies every seed into classification_rules with user_id set", async () => {
+    const userId = await createTestUser("basic");
+    const inserted = await copyRuleSeedsToUser(userId);
+    expect(inserted).toBe(seedCount);
+
+    const rules = await db
+      .select({ pattern: classificationRules.pattern })
+      .from(classificationRules)
+      .where(eq(classificationRules.userId, userId));
+    expect(rules).toHaveLength(seedCount);
+  });
+
+  it("is idempotent — second call returns 0 and row count is stable", async () => {
+    const userId = await createTestUser("idempotent");
+    const first = await copyRuleSeedsToUser(userId);
+    expect(first).toBe(seedCount);
+
+    const second = await copyRuleSeedsToUser(userId);
+    expect(second).toBe(0);
+
+    const [row] = await db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(classificationRules)
+      .where(eq(classificationRules.userId, userId));
+    expect(row.n).toBe(seedCount);
+  });
+
+  it("tops up a partial rule set", async () => {
+    const userId = await createTestUser("partial");
+    // Simulate a user who manually deleted one rule: copy, then delete one,
+    // then copy again — the second call should re-insert only the missing row.
+    await copyRuleSeedsToUser(userId);
+
+    const [anyRule] = await db
+      .select({
+        id: classificationRules.id,
+        pattern: classificationRules.pattern,
+        categorySlug: classificationRules.categorySlug,
+      })
+      .from(classificationRules)
+      .where(eq(classificationRules.userId, userId))
+      .limit(1);
+
+    await db
+      .delete(classificationRules)
+      .where(and(eq(classificationRules.userId, userId), eq(classificationRules.id, anyRule.id)));
+
+    const topUp = await copyRuleSeedsToUser(userId);
+    expect(topUp).toBe(1);
+
+    const [row] = await db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(classificationRules)
+      .where(eq(classificationRules.userId, userId));
+    expect(row.n).toBe(seedCount);
+  });
+
+  it("keeps users isolated — copying for userB does not affect userA", async () => {
+    const userA = await createTestUser("iso-a");
+    const userB = await createTestUser("iso-b");
+
+    await copyRuleSeedsToUser(userA);
+    await copyRuleSeedsToUser(userB);
+
+    const [countA] = await db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(classificationRules)
+      .where(eq(classificationRules.userId, userA));
+    const [countB] = await db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(classificationRules)
+      .where(eq(classificationRules.userId, userB));
+
+    expect(countA.n).toBe(seedCount);
+    expect(countB.n).toBe(seedCount);
+  });
+});

--- a/src/lib/auth/signup.ts
+++ b/src/lib/auth/signup.ts
@@ -1,0 +1,30 @@
+import { sql } from "drizzle-orm";
+import { db as defaultDb, type DB } from "@/lib/db";
+import { classificationRuleSeeds, classificationRules } from "@/lib/db/schema";
+
+/**
+ * Copy every row from `classification_rule_seeds` into `classification_rules`
+ * with the new user's id. Called once during signup, after the `users` row is
+ * inserted.
+ *
+ * Idempotent: the unique index `(user_id, pattern, category_slug)` combined
+ * with ON CONFLICT DO NOTHING makes this safe to re-run (e.g. if the signup
+ * callback retries). Returns the number of rule rows materialized.
+ */
+export async function copyRuleSeedsToUser(
+  userId: number,
+  database: DB = defaultDb,
+): Promise<number> {
+  const result = await database.execute<{ id: number }>(sql`
+    INSERT INTO classification_rules (user_id, pattern, category_slug, priority, active)
+    SELECT ${userId}, pattern, category_slug, priority, true
+    FROM ${classificationRuleSeeds}
+    ON CONFLICT (user_id, pattern, category_slug) DO NOTHING
+    RETURNING id
+  `);
+  return result.length;
+}
+
+// Re-export the table to keep the DI story obvious: callers pass a DB that
+// exposes classificationRules; callers shouldn't need to know about seeds.
+export { classificationRules };


### PR DESCRIPTION
## Summary

PR 4 of the #183 chain — the final one. New users now land with the full \`classification_rule_seeds\` template copied into their own \`classification_rules\` instead of an empty set.

## How it works

\`\`\`ts
// src/lib/auth/signup.ts
copyRuleSeedsToUser(userId)
  → INSERT INTO classification_rules (user_id, pattern, category_slug, priority, active)
    SELECT \${userId}, pattern, category_slug, priority, true
    FROM classification_rule_seeds
    ON CONFLICT (user_id, pattern, category_slug) DO NOTHING
    RETURNING id
\`\`\`

The unique index on \`(user_id, pattern, category_slug)\` added in PR 2 makes this idempotent: returns the count of newly materialized rows, zero on re-run.

Wired into \`signIn\` in \`src/auth.ts\`:

- **New user** (Google login, no matching email row): insert the \`users\` row, then \`copyRuleSeedsToUser(inserted.id)\`.
- **Existing user** (already has a row): top-up call runs on every login as a no-op for established users, but it fills in the template for bootstrap users (user 1) that predate the \`classification_rule_seeds\` table.

## Tests

\`src/lib/auth/signup.test.ts\` — 4 integration tests:

- Basic copy: every seed becomes a rule, count matches \`classification_rule_seeds\`.
- Idempotent: second call returns 0, row count stable.
- Partial top-up: delete one rule, re-run → re-inserts exactly the missing row.
- Two users isolated: copying for userB doesn't affect userA's rule count.

## Test plan

- [x] \`bun run lint\` — clean
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun run test\` — **282 / 282 pass** (278 from PR 3b + 4 new signup tests)

## Chain summary

#183 arrived with:

- **PR 0 #190/#191** — dedup classification_rules + idempotent seed (prerequisite)
- **PR 1 #192** — user_id NOT NULL DEFAULT 1 on 12 tenant tables + telegram rename
- **PR 2 #193** — composite (user_id, …) indexes per doc §5, unique (user_id, pattern, category_slug) on classification_rules, unique (user_id, kind, value) on counterparty_aliases, unique (user_id, year_month) on insights_reports
- **PR A #195 + PR B #196** (side-quest #194 — webhook per-user auth) — webhook_tokens table + UI + SMS/debug route swap
- **PR 3a #197** — userId plumbing across every tenant query and INSERT
- **PR 3b #198** — drop DEFAULT 1 + two-user isolation integration test
- **PR 4 (this)** — signup → seeds copy

Closes #183.

Outstanding follow-ups tracked in separate issues: #185 (Telegram multi-bot / webhook migration) and #184 (invite-code signup flow, if still needed beyond the existing invite_codes schema).