### PR TITLE
feat(ci): deploy to DO droplet on push to main (#204)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,196 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to deploy (defaults to main)"
+        required: false
+        default: "main"
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to DigitalOcean
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') }}
+
+    env:
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      APP_HEALTH_URL: ${{ secrets.APP_HEALTH_URL }}
+      APP_ROOT: /srv/findash
+
+    steps:
+      - name: Resolve target ref
+        id: target
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            echo "ref=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ inputs.ref }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.target.outputs.ref }}
+          fetch-depth: 1
+
+      - name: Resolve SHA
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build standalone artifact
+        env:
+          # Build-time stubs only. Real secrets live on the droplet in
+          # /srv/findash/env/findash.env and are read by systemd at process start.
+          AUTH_SECRET: build-dummy-never-used-in-prod
+          BOOTSTRAP_USER_EMAIL: build@findash.local
+          BOOTSTRAP_USER_NAME: Build Bootstrap
+        run: bun run build
+
+      - name: Package release tarball
+        env:
+          GIT_SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -eu
+          STAGE=release-stage
+          mkdir -p "$STAGE"
+          cp -r .next/standalone/. "$STAGE"/
+          mkdir -p "$STAGE/.next"
+          cp -r .next/static "$STAGE/.next/static"
+          if [ -d public ]; then cp -r public "$STAGE/public"; fi
+          # drizzle-orm/postgres-js/migrator isn't traced by Next's standalone
+          # output (no app code imports it), so overlay the full drizzle-orm
+          # and postgres packages. Tarball stays well under 50 MB.
+          cp -r node_modules/drizzle-orm "$STAGE/node_modules/drizzle-orm"
+          cp -r node_modules/postgres "$STAGE/node_modules/postgres"
+          cp -r drizzle "$STAGE/drizzle"
+          cp scripts/migrate-prod.ts "$STAGE/migrate-prod.ts"
+          echo "$GIT_SHA" > "$STAGE/GIT_SHA"
+          tar -czf release.tar.gz -C "$STAGE" .
+          ls -lh release.tar.gz
+
+      - name: Setup SSH
+        run: |
+          set -eu
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Upload tarball
+        env:
+          GIT_SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -eu
+          scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new \
+            release.tar.gz "$DEPLOY_USER@$DEPLOY_HOST:/tmp/release-$GIT_SHA.tar.gz"
+
+      - name: Extract release + write release.env
+        env:
+          GIT_SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -eu
+          RELEASE_DIR="$APP_ROOT/app/releases/$GIT_SHA"
+          TARBALL="/tmp/release-$GIT_SHA.tar.gz"
+          ENV_FILE="$APP_ROOT/env/release.env"
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" "
+            set -eu
+            sudo -n -u findash install -d -m 0755 '$RELEASE_DIR'
+            sudo -n -u findash tar -xzf '$TARBALL' -C '$RELEASE_DIR'
+            rm -f '$TARBALL'
+            printf 'GIT_SHA=%s\n' '$GIT_SHA' | sudo -n -u findash tee '$ENV_FILE' >/dev/null
+            sudo -n -u findash chmod 0640 '$ENV_FILE'
+          "
+
+      - name: Run migrations
+        env:
+          GIT_SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -eu
+          RELEASE_DIR="$APP_ROOT/app/releases/$GIT_SHA"
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" "
+            set -eu
+            cd '$RELEASE_DIR'
+            sudo -n -u findash /usr/local/bin/bun migrate-prod.ts
+          "
+
+      - name: Flip symlink + restart findash
+        id: flip
+        env:
+          GIT_SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -eu
+          PREV=$(ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+            "readlink '$APP_ROOT/app/current' 2>/dev/null || true")
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" "
+            set -eu
+            sudo -n -u findash ln -sfn '$APP_ROOT/app/releases/$GIT_SHA' '$APP_ROOT/app/current'
+            sudo -n systemctl restart findash.service
+          "
+
+      - name: Health probe
+        run: |
+          set -eu
+          for i in $(seq 1 15); do
+            body=$(curl -fsS --max-time 5 "$APP_HEALTH_URL" 2>/dev/null || true)
+            if echo "$body" | grep -q '"ok":true'; then
+              echo "health OK on attempt $i"
+              echo "$body"
+              exit 0
+            fi
+            echo "health $i/15: not ready (body: ${body:-<empty>})"
+            sleep 3
+          done
+          echo "health check failed after 15 attempts"
+          exit 1
+
+      - name: Rollback on failure
+        if: failure() && steps.flip.outputs.prev != ''
+        env:
+          PREV: ${{ steps.flip.outputs.prev }}
+        run: |
+          set -eu
+          echo "rolling back to $PREV"
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" "
+            set -eu
+            sudo -n -u findash ln -sfn '$PREV' '$APP_ROOT/app/current'
+            sudo -n systemctl restart findash.service
+          "
+
+      - name: Prune old releases (keep 5)
+        if: success()
+        run: |
+          set -eu
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" "
+            set -eu
+            cd '$APP_ROOT/app/releases'
+            ls -1t | tail -n +6 | while read -r rel; do
+              [ -n \"\$rel\" ] || continue
+              sudo -n -u findash rm -rf \"\$rel\"
+              echo \"pruned \$rel\"
+            done
+          "

--- a/infra/systemd/findash.service
+++ b/infra/systemd/findash.service
@@ -9,6 +9,9 @@ User=findash
 Group=findash
 WorkingDirectory=/srv/findash/app/current
 EnvironmentFile=/srv/findash/env/findash.env
+# Per-release env injected by the CD workflow (GIT_SHA etc.). Optional — if
+# the droplet hasn't had a CD deploy yet, systemd still starts fine.
+EnvironmentFile=-/srv/findash/env/release.env
 Environment=NODE_ENV=production
 Environment=PORT=3000
 Environment=HOSTNAME=127.0.0.1

--- a/scripts/migrate-prod.ts
+++ b/scripts/migrate-prod.ts
@@ -1,0 +1,32 @@
+// Production migration runner. Uses drizzle-orm's runtime migrator so the
+// droplet doesn't need drizzle-kit (dev dep). Invoked from the CD workflow
+// as:  sudo -n -u findash bun migrate-prod.ts
+//
+// Expects:
+//   - cwd at the release dir (reads ./drizzle/ for migration SQL)
+//   - Postgres reachable via peer auth over /var/run/postgresql (no password)
+//   - PGDATABASE env set (defaults to `findash` via src/lib/db parity)
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import postgres from "postgres";
+
+const client = postgres({
+  host: process.env.PGHOST ?? "/var/run/postgresql",
+  database: process.env.PGDATABASE ?? "findash",
+  username: process.env.PGUSER ?? process.env.USER,
+  port: process.env.PGPORT ? Number(process.env.PGPORT) : undefined,
+  password: process.env.PGPASSWORD,
+  max: 1,
+  prepare: false,
+});
+
+const db = drizzle(client);
+
+console.log(
+  `[migrate-prod] applying migrations from ./drizzle against ${process.env.PGDATABASE ?? "findash"}...`,
+);
+await migrate(db, { migrationsFolder: "./drizzle" });
+console.log("[migrate-prod] done.");
+
+await client.end();


### PR DESCRIPTION
## Summary

CD workflow for the DigitalOcean droplet. Triggers on CI-green pushes to `main`, with `workflow_dispatch` for manual + rollback-adjacent operations.

## Flow

1. Resolve target ref → checkout → setup Bun @ `.bun-version`
2. `bun install --frozen-lockfile` → `bun run build` (produces `.next/standalone/`)
3. Package tarball: standalone output + `.next/static` + `public/` + `drizzle/` (migrations) + `migrate-prod.ts` + full `node_modules/{drizzle-orm,postgres}` (overlays what the standalone tracer misses for the runtime migrator)
4. `scp` to droplet, `ssh` as `deploy` user, extract into `/srv/findash/app/releases/<sha>/` as `findash` (via narrow sudoers)
5. Write `/srv/findash/env/release.env` with `GIT_SHA=<sha>` — systemd picks it up via the new optional `EnvironmentFile=-…`
6. Run migrations: `sudo -u findash bun migrate-prod.ts` — uses `drizzle-orm/postgres-js/migrator` (runtime, no drizzle-kit needed on the droplet)
7. Flip `/srv/findash/app/current` symlink, `systemctl restart findash.service`
8. Health probe `$APP_HEALTH_URL` (15 tries × 3s = 45s budget)
9. On probe failure: flip symlink back to previous release, restart — and fail the job
10. On success: prune releases, keep last 5

## Security posture

- `deploy` user has narrow `sudoers.d` — can run ANY command as `findash` (for file ops), but only `systemctl {restart,reload,status} findash.service` as root. No root shell escalation.
- `DEPLOY_SSH_KEY` is a dedicated ed25519 keypair, separate from the root provisioning key.
- Build-time env (`AUTH_SECRET`, `BOOTSTRAP_USER_*`) are CI stubs. Real values live on the droplet at `/srv/findash/env/findash.env` (mode 0640, root:findash). Never flow through GH Actions.

## Test plan

- [x] `bun run build` produces `.next/standalone/server.js` locally — works with `output: "standalone"` (already merged in #202).
- [x] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(open(...))"`).
- [x] `scripts/migrate-prod.ts` typechecks clean.
- [x] `infra/systemd/findash.service` — `EnvironmentFile=-` (with leading `-`) is the standard systemd "optional" marker; unit still verifies on a system where the file is absent.
- [ ] First real deploy end-to-end — triggered manually via `workflow_dispatch` once this merges (tracked in T6, next step).
- [ ] Rollback path — will exercise by intentionally failing a probe during the first deploy smoke.

## Prerequisites (already done via ops)

- Droplet bootstrap complete (bun, Postgres 17, Caddy, UFW, fail2ban, swap) — `infra/bootstrap.sh` ran green on `147.182.138.79`.
- CF origin cert installed at `/etc/caddy/origin.{pem,key}`.
- `deploy` user exists with SSH pubkey authorized + narrow sudoers.
- GitHub Secrets set: `DEPLOY_SSH_KEY`, `DEPLOY_HOST`, `DEPLOY_USER`, `APP_HEALTH_URL`.

## Follow-ups (separate PRs)

- T7 — `docs/deploy.md` runbook (topology, day-2 ops, rollback, restore)
- T8 — `infra/cron/findash-backup` (daily `pg_dump` + weekly R2 sync)
- Post-T6: update `sdd/feat-telegram-multibot/design` in engram (webhook story flips from Tailscale Funnel to `https://findash.alejoframes.com`)

Closes #204