### PR TITLE
fix(infra): install awscli via pipx instead of apt (#236)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -435,10 +435,12 @@ chmod 600 /srv/findash/env/r2.env
 
 ### Step 4 — Ensure awscli is installed
 
-`bootstrap.sh` handles this automatically. If running on an existing droplet without re-running bootstrap:
+`bootstrap.sh` handles this automatically via pipx (Ubuntu 24.04 dropped the `awscli` apt package). If running on an existing droplet without re-running bootstrap:
 
 ```bash
-apt-get install -y awscli
+apt-get install -y pipx
+PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install awscli
+aws --version   # sanity check
 ```
 
 ### Step 5 — Verify connectivity

--- a/infra/bootstrap.sh
+++ b/infra/bootstrap.sh
@@ -17,7 +17,9 @@
 #   8. fail2ban on sshd + unattended security upgrades + 2 GB swap
 #   9. Install the systemd unit and Caddyfile from the repo (does NOT enable;
 #      the first real deploy will flip `app/current` and start the service)
-#  10. Install backup cron + awscli; create /srv/findash/backups/daily/
+#  10. Install backup cron; create /srv/findash/backups/daily/
+#  11. Install awscli via pipx (apt dropped it on 24.04) — system-wide so the
+#      findash user can invoke it from the cron for weekly R2 sync.
 #
 # Cloudflare origin cert is NOT fetched here — paste the PEM + key at
 # /etc/caddy/origin.pem and /etc/caddy/origin.key after the T2 ops step.
@@ -44,12 +46,14 @@ apt-get update -y
 DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
 log "apt: install base packages"
+# `awscli` was dropped from the Ubuntu 24.04 (noble) archive; we install it
+# via pipx further down. `pipx` itself comes from apt.
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl ca-certificates gnupg lsb-release \
   ufw fail2ban unattended-upgrades \
   build-essential rsync unzip \
   debian-keyring debian-archive-keyring apt-transport-https \
-  awscli
+  pipx
 
 log "users: ensure $FINDASH_USER and $DEPLOY_USER exist"
 for u in "$FINDASH_USER" "$DEPLOY_USER"; do
@@ -162,6 +166,22 @@ install -m 0755 -o root -g root "$REPO_ROOT/infra/cron/findash-backup.sh" /usr/l
 
 log "backup: install cron file to /etc/cron.d"
 install -m 0644 -o root -g root "$REPO_ROOT/infra/cron/findash-backup.cron" /etc/cron.d/findash-backup
+
+log "awscli: install via pipx (system-wide shim in /usr/local/bin)"
+# Ubuntu 24.04 dropped the awscli .deb. pipx isolates the venv; PIPX_BIN_DIR
+# override puts the `aws` shim in /usr/local/bin so it's on PATH for every
+# user (root for deploys, findash for the weekly R2 sync in backup.sh).
+# awscli is only needed for R2 off-site sync — local daily dumps work without it.
+export PIPX_HOME=/opt/pipx
+export PIPX_BIN_DIR=/usr/local/bin
+install -d -m 0755 -o root -g root "$PIPX_HOME"
+if ! command -v aws >/dev/null 2>&1; then
+  pipx install awscli
+else
+  log "  aws already on PATH — running pipx upgrade (idempotent)"
+  pipx upgrade awscli || true
+fi
+aws --version >&2
 
 cat >&2 <<EOF
 

--- a/infra/cron/README.md
+++ b/infra/cron/README.md
@@ -41,7 +41,7 @@ ssh root@droplet 'sudo -u findash /usr/local/bin/findash-backup.sh --force-r2'
 
 `infra/bootstrap.sh` handles:
 
-- Installing `awscli` via apt
+- Installing `awscli` via pipx into `/usr/local/bin` (apt dropped the package in Ubuntu 24.04)
 - Creating `/srv/findash/backups/daily/` with correct ownership
 - Copying `findash-backup.sh` to `/usr/local/bin/findash-backup.sh` (0755)
 - Installing `findash-backup.cron` to `/etc/cron.d/findash-backup` (0644)


### PR DESCRIPTION
## Summary

- Ubuntu 24.04 dropped the `awscli` .deb package; `infra/bootstrap.sh` currently dies on a fresh droplet with `Package 'awscli' has no installation candidate`.
- Swap apt → pipx. `pipx` itself comes from apt. We install awscli with `PIPX_HOME=/opt/pipx` + `PIPX_BIN_DIR=/usr/local/bin` so the shim is on every user's PATH — root (deploys) and findash (weekly R2 sync in `findash-backup.sh`).
- Idempotent: the install is guarded by `command -v aws` before calling `pipx install`; re-runs just `pipx upgrade` (swallowing errors so no-op re-runs stay green).
- Docs updated: `docs/deploy.md` §10 step 4 + `infra/cron/README.md`.

## Verified on the live droplet

```
$ pipx install awscli           # → /usr/local/bin/aws
$ aws --version                  # root → aws-cli/1.44.81
$ sudo -u findash aws --version  # findash → same binary, same version
```

## Why it matters

- #186 is closed with a hand-installed backup cron; this closes the loop so the next fresh-droplet rebuild (DR, or friends forking their own) won't re-hit the apt dead end.
- Unblocks the R2 off-site sync path (step §10 in the deploy doc).

## Test plan

- [x] Command-v guard prevents re-install on repeat runs (tested on live droplet with aws already present — `pipx upgrade` path).
- [x] `aws --version` works as root.
- [x] `aws --version` works as findash user (same binary on PATH).
- [ ] Full `infra/bootstrap.sh` replay on a fresh droplet — deferred; will validate next time a droplet is rebuilt.

Closes #236