### PR TITLE
feat(crypto): aes-256-gcm symmetric encryption helper (#185)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,13 @@ TELEGRAM_ALLOWED_USER_IDS=
 # Opcional — setealo a "1" para apagar el worker de Telegram sin tocar el token.
 # FINDASH_DISABLE_TELEGRAM=1
 
+# AES-256-GCM key para encriptar tokens de bots de Telegram en la tabla
+# telegram_bots (flujo multi-bot por usuario — issue #185).
+# Generá con: openssl rand -base64 32
+# Decode tiene que dar EXACTAMENTE 32 bytes. Rotar esta key invalida todos
+# los tokens guardados: los usuarios tienen que volver a registrar su bot.
+TELEGRAM_TOKEN_ENCRYPTION_KEY=
+
 # FX refresh token — protege POST /api/fx/refresh (cron externo)
 # Generá con: openssl rand -hex 32
 FX_REFRESH_TOKEN=replace-with-output-of-openssl-rand-hex-32

--- a/src/lib/crypto/symmetric.test.ts
+++ b/src/lib/crypto/symmetric.test.ts
@@ -1,0 +1,53 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { decrypt, encrypt, InvalidTokenError } from "./symmetric";
+
+describe("crypto/symmetric", () => {
+  it("round-trips ascii plaintext", () => {
+    const plaintext = "1234567890:AAHabc_def-ghi";
+    expect(decrypt(encrypt(plaintext))).toBe(plaintext);
+  });
+
+  it("round-trips non-ascii plaintext", () => {
+    const plaintext = "héllo 🌎 — ¡hola, mundo!";
+    expect(decrypt(encrypt(plaintext))).toBe(plaintext);
+  });
+
+  it("round-trips empty string", () => {
+    expect(decrypt(encrypt(""))).toBe("");
+  });
+
+  it("produces a different ciphertext on each call (random IV)", () => {
+    const plaintext = "repeat";
+    expect(encrypt(plaintext)).not.toBe(encrypt(plaintext));
+  });
+
+  it("decrypt rejects payload tampered in the ciphertext region", () => {
+    const buf = Buffer.from(encrypt("sensitive"), "base64");
+    // Flip a byte in the ciphertext body (after 12-byte IV, before 16-byte tag).
+    buf[14] ^= 0x01;
+    expect(() => decrypt(buf.toString("base64"))).toThrow(InvalidTokenError);
+  });
+
+  it("decrypt rejects payload tampered in the auth tag", () => {
+    const buf = Buffer.from(encrypt("sensitive"), "base64");
+    // Flip a byte in the last 16 bytes (auth tag).
+    buf[buf.length - 1] ^= 0x01;
+    expect(() => decrypt(buf.toString("base64"))).toThrow(InvalidTokenError);
+  });
+
+  it("decrypt rejects payload encrypted with a different key", () => {
+    const wrongKey = Buffer.alloc(32, 0x2a);
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv("aes-256-gcm", wrongKey, iv);
+    const ciphertext = Buffer.concat([cipher.update("hello", "utf8"), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    const payload = Buffer.concat([iv, ciphertext, authTag]).toString("base64");
+    expect(() => decrypt(payload)).toThrow(InvalidTokenError);
+  });
+
+  it("decrypt rejects payload shorter than iv+tag minimum", () => {
+    const tooShort = Buffer.alloc(10).toString("base64");
+    expect(() => decrypt(tooShort)).toThrow(InvalidTokenError);
+  });
+});

--- a/src/lib/crypto/symmetric.ts
+++ b/src/lib/crypto/symmetric.ts
@@ -1,0 +1,59 @@
+import crypto from "node:crypto";
+
+const KEY_ENV = "TELEGRAM_TOKEN_ENCRYPTION_KEY";
+const ALGORITHM = "aes-256-gcm";
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+
+export class InvalidTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidTokenError";
+  }
+}
+
+function loadKey(): Buffer {
+  const raw = process.env[KEY_ENV];
+  if (!raw) {
+    throw new Error(
+      `[crypto/symmetric] ${KEY_ENV} must be set. Generate with: openssl rand -base64 32`,
+    );
+  }
+  const key = Buffer.from(raw, "base64");
+  if (key.length !== KEY_BYTES) {
+    throw new Error(
+      `[crypto/symmetric] ${KEY_ENV} decodes to ${key.length} bytes; expected ${KEY_BYTES}. ` +
+        `Generate with: openssl rand -base64 32`,
+    );
+  }
+  return key;
+}
+
+const KEY = loadKey();
+
+export function encrypt(plaintext: string): string {
+  const iv = crypto.randomBytes(IV_BYTES);
+  const cipher = crypto.createCipheriv(ALGORITHM, KEY, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, ciphertext, authTag]).toString("base64");
+}
+
+export function decrypt(payload: string): string {
+  const buf = Buffer.from(payload, "base64");
+  if (buf.length < IV_BYTES + AUTH_TAG_BYTES) {
+    throw new InvalidTokenError("payload too short");
+  }
+  const iv = buf.subarray(0, IV_BYTES);
+  const authTag = buf.subarray(buf.length - AUTH_TAG_BYTES);
+  const ciphertext = buf.subarray(IV_BYTES, buf.length - AUTH_TAG_BYTES);
+  const decipher = crypto.createDecipheriv(ALGORITHM, KEY, iv);
+  decipher.setAuthTag(authTag);
+  try {
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return plaintext.toString("utf8");
+  } catch {
+    throw new InvalidTokenError("auth tag mismatch — ciphertext tampered or wrong key");
+  }
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,12 +1,15 @@
 /**
  * Vitest global setup — runs BEFORE any test file is imported.
  *
- * Two jobs:
+ * Jobs:
  *   1. Force integration tests to target the `findash_test` Postgres DB,
  *      NEVER the dev DB. Tests DELETE rows during cleanup, so running them
  *      against a DB with real data would silently destroy work.
  *   2. Hard-fail if anything tried to override this with a non-test DB name
  *      (e.g. someone exported PGDATABASE=findash in their shell).
+ *   3. Set a deterministic TELEGRAM_TOKEN_ENCRYPTION_KEY so the crypto
+ *      module (`src/lib/crypto/symmetric.ts`) loads successfully under test.
+ *      The module throws at import time if the key is missing or malformed.
  *
  * See `src/lib/db/index.ts` — it reads `process.env.PGDATABASE` at import
  * time, so this file MUST run before any `import { db } from ...` happens.
@@ -23,3 +26,7 @@ if (process.env.PGDATABASE !== TEST_DB_NAME) {
       `Refusing to run tests against a non-test database.`,
   );
 }
+
+// 32 zero bytes, base64-encoded. Deterministic so tampering tests are stable;
+// trivially insecure — do NOT reuse anywhere outside the test runtime.
+process.env.TELEGRAM_TOKEN_ENCRYPTION_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";


### PR DESCRIPTION
First PR in the #185 Telegram multi-bot chain (1 of 5).

Closes #217.

## What

Adds `src/lib/crypto/symmetric.ts` — `encrypt(plaintext)` / `decrypt(ciphertext)` for AES-256-GCM with a 12-byte random IV per call and 16-byte auth tag. Wire format is base64(iv || ciphertext || authTag).

The module reads `TELEGRAM_TOKEN_ENCRYPTION_KEY` once at import time and throws if the decoded key is not exactly 32 bytes. `decrypt` throws `InvalidTokenError` on auth tag mismatch or short payload — never silently returns gibberish.

## Why

PR3 of this chain will persist BotFather tokens in `telegram_bots.token_encrypted` and needs the plaintext back at outbound-call time (to hit `api.telegram.org/bot{TOKEN}/...`). Hashing like the webhook-tokens table does won't work — this is a reversible secret.

Clean-slate pre-prod, no data migration.

## Files

- NEW `src/lib/crypto/symmetric.ts`
- NEW `src/lib/crypto/symmetric.test.ts` — 8 cases: round-trip ascii/non-ascii/empty, IV randomness, ciphertext tamper, authTag tamper, wrong-key rejection, short payload rejection.
- MODIFY `.env.example` — documents the new var + `openssl rand -base64 32` generation command.
- MODIFY `vitest.setup.ts` — injects a deterministic zero-byte key so tamper tests are stable. Insecure by design, test-only.

## Out of scope (landing in later PRs)

- #218 (PR2): `telegram_bots` schema, drop `telegram_poll_state`, delete `poll-worker.ts`.
- #219 (PR3): `/api/telegram/webhook/[botId]/route.ts` and `userId` refactor in router/session.
- #220 (PR4): `/settings/telegram` UI + register/revoke server actions.
- #221 (PR5): cleanup (optional).

## References

- Parent tracking issue: #185
- Umbrella: #179
- Design: `docs/multi-user-plan.md` §2.7 + §3.1
- SDD artifacts in engram under `sdd/feat-telegram-multibot/{proposal,spec,design,tasks}`.

## Test plan

- [x] `bun run test` — 294/294 green
- [x] `bun run typecheck` — green
- [x] `bun run lint` — green
- [x] `bun run format:check` — green
- [ ] CI green on this branch