### PR TITLE
feat(telegram): per-user webhook route + userId threading (#185)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
       # column defaults to. Without it the FK in #183's migrations fails.
       BOOTSTRAP_USER_EMAIL: ci@findash.local
       BOOTSTRAP_USER_NAME: CI Bootstrap
+      # Required by src/lib/crypto/symmetric.ts at module-load time — Next.js
+      # page-data collection imports the webhook route (#185) during `next build`.
+      # 32 zero bytes base64. Real key lives in prod findash.env.
+      TELEGRAM_TOKEN_ENCRYPTION_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,10 @@ jobs:
           AUTH_SECRET: build-dummy-never-used-in-prod
           BOOTSTRAP_USER_EMAIL: build@findash.local
           BOOTSTRAP_USER_NAME: Build Bootstrap
+          # Required by src/lib/crypto/symmetric.ts at module-load time —
+          # Next.js page-data collection imports the webhook route. 32 zero
+          # bytes base64. Real key lives on the droplet in findash.env.
+          TELEGRAM_TOKEN_ENCRYPTION_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
         run: bun run build
 
       - name: Package release tarball

--- a/src/app/api/telegram/webhook/[botId]/route.test.ts
+++ b/src/app/api/telegram/webhook/[botId]/route.test.ts
@@ -1,0 +1,127 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { telegramBots } from "@/lib/db/schema";
+import { encrypt } from "@/lib/crypto/symmetric";
+import { POST } from "./route";
+
+const TEST_USER_ID = 1;
+const SECRET = "a".repeat(64);
+const TOKEN = "1234567890:AAHxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+async function cleanup() {
+  await db.delete(telegramBots).where(eq(telegramBots.userId, TEST_USER_ID));
+}
+
+async function seedBot(): Promise<number> {
+  const [row] = await db
+    .insert(telegramBots)
+    .values({
+      userId: TEST_USER_ID,
+      tokenEncrypted: encrypt(TOKEN),
+      username: "vitest_bot",
+      webhookSecret: SECRET,
+    })
+    .returning({ id: telegramBots.id });
+  return row.id;
+}
+
+function request(
+  botId: number | string,
+  init: { headers?: Record<string, string>; body?: string } = {},
+) {
+  return new Request(`http://localhost:3100/api/telegram/webhook/${botId}`, {
+    method: "POST",
+    headers: init.headers,
+    body: init.body,
+  });
+}
+
+async function callPost(
+  botId: number | string,
+  init: { headers?: Record<string, string>; body?: string } = {},
+) {
+  return POST(request(botId, init), { params: Promise.resolve({ botId: String(botId) }) });
+}
+
+describe("POST /api/telegram/webhook/[botId]", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+  afterAll(async () => {
+    await db.$client.end({ timeout: 1 });
+  });
+
+  it("returns 401 when botId is not a positive integer", async () => {
+    const res = await callPost("abc");
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized" });
+  });
+
+  it("returns 401 when botId matches no row", async () => {
+    const res = await callPost(999_999);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the secret header is missing", async () => {
+    const botId = await seedBot();
+    const res = await callPost(botId, {
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the secret header is wrong", async () => {
+    const botId = await seedBot();
+    const res = await callPost(botId, {
+      headers: {
+        "content-type": "application/json",
+        "x-telegram-bot-api-secret-token": "wrong-secret",
+      },
+      body: "{}",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when the body is not valid JSON", async () => {
+    const botId = await seedBot();
+    const res = await callPost(botId, {
+      headers: {
+        "content-type": "application/json",
+        "x-telegram-bot-api-secret-token": SECRET,
+      },
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "bad request" });
+  });
+
+  it("returns 200 for a valid empty Update (no message, no callback_query)", async () => {
+    const botId = await seedBot();
+    const res = await callPost(botId, {
+      headers: {
+        "content-type": "application/json",
+        "x-telegram-bot-api-secret-token": SECRET,
+      },
+      body: JSON.stringify({ update_id: 42 }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("returns 200 but logs when the stored token ciphertext is corrupt", async () => {
+    const botId = await seedBot();
+    await db
+      .update(telegramBots)
+      .set({ tokenEncrypted: "not-a-valid-ciphertext" })
+      .where(eq(telegramBots.id, botId));
+    const res = await callPost(botId, {
+      headers: {
+        "content-type": "application/json",
+        "x-telegram-bot-api-secret-token": SECRET,
+      },
+      body: JSON.stringify({ update_id: 42 }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/telegram/webhook/[botId]/route.ts
+++ b/src/app/api/telegram/webhook/[botId]/route.ts
@@ -1,0 +1,82 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { telegramBots } from "@/lib/db/schema";
+import { decrypt } from "@/lib/crypto/symmetric";
+import { createTelegramClient } from "@/lib/telegram/client";
+import { handleUpdate, type RouterDeps } from "@/lib/telegram/router";
+import type { TelegramUpdate } from "@/lib/telegram/types";
+import { listAccountsDetailed } from "@/lib/accounts/queries";
+import { listCategories } from "@/lib/transactions/queries";
+import { parseTransactionMessage } from "@/lib/ai/transaction-nlu";
+import { extractTransactionsFromImage } from "@/lib/ingestion/ocr";
+import { transcribeAudio } from "@/lib/stt/transcribe";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const SECRET_HEADER = "x-telegram-bot-api-secret-token";
+
+function unauthorized() {
+  return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export async function POST(req: Request, { params }: { params: Promise<{ botId: string }> }) {
+  const { botId: botIdRaw } = await params;
+  const botId = Number.parseInt(botIdRaw, 10);
+  if (!Number.isInteger(botId) || botId <= 0) return unauthorized();
+
+  const rows = await db.select().from(telegramBots).where(eq(telegramBots.id, botId)).limit(1);
+  const bot = rows[0];
+  if (!bot) return unauthorized();
+
+  const provided = req.headers.get(SECRET_HEADER);
+  if (!provided || !constantTimeEquals(provided, bot.webhookSecret)) {
+    return unauthorized();
+  }
+
+  let update: TelegramUpdate;
+  try {
+    update = (await req.json()) as TelegramUpdate;
+  } catch {
+    return NextResponse.json({ error: "bad request" }, { status: 400 });
+  }
+
+  let token: string;
+  try {
+    token = decrypt(bot.tokenEncrypted);
+  } catch (err) {
+    // Ciphertext corrupt or encryption key rotated. Log + 200: Telegram
+    // retrying won't help until the bot is re-registered.
+    console.error("[telegram/webhook] failed to decrypt token", { botId, err });
+    return NextResponse.json({ ok: true });
+  }
+
+  const client = createTelegramClient({ token });
+  const deps: RouterDeps = {
+    userId: bot.userId,
+    listAccounts: () => listAccountsDetailed(bot.userId),
+    listCategories,
+    parseNlu: (p) => parseTransactionMessage({ text: p.text, context: p.context }),
+    runOcr: (p) => extractTransactionsFromImage(p),
+    transcribeVoice: (p) => transcribeAudio(p),
+  };
+
+  try {
+    await handleUpdate(update, client, deps);
+  } catch (err) {
+    // Telegram retries on non-2xx, which would pile up broken updates.
+    // Swallow downstream errors and return 200; the error is logged for ops.
+    console.error("[telegram/webhook] handler threw", { botId, err });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/telegram/client.ts
+++ b/src/lib/telegram/client.ts
@@ -10,6 +10,13 @@ const TELEGRAM_HOST = "api.telegram.org";
 
 type TelegramResponse<T> = { ok: true; result: T } | { ok: false; description: string };
 
+export type TelegramBotProfile = {
+  id: number;
+  is_bot: boolean;
+  first_name: string;
+  username: string;
+};
+
 export type TelegramClient = {
   getUpdates: (opts: {
     offset?: number;
@@ -21,6 +28,9 @@ export type TelegramClient = {
   answerCallbackQuery: (opts: { callback_query_id: string; text?: string }) => Promise<void>;
   getFile: (fileId: string) => Promise<TelegramFile>;
   downloadFile: (filePath: string) => Promise<Buffer>;
+  getMe: () => Promise<TelegramBotProfile>;
+  setWebhook: (opts: { url: string; secretToken: string }) => Promise<void>;
+  deleteWebhook: (opts?: { dropPendingUpdates?: boolean }) => Promise<void>;
 };
 
 // Built on node:https (not fetch) because undici's default fetch in Node 20+
@@ -153,6 +163,29 @@ export function createTelegramClient(opts: { token: string }): TelegramClient {
         path: `/file/bot${opts.token}/${filePath}`,
         timeoutMs: 30_000,
       });
+    },
+    async getMe() {
+      return call<TelegramBotProfile>("getMe", {}, 10_000);
+    },
+    async setWebhook({ url, secretToken }) {
+      await call<true>(
+        "setWebhook",
+        {
+          url,
+          secret_token: secretToken,
+          allowed_updates: ["message", "callback_query"],
+        },
+        15_000,
+      );
+    },
+    async deleteWebhook(deleteOpts) {
+      await call<true>(
+        "deleteWebhook",
+        {
+          drop_pending_updates: deleteOpts?.dropPendingUpdates ?? false,
+        },
+        10_000,
+      );
     },
   };
 }

--- a/src/lib/telegram/router.ts
+++ b/src/lib/telegram/router.ts
@@ -36,6 +36,7 @@ import { buildDraftFromParsedSms } from "@/lib/telegram/sms-draft";
 import { buildDraftFromOcrRow } from "@/lib/telegram/ocr-draft";
 
 export type RouterDeps = {
+  userId: number;
   listAccounts: () => Promise<AccountDetail[]>;
   listCategories: () => Promise<NluCategoryOption[]>;
   parseNlu: (opts: {
@@ -119,25 +120,26 @@ function pickDefaultCurrency(accounts: NluAccountOption[], accountId?: number): 
 
 async function advanceFlow(opts: {
   chatId: number;
-  userId: number;
+  telegramUserId: number;
   state: TelegramSessionState;
   accounts: NluAccountOption[];
   categories: NluCategoryOption[];
   client: TelegramClient;
+  deps: RouterDeps;
 }): Promise<void> {
-  const { chatId, userId, state, accounts, categories, client } = opts;
+  const { chatId, telegramUserId, state, accounts, categories, client, deps } = opts;
   const draft = state.draft;
 
   if (!draft.amountCents) {
     const next: TelegramSessionState = { ...state, step: "awaiting_amount" };
-    await upsertSession({ chatId, telegramUserId: userId, state: next });
+    await upsertSession({ chatId, userId: deps.userId, telegramUserId, state: next });
     await client.sendMessage({ chat_id: chatId, text: renderAskAmount() });
     return;
   }
 
   if (typeof draft.accountId !== "number") {
     const next: TelegramSessionState = { ...state, step: "awaiting_account" };
-    await upsertSession({ chatId, telegramUserId: userId, state: next });
+    await upsertSession({ chatId, userId: deps.userId, telegramUserId, state: next });
     await client.sendMessage({
       chat_id: chatId,
       text: renderAskAccount(),
@@ -153,7 +155,7 @@ async function advanceFlow(opts: {
     reply_markup: confirmKeyboard(),
   });
   next.promptMessageId = sent.message_id;
-  await upsertSession({ chatId, telegramUserId: userId, state: next });
+  await upsertSession({ chatId, userId: deps.userId, telegramUserId, state: next });
 }
 
 async function handlePhoto(
@@ -180,7 +182,7 @@ async function handlePhoto(
     sourceMessageId: message.message_id,
     photoFileId: largest.file_id,
   };
-  await upsertSession({ chatId, telegramUserId: userId, state });
+  await upsertSession({ chatId, userId: deps.userId, telegramUserId: userId, state });
 
   await client.sendMessage({
     chat_id: chatId,
@@ -242,7 +244,15 @@ async function runOcrAndAdvance(opts: {
       sourceMessageId: session.sourceMessageId,
       externalIdOverride: externalId,
     };
-    await advanceFlow({ chatId, userId, state: next, accounts, categories, client });
+    await advanceFlow({
+      chatId,
+      telegramUserId: userId,
+      state: next,
+      accounts,
+      categories,
+      client,
+      deps,
+    });
     return;
   }
 
@@ -260,7 +270,7 @@ async function runOcrAndAdvance(opts: {
     reply_markup: batchConfirmKeyboard(batch.length),
   });
   next.promptMessageId = sent.message_id;
-  await upsertSession({ chatId, telegramUserId: userId, state: next });
+  await upsertSession({ chatId, userId: deps.userId, telegramUserId: userId, state: next });
 }
 
 function mediaTypeFromPath(filePath: string): OcrMediaType {
@@ -353,7 +363,15 @@ async function handleText(
       const patched = mergeDraft(existing, { amountCents });
       const accounts = accountsToNluOptions(await deps.listAccounts());
       const categories = await deps.listCategories();
-      await advanceFlow({ chatId, userId, state: patched, accounts, categories, client });
+      await advanceFlow({
+        chatId,
+        telegramUserId: userId,
+        state: patched,
+        accounts,
+        categories,
+        client,
+        deps,
+      });
       return;
     }
   }
@@ -375,7 +393,15 @@ async function handleText(
       externalIdOverride: externalId,
     };
     const accounts = accountsToNluOptions(accountsFull);
-    await advanceFlow({ chatId, userId, state, accounts, categories, client });
+    await advanceFlow({
+      chatId,
+      telegramUserId: userId,
+      state,
+      accounts,
+      categories,
+      client,
+      deps,
+    });
     return;
   }
   if (smsParsed.reason === "failed" || smsParsed.reason === "non_transactional") {
@@ -434,7 +460,7 @@ async function handleText(
     sourceMessageId: message.message_id,
   };
 
-  await advanceFlow({ chatId, userId, state, accounts, categories, client });
+  await advanceFlow({ chatId, telegramUserId: userId, state, accounts, categories, client, deps });
 }
 
 async function handleCallback(
@@ -470,8 +496,7 @@ async function handleCallback(
       return;
     }
     await client.answerCallbackQuery({ callback_query_id: cb.id });
-    // Single-bot poll worker scopes to user 1 until #185 wires per-user bots.
-    const result = await insertBatch({ userId: 1, items: session.batch, chatId });
+    const result = await insertBatch({ userId: deps.userId, items: session.batch, chatId });
     await client.sendMessage({
       chat_id: chatId,
       text: renderBatchInserted({
@@ -490,12 +515,19 @@ async function handleCallback(
   if (data === CALLBACK.CONFIRM) {
     if (!isDraftComplete(session.draft)) {
       await client.answerCallbackQuery({ callback_query_id: cb.id, text: "Faltan datos" });
-      await advanceFlow({ chatId, userId, state: session, accounts, categories, client });
+      await advanceFlow({
+        chatId,
+        telegramUserId: userId,
+        state: session,
+        accounts,
+        categories,
+        client,
+        deps,
+      });
       return;
     }
     const result = await insertFromDraft({
-      // Single-bot poll worker scopes to user 1 until #185 wires per-user bots.
-      userId: 1,
+      userId: deps.userId,
       draft: session.draft,
       chatId,
       sourceMessageId: session.sourceMessageId,
@@ -526,7 +558,7 @@ async function handleCallback(
 
   if (data === CALLBACK.EDIT_ACCOUNT) {
     const next: TelegramSessionState = { ...session, step: "awaiting_account" };
-    await upsertSession({ chatId, telegramUserId: userId, state: next });
+    await upsertSession({ chatId, userId: deps.userId, telegramUserId: userId, state: next });
     await client.answerCallbackQuery({ callback_query_id: cb.id });
     await client.sendMessage({
       chat_id: chatId,
@@ -538,7 +570,7 @@ async function handleCallback(
 
   if (data === CALLBACK.EDIT_CATEGORY) {
     const next: TelegramSessionState = { ...session, step: "awaiting_category" };
-    await upsertSession({ chatId, telegramUserId: userId, state: next });
+    await upsertSession({ chatId, userId: deps.userId, telegramUserId: userId, state: next });
     await client.answerCallbackQuery({ callback_query_id: cb.id });
     await client.sendMessage({
       chat_id: chatId,
@@ -550,7 +582,15 @@ async function handleCallback(
 
   if (data === CALLBACK.BACK) {
     await client.answerCallbackQuery({ callback_query_id: cb.id });
-    await advanceFlow({ chatId, userId, state: session, accounts, categories, client });
+    await advanceFlow({
+      chatId,
+      telegramUserId: userId,
+      state: session,
+      accounts,
+      categories,
+      client,
+      deps,
+    });
     return;
   }
 
@@ -581,7 +621,15 @@ async function handleCallback(
       currency: picked.currency,
     });
     await client.answerCallbackQuery({ callback_query_id: cb.id });
-    await advanceFlow({ chatId, userId, state: patched, accounts, categories, client });
+    await advanceFlow({
+      chatId,
+      telegramUserId: userId,
+      state: patched,
+      accounts,
+      categories,
+      client,
+      deps,
+    });
     return;
   }
 
@@ -593,7 +641,15 @@ async function handleCallback(
     }
     const patched = mergeDraft(session, { categorySlug: slug });
     await client.answerCallbackQuery({ callback_query_id: cb.id });
-    await advanceFlow({ chatId, userId, state: patched, accounts, categories, client });
+    await advanceFlow({
+      chatId,
+      telegramUserId: userId,
+      state: patched,
+      accounts,
+      categories,
+      client,
+      deps,
+    });
     return;
   }
 

--- a/src/lib/telegram/router.voice.test.ts
+++ b/src/lib/telegram/router.voice.test.ts
@@ -34,12 +34,16 @@ function buildClient(): {
       downloadCalls.push(path);
       return Buffer.from("fake-audio-bytes");
     },
+    getMe: async () => ({ id: 1, is_bot: true, first_name: "Bot", username: "bot" }),
+    setWebhook: async () => {},
+    deleteWebhook: async () => {},
   };
   return { client, sent, getFileCalls, downloadCalls };
 }
 
 function buildDeps(overrides: Partial<RouterDeps> = {}): RouterDeps {
   return {
+    userId: 1,
     listAccounts: async () => [],
     listCategories: async () => [],
     parseNlu: async () => {

--- a/src/lib/telegram/session.ts
+++ b/src/lib/telegram/session.ts
@@ -30,17 +30,15 @@ export async function getSession(chatId: number): Promise<TelegramSessionState |
 
 export async function upsertSession(opts: {
   chatId: number;
+  userId: number;
   telegramUserId: number;
   state: TelegramSessionState;
 }): Promise<void> {
   const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
-  // Single-bot poll worker scopes every session to user 1; #185 will resolve
-  // the Telegram chat → Findash user via telegram_bots + webhooks.
-  const userId = 1;
   await db
     .insert(telegramSessions)
     .values({
-      userId,
+      userId: opts.userId,
       chatId: BigInt(opts.chatId),
       telegramUserId: BigInt(opts.telegramUserId),
       state: opts.state,
@@ -50,7 +48,7 @@ export async function upsertSession(opts: {
     .onConflictDoUpdate({
       target: telegramSessions.chatId,
       set: {
-        userId,
+        userId: opts.userId,
         telegramUserId: BigInt(opts.telegramUserId),
         state: opts.state,
         updatedAt: new Date(),


### PR DESCRIPTION
PR 3 of 5 in the #185 Telegram multi-bot chain. **Restores** Telegram ingestion on the per-user webhook architecture set up by PR1 (#217) and PR2 (#218).

Closes #219.

## What

**New route \`src/app/api/telegram/webhook/[botId]/route.ts\`:**

- POST only, \`dynamic = "force-dynamic"\`, Node runtime
- \`await params\` per Next.js 16
- Looks up \`telegram_bots\` row by id, rejects with **401 for any auth failure** (unparseable \`botId\`, unknown row, missing or wrong secret header) — constant-time compare via \`crypto.timingSafeEqual\`
- **400** on malformed JSON body
- Decrypts token via \`src/lib/crypto/symmetric\`; on decrypt failure logs and returns **200** so Telegram does not retry against a broken bot
- Builds per-request \`TelegramClient\` + \`RouterDeps\` with \`userId\` resolved from the bot row. \`listAccounts\` scoped to that user; other deps share the existing NLU/OCR/STT pipelines.
- Swallows downstream errors from \`handleUpdate\` and returns **200** (log only) — Telegram retries on non-2xx which would pile up broken updates.

**\`userId\` threading (kills the #185 hardcodes):**

- \`RouterDeps\` gains \`userId: number\`. \`handleUpdate\` now receives the Findash user id via deps; the old hardcoded \`userId = 1\` literals in \`router.ts\` (\`insertBatch\`, \`insertFromDraft\`, \`upsertSession\` callsites) and in \`session.ts\` (\`upsertSession\` body) are removed.
- \`advanceFlow\` was the only internal helper without access to \`deps\`. Renamed its local \`userId\` parameter to \`telegramUserId\` for clarity and added \`deps\` to its opts shape. 8 callers updated.
- \`upsertSession\` now takes both \`userId\` (Findash) and \`telegramUserId\` (Telegram) as required parameters.

**\`TelegramClient\` additions (\`client.ts\`):**

- \`getMe()\`
- \`setWebhook({ url, secretToken })\`
- \`deleteWebhook({ dropPendingUpdates? })\`

All three route via the existing \`httpsJson\` helper (same IPv4-pinned stack as \`sendMessage\`). PR4 (#220) will consume \`setWebhook\` + \`getMe\` from the \`/settings/telegram\` registration flow.

## Tests

**7 new cases in \`route.test.ts\`:**
- bad \`botId\` (\`abc\`) → 401
- unknown \`botId\` → 401
- missing secret → 401
- wrong secret → 401
- malformed JSON → 400
- empty valid Update → 200
- corrupt ciphertext stored in \`token_encrypted\` → 200 (logged, not retry-triggering)

\`router.voice.test.ts\` fixture extended with \`userId\` + the three new \`TelegramClient\` methods.

## Out of scope

- PR4 (#220): \`/settings/telegram\` UI + \`registerBot\` / \`revokeBot\` actions.
- PR5 (#221): cleanup.

## Test plan

- [x] \`bun run test\` — 292/292 green (was 285; +7 webhook cases)
- [x] \`bun run typecheck\` — green
- [x] \`bun run lint\` — green
- [x] \`bun run format:check\` — green
- [x] \`grep -rn 'userId: 1\|userId = 1' src/lib/telegram/\` — zero matches in production code
- [ ] CI green on this branch