### PR TITLE
feat(admin): users + role gate for invite minting (#189)

### DIFF
--- a/drizzle/0018_simple_pestilence.sql
+++ b/drizzle/0018_simple_pestilence.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "users" ADD COLUMN "role" varchar(20) DEFAULT 'user' NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "active" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_role_check" CHECK ("users"."role" IN ('admin', 'user'));--> statement-breakpoint
+UPDATE "users" SET "role" = 'admin' WHERE "id" = 1;

--- a/drizzle/meta/0018_snapshot.json
+++ b/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,2365 @@
+{
+  "id": "7ba54823-6fc6-4a64-9a1c-0fab3653bfa2",
+  "prevId": "b770f3c0-f283-4654-a633-fef0c1d9dd77",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_category_slug_categories_slug_fk": {
+          "name": "budgets_category_slug_categories_slug_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_slug_categories_slug_fk": {
+          "name": "categories_parent_slug_categories_slug_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_categories_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_category_slug_categories_slug_fk": {
+          "name": "classification_rules_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_default_category_slug_categories_slug_fk": {
+          "name": "counterparties_default_category_slug_categories_slug_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_category_slug_categories_slug_fk": {
+          "name": "recurring_transactions_category_slug_categories_slug_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_category_slug_categories_slug_fk": {
+          "name": "transactions_category_slug_categories_slug_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "ai",
+        "manual",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1776568200000,
       "tag": "0017_nebulous_rachel_grey",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1776568300000,
+      "tag": "0018_simple_pestilence",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/settings/invites/actions.ts
+++ b/src/app/(app)/settings/invites/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import { getSessionUser } from "@/lib/auth/session";
+import { requireAdmin } from "@/lib/auth/session";
 import { mintInviteCode, setInviteDisabled } from "@/lib/invite-codes";
 import { buildSignupUrl } from "./signup-url";
 
@@ -20,7 +20,7 @@ export async function mintInviteCodeAction(
   _prev: MintActionState,
   formData: FormData,
 ): Promise<MintActionState> {
-  const session = await getSessionUser();
+  const session = await requireAdmin();
   const parsed = mintSchema.safeParse({
     maxUses: formData.get("maxUses"),
     expiresInDays: formData.get("expiresInDays") || undefined,
@@ -47,7 +47,7 @@ const toggleSchema = z.object({
 });
 
 export async function setInviteDisabledAction(formData: FormData): Promise<void> {
-  const session = await getSessionUser();
+  const session = await requireAdmin();
   const parsed = toggleSchema.safeParse({
     code: formData.get("code"),
     disabled: formData.get("disabled"),

--- a/src/app/(app)/settings/invites/page.tsx
+++ b/src/app/(app)/settings/invites/page.tsx
@@ -1,3 +1,4 @@
+import { notFound } from "next/navigation";
 import { getSessionUser } from "@/lib/auth/session";
 import { getInviteStatus, listInviteCodesFor } from "@/lib/invite-codes";
 import { InvitesManager } from "./invites-manager";
@@ -7,6 +8,7 @@ export const dynamic = "force-dynamic";
 
 export default async function InvitesPage() {
   const session = await getSessionUser();
+  if (session.role !== "admin") notFound();
   const codes = await listInviteCodesFor(session.id);
   const now = new Date();
   const invites = await Promise.all(

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getSessionUser } from "@/lib/auth/session";
 
 const LINKS = [
   {
@@ -31,22 +32,33 @@ const LINKS = [
     description:
       "Register your BotFather bot. Findash encrypts the token at rest and serves the webhook at /api/telegram/webhook/<botId>.",
   },
+];
+
+const ADMIN_LINKS = [
   {
     href: "/settings/invites",
     title: "Invitaciones",
     description:
       "Generá códigos para que más gente pueda crear cuenta. El registro en Findash es cerrado — solo quien tiene un link válido se puede firmar.",
   },
+  {
+    href: "/settings/users",
+    title: "Usuarios",
+    description:
+      "Listado de usuarios con toggle activo/inactivo y cambio de rol. Solo visible para admins.",
+  },
 ];
 
-export default function SettingsPage() {
+export default async function SettingsPage() {
+  const session = await getSessionUser();
+  const links = session.role === "admin" ? [...LINKS, ...ADMIN_LINKS] : LINKS;
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
       <header>
         <h1 className="text-h1">Settings</h1>
       </header>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        {LINKS.map((l) => (
+        {links.map((l) => (
           <Link key={l.href} href={l.href}>
             <Card className="hover:border-foreground/30 transition">
               <CardHeader>

--- a/src/app/(app)/settings/users/actions.ts
+++ b/src/app/(app)/settings/users/actions.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/auth/session";
+import { setUserActive, setUserRole, type UpdateResult } from "@/lib/users/queries";
+
+export type UserActionResult = { status: "ok" } | { status: "error"; message: string };
+
+const toggleSchema = z.object({
+  userId: z.coerce.number().int().positive(),
+  active: z.coerce.boolean(),
+});
+
+export async function setUserActiveAction(formData: FormData): Promise<UserActionResult> {
+  await requireAdmin();
+  const parsed = toggleSchema.safeParse({
+    userId: formData.get("userId"),
+    active: formData.get("active"),
+  });
+  if (!parsed.success) return { status: "error", message: "Datos inválidos." };
+  const outcome: UpdateResult = await setUserActive(parsed.data);
+  if (outcome === "last-admin") {
+    return { status: "error", message: "No se puede desactivar al último admin activo." };
+  }
+  revalidatePath("/settings/users");
+  return { status: "ok" };
+}
+
+const roleSchema = z.object({
+  userId: z.coerce.number().int().positive(),
+  role: z.enum(["admin", "user"]),
+});
+
+export async function setUserRoleAction(formData: FormData): Promise<UserActionResult> {
+  await requireAdmin();
+  const parsed = roleSchema.safeParse({
+    userId: formData.get("userId"),
+    role: formData.get("role"),
+  });
+  if (!parsed.success) return { status: "error", message: "Datos inválidos." };
+  const outcome: UpdateResult = await setUserRole(parsed.data);
+  if (outcome === "last-admin") {
+    return { status: "error", message: "No se puede demotar al último admin activo." };
+  }
+  revalidatePath("/settings/users");
+  return { status: "ok" };
+}

--- a/src/app/(app)/settings/users/page.tsx
+++ b/src/app/(app)/settings/users/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from "next/navigation";
+import { getSessionUser } from "@/lib/auth/session";
+import { listAllUsers } from "@/lib/users/queries";
+import { UsersManager } from "./users-manager";
+
+export const dynamic = "force-dynamic";
+
+export default async function UsersPage() {
+  const session = await getSessionUser();
+  if (session.role !== "admin") notFound();
+  const rows = await listAllUsers();
+  const users = rows.map((u) => ({
+    id: u.id,
+    email: u.email,
+    name: u.name,
+    pictureUrl: u.pictureUrl,
+    role: u.role,
+    active: u.active,
+    createdAt: u.createdAt.toISOString(),
+  }));
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-h1">Usuarios</h1>
+        <p className="text-body text-muted-foreground">
+          Gestión de usuarios: promoción/democión de rol y activación/desactivación. Las acciones
+          destructivas siempre dejan al menos un admin activo.
+        </p>
+      </header>
+      <UsersManager users={users} currentUserId={session.id} />
+    </main>
+  );
+}

--- a/src/app/(app)/settings/users/users-manager.tsx
+++ b/src/app/(app)/settings/users/users-manager.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useTransition } from "react";
+import { PowerIcon, PowerOffIcon, ShieldIcon, UserIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { setUserActiveAction, setUserRoleAction } from "./actions";
+
+type UserRow = {
+  id: number;
+  email: string;
+  name: string;
+  pictureUrl: string | null;
+  role: "admin" | "user";
+  active: boolean;
+  createdAt: string;
+};
+
+export function UsersManager({
+  users,
+  currentUserId,
+}: {
+  users: UserRow[];
+  currentUserId: number;
+}) {
+  const [pending, startTransition] = useTransition();
+
+  function toggleActive(u: UserRow) {
+    const next = !u.active;
+    const fd = new FormData();
+    fd.set("userId", String(u.id));
+    fd.set("active", next ? "true" : "false");
+    startTransition(async () => {
+      const result = await setUserActiveAction(fd);
+      if (result.status === "error") toast.error(result.message);
+      else toast.success(next ? `Usuario activado` : `Usuario desactivado`);
+    });
+  }
+
+  function toggleRole(u: UserRow) {
+    const next: "admin" | "user" = u.role === "admin" ? "user" : "admin";
+    const fd = new FormData();
+    fd.set("userId", String(u.id));
+    fd.set("role", next);
+    startTransition(async () => {
+      const result = await setUserRoleAction(fd);
+      if (result.status === "error") toast.error(result.message);
+      else toast.success(next === "admin" ? `Promovido a admin` : `Demotado a user`);
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {users.map((u) => {
+        const isSelf = u.id === currentUserId;
+        return (
+          <Card key={u.id}>
+            <CardHeader className="flex flex-row items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                {u.pictureUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={u.pictureUrl}
+                    alt=""
+                    className="size-10 rounded-full object-cover"
+                    referrerPolicy="no-referrer"
+                  />
+                ) : (
+                  <div className="bg-muted size-10 rounded-full" />
+                )}
+                <div className="flex flex-col">
+                  <CardTitle className="text-base">
+                    {u.name}
+                    {isSelf && <span className="text-muted-foreground ml-2 text-xs">(vos)</span>}
+                  </CardTitle>
+                  <span className="text-muted-foreground text-xs">{u.email}</span>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant={u.role === "admin" ? "default" : "secondary"}>{u.role}</Badge>
+                <Badge variant={u.active ? "outline" : "destructive"}>
+                  {u.active ? "activo" : "inactivo"}
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-muted-foreground text-xs">
+                Creado: {new Date(u.createdAt).toLocaleDateString("es-CO")}
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={pending}
+                  onClick={() => toggleRole(u)}
+                >
+                  {u.role === "admin" ? (
+                    <>
+                      <UserIcon className="mr-1 size-4" /> Demotar a user
+                    </>
+                  ) : (
+                    <>
+                      <ShieldIcon className="mr-1 size-4" /> Promover a admin
+                    </>
+                  )}
+                </Button>
+                <Button
+                  size="sm"
+                  variant={u.active ? "destructive" : "default"}
+                  disabled={pending}
+                  onClick={() => toggleActive(u)}
+                >
+                  {u.active ? (
+                    <>
+                      <PowerOffIcon className="mr-1 size-4" /> Desactivar
+                    </>
+                  ) : (
+                    <>
+                      <PowerIcon className="mr-1 size-4" /> Activar
+                    </>
+                  )}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -44,7 +44,9 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
               role="alert"
               className="border-destructive/30 bg-destructive/10 text-destructive rounded-md border px-3 py-2 text-sm"
             >
-              No pudimos iniciar sesión. Intentá de nuevo.
+              {params.error === "account-disabled"
+                ? "Tu cuenta fue desactivada. Contactá a un admin para reactivarla."
+                : "No pudimos iniciar sesión. Intentá de nuevo."}
             </p>
           ) : null}
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -12,6 +12,8 @@ declare module "next-auth" {
   interface Session {
     user: {
       id: number;
+      role: "admin" | "user";
+      active: boolean;
     } & Omit<NonNullable<DefaultSession["user"]>, "id">;
   }
 }
@@ -19,6 +21,8 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   interface JWT {
     userId?: number;
+    role?: "admin" | "user";
+    active?: boolean;
   }
 }
 
@@ -84,22 +88,33 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       }
       return true;
     },
-    async jwt({ token, trigger }) {
-      if ((trigger === "signIn" || !token.userId) && token.email) {
-        const row = await db
-          .select({ id: users.id })
-          .from(users)
-          .where(eq(users.email, token.email))
-          .limit(1);
-        if (row[0]) {
-          token.userId = row[0].id;
-        }
+    async jwt({ token }) {
+      // Refresh identity + role + active flag on every request. At 5-user
+      // scale one SELECT per request is negligible and keeps deactivation /
+      // role changes effective without waiting for a new sign-in.
+      if (!token.email) return token;
+      const row = await db
+        .select({ id: users.id, role: users.role, active: users.active })
+        .from(users)
+        .where(eq(users.email, token.email))
+        .limit(1);
+      if (row[0]) {
+        token.userId = row[0].id;
+        token.role = row[0].role === "admin" ? "admin" : "user";
+        token.active = row[0].active;
       }
       return token;
     },
     async session({ session, token }) {
       if (typeof token.userId === "number" && session.user) {
-        (session.user as { id: number }).id = token.userId;
+        const u = session.user as {
+          id: number;
+          role: "admin" | "user";
+          active: boolean;
+        };
+        u.id = token.userId;
+        u.role = token.role ?? "user";
+        u.active = token.active ?? true;
       }
       return session;
     },

--- a/src/lib/auth/session.test.ts
+++ b/src/lib/auth/session.test.ts
@@ -6,7 +6,7 @@ vi.mock("@/auth", () => ({
 }));
 
 import { auth } from "@/auth";
-import { getSessionUser, getSessionUserOrNull } from "./session";
+import { getSessionUser, getSessionUserOrNull, requireAdmin } from "./session";
 
 const mockAuth = auth as unknown as Mock<() => Promise<Session | null>>;
 
@@ -16,6 +16,8 @@ function session(overrides?: Partial<Session["user"]>): Session {
       id: 7,
       email: "ada@example.com",
       name: "Ada Lovelace",
+      role: "user",
+      active: true,
       ...overrides,
     },
     expires: "9999-01-01T00:00:00.000Z",
@@ -45,12 +47,14 @@ describe("getSessionUser", () => {
     await expect(getSessionUser()).rejects.toThrow("UNAUTHENTICATED");
   });
 
-  it("returns the session user when everything is present", async () => {
-    mockAuth.mockResolvedValue(session());
+  it("returns the session user (including role and active) when everything is present", async () => {
+    mockAuth.mockResolvedValue(session({ role: "admin", active: true }));
     await expect(getSessionUser()).resolves.toEqual({
       id: 7,
       email: "ada@example.com",
       name: "Ada Lovelace",
+      role: "admin",
+      active: true,
     });
   });
 
@@ -60,6 +64,19 @@ describe("getSessionUser", () => {
       id: 7,
       email: "ada@example.com",
       name: "ada@example.com",
+      role: "user",
+      active: true,
+    });
+  });
+
+  it("defaults role to 'user' and active to true when token fields missing", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 7, email: "ada@example.com", name: "Ada" },
+      expires: "9999-01-01T00:00:00.000Z",
+    } as unknown as Session);
+    await expect(getSessionUser()).resolves.toMatchObject({
+      role: "user",
+      active: true,
     });
   });
 });
@@ -74,12 +91,35 @@ describe("getSessionUserOrNull", () => {
     await expect(getSessionUserOrNull()).resolves.toBeNull();
   });
 
-  it("returns the user when session is valid", async () => {
-    mockAuth.mockResolvedValue(session());
+  it("returns the user with role/active when session is valid", async () => {
+    mockAuth.mockResolvedValue(session({ role: "admin", active: true }));
     await expect(getSessionUserOrNull()).resolves.toEqual({
       id: 7,
       email: "ada@example.com",
       name: "Ada Lovelace",
+      role: "admin",
+      active: true,
     });
+  });
+});
+
+describe("requireAdmin", () => {
+  beforeEach(() => {
+    mockAuth.mockReset();
+  });
+
+  it("throws FORBIDDEN for a non-admin session", async () => {
+    mockAuth.mockResolvedValue(session({ role: "user" }));
+    await expect(requireAdmin()).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("throws UNAUTHENTICATED when there is no session", async () => {
+    mockAuth.mockResolvedValue(null);
+    await expect(requireAdmin()).rejects.toThrow("UNAUTHENTICATED");
+  });
+
+  it("returns the user when role is admin", async () => {
+    mockAuth.mockResolvedValue(session({ role: "admin" }));
+    await expect(requireAdmin()).resolves.toMatchObject({ role: "admin" });
   });
 });

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -4,6 +4,8 @@ export type SessionUser = {
   id: number;
   email: string;
   name: string;
+  role: "admin" | "user";
+  active: boolean;
 };
 
 export async function getSessionUser(): Promise<SessionUser> {
@@ -15,6 +17,8 @@ export async function getSessionUser(): Promise<SessionUser> {
     id: session.user.id,
     email: session.user.email,
     name: session.user.name ?? session.user.email,
+    role: session.user.role ?? "user",
+    active: session.user.active ?? true,
   };
 }
 
@@ -27,5 +31,15 @@ export async function getSessionUserOrNull(): Promise<SessionUser | null> {
     id: session.user.id,
     email: session.user.email,
     name: session.user.name ?? session.user.email,
+    role: session.user.role ?? "user",
+    active: session.user.active ?? true,
   };
+}
+
+export async function requireAdmin(): Promise<SessionUser> {
+  const user = await getSessionUser();
+  if (user.role !== "admin") {
+    throw new Error("FORBIDDEN");
+  }
+  return user;
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -18,15 +18,21 @@ import {
   type AnyPgColumn,
 } from "drizzle-orm/pg-core";
 
-export const users = pgTable("users", {
-  id: serial("id").primaryKey(),
-  googleSub: varchar("google_sub", { length: 255 }).unique(),
-  email: varchar("email", { length: 320 }).notNull().unique(),
-  name: varchar("name", { length: 200 }).notNull(),
-  pictureUrl: text("picture_url"),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-});
+export const users = pgTable(
+  "users",
+  {
+    id: serial("id").primaryKey(),
+    googleSub: varchar("google_sub", { length: 255 }).unique(),
+    email: varchar("email", { length: 320 }).notNull().unique(),
+    name: varchar("name", { length: 200 }).notNull(),
+    pictureUrl: text("picture_url"),
+    role: varchar("role", { length: 20 }).notNull().default("user"),
+    active: boolean("active").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [check("users_role_check", sql`${t.role} IN ('admin', 'user')`)],
+);
 
 export const inviteCodes = pgTable(
   "invite_codes",

--- a/src/lib/users/queries.test.ts
+++ b/src/lib/users/queries.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { countActiveAdmins, listAllUsers, setUserActive, setUserRole } from "./queries";
+
+// These tests mutate the `users` table — they live in findash_test (forced by
+// vitest.setup.ts). We tag test users with a distinct email suffix so cleanup
+// only wipes rows we created, never the bootstrap admin (id=1) that other
+// suites depend on.
+const TAG = "+users-queries-test@findash.local";
+
+async function createUser(opts: {
+  email: string;
+  name: string;
+  role: "admin" | "user";
+  active: boolean;
+}): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({
+      email: opts.email,
+      name: opts.name,
+      role: opts.role,
+      active: opts.active,
+      googleSub: `sub-${opts.email}`,
+    })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function cleanup() {
+  await db
+    .delete(users)
+    .where(
+      inArray(users.email, [`admin-a${TAG}`, `admin-b${TAG}`, `regular${TAG}`, `inactive${TAG}`]),
+    );
+}
+
+describe("users/queries", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("listAllUsers returns rows in id order with role + active fields", async () => {
+    const aId = await createUser({
+      email: `admin-a${TAG}`,
+      name: "Admin A",
+      role: "admin",
+      active: true,
+    });
+    const rId = await createUser({
+      email: `regular${TAG}`,
+      name: "Regular",
+      role: "user",
+      active: true,
+    });
+    const all = await listAllUsers();
+    const mine = all.filter((u) => u.id === aId || u.id === rId);
+    expect(mine.map((u) => [u.role, u.active])).toEqual([
+      ["admin", true],
+      ["user", true],
+    ]);
+  });
+
+  it("refuses to deactivate the last active admin", async () => {
+    // Temporarily demote the bootstrap admin so our seeded admin-a is the
+    // only active admin. Restore afterwards.
+    await db.update(users).set({ role: "user" }).where(eq(users.id, 1));
+    try {
+      const aId = await createUser({
+        email: `admin-a${TAG}`,
+        name: "Admin A",
+        role: "admin",
+        active: true,
+      });
+      expect(await countActiveAdmins()).toBe(1);
+      const result = await setUserActive({ userId: aId, active: false });
+      expect(result).toBe("last-admin");
+      expect(await countActiveAdmins()).toBe(1);
+    } finally {
+      await db.update(users).set({ role: "admin" }).where(eq(users.id, 1));
+    }
+  });
+
+  it("allows deactivating an admin when another active admin exists", async () => {
+    const aId = await createUser({
+      email: `admin-a${TAG}`,
+      name: "Admin A",
+      role: "admin",
+      active: true,
+    });
+    const bId = await createUser({
+      email: `admin-b${TAG}`,
+      name: "Admin B",
+      role: "admin",
+      active: true,
+    });
+    const result = await setUserActive({ userId: aId, active: false });
+    expect(result).toBe("ok");
+    const [after] = await db.select({ active: users.active }).from(users).where(eq(users.id, aId));
+    expect(after.active).toBe(false);
+    // Cleanup: also delete bId via cleanup() helper; nothing else to do.
+    expect(bId).toBeGreaterThan(0);
+  });
+
+  it("refuses to demote the last active admin", async () => {
+    await db.update(users).set({ role: "user" }).where(eq(users.id, 1));
+    try {
+      const aId = await createUser({
+        email: `admin-a${TAG}`,
+        name: "Admin A",
+        role: "admin",
+        active: true,
+      });
+      const result = await setUserRole({ userId: aId, role: "user" });
+      expect(result).toBe("last-admin");
+      const [after] = await db.select({ role: users.role }).from(users).where(eq(users.id, aId));
+      expect(after.role).toBe("admin");
+    } finally {
+      await db.update(users).set({ role: "admin" }).where(eq(users.id, 1));
+    }
+  });
+
+  it("allows demoting an admin when another active admin exists", async () => {
+    const aId = await createUser({
+      email: `admin-a${TAG}`,
+      name: "Admin A",
+      role: "admin",
+      active: true,
+    });
+    await createUser({
+      email: `admin-b${TAG}`,
+      name: "Admin B",
+      role: "admin",
+      active: true,
+    });
+    const result = await setUserRole({ userId: aId, role: "user" });
+    expect(result).toBe("ok");
+    const [after] = await db.select({ role: users.role }).from(users).where(eq(users.id, aId));
+    expect(after.role).toBe("user");
+  });
+
+  it("inactive admins don't count toward the last-admin guard (can deactivate them)", async () => {
+    // An "inactive admin" should be treated as a non-participating admin for
+    // the purposes of the invariant — their row doesn't protect anyone.
+    const inactiveId = await createUser({
+      email: `inactive${TAG}`,
+      name: "Inactive Admin",
+      role: "admin",
+      active: false,
+    });
+    const result = await setUserActive({ userId: inactiveId, active: false });
+    expect(result).toBe("ok");
+  });
+
+  it("promoting and reactivating are always allowed (no guard needed)", async () => {
+    const rId = await createUser({
+      email: `regular${TAG}`,
+      name: "Regular",
+      role: "user",
+      active: true,
+    });
+    expect(await setUserRole({ userId: rId, role: "admin" })).toBe("ok");
+    const inactiveId = await createUser({
+      email: `inactive${TAG}`,
+      name: "Inactive",
+      role: "user",
+      active: false,
+    });
+    expect(await setUserActive({ userId: inactiveId, active: true })).toBe("ok");
+  });
+});

--- a/src/lib/users/queries.ts
+++ b/src/lib/users/queries.ts
@@ -1,0 +1,153 @@
+import { and, eq, ne, sql } from "drizzle-orm";
+import { db as defaultDb, type DB } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+
+export type UserRole = "admin" | "user";
+
+export type UserRow = {
+  id: number;
+  email: string;
+  name: string;
+  pictureUrl: string | null;
+  role: UserRole;
+  active: boolean;
+  createdAt: Date;
+};
+
+function toUserRow(r: {
+  id: number;
+  email: string;
+  name: string;
+  pictureUrl: string | null;
+  role: string;
+  active: boolean;
+  createdAt: Date;
+}): UserRow {
+  return { ...r, role: r.role === "admin" ? "admin" : "user" };
+}
+
+export async function listAllUsers(db: DB = defaultDb): Promise<UserRow[]> {
+  const rows = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      pictureUrl: users.pictureUrl,
+      role: users.role,
+      active: users.active,
+      createdAt: users.createdAt,
+    })
+    .from(users)
+    .orderBy(users.id);
+  return rows.map(toUserRow);
+}
+
+/**
+ * Counts currently-active admins. Used to enforce the last-admin invariant
+ * before deactivating or demoting a user.
+ */
+export async function countActiveAdmins(db: DB = defaultDb): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(users)
+    .where(and(eq(users.role, "admin"), eq(users.active, true)));
+  return row?.n ?? 0;
+}
+
+/**
+ * Atomic last-admin guard. Applies the patch only if doing so preserves at
+ * least one other active admin besides `targetUserId`. Returns `true` if
+ * the update happened, `false` if the guard blocked it.
+ */
+async function updateIfNotLastAdmin(opts: {
+  db: DB;
+  targetUserId: number;
+  patch: Partial<{ role: UserRole; active: boolean }>;
+}): Promise<boolean> {
+  const { db, targetUserId, patch } = opts;
+  const result = await db
+    .update(users)
+    .set({ ...patch, updatedAt: new Date() })
+    .where(
+      and(
+        eq(users.id, targetUserId),
+        sql`EXISTS (SELECT 1 FROM users u2 WHERE u2.id <> ${targetUserId} AND u2.role = 'admin' AND u2.active = true)`,
+      ),
+    )
+    .returning({ id: users.id });
+  return result.length > 0;
+}
+
+export type UpdateResult = "ok" | "last-admin";
+
+export async function setUserActive(opts: {
+  userId: number;
+  active: boolean;
+  db?: DB;
+}): Promise<UpdateResult> {
+  const db = opts.db ?? defaultDb;
+  if (opts.active) {
+    // Reactivating is always safe — no admin-count concern.
+    await db
+      .update(users)
+      .set({ active: true, updatedAt: new Date() })
+      .where(eq(users.id, opts.userId));
+    return "ok";
+  }
+  // Deactivating: block if target is the last active admin.
+  const [target] = await db
+    .select({ role: users.role, active: users.active })
+    .from(users)
+    .where(eq(users.id, opts.userId))
+    .limit(1);
+  if (!target) return "ok";
+  if (target.role !== "admin" || !target.active) {
+    await db
+      .update(users)
+      .set({ active: false, updatedAt: new Date() })
+      .where(eq(users.id, opts.userId));
+    return "ok";
+  }
+  const ok = await updateIfNotLastAdmin({
+    db,
+    targetUserId: opts.userId,
+    patch: { active: false },
+  });
+  return ok ? "ok" : "last-admin";
+}
+
+export async function setUserRole(opts: {
+  userId: number;
+  role: UserRole;
+  db?: DB;
+}): Promise<UpdateResult> {
+  const db = opts.db ?? defaultDb;
+  if (opts.role === "admin") {
+    // Promoting is always safe.
+    await db
+      .update(users)
+      .set({ role: "admin", updatedAt: new Date() })
+      .where(eq(users.id, opts.userId));
+    return "ok";
+  }
+  // Demoting: block if target is the last active admin.
+  const [target] = await db
+    .select({ role: users.role, active: users.active })
+    .from(users)
+    .where(eq(users.id, opts.userId))
+    .limit(1);
+  if (!target) return "ok";
+  if (target.role !== "admin" || !target.active) {
+    await db
+      .update(users)
+      .set({ role: "user", updatedAt: new Date() })
+      .where(and(eq(users.id, opts.userId), ne(users.role, "user")));
+    return "ok";
+  }
+  const ok = await updateIfNotLastAdmin({
+    db,
+    targetUserId: opts.userId,
+    patch: { role: "user" },
+  });
+  return ok ? "ok" : "last-admin";
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,14 +1,30 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 
-export default auth((req) => {
-  const isLoggedIn = !!req.auth;
-  const { pathname, search } = req.nextUrl;
+// Names the Auth.js v5 JWT session cookie can go by, across http and https.
+// We clear both on deactivation so the browser can't hold a stale token.
+const SESSION_COOKIES = ["authjs.session-token", "__Secure-authjs.session-token"];
 
-  if (!isLoggedIn) {
+export default auth((req) => {
+  const { pathname, search } = req.nextUrl;
+  const session = req.auth;
+
+  if (!session?.user) {
     const loginUrl = new URL("/login", req.nextUrl);
     loginUrl.searchParams.set("callbackUrl", pathname + search);
     return NextResponse.redirect(loginUrl);
+  }
+
+  // Deactivated users carry a still-valid JWT until expiry; the jwt callback
+  // rewrote `active` from the DB on this request, so if we see `false` here
+  // the ban is authoritative. Clear the cookie and kick them to /login with
+  // a recognizable error code.
+  if (session.user.active === false) {
+    const loginUrl = new URL("/login", req.nextUrl);
+    loginUrl.searchParams.set("error", "account-disabled");
+    const res = NextResponse.redirect(loginUrl);
+    for (const name of SESSION_COOKIES) res.cookies.delete(name);
+    return res;
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Summary

Adds a proper admin surface on top of the multi-user stack so that invite minting is restricted, users can be soft-deactivated, and admins can promote/demote without ever losing the last admin.

- **Schema (migration 0018)**: `users.role VARCHAR(20) NOT NULL DEFAULT 'user' CHECK (role IN ('admin','user'))` and `users.active BOOLEAN NOT NULL DEFAULT true`. The migration itself bootstraps `id=1` to `admin` so fresh deploys start with exactly one admin — no one-shot scripts to remember.
- **Auth/session**: the JWT callback refreshes identity + role + active on every request (5-user scale, one SELECT per req is nothing), session surfaces them on `req.auth.user`. `getSessionUser()` now returns `role`/`active`; new `requireAdmin()` helper throws `FORBIDDEN`.
- **Invite gate**: `/settings/invites` page renders `notFound()` for non-admins; `mintInviteCodeAction` + `setInviteDisabledAction` call `requireAdmin()`. Settings landing hides admin-only tiles for non-admins.
- **`/settings/users`**: new admin-only page listing every user, with toggle-active and role-change actions. The last-admin invariant is enforced **at the SQL layer** — the update only applies when an `EXISTS` subquery confirms another active admin remains, so there's no TOCTOU window between the "is last admin?" check and the write.
- **Session invalidation**: `proxy.ts` sees `req.auth.user.active === false` → clears the `authjs.session-token` cookie (both http and `__Secure-` variants) and redirects to `/login?error=account-disabled`. Login page displays a friendly copy.
- **Tests**: session helper covers role/active/requireAdmin; `users/queries.test.ts` exercises deactivate-last-admin, demote-last-admin, and the cases where the guard should NOT fire (inactive admin, second admin present, promote, reactivate).

## Why it matters

Closes one of the last #179 umbrella gaps — invites were previously open to any authenticated user, and there was no way to boot a misbehaving friend. Prereq for deprecating the Tailscale-only threat model.

## Test plan

- [x] `bun run lint` — green
- [x] `bunx tsc --noEmit` — green
- [x] `bun run format:check` — green
- [x] `bun run test` — 340/340 (7 new cases in users/queries, 3 new cases in session)
- [x] `bun run db:migrate` applied cleanly to dev + test DBs; journal `when` is monotonic
- [ ] Manual smoke: log in as admin → /settings/invites renders + mint works. Log in as non-admin → /settings/invites 404s, tile is hidden. Admin deactivates a non-admin → that user is redirected to /login?error=account-disabled on next request. Admin tries to demote/deactivate themselves (as sole admin) → toast error, no DB change.

Closes #189