### PR TITLE
feat(cron): fan out recurring-gap detector across all users (#225)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -22,22 +22,30 @@ export async function register() {
   globalThis.__findashBgRegistered = true;
 
   const cron = (await import("node-cron")).default;
-  const { closePreviousMonth } = await import("@/lib/recurring/gap-detector");
+  const { closePreviousMonthForAllUsers } = await import("@/lib/recurring/gap-detector");
 
   // Day 5 of each month at 06:00 America/Bogota — gives a 4-day grace window
   // for late-posting SMS/Apple Pay events before we finalize gaps.
-  // NOTE: scopes to user 1. Iterating all active users is tracked in #225.
   cron.schedule(
     "0 6 5 * *",
     async () => {
       try {
-        const result = await closePreviousMonth(1);
-        console.log(
-          `[findash] recurring-gap detector closed ${result.yearMonth}:`,
-          JSON.stringify(result),
-        );
+        const results = await closePreviousMonthForAllUsers();
+        for (const entry of results) {
+          if (entry.ok) {
+            console.log(
+              `[findash] recurring-gap detector closed ${entry.result.yearMonth} for user ${entry.userId}:`,
+              JSON.stringify(entry.result),
+            );
+          } else {
+            console.error(
+              `[findash] recurring-gap detector failed for user ${entry.userId}:`,
+              entry.error,
+            );
+          }
+        }
       } catch (err) {
-        console.error("[findash] recurring-gap detector failed:", err);
+        console.error("[findash] recurring-gap detector fan-out failed:", err);
       }
     },
     { timezone: "America/Bogota" },

--- a/src/lib/recurring/gap-detector.test.ts
+++ b/src/lib/recurring/gap-detector.test.ts
@@ -1,8 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { and, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, recurringGaps, recurringTransactions, transactions } from "@/lib/db/schema";
-import { detectGapsForMonth, previousYearMonth } from "./gap-detector";
+import {
+  accounts,
+  recurringGaps,
+  recurringTransactions,
+  transactions,
+  users,
+} from "@/lib/db/schema";
+import {
+  closePreviousMonthForAllUsers,
+  detectGapsForMonth,
+  previousYearMonth,
+} from "./gap-detector";
 
 const TEST_ACCOUNT = "__gap_test_account__";
 
@@ -302,6 +312,85 @@ describe("detectGapsForMonth (integration)", () => {
     const result = await detectGapsForMonth(TEST_USER_ID, "2026-04");
     expect(result.autoLinked).toBe(0);
     expect(result.gapsCreated).toBe(1);
+  });
+});
+
+describe("closePreviousMonthForAllUsers (integration)", () => {
+  const SECOND_USER_EMAIL = "__gap_test_user2@example.com";
+  const SECOND_ACCOUNT = "__gap_test_account_u2";
+
+  async function cleanupFanout() {
+    await cleanup();
+    await db.execute(sql`DELETE FROM accounts WHERE name = ${SECOND_ACCOUNT}`);
+    await db.execute(sql`DELETE FROM users WHERE email = ${SECOND_USER_EMAIL}`);
+  }
+
+  beforeEach(cleanupFanout);
+  afterEach(cleanupFanout);
+
+  it("runs closePreviousMonth for every user and returns per-user results", async () => {
+    const acct1 = await seedAccount();
+    await seedRecurring(acct1, {
+      label: "__gap_test user1 rent",
+      amountCents: BigInt(-250000),
+      dayOfMonth: 5,
+    });
+
+    const [u2] = await db
+      .insert(users)
+      .values({ email: SECOND_USER_EMAIL, name: "Gap Fan-out Test" })
+      .returning({ id: users.id });
+
+    const [acct2] = await db
+      .insert(accounts)
+      .values({
+        userId: u2.id,
+        name: SECOND_ACCOUNT,
+        institution: "Test",
+        type: "savings",
+        currency: "COP",
+      })
+      .returning({ id: accounts.id });
+
+    await db.insert(recurringTransactions).values({
+      userId: u2.id,
+      accountId: acct2.id,
+      label: "__gap_test user2 netflix",
+      amountCents: BigInt(-49000),
+      currency: "COP",
+      dayOfMonth: 10,
+      active: true,
+      skippedMonths: [],
+    });
+
+    // today = 2026-05-05 → closes 2026-04
+    const results = await closePreviousMonthForAllUsers(new Date("2026-05-05T12:00:00Z"));
+
+    const u1Entry = results.find((r) => r.userId === TEST_USER_ID);
+    const u2Entry = results.find((r) => r.userId === u2.id);
+
+    expect(u1Entry?.ok).toBe(true);
+    expect(u2Entry?.ok).toBe(true);
+
+    if (u1Entry?.ok) {
+      expect(u1Entry.result.yearMonth).toBe("2026-04");
+      // seeded 1 recurring for user 1 in this test — real seed may add more,
+      // so assert "at least our one" rather than an exact count.
+      expect(u1Entry.result.checkedRecurrings).toBeGreaterThanOrEqual(1);
+    }
+    if (u2Entry?.ok) {
+      expect(u2Entry.result.yearMonth).toBe("2026-04");
+      expect(u2Entry.result.checkedRecurrings).toBe(1);
+      expect(u2Entry.result.gapsCreated).toBe(1);
+    }
+
+    // Gap for user 2 is scoped to user 2's recurring
+    const u2Gaps = await db
+      .select({ id: recurringGaps.id })
+      .from(recurringGaps)
+      .innerJoin(recurringTransactions, eq(recurringGaps.recurringId, recurringTransactions.id))
+      .where(and(eq(recurringTransactions.userId, u2.id), eq(recurringGaps.yearMonth, "2026-04")));
+    expect(u2Gaps.length).toBe(1);
   });
 });
 

--- a/src/lib/recurring/gap-detector.ts
+++ b/src/lib/recurring/gap-detector.ts
@@ -1,6 +1,6 @@
-import { and, eq, gte, inArray, isNull, lte } from "drizzle-orm";
+import { and, asc, eq, gte, inArray, isNull, lte } from "drizzle-orm";
 import { db as defaultDb, type DB } from "@/lib/db";
-import { recurringGaps, recurringTransactions, transactions } from "@/lib/db/schema";
+import { recurringGaps, recurringTransactions, transactions, users } from "@/lib/db/schema";
 
 const DEFAULT_WINDOW_BEFORE_DAYS = 10;
 const DEFAULT_WINDOW_AFTER_DAYS = 5;
@@ -180,6 +180,32 @@ export async function closePreviousMonth(
   database: DB = defaultDb,
 ): Promise<DetectResult> {
   return detectGapsForMonth(userId, previousYearMonth(today), database);
+}
+
+export type UserCloseResult =
+  | { userId: number; ok: true; result: DetectResult }
+  | { userId: number; ok: false; error: unknown };
+
+/**
+ * Fan-out wrapper for the monthly cron. Runs closePreviousMonth for every
+ * user sequentially; a failure on one user is captured and does not stop the
+ * rest. Callers are responsible for logging / alerting on the returned list.
+ */
+export async function closePreviousMonthForAllUsers(
+  today: Date = new Date(),
+  database: DB = defaultDb,
+): Promise<UserCloseResult[]> {
+  const rows = await database.select({ id: users.id }).from(users).orderBy(asc(users.id));
+  const out: UserCloseResult[] = [];
+  for (const { id } of rows) {
+    try {
+      const result = await closePreviousMonth(id, today, database);
+      out.push({ userId: id, ok: true, result });
+    } catch (error) {
+      out.push({ userId: id, ok: false, error });
+    }
+  }
+  return out;
 }
 
 export { DEFAULT_WINDOW_BEFORE_DAYS, DEFAULT_WINDOW_AFTER_DAYS };


### PR DESCRIPTION
Closes #225.

## Summary
- Add `closePreviousMonthForAllUsers()` in `gap-detector.ts` that iterates every row in `users` and runs `closePreviousMonth(userId)` sequentially, returning a per-user result (`ok | error`).
- `src/instrumentation.ts` cron callback now fans out via the new helper and logs each user's outcome separately — a failure for one user no longer kills the whole month for everyone else.
- Integration test exercises the fan-out with two users (seeded user 1 + a fresh `__gap_test_user2@example.com`), asserting both are processed and user 2's gap lands scoped to user 2's recurring.

## Notes
- Predicate is `SELECT id FROM users` — there is no `active` flag on the schema and signup is already invite-gated, so every row is a real user.
- Sequential iteration, not parallel. Monthly cron, small user count (phase-4 = 5 friends); simpler to reason about and keeps DB pressure bounded.

## Test plan
- [x] `bun run test src/lib/recurring/gap-detector.test.ts` — 13/13 green
- [x] `bun run test` — 301/301 green
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [x] `bun run format:check`