### PR TITLE
fix(infra): Caddyfile log path unreachable by caddy user (#208)

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -25,8 +25,10 @@ findash.alejoframes.com {
 		header_up X-Forwarded-Proto https
 	}
 
+	# Log to Caddy's native /var/log/caddy/ (owned by the caddy user).
+	# /srv/findash/logs is owned by `findash`, which caddy can't write to.
 	log {
-		output file /srv/findash/logs/caddy-access.log {
+		output file /var/log/caddy/findash-access.log {
 			roll_size 50mb
 			roll_keep 7
 		}


### PR DESCRIPTION
## Summary

Caddyfile writes access log to \`/srv/findash/logs/\` which is owned by \`findash:findash\` (0750). Caddy runs as user \`caddy\` and can't write there, so the service fails to start with \`permission denied\`.

Switched to \`/var/log/caddy/\` which the Caddy package creates as \`caddy:caddy\` during install — idiomatic, no perm patches needed.

## Test plan

- [x] Patched on prod droplet — caddy starts clean, binds :443, serves the CF origin cert.
- [x] Lint/format/typecheck — no code changes, only Caddyfile contents.
- [ ] CI green.

Closes #208