### PR TITLE
fix(infra): bootstrap.sh missing unzip + Caddy keyring path (#205)

### DIFF
--- a/infra/bootstrap.sh
+++ b/infra/bootstrap.sh
@@ -46,7 +46,8 @@ log "apt: install base packages"
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl ca-certificates gnupg lsb-release \
   ufw fail2ban unattended-upgrades \
-  build-essential rsync
+  build-essential rsync unzip \
+  debian-keyring debian-archive-keyring apt-transport-https
 
 log "users: ensure $FINDASH_USER and $DEPLOY_USER exist"
 for u in "$FINDASH_USER" "$DEPLOY_USER"; do
@@ -100,10 +101,13 @@ fi
 
 log "caddy 2: install"
 if ! command -v caddy &>/dev/null; then
-  install -d /etc/apt/keyrings
-  curl -fsSL "https://dl.cloudsmith.io/public/caddy/stable/gpg.key" |
-    gpg --dearmor -o /etc/apt/keyrings/caddy-stable.gpg
-  curl -fsSL "https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt" \
+  # Caddy's cloudsmith sources.list (debian.deb.txt) declares
+  # signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg — the
+  # keyring MUST land at that exact path or apt rejects the repo with
+  # NO_PUBKEY. Match the vendor's documented install flow exactly.
+  curl -1sLf "https://dl.cloudsmith.io/public/caddy/stable/gpg.key" |
+    gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  curl -1sLf "https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt" \
     >/etc/apt/sources.list.d/caddy-stable.list
   apt-get update -y
   apt-get install -y caddy


### PR DESCRIPTION
## Summary

Hotfix for #202 scaffolding — `infra/bootstrap.sh` fails on a fresh Ubuntu 24.04 droplet due to two issues. Both caught during the first real run on prod droplet (147.182.138.79) and patched in-place; this PR makes the script correct for the next fresh provision.

## Bug 1 — `unzip` missing

Bun's installer needs `unzip` to extract the release tarball; without it: `error: unzip is required to install bun`. Added to the base packages apt-get install line (alongside `debian-keyring debian-archive-keyring apt-transport-https` which are the companion packages Caddy's vendor docs list).

## Bug 2 — Caddy keyring path mismatch

Cloudsmith's `debian.deb.txt` hard-codes `signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg`; our script wrote the key to `/etc/apt/keyrings/caddy-stable.gpg`. `apt-get update` then fails with `NO_PUBKEY ABA1F9B8875A6661`. Matched the vendor's documented flow exactly (path + `curl -1sLf` flag set).

## Test plan

- [x] Applied both fixes manually on the existing droplet — bootstrap now runs end-to-end clean.
- [x] Idempotent re-run verified (packages already installed, creates/overwrites are no-ops).
- [x] `bash -n infra/bootstrap.sh` clean.
- [ ] CI (lint + format + typecheck + test + build) — pending.

Closes #205