### PR TITLE
fix(auth): allow bearer-token API routes to bypass proxy (#200)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,11 +14,6 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Sin esta key, el bot de Telegram responde con error al recibir voice notes.
 GROQ_API_KEY=gsk-your-key-here
 
-# Ingestion webhook token — secreto compartido server ↔ iOS Shortcut
-# Generá UNA VEZ: openssl rand -hex 32
-# Pegá el MISMO valor en .env.local y en el header Authorization del Shortcut.
-INGEST_WEBHOOK_TOKEN=replace-with-output-of-openssl-rand-hex-32
-
 # Telegram bot — canal unificado para ingreso mobile
 # Creá un bot con @BotFather (/newbot) y pegá el token acá.
 # Setealo vacío para desactivar el worker de long-poll.
@@ -50,3 +45,8 @@ AUTH_GOOGLE_SECRET=
 # Corré `bun run db:seed` después de setear esto para crear el row.
 BOOTSTRAP_USER_EMAIL=
 BOOTSTRAP_USER_NAME=
+
+# Ingestion webhook token — per-user bearer para /api/ingest/{sms,debug}
+# Mintealo desde /settings/webhooks o corré `bun run db:bootstrap:webhook-tokens`.
+# El plaintext se muestra UNA vez — copialo acá y en el header Authorization del Shortcut.
+FINDASH_WEBHOOK_TOKEN=

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock @/auth so importing ./proxy doesn't pull NextAuth / @/lib/db into the
+// test — this is a pure config test for the matcher regex.
+vi.mock("@/auth", () => ({
+  auth: (handler: unknown) => handler,
+}));
+
+import { config } from "./proxy";
+
+// Next.js anchors the matcher against the full pathname. Mirror that here so
+// the negative lookahead isn't sidestepped by substring matches.
+function matches(path: string): boolean {
+  const [pattern] = config.matcher;
+  return new RegExp(`^${pattern}$`).test(path);
+}
+
+describe("proxy matcher", () => {
+  it("runs the proxy on protected app routes", () => {
+    for (const path of ["/", "/transactions", "/budgets", "/settings/webhooks"]) {
+      expect(matches(path), `${path} should be proxied`).toBe(true);
+    }
+  });
+
+  it("exempts bearer-token API routes (regression for #200)", () => {
+    for (const path of [
+      "/api/ingest/sms",
+      "/api/ingest/debug",
+      "/api/ingest/ocr",
+      "/api/fx/refresh",
+    ]) {
+      expect(matches(path), `${path} must bypass the session proxy`).toBe(false);
+    }
+  });
+
+  it("exempts auth, telegram, login/signup, and static assets", () => {
+    for (const path of [
+      "/api/auth/callback/google",
+      "/api/telegram/webhook",
+      "/login",
+      "/signup",
+      "/_next/static/chunks/main.js",
+      "/_next/image",
+      "/favicon.ico",
+      "/logo.png",
+      "/icon.svg",
+    ]) {
+      expect(matches(path), `${path} should be exempt`).toBe(false);
+    }
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,8 +14,11 @@ export default auth((req) => {
   return NextResponse.next();
 });
 
+// Routes under api/ingest and api/fx/refresh authenticate via bearer token
+// in their own handlers; they must bypass the session-based proxy or they
+// get 307-redirected to /login before the handler ever runs.
 export const config = {
   matcher: [
-    "/((?!api/auth|api/telegram/webhook|login|signup|_next/static|_next/image|favicon.ico|.*\\.(?:png|svg|ico|webmanifest)$).*)",
+    "/((?!api/auth|api/telegram/webhook|api/ingest|api/fx/refresh|login|signup|_next/static|_next/image|favicon.ico|.*\\.(?:png|svg|ico|webmanifest)$).*)",
   ],
 };


### PR DESCRIPTION
## Summary

- `src/proxy.ts` matcher now exempts `api/ingest/*` and `api/fx/refresh` — these endpoints authenticate via Bearer token in their own handlers; the session-based proxy was 307-redirecting them to `/login` before the handler ever ran. Regression from #187.
- New `src/proxy.test.ts` locks the matcher behavior so future edits can't silently drop any bearer-auth route.
- `.env.example` drops the retired `INGEST_WEBHOOK_TOKEN` block and documents the per-user `FINDASH_WEBHOOK_TOKEN` flow introduced in #195/#196.

## Test plan

- [x] `bun run test src/proxy.test.ts` — 3/3 passing (proxied routes, bearer exemptions, static/auth exemptions)
- [x] `bun run lint` / `prettier --check` / `bun run typecheck` — clean
- [x] `curl -X POST /api/ingest/sms` with invalid Bearer → `HTTP 401 {"error":"Unauthorized"}` (handler ran, was 307→login before fix)
- [x] `./scripts/test-sms-ingest.sh` with minted token → 9/9 2xx JSON responses

Closes #200