### PR TITLE
feat(settings): /settings/telegram bot register + revoke UI (#185)

### DIFF
--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -1,45 +1,164 @@
 # Telegram bot
 
-> **Work in progress.** Issue [#185](../../../issues/185) is migrating from a
-> single long-poll bot to per-user webhooks. This doc is pruned mid-flight:
-> the old polling setup is gone, the new `/settings/telegram` UI lands in
-> PR4 ([#220](../../../issues/220)). Once that ships, this file is rewritten
-> end-to-end.
+Cada usuario de Findash registra su propio bot de Telegram. La arquitectura
+es **webhook por usuario** (no hay long-poll, no hay bot compartido): cada
+bot apunta a `/api/telegram/webhook/<botId>`, el handler resuelve el
+`userId` desde la tabla `telegram_bots` y despacha al router con las deps
+de ese user.
 
-## Status
+Issue de referencia: [#185](../../../issues/185).
 
-- PR1 ([#217](../../../issues/217)) ✅ — AES-256-GCM crypto helper.
-- PR2 ([#218](../../../issues/218)) — **this PR**. Adds `telegram_bots`
-  table, drops `telegram_poll_state`, deletes the long-poll worker. Telegram
-  ingestion is intentionally non-functional until PR3 ships.
-- PR3 ([#219](../../../issues/219)) — webhook route
-  (`/api/telegram/webhook/[botId]`) + `userId` threading through the router.
-- PR4 ([#220](../../../issues/220)) — `/settings/telegram` UI to paste a
-  BotFather token, call `setWebhook`, persist the encrypted row.
-- PR5 ([#221](../../../issues/221)) — cleanup, if anything remains.
+## Setup (una vez por usuario)
 
-## Env
+### 1. Pre-requisitos en prod
 
-Set once in `.env.local` (dev) and `/srv/findash/env/findash.env` (prod):
+Estas tareas son responsabilidad del operador del droplet — si estás
+registrando un bot en findash.alejoframes.com ya están hechas:
+
+- `TELEGRAM_TOKEN_ENCRYPTION_KEY` en `/srv/findash/env/findash.env`
+  (32 bytes base64, generada con `openssl rand -base64 32`). Rotar la key
+  invalida todos los tokens guardados — los usuarios tienen que volver a
+  registrar su bot.
+- `AUTH_URL=https://findash.<dominio>` en el mismo env. Sirve como base
+  para el `webhook_url` que Findash le pasa a Telegram.
+
+### 2. Crear el bot con BotFather
+
+1. Abrí Telegram, mandale `/newbot` a
+   [@BotFather](https://t.me/BotFather).
+2. Elegí un display name (ej: `Findash de Alejo`) y un username que
+   termine en `bot` (ej: `@alejo_findash_bot`).
+3. BotFather devuelve un token `1234567890:AAH...`. Copialo.
+
+### 3. Registrarlo en Findash
+
+1. Entrá a `/settings/telegram`.
+2. Pegá el token en el input "BotFather token" (se manda como password
+   — nunca queda visible).
+3. Click "Register bot".
+
+Qué hace el server action por detrás (`registerBotAction`):
+
+1. Valida el formato del token (`/^\d{8,12}:[A-Za-z0-9_-]{30,}$/`).
+2. Si ya tenés un bot registrado → error ("delete it first").
+3. Resuelve `AUTH_URL` como base del webhook. Sin `AUTH_URL` → error.
+4. Llama `getMe` contra el token para validar que Telegram lo acepta y
+   levantar el `@username`.
+5. Inserta la fila en `telegram_bots` con el token encriptado
+   (AES-256-GCM) y un `webhook_secret` de 32 bytes hex.
+6. Llama `setWebhook(https://<AUTH_URL>/api/telegram/webhook/<botId>,
+   secret_token=<webhook_secret>, allowed_updates=[message,callback_query])`.
+7. Si `setWebhook` falla → borra la fila (rollback) y te muestra el
+   error.
+
+### 4. Probarlo
+
+Abrí Telegram, buscá tu bot (`@<username>`), mandale `/start`. Debería
+responder con la bienvenida. Si no responde, ver [Troubleshooting](#troubleshooting).
+
+## Uso
+
+Todos los flujos del bot (texto libre, SMS reenviado, foto con OCR, voz
+con Whisper) siguen igual que antes — cambió sólo la capa de transporte.
+
+Ejemplos:
+
+| Mensaje | Interpretación |
+| --- | --- |
+| `pagué 45k en el restaurante` | Gasto 45.000 COP, categoría restaurantes |
+| `70 mil uber` | Gasto 70.000 COP, categoría transporte |
+| `mercado 123.450 con la visa *2575` | Gasto 123.450 COP, cuenta Visa *2575 |
+| `ayer gasté 30k en gasolina` | Gasto 30.000 COP, fecha ayer |
+| `ingresé 2 millones del sueldo` | Ingreso 2.000.000 COP |
+
+El bot responde con inline keyboard: ✅ Confirmar · ❌ Cancelar · ✏️
+Cuenta · ✏️ Categoría. Si falta monto o cuenta, el bot pregunta antes de
+mostrar el card de confirmación. Las sesiones expiran a los 30 minutos.
+
+## Revocar un bot
+
+`/settings/telegram` → "Delete bot". El server action:
+
+1. Descifra el token guardado.
+2. Llama `deleteWebhook` contra la API de Telegram. Si Telegram falla
+   (5xx, red caída), logueamos y seguimos con el delete local.
+3. Borra la fila de `telegram_bots` y los `telegram_sessions` de ese
+   user (los sessions referencian estado producido por este bot).
+
+Tras revocar podés registrar otro bot — el flujo vuelve a la tarjeta de
+registro.
+
+## Operación
+
+### Apagar TODOS los workers en background
 
 ```
-TELEGRAM_TOKEN_ENCRYPTION_KEY=<openssl rand -base64 32>
+FINDASH_DISABLE_CRON=1
 ```
 
-The decoded key must be exactly 32 bytes. Rotating it invalidates every
-stored bot token — users have to re-register from `/settings/telegram`
-(no migration tooling is planned; clean slate by design).
+Esto solo apaga el cron de recurring-gap. Los webhooks siguen respondiendo
+(son request-scoped, no workers).
 
-## After PR4 ships
+### Rotar la encryption key
 
-1. Open `/settings/telegram` in the app.
-2. Create a bot with `@BotFather` on Telegram (`/newbot`).
-3. Paste the BotFather token in the form.
-4. The server calls `setWebhook` against
-   `https://findash.alejoframes.com/api/telegram/webhook/<your-bot-id>` with
-   a per-bot secret header; the row is persisted with the token AES-GCM
-   encrypted.
-5. Start chatting with your bot in Telegram.
+Rotación destructiva — todos los usuarios quedan sin bot funcional hasta
+que re-registren.
 
-Further detail (messaging commands, troubleshooting, revoke flow) will land
-alongside PR4.
+```
+# en el droplet, como root
+sudo nano /srv/findash/env/findash.env
+# reemplazá TELEGRAM_TOKEN_ENCRYPTION_KEY con una key nueva
+sudo systemctl restart findash
+```
+
+Después, cada usuario tiene que ir a `/settings/telegram`, borrar su
+bot (el DELETE logra decryptar el token viejo con la nueva key? NO — va
+a tirar `InvalidTokenError`. El server action maneja eso: loguea,
+no llama `deleteWebhook`, borra la fila igual), y registrarlo de nuevo.
+
+## Troubleshooting
+
+### "AUTH_URL must be set"
+
+El server action no encontró `AUTH_URL` en el env. En prod tiene que
+estar en `/srv/findash/env/findash.env`. En dev no podés registrar bots
+desde localhost (Telegram necesita HTTPS público) — usá un tunnel tipo
+cloudflared si querés probar local:
+`cloudflared tunnel --url http://localhost:3100` y pegás esa URL en
+`.env.local:AUTH_URL`.
+
+### "Telegram rejected the token"
+
+El `getMe` contra `api.telegram.org/bot<TOKEN>/getMe` devolvió un 401 u
+otro error. Típicamente el token está mal copiado (espacios, newlines,
+caracteres invisibles). Volvé a copiar desde BotFather.
+
+### "setWebhook failed"
+
+Causas comunes:
+
+- `AUTH_URL` apunta a un host que Telegram no puede resolver
+  (localhost, IP privada, puerto non-443).
+- El cert TLS no es válido para Telegram — revisá el setup de Cloudflare
+  Full (strict) o el origin cert en Caddy.
+- Rate limit transitorio — re-intentá en unos minutos.
+
+La fila queda auto-roll-backeada: no hace falta limpiar manualmente.
+
+### El bot no responde a `/start`
+
+1. Verificá que el webhook está configurado:
+   `curl "https://api.telegram.org/bot<TOKEN>/getWebhookInfo"`. El `url`
+   debería matchear `https://<tu-dominio>/api/telegram/webhook/<botId>`.
+2. Si `last_error_message` está poblado, ese es el error que Telegram ve
+   cuando intenta POSTear al webhook. Típicamente 401
+   (`webhook_secret` drift), 404 (botId borrado), o timeout.
+3. Mirá los logs del droplet:
+   `sudo journalctl -u findash -n 200 --no-pager | grep telegram`.
+
+### Mensajes duplicados
+
+Los `externalId` en `transactions` para transacciones vía Telegram son
+`tg:<chatId>:<messageId>`. El UNIQUE `(accountId, externalId)` garantiza
+idempotencia — si Telegram retrasmite el mismo update (por ejemplo
+después de un 5xx), la segunda inserción se descarta como `duplicated`.

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -25,6 +25,12 @@ const LINKS = [
     description:
       "Per-user bearer tokens for the SMS and debug ingest endpoints. Mint, copy once, revoke when needed.",
   },
+  {
+    href: "/settings/telegram",
+    title: "Telegram bot",
+    description:
+      "Register your BotFather bot. Findash encrypts the token at rest and serves the webhook at /api/telegram/webhook/<botId>.",
+  },
 ];
 
 export default function SettingsPage() {

--- a/src/app/(app)/settings/telegram/actions.test.ts
+++ b/src/app/(app)/settings/telegram/actions.test.ts
@@ -1,0 +1,229 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { telegramBots, telegramSessions } from "@/lib/db/schema";
+import { encrypt } from "@/lib/crypto/symmetric";
+
+const TEST_USER_ID = 1;
+const VALID_TOKEN = "1234567890:AAHxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+// Mock module shared between tests. The factory must be synchronous so
+// vi.hoisted is the right pattern for references from both the mock and
+// the test bodies.
+const { mockGetMe, mockSetWebhook, mockDeleteWebhook } = vi.hoisted(() => ({
+  mockGetMe: vi.fn(),
+  mockSetWebhook: vi.fn(),
+  mockDeleteWebhook: vi.fn(),
+}));
+
+vi.mock("@/lib/telegram/client", () => ({
+  createTelegramClient: () => ({
+    getUpdates: vi.fn(),
+    sendMessage: vi.fn(),
+    editMessage: vi.fn(),
+    answerCallbackQuery: vi.fn(),
+    getFile: vi.fn(),
+    downloadFile: vi.fn(),
+    getMe: mockGetMe,
+    setWebhook: mockSetWebhook,
+    deleteWebhook: mockDeleteWebhook,
+  }),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: async () => ({
+    id: TEST_USER_ID,
+    email: "test@findash.local",
+    name: "Test User",
+  }),
+}));
+
+// revalidatePath throws "static generation store missing" outside a Next.js
+// request context — harmless no-op in tests.
+vi.mock("next/cache", () => ({
+  revalidatePath: () => {},
+  revalidateTag: () => {},
+}));
+
+// Imported AFTER the mocks so they resolve to the stubs above.
+const { registerBotAction, revokeBotAction } = await import("./actions");
+
+async function cleanup() {
+  await db.delete(telegramBots).where(eq(telegramBots.userId, TEST_USER_ID));
+  await db.delete(telegramSessions).where(eq(telegramSessions.userId, TEST_USER_ID));
+}
+
+function formData(input: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(input)) fd.set(k, v);
+  return fd;
+}
+
+describe("settings/telegram actions", () => {
+  beforeAll(() => {
+    process.env.AUTH_URL = "https://findash.test";
+  });
+
+  beforeEach(async () => {
+    mockGetMe.mockReset();
+    mockSetWebhook.mockReset();
+    mockDeleteWebhook.mockReset();
+    await cleanup();
+  });
+
+  afterEach(cleanup);
+  afterAll(async () => {
+    await db.$client.end({ timeout: 1 });
+  });
+
+  describe("registerBotAction", () => {
+    it("inserts the row and calls setWebhook on happy path", async () => {
+      mockGetMe.mockResolvedValue({
+        id: 99,
+        is_bot: true,
+        first_name: "Test",
+        username: "happy_path_bot",
+      });
+      mockSetWebhook.mockResolvedValue(undefined);
+
+      const result = await registerBotAction({ status: "idle" }, formData({ token: VALID_TOKEN }));
+
+      expect(result).toEqual({ status: "success", username: "happy_path_bot" });
+
+      const rows = await db
+        .select()
+        .from(telegramBots)
+        .where(eq(telegramBots.userId, TEST_USER_ID));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].username).toBe("happy_path_bot");
+      expect(rows[0].webhookSecret).toMatch(/^[0-9a-f]{64}$/);
+
+      expect(mockSetWebhook).toHaveBeenCalledTimes(1);
+      const call = mockSetWebhook.mock.calls[0][0] as { url: string; secretToken: string };
+      expect(call.url).toBe(`https://findash.test/api/telegram/webhook/${rows[0].id}`);
+      expect(call.secretToken).toBe(rows[0].webhookSecret);
+    });
+
+    it("rejects an invalid token format without touching Telegram", async () => {
+      const result = await registerBotAction(
+        { status: "idle" },
+        formData({ token: "not-a-token" }),
+      );
+      expect(result.status).toBe("error");
+      expect(mockGetMe).not.toHaveBeenCalled();
+      expect(mockSetWebhook).not.toHaveBeenCalled();
+
+      const rows = await db
+        .select()
+        .from(telegramBots)
+        .where(eq(telegramBots.userId, TEST_USER_ID));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("returns an error when the user already has a bot", async () => {
+      await db.insert(telegramBots).values({
+        userId: TEST_USER_ID,
+        tokenEncrypted: encrypt(VALID_TOKEN),
+        username: "existing_bot",
+        webhookSecret: "a".repeat(64),
+      });
+
+      const result = await registerBotAction({ status: "idle" }, formData({ token: VALID_TOKEN }));
+      expect(result.status).toBe("error");
+      expect(mockGetMe).not.toHaveBeenCalled();
+    });
+
+    it("returns an error and inserts nothing when getMe fails", async () => {
+      mockGetMe.mockRejectedValue(new Error("401 Unauthorized"));
+
+      const result = await registerBotAction({ status: "idle" }, formData({ token: VALID_TOKEN }));
+      expect(result.status).toBe("error");
+
+      const rows = await db
+        .select()
+        .from(telegramBots)
+        .where(eq(telegramBots.userId, TEST_USER_ID));
+      expect(rows).toHaveLength(0);
+      expect(mockSetWebhook).not.toHaveBeenCalled();
+    });
+
+    it("rolls back the row when setWebhook throws", async () => {
+      mockGetMe.mockResolvedValue({
+        id: 99,
+        is_bot: true,
+        first_name: "Test",
+        username: "rollback_bot",
+      });
+      mockSetWebhook.mockRejectedValue(new Error("DNS lookup failed"));
+
+      const result = await registerBotAction({ status: "idle" }, formData({ token: VALID_TOKEN }));
+      expect(result.status).toBe("error");
+      if (result.status === "error") {
+        expect(result.message).toMatch(/setWebhook failed/);
+      }
+
+      const rows = await db
+        .select()
+        .from(telegramBots)
+        .where(eq(telegramBots.userId, TEST_USER_ID));
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe("revokeBotAction", () => {
+    it("deletes the bot row + sessions and calls deleteWebhook", async () => {
+      await db.insert(telegramBots).values({
+        userId: TEST_USER_ID,
+        tokenEncrypted: encrypt(VALID_TOKEN),
+        username: "to_revoke",
+        webhookSecret: "b".repeat(64),
+      });
+      await db.insert(telegramSessions).values({
+        chatId: BigInt(12345),
+        userId: TEST_USER_ID,
+        telegramUserId: BigInt(67890),
+        state: { step: "idle", draft: {}, sourceChatId: 12345 },
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      mockDeleteWebhook.mockResolvedValue(undefined);
+
+      await revokeBotAction();
+
+      const bots = await db
+        .select()
+        .from(telegramBots)
+        .where(eq(telegramBots.userId, TEST_USER_ID));
+      expect(bots).toHaveLength(0);
+      const sessions = await db
+        .select()
+        .from(telegramSessions)
+        .where(eq(telegramSessions.userId, TEST_USER_ID));
+      expect(sessions).toHaveLength(0);
+      expect(mockDeleteWebhook).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op when no bot exists", async () => {
+      await expect(revokeBotAction()).resolves.toBeUndefined();
+      expect(mockDeleteWebhook).not.toHaveBeenCalled();
+    });
+
+    it("still deletes the local row when deleteWebhook throws", async () => {
+      await db.insert(telegramBots).values({
+        userId: TEST_USER_ID,
+        tokenEncrypted: encrypt(VALID_TOKEN),
+        username: "tg_down",
+        webhookSecret: "c".repeat(64),
+      });
+      mockDeleteWebhook.mockRejectedValue(new Error("502 Bad Gateway from Telegram"));
+
+      await revokeBotAction();
+
+      const bots = await db
+        .select()
+        .from(telegramBots)
+        .where(eq(telegramBots.userId, TEST_USER_ID));
+      expect(bots).toHaveLength(0);
+      expect(mockDeleteWebhook).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/app/(app)/settings/telegram/actions.ts
+++ b/src/app/(app)/settings/telegram/actions.ts
@@ -1,0 +1,151 @@
+"use server";
+
+import { randomBytes } from "node:crypto";
+import { revalidatePath } from "next/cache";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { telegramBots, telegramSessions } from "@/lib/db/schema";
+import { decrypt, encrypt } from "@/lib/crypto/symmetric";
+import { getSessionUser } from "@/lib/auth/session";
+import { createTelegramClient } from "@/lib/telegram/client";
+
+const BOT_TOKEN_REGEX = /^\d{8,12}:[A-Za-z0-9_-]{30,}$/;
+
+const registerSchema = z.object({
+  token: z
+    .string()
+    .trim()
+    .regex(BOT_TOKEN_REGEX, "Invalid BotFather token format (expected <digits>:<base62_-_>)."),
+});
+
+export type RegisterActionState =
+  | { status: "idle" }
+  | { status: "error"; message: string }
+  | { status: "success"; username: string };
+
+function resolveWebhookBaseUrl(): string {
+  const url = process.env.AUTH_URL?.trim();
+  if (!url) {
+    throw new Error(
+      "AUTH_URL must be set to register a Telegram webhook (Telegram requires HTTPS public URL).",
+    );
+  }
+  return url.replace(/\/+$/, "");
+}
+
+export async function registerBotAction(
+  _prev: RegisterActionState,
+  formData: FormData,
+): Promise<RegisterActionState> {
+  const session = await getSessionUser();
+
+  const parsed = registerSchema.safeParse({ token: formData.get("token") });
+  if (!parsed.success) {
+    return { status: "error", message: parsed.error.issues[0]?.message ?? "Invalid input." };
+  }
+  const token = parsed.data.token;
+
+  const existing = await db
+    .select({ id: telegramBots.id })
+    .from(telegramBots)
+    .where(eq(telegramBots.userId, session.id))
+    .limit(1);
+  if (existing.length > 0) {
+    return {
+      status: "error",
+      message: "You already have a bot registered. Delete it first to register a new one.",
+    };
+  }
+
+  let baseUrl: string;
+  try {
+    baseUrl = resolveWebhookBaseUrl();
+  } catch (err) {
+    return { status: "error", message: err instanceof Error ? err.message : "Missing AUTH_URL." };
+  }
+
+  const client = createTelegramClient({ token });
+
+  let username: string;
+  try {
+    const me = await client.getMe();
+    username = me.username;
+  } catch (err) {
+    return {
+      status: "error",
+      message: `Telegram rejected the token: ${err instanceof Error ? err.message : "unknown"}`,
+    };
+  }
+
+  const webhookSecret = randomBytes(32).toString("hex");
+
+  // Insert first to obtain the serial id that the webhook URL embeds, then
+  // setWebhook. If Telegram rejects the URL (DNS, unreachable, bad TLS),
+  // delete the row so the UI goes back to the empty state.
+  const [row] = await db
+    .insert(telegramBots)
+    .values({
+      userId: session.id,
+      tokenEncrypted: encrypt(token),
+      username,
+      webhookSecret,
+    })
+    .returning({ id: telegramBots.id });
+
+  try {
+    await client.setWebhook({
+      url: `${baseUrl}/api/telegram/webhook/${row.id}`,
+      secretToken: webhookSecret,
+    });
+  } catch (err) {
+    await db.delete(telegramBots).where(eq(telegramBots.id, row.id));
+    return {
+      status: "error",
+      message: `setWebhook failed: ${err instanceof Error ? err.message : "unknown"}. Row rolled back.`,
+    };
+  }
+
+  revalidatePath("/settings/telegram");
+  return { status: "success", username };
+}
+
+export async function revokeBotAction(): Promise<void> {
+  const session = await getSessionUser();
+
+  const [bot] = await db
+    .select()
+    .from(telegramBots)
+    .where(eq(telegramBots.userId, session.id))
+    .limit(1);
+  if (!bot) {
+    revalidatePath("/settings/telegram");
+    return;
+  }
+
+  let token: string | null = null;
+  try {
+    token = decrypt(bot.tokenEncrypted);
+  } catch (err) {
+    console.error("[telegram/revokeBot] decrypt failed — deleting row without Telegram call", err);
+  }
+
+  if (token) {
+    try {
+      await createTelegramClient({ token }).deleteWebhook();
+    } catch (err) {
+      console.error(
+        "[telegram/revokeBot] deleteWebhook failed — continuing with local delete anyway",
+        err,
+      );
+    }
+  }
+
+  await db.delete(telegramBots).where(eq(telegramBots.id, bot.id));
+  // Chat sessions are keyed by chat_id but scoped to this user_id — they
+  // reference state that only this bot could produce. Sweeping avoids stale
+  // rows pointing at a deleted bot.
+  await db.delete(telegramSessions).where(eq(telegramSessions.userId, session.id));
+
+  revalidatePath("/settings/telegram");
+}

--- a/src/app/(app)/settings/telegram/page.tsx
+++ b/src/app/(app)/settings/telegram/page.tsx
@@ -1,0 +1,45 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { telegramBots } from "@/lib/db/schema";
+import { getSessionUser } from "@/lib/auth/session";
+import { TelegramBotManager } from "./telegram-bot-manager";
+
+export const dynamic = "force-dynamic";
+
+export default async function TelegramSettingsPage() {
+  const session = await getSessionUser();
+  const [bot] = await db
+    .select({
+      id: telegramBots.id,
+      username: telegramBots.username,
+      createdAt: telegramBots.createdAt,
+    })
+    .from(telegramBots)
+    .where(eq(telegramBots.userId, session.id))
+    .limit(1);
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-h1">Telegram bot</h1>
+        <p className="text-body text-muted-foreground">
+          Register your personal Telegram bot to log transactions by message, voice, or photo. Each
+          Findash user has exactly one bot; the BotFather token is stored AES-256-GCM encrypted and
+          Telegram posts updates to{" "}
+          <code className="font-mono">/api/telegram/webhook/&lt;botId&gt;</code>.
+        </p>
+      </header>
+      <TelegramBotManager
+        bot={
+          bot
+            ? {
+                id: bot.id,
+                username: bot.username,
+                createdAt: bot.createdAt.toISOString(),
+              }
+            : null
+        }
+      />
+    </main>
+  );
+}

--- a/src/app/(app)/settings/telegram/telegram-bot-manager.tsx
+++ b/src/app/(app)/settings/telegram/telegram-bot-manager.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useActionState, useTransition } from "react";
+import { Trash2Icon } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { registerBotAction, revokeBotAction, type RegisterActionState } from "./actions";
+
+type Bot = {
+  id: number;
+  username: string;
+  createdAt: string;
+};
+
+const INITIAL_STATE: RegisterActionState = { status: "idle" };
+
+export function TelegramBotManager({ bot }: { bot: Bot | null }) {
+  const [state, formAction, pending] = useActionState(registerBotAction, INITIAL_STATE);
+  const [revoking, startRevoke] = useTransition();
+
+  function onRevoke() {
+    if (!bot) return;
+    if (!confirm(`Delete bot @${bot.username}? Telegram webhook will be removed.`)) return;
+    startRevoke(async () => {
+      try {
+        await revokeBotAction();
+        toast.success("Bot deleted");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Delete failed");
+      }
+    });
+  }
+
+  if (bot) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Registered bot</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex items-center gap-3">
+            <Badge variant="outline">@{bot.username}</Badge>
+            <span className="text-muted-foreground text-xs">
+              Registered {new Date(bot.createdAt).toLocaleString()}
+            </span>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            Open Telegram and chat with{" "}
+            <a
+              className="underline"
+              href={`https://t.me/${bot.username}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              @{bot.username}
+            </a>
+            . Send <code className="font-mono">/start</code> to verify the webhook is reachable.
+          </p>
+          <div>
+            <Button type="button" variant="destructive" disabled={revoking} onClick={onRevoke}>
+              <Trash2Icon className="size-4" />
+              {revoking ? "Deleting..." : "Delete bot"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Register a bot</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form action={formAction} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="token">BotFather token</Label>
+            <Input
+              id="token"
+              name="token"
+              type="password"
+              placeholder="1234567890:AAH..."
+              autoComplete="off"
+              required
+            />
+            <p className="text-muted-foreground text-xs">
+              Create a bot by messaging{" "}
+              <a
+                className="underline"
+                href="https://t.me/BotFather"
+                target="_blank"
+                rel="noreferrer"
+              >
+                @BotFather
+              </a>{" "}
+              with <code className="font-mono">/newbot</code>. Paste the token it returns — Findash
+              encrypts it before storing and never displays it again.
+            </p>
+          </div>
+          <div>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Registering..." : "Register bot"}
+            </Button>
+          </div>
+        </form>
+        {state.status === "error" && (
+          <p className="text-destructive mt-3 text-sm">{state.message}</p>
+        )}
+        {state.status === "success" && (
+          <p className="text-muted-foreground mt-3 text-sm">
+            Registered as <code className="font-mono">@{state.username}</code>. Refresh to see the
+            management card.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
PR 4 of 5 in the #185 Telegram multi-bot chain. Ships the last piece users actually touch.

Closes #220.

## What

**Server actions (`actions.ts`):**

- `registerBotAction(prev, formData)` — Zod-validates `/^\d{8,12}:[A-Za-z0-9_-]{30,}$/`, checks the user does not already have a row, reads `AUTH_URL` for the webhook base, calls `getMe` to validate the token and pull `@username`, inserts the row with AES-256-GCM encrypted token + 32-byte hex `webhook_secret`, then calls `setWebhook(https://<AUTH_URL>/api/telegram/webhook/<id>, secret_token, allowed_updates=[message,callback_query])`. **Rolls back the row if `setWebhook` throws**.
- `revokeBotAction()` — decrypts the token best-effort, calls `deleteWebhook` (logs + continues on failure — prod Telegram-side revoke is not load-bearing for local consistency), deletes the bot row and sweeps this user's `telegram_sessions` rows.

**UI (`page.tsx` + `telegram-bot-manager.tsx`):**

- Server component loads the single bot row via `session.id`; passes to a client manager that renders either a `RegisterForm` or a `RegisteredCard`.
- Register form uses `useActionState`, shadcn `Input` (`type=password` for the token), surfaces `state.message` on error.
- Registered card shows `@username`, registered-at, a `t.me/<username>` link, a destructive Delete button. `useTransition` guards the action call and toasts via `sonner`.

**Tests (`actions.test.ts`):** 8 integration cases — `vi.hoisted` mocks for `createTelegramClient` + `getSessionUser`, `next/cache` `revalidatePath` mocked (throws ``static generation store missing`` outside a request context).

- register happy path inserts row, builds correct webhook URL + `secret_token`
- register rejects bad token format without touching Telegram
- register rejects when a bot already exists
- register returns error + no-op when `getMe` throws
- register rolls back the row when `setWebhook` throws
- revoke deletes bot + sessions + calls `deleteWebhook`
- revoke is a no-op when no bot exists
- revoke still deletes locally when `deleteWebhook` throws

**Settings index:** new ``Telegram bot`` card in `LINKS`.

**Docs (`docs/telegram-bot.md`):** full rewrite to match the per-user webhook flow — BotFather onboarding, encryption key rotation semantics, revoke flow, and troubleshooting (`AUTH_URL` missing, `setWebhook` failures, `getWebhookInfo` diagnostic).

## Env requirements

- `AUTH_URL` — already present in `.env.example`. Must be set to a public HTTPS URL Telegram can reach for `setWebhook` to succeed. Prod already has `AUTH_URL=https://findash.alejoframes.com`.
- `TELEGRAM_TOKEN_ENCRYPTION_KEY` — already required by PR1 and now set in prod (`/srv/findash/env/findash.env`).

No new env vars.

## Out of scope

- PR5 (#221): cleanup audit — skip if nothing remains.

## Test plan

- [x] `bun run test` — 300/300 green (was 292; +8 actions cases)
- [x] `bun run typecheck` — green
- [x] `bun run lint` — green
- [x] `bun run format:check` — green
- [ ] CI green on this branch
- [ ] Smoke test once deployed: open `/settings/telegram`, paste a real BotFather token, see \`Registered as @xxx\`, send \`/start\` to the bot, get a reply, then Delete and confirm the form reappears.