### PR TITLE
chore(telegram): tighten comments + drop long-poll drain timeout (#185)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,8 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 GROQ_API_KEY=gsk-your-key-here
 
 # Telegram multi-bot — cada usuario registra su bot de BotFather desde
-# /settings/telegram. El runtime (PR3/4 de #185) persiste el token encriptado
-# en la tabla telegram_bots y sirve el webhook en
-# /api/telegram/webhook/[botId]. No hay TELEGRAM_BOT_TOKEN global: si querés
-# probar el flujo, registrá tu bot desde la UI después de que mergee PR4.
+# /settings/telegram. El token se guarda encriptado en telegram_bots y
+# Telegram POSTea a /api/telegram/webhook/[botId]. Ver docs/telegram-bot.md.
 
 # AES-256-GCM key para encriptar tokens de bots de Telegram en la tabla
 # telegram_bots. Generá con: openssl rand -base64 32

--- a/infra/systemd/findash.service
+++ b/infra/systemd/findash.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Findash — personal finance dashboard (Next.js + Telegram worker)
+Description=Findash — personal finance dashboard (Next.js)
 After=network.target postgresql.service
 Requires=postgresql.service
 
@@ -19,9 +19,9 @@ Environment=HOSTNAME=127.0.0.1
 ExecStart=/usr/local/bin/bun server.js
 Restart=always
 RestartSec=3
-# Give the Telegram long-poll worker (src/instrumentation.ts) up to 30s to
-# drain on SIGTERM. Once #185 flips it to a webhook, this can drop to 10s.
-TimeoutStopSec=30
+# Telegram is webhook-based since #185, so there is no long-poll worker
+# to drain. 10s is plenty for Next.js to finish in-flight requests.
+TimeoutStopSec=10
 KillSignal=SIGTERM
 StandardOutput=journal
 StandardError=journal

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -8,12 +8,12 @@ declare global {
  * Next.js 16 instrumentation hook — runs once per worker on boot. Registers:
  * - recurring-gap detector cron (monthly)
  *
- * Telegram used to run a long-poll worker here; #185 moved that to per-user
+ * Telegram used to run a long-poll worker here; #185 moved it to per-user
  * webhooks (`src/app/api/telegram/webhook/[botId]/route.ts`) so there is no
  * background worker to wire up anymore.
  *
- * Runs only in the Node.js runtime (skipped on Edge). Disable all background
- * work with `FINDASH_DISABLE_CRON=1`.
+ * Runs only in the Node.js runtime (skipped on Edge). Disable the cron with
+ * `FINDASH_DISABLE_CRON=1`.
  */
 export async function register() {
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
@@ -26,8 +26,7 @@ export async function register() {
 
   // Day 5 of each month at 06:00 America/Bogota — gives a 4-day grace window
   // for late-posting SMS/Apple Pay events before we finalize gaps.
-  // NOTE: scopes to user 1. Iterating all active users is tracked separately
-  // from #185 — the hardcode survives this PR on purpose.
+  // NOTE: scopes to user 1. Iterating all active users is tracked in #225.
   cron.schedule(
     "0 6 5 * *",
     async () => {


### PR DESCRIPTION
PR 5 of 5 — cleanup after the #185 Telegram multi-bot chain. Also the last PR, so it closes #185.

Closes #221.
Closes #185.

## What

- **`infra/systemd/findash.service`**: `TimeoutStopSec` **30 → 10**. The long-poll worker that needed 30s to drain on SIGTERM is gone (webhook-based since PR3 #223); 10s is ample for Next.js to finish in-flight requests. Also dropped ``+ Telegram worker`` from the unit ``Description``.
- **`src/instrumentation.ts`**: tightened the file docstring (disable hint now mentions only the cron since there's no more worker) and pointed the recurring-gap cron comment at **#225** — the new followup for iterating all active users instead of hardcoded `user_id=1`.
- **`.env.example`**: removed the ``PR3/4 pending`` language from the Telegram block — both PRs are live. Points at `docs/telegram-bot.md` for the full flow.

No production behavior change beyond the shorter shutdown window.

## Followup filed

**#225** — \`chore(cron): recurring-gap cron iterates all active users instead of hardcoded user_id=1\`. Out of scope for #185 per the original spec's non-goals (``Updating closePreviousMonth(1) cron hardcode... is a separate cleanup``).

## Audit results (context for future readers)

Grepped the tree for residual #185 artifacts. These are intentionally kept — they are historical references, not stale code:

- Drizzle snapshot JSONs 0008-0012: frozen schema snapshots — never edited
- `drizzle/0016_telegram_bots_drop_poll_state.sql`: the migration file itself
- `docs/multi-user-plan.md`: design doc, historical reference
- `.github/workflows/ci.yml:51`: comment explaining why `TELEGRAM_TOKEN_ENCRYPTION_KEY` is stubbed at build time
- `docs/telegram-bot.md:9`: forward reference to #185

## Test plan

- [x] `bun run test` — 300/300 green
- [x] `bun run typecheck` — green
- [x] `bun run lint` — green
- [ ] CI green on this branch