### PR TITLE
fix(db): bump drizzle migration 0016 `when` above 0015 (#227)

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -117,7 +117,7 @@
     {
       "idx": 16,
       "version": "7",
-      "when": 1776536908532,
+      "when": 1776568100000,
       "tag": "0016_telegram_bots_drop_poll_state",
       "breakpoints": true
     }


### PR DESCRIPTION
Closes #227.

## What

One-byte fix in \`drizzle/meta/_journal.json\`: entry 16's \`when\` field was \`1776536908532\` (2026-04-17 10:28 UTC), which is **earlier** than 0015's \`when: 1776568000000\` (2026-04-18). Bumped to \`1776568100000\` — 100s after 0015.

## Why

drizzle-orm/postgres-js/migrator applies migrations in journal order but gates each with \`lastDbMigration.created_at < migration.when\`. If the \`when\` of a later migration is numerically smaller than a predecessor's, the check fails and the migration is silently skipped on every fresh database build.

This broke:
- **Production**: \`telegram_bots\` table was never created on the DO droplet. \`/settings/telegram\` 500'd on first user visit. Already patched manually (SQL applied + \`__drizzle_migrations\` row inserted with the same \`1776568100000\` \`created_at\`).
- **Any new environment** built from main: fresh \`findash_test\` clones, replicas, new dev machines. CI's \`findash_test\` worked only because no test touched \`telegram_bots\` — had any such test existed in #218's PR, it would have caught this.

## Prevention

A pre-commit lint that validates \`_journal.json\` entries have strictly increasing \`when\` is a good idea. Not in this PR — will file a separate followup if the user wants it. For now, this one-line fix unblocks any new environment.

## Test plan

- [x] Prod already patched (telegram_bots exists, \`__drizzle_migrations\` has 17 rows, timestamps now strictly monotonic)
- [ ] CI green on this branch (should be — only journal file changed; the existing test DB \`findash_test\` state isn't affected)
- [ ] After merge, auto-deploy runs migrate-prod.ts again; it should be a no-op (the \`when\` stamped on the already-inserted \`__drizzle_migrations\` row matches)