### PR TITLE
chore(infra): initial DO deploy scaffolding (#202)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,18 @@ AUTH_SECRET=replace-with-output-of-openssl-rand-base64-32
 AUTH_GOOGLE_ID=
 AUTH_GOOGLE_SECRET=
 
+# NextAuth — requerido SOLO en prod detrás de un reverse proxy (Caddy/Cloudflare).
+# En dev NextAuth auto-detecta desde la request; dejá ambas vacías.
+# En prod seteá en findash.env del droplet:
+#   AUTH_URL=https://findash.<tu-dominio>
+#   AUTH_TRUST_HOST=true
+AUTH_URL=
+AUTH_TRUST_HOST=
+
+# Git SHA del deploy actual — lo inyecta el workflow de CD, se muestra en
+# /api/health. En dev dejalo vacío.
+GIT_SHA=
+
 # Bootstrap — el email que se seedeá como user 1 (tu cuenta de Google personal).
 # En el primer login con Google, el row existente se linkea al google_sub.
 # Corré `bun run db:seed` después de setear esto para crear el row.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,24 @@
+# infra/
+
+Droplet-side scaffolding for the DigitalOcean deploy. The full runbook
+(topology, day-2 ops, rollback, backup restore, secret rotation) lives
+at [`docs/deploy.md`](../docs/deploy.md) — landed separately in T7.
+
+## Files
+
+| Path                      | Purpose                                                                                       |
+| ------------------------- | --------------------------------------------------------------------------------------------- |
+| `bootstrap.sh`            | Idempotent server bootstrap. Run once on a fresh droplet with `sudo bash infra/bootstrap.sh`. |
+| `systemd/findash.service` | systemd unit for the Next.js + Telegram worker process.                                       |
+| `caddy/Caddyfile`         | Reverse proxy config for Cloudflare Full (strict) TLS.                                        |
+
+## Quick start (first-time droplet bring-up)
+
+1. Clone the repo on the droplet (e.g. `/home/deploy/personal-financial-dashboard`).
+2. `sudo bash infra/bootstrap.sh`.
+3. Paste the Cloudflare origin cert at `/etc/caddy/origin.{pem,key}`.
+4. Populate `/srv/findash/env/findash.env` (all variables from `.env.example`).
+5. Run the first CD deploy. On success: `systemctl enable --now findash caddy`.
+6. `curl https://<your-subdomain>/api/health` — expect `{"ok":true,"db":"ok"}`.
+
+The CD workflow (T5) automates step 5 for every push to `main`.

--- a/infra/bootstrap.sh
+++ b/infra/bootstrap.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# findash — DigitalOcean droplet bootstrap (Ubuntu 24.04 LTS).
+#
+# Idempotent: safe to re-run after edits. Designed to be invoked from the
+# repo root on a freshly-provisioned droplet:
+#
+#   sudo bash infra/bootstrap.sh
+#
+# What it does (in order):
+#   1. apt update + security upgrade
+#   2. Create `findash` (runtime) and `deploy` (CD target) OS users
+#   3. Install Bun pinned to the version in .bun-version
+#   4. Install PostgreSQL 17 from PGDG + create role/database via peer auth
+#   5. Install Caddy 2 (reverse proxy with Cloudflare origin cert)
+#   6. Create /srv/findash/{app/releases,app/current,env,backups,logs} layout
+#   7. UFW default-deny + allow 22/80/443; block 5432 from the public
+#   8. fail2ban on sshd + unattended security upgrades + 2 GB swap
+#   9. Install the systemd unit and Caddyfile from the repo (does NOT enable;
+#      the first real deploy will flip `app/current` and start the service)
+#
+# Cloudflare origin cert is NOT fetched here — paste the PEM + key at
+# /etc/caddy/origin.pem and /etc/caddy/origin.key after the T2 ops step.
+#
+set -euo pipefail
+
+FINDASH_USER="${FINDASH_USER:-findash}"
+DEPLOY_USER="${DEPLOY_USER:-deploy}"
+APP_ROOT="/srv/findash"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUN_VERSION="$(tr -d '[:space:]' <"$REPO_ROOT/.bun-version")"
+
+log() { printf '[bootstrap] %s\n' "$*" >&2; }
+
+if [[ $EUID -ne 0 ]]; then
+  log "must run as root (try: sudo bash infra/bootstrap.sh)"
+  exit 1
+fi
+
+log "apt: update + security upgrade"
+apt-get update -y
+DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
+
+log "apt: install base packages"
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  curl ca-certificates gnupg lsb-release \
+  ufw fail2ban unattended-upgrades \
+  build-essential rsync
+
+log "users: ensure $FINDASH_USER and $DEPLOY_USER exist"
+for u in "$FINDASH_USER" "$DEPLOY_USER"; do
+  if ! id "$u" &>/dev/null; then
+    useradd -m -s /bin/bash "$u"
+    log "  created $u"
+  fi
+done
+
+log "layout: $APP_ROOT/{app/releases,env,backups,logs}"
+install -d -m 0755 -o "$FINDASH_USER" -g "$FINDASH_USER" "$APP_ROOT"
+install -d -m 0755 -o "$FINDASH_USER" -g "$FINDASH_USER" "$APP_ROOT/app"
+install -d -m 0755 -o "$FINDASH_USER" -g "$FINDASH_USER" "$APP_ROOT/app/releases"
+install -d -m 0750 -o root -g "$FINDASH_USER" "$APP_ROOT/env"
+install -d -m 0750 -o "$FINDASH_USER" -g "$FINDASH_USER" "$APP_ROOT/backups"
+install -d -m 0750 -o "$FINDASH_USER" -g "$FINDASH_USER" "$APP_ROOT/logs"
+
+if [[ ! -f "$APP_ROOT/env/findash.env" ]]; then
+  install -m 0640 -o root -g "$FINDASH_USER" /dev/null "$APP_ROOT/env/findash.env"
+  log "  created empty $APP_ROOT/env/findash.env — populate before starting findash.service"
+fi
+
+log "bun: install pinned version $BUN_VERSION"
+current_bun="$(bun --version 2>/dev/null || echo none)"
+if [[ "$current_bun" != "$BUN_VERSION" ]]; then
+  sudo -u "$FINDASH_USER" bash -c \
+    "curl -fsSL https://bun.sh/install | bash -s bun-v$BUN_VERSION"
+  ln -sf "/home/$FINDASH_USER/.bun/bin/bun" /usr/local/bin/bun
+fi
+
+log "postgres 17: install from PGDG"
+if ! command -v psql &>/dev/null; then
+  install -d /etc/apt/keyrings
+  curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc |
+    gpg --dearmor -o /etc/apt/keyrings/pgdg.gpg
+  codename="$(lsb_release -cs)"
+  printf 'deb [signed-by=/etc/apt/keyrings/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt %s-pgdg main\n' \
+    "$codename" >/etc/apt/sources.list.d/pgdg.list
+  apt-get update -y
+  DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-17 postgresql-contrib-17
+fi
+systemctl enable --now postgresql
+
+log "postgres: ensure role + database for $FINDASH_USER (peer auth)"
+if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='$FINDASH_USER'" | grep -q 1; then
+  sudo -u postgres createuser --createdb "$FINDASH_USER"
+fi
+if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='findash'" | grep -q 1; then
+  sudo -u "$FINDASH_USER" createdb findash
+fi
+
+log "caddy 2: install"
+if ! command -v caddy &>/dev/null; then
+  install -d /etc/apt/keyrings
+  curl -fsSL "https://dl.cloudsmith.io/public/caddy/stable/gpg.key" |
+    gpg --dearmor -o /etc/apt/keyrings/caddy-stable.gpg
+  curl -fsSL "https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt" \
+    >/etc/apt/sources.list.d/caddy-stable.list
+  apt-get update -y
+  apt-get install -y caddy
+fi
+
+log "caddy: install Caddyfile from repo"
+install -m 0644 "$REPO_ROOT/infra/caddy/Caddyfile" /etc/caddy/Caddyfile
+
+if [[ ! -s /etc/caddy/origin.pem || ! -s /etc/caddy/origin.key ]]; then
+  log "WARNING: Cloudflare origin cert missing at /etc/caddy/origin.{pem,key}"
+  log "  paste the CF-issued cert before enabling caddy.service"
+fi
+
+log "systemd: install findash.service from repo"
+install -m 0644 "$REPO_ROOT/infra/systemd/findash.service" /etc/systemd/system/findash.service
+systemctl daemon-reload
+
+log "ufw: default-deny + allow 22/80/443"
+ufw --force reset >/dev/null
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow 22/tcp
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw --force enable
+
+log "fail2ban: enable"
+systemctl enable --now fail2ban
+
+log "unattended-upgrades: enable periodic security updates"
+cat >/etc/apt/apt.conf.d/20auto-upgrades <<'EOF'
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+EOF
+
+log "swap: ensure 2 GB /swapfile"
+if ! swapon --show | grep -q '^/swapfile'; then
+  fallocate -l 2G /swapfile
+  chmod 600 /swapfile
+  mkswap /swapfile >/dev/null
+  swapon /swapfile
+  grep -q '^/swapfile' /etc/fstab || echo '/swapfile none swap sw 0 0' >>/etc/fstab
+fi
+
+cat >&2 <<EOF
+
+[bootstrap] done.
+
+Next steps (manual, in order):
+  1. Paste the Cloudflare origin cert:
+       /etc/caddy/origin.pem   (0644 root:root)
+       /etc/caddy/origin.key   (0600 root:caddy)
+  2. Populate $APP_ROOT/env/findash.env with prod values
+     (start from .env.example — fill every variable).
+  3. Run the first CD deploy (or manually rsync .next/standalone/ to
+     $APP_ROOT/app/releases/<sha> and flip the app/current symlink).
+  4. systemctl enable --now findash.service caddy
+  5. curl https://<your-subdomain>/api/health → expect {ok:true,db:"ok"}.
+EOF

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,0 +1,35 @@
+# Findash origin — fronted by Cloudflare (Full strict).
+#
+# Cloudflare terminates TLS for the user, then re-encrypts to this origin
+# using the CF-issued origin cert served below. DO NOT enable Caddy's
+# automatic Let's Encrypt — the hostname is not publicly resolvable to
+# this origin (CF proxies it), so the ACME challenge would fail.
+#
+# Expected on-disk:
+#   /etc/caddy/origin.pem   (0644 root:root)  — CF origin cert (15yr)
+#   /etc/caddy/origin.key   (0600 root:caddy) — matching private key
+#
+# Update the hostname below once the final subdomain is confirmed
+# (design recommends findash.<user-domain>).
+
+findash.alejoframes.com {
+	tls /etc/caddy/origin.pem /etc/caddy/origin.key
+
+	encode zstd gzip
+
+	# Forward real client IP from Cloudflare. Cloudflare sets
+	# `CF-Connecting-IP`; we surface it as `X-Forwarded-For` for Next.js.
+	reverse_proxy 127.0.0.1:3000 {
+		header_up Host {host}
+		header_up X-Forwarded-For {http.request.header.CF-Connecting-IP}
+		header_up X-Forwarded-Proto https
+	}
+
+	log {
+		output file /srv/findash/logs/caddy-access.log {
+			roll_size 50mb
+			roll_keep 7
+		}
+		format json
+	}
+}

--- a/infra/systemd/findash.service
+++ b/infra/systemd/findash.service
@@ -1,0 +1,40 @@
+[Unit]
+Description=Findash — personal finance dashboard (Next.js + Telegram worker)
+After=network.target postgresql.service
+Requires=postgresql.service
+
+[Service]
+Type=simple
+User=findash
+Group=findash
+WorkingDirectory=/srv/findash/app/current
+EnvironmentFile=/srv/findash/env/findash.env
+Environment=NODE_ENV=production
+Environment=PORT=3000
+Environment=HOSTNAME=127.0.0.1
+ExecStart=/usr/local/bin/bun server.js
+Restart=always
+RestartSec=3
+# Give the Telegram long-poll worker (src/instrumentation.ts) up to 30s to
+# drain on SIGTERM. Once #185 flips it to a webhook, this can drop to 10s.
+TimeoutStopSec=30
+KillSignal=SIGTERM
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=findash
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/srv/findash/logs
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+RestrictRealtime=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Produces a self-contained .next/standalone/ bundle the CD pipeline can
+  // rsync + run via `bun server.js` — no node_modules install on the droplet.
+  output: "standalone",
   allowedDevOrigins: ["ia-server.tailcabcc8.ts.net"],
 };
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  let dbOk = false;
+  try {
+    await db.execute(sql`SELECT 1`);
+    dbOk = true;
+  } catch {
+    dbOk = false;
+  }
+
+  return NextResponse.json(
+    {
+      ok: dbOk,
+      sha: process.env.GIT_SHA ?? null,
+      db: dbOk ? "ok" : "fail",
+    },
+    { status: dbOk ? 200 : 503 },
+  );
+}

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -33,6 +33,10 @@ describe("proxy matcher", () => {
     }
   });
 
+  it("exempts /api/health so CD + Cloudflare probes don't hit /login", () => {
+    expect(matches("/api/health"), "/api/health must be publicly probeable").toBe(false);
+  });
+
   it("exempts auth, telegram, login/signup, and static assets", () => {
     for (const path of [
       "/api/auth/callback/google",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,11 +14,11 @@ export default auth((req) => {
   return NextResponse.next();
 });
 
-// Routes under api/ingest and api/fx/refresh authenticate via bearer token
-// in their own handlers; they must bypass the session-based proxy or they
-// get 307-redirected to /login before the handler ever runs.
+// Public endpoints (health check, bearer-token APIs, OAuth callbacks, static
+// assets) must bypass the session-based proxy — otherwise they get 307'd to
+// /login before their own handler (or Next.js's static handler) ever runs.
 export const config = {
   matcher: [
-    "/((?!api/auth|api/telegram/webhook|api/ingest|api/fx/refresh|login|signup|_next/static|_next/image|favicon.ico|.*\\.(?:png|svg|ico|webmanifest)$).*)",
+    "/((?!api/auth|api/telegram/webhook|api/ingest|api/fx/refresh|api/health|login|signup|_next/static|_next/image|favicon.ico|.*\\.(?:png|svg|ico|webmanifest)$).*)",
   ],
 };


### PR DESCRIPTION
## Summary

First PR in the DigitalOcean deploy chain. Repo-only changes — can land before the droplet exists. SDD artifacts in engram under `sdd/feat-digitalocean-deploy/*`.

**3 commits**:

1. `feat(health): public /api/health endpoint for CD probes` — liveness + DB ping, returns `{ok, sha, db}` (200/503). Allowlist'd in `src/proxy.ts` so CF health probes don't get 307'd.
2. `chore(next): enable standalone output for deploy artifact` — `output: "standalone"` so the CD pipeline ships a self-contained bundle, no `node_modules` install on the droplet.
3. `chore(infra): DO deploy scaffolding` — idempotent `infra/bootstrap.sh`, `infra/systemd/findash.service` (hardened unit with `ProtectSystem=strict`), `infra/caddy/Caddyfile` (Cloudflare Full strict with origin cert), `infra/README.md`, and `.env.example` additions (`AUTH_URL`, `AUTH_TRUST_HOST`, `GIT_SHA`).

## Architectural context

- **TLS**: Cloudflare Full (strict) proxied + CF-issued 15yr origin cert served by Caddy.
- **Supervision**: systemd unit honors the existing Telegram long-poll worker (`src/instrumentation.ts`) until #185 flips it to webhooks — `TimeoutStopSec=30` gives clean SIGTERM drain.
- **Database**: Postgres 17 on-droplet, peer auth via `/var/run/postgresql` — matches `src/lib/db/index.ts` default and ia-server parity.
- **Secrets**: `/srv/findash/env/findash.env` (0640 root:findash) + systemd `EnvironmentFile=`. GH Actions never sees app runtime secrets.
- **Region**: NYC3 (55–75ms from Colombia).
- **Caddy bind**: serves HTTPS on :443 with CF origin cert; proxies to `127.0.0.1:3000`. No public ACME — the hostname is CF-proxied, ACME would fail.

## Out of scope (later PRs in the chain)

- T5: GitHub Actions deploy workflow (`.github/workflows/deploy.yml`)
- T7: `docs/deploy.md` runbook
- T8: `infra/cron/findash-backup` (daily `pg_dump` + weekly CF R2 sync)

## Test plan

- [x] `bun run test` — 286/286 passing (new proxy test covers `/api/health` allowlist)
- [x] `bun run lint` / `prettier --check` / `bun run typecheck` — clean
- [x] `curl http://localhost:3100/api/health` — `HTTP 200 {"ok":true,"sha":null,"db":"ok"}`
- [x] `bash -n infra/bootstrap.sh` — syntactically valid
- [x] `systemd-analyze verify infra/systemd/findash.service` — the only warning is that `/usr/local/bin/bun` doesn't exist locally; on the droplet `bootstrap.sh` creates the symlink from the pinned version in `.bun-version`
- [ ] `caddy validate` — not runnable locally (Caddy not installed); will verify on the droplet during T3 ops
- [ ] `shellcheck infra/bootstrap.sh` — not runnable locally (shellcheck not installed); syntax-checked with `bash -n`

Closes #202