### PR TITLE
fix(ci): write release.env inside release dir (#210)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,10 @@ jobs:
           set -eu
           RELEASE_DIR="$APP_ROOT/app/releases/$GIT_SHA"
           TARBALL="/tmp/release-$GIT_SHA.tar.gz"
-          ENV_FILE="$APP_ROOT/env/release.env"
+          # release.env lives INSIDE the release dir so it moves with the
+          # symlink (systemd EnvironmentFile follows /srv/findash/app/current).
+          # Findash owns the release dir — no cross-group perm juggling.
+          ENV_FILE="$RELEASE_DIR/release.env"
           ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" "
             set -eu
             sudo -n -u findash install -d -m 0755 '$RELEASE_DIR'

--- a/infra/systemd/findash.service
+++ b/infra/systemd/findash.service
@@ -9,9 +9,10 @@ User=findash
 Group=findash
 WorkingDirectory=/srv/findash/app/current
 EnvironmentFile=/srv/findash/env/findash.env
-# Per-release env injected by the CD workflow (GIT_SHA etc.). Optional — if
-# the droplet hasn't had a CD deploy yet, systemd still starts fine.
-EnvironmentFile=-/srv/findash/env/release.env
+# Per-release env (GIT_SHA etc.) lives inside the release dir so it moves
+# with the symlink on deploy / rollback. Optional — systemd starts fine if
+# the droplet hasn't had a CD deploy yet.
+EnvironmentFile=-/srv/findash/app/current/release.env
 Environment=NODE_ENV=production
 Environment=PORT=3000
 Environment=HOSTNAME=127.0.0.1


### PR DESCRIPTION
## Summary

First CD deploy (run 24609782493) failed: \`tee: /srv/findash/env/release.env: Permission denied\`.

\`/srv/findash/env/\` is \`0750 root:findash\` — findash group has no write bit. \`sudo -u findash tee ... /srv/findash/env/release.env\` fails at file creation.

## Fix

Move \`release.env\` INSIDE the release dir. systemd points at \`/srv/findash/app/current/release.env\` — the symlink carries it forward on deploy and back on rollback.

**Bonus:** each release is now self-contained; rollback brings its env with it, no stale cross-release state.

## Changes

- \`infra/systemd/findash.service\`: \`EnvironmentFile=-/srv/findash/app/current/release.env\`
- \`.github/workflows/deploy.yml\`: write to \`$RELEASE_DIR/release.env\`

## Test plan

- [x] Droplet systemd unit patched manually, \`systemctl daemon-reload\` + \`systemd-analyze verify\` clean.
- [ ] CI green — pending.
- [ ] Re-deploy via \`workflow_dispatch\` after merge — will confirm the tee step passes.

Closes #210