### PR TITLE
feat(auth): dev-only login bypass for local testing (#241)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,21 @@ AUTH_TRUST_HOST=
 # /api/health. En dev dejalo vacío.
 GIT_SHA=
 
+# ---------------------------------------------------------------------------
+# DEV-ONLY — DO NOT SET IN PRODUCTION. Seriously. Never.
+# ---------------------------------------------------------------------------
+# Enables GET /api/dev/login?email=<seeded-email>&redirect=<path>, which mints
+# a valid NextAuth session cookie for the given user so headless clients
+# (chrome-devtools MCP, curl, Playwright) can bypass the Google OAuth wall
+# during local testing.
+#
+# Triple-gated at the route level: NODE_ENV !== 'production' AND
+# DEV_AUTH_BYPASS === '1' AND Host header starts with localhost/127.0.0.1.
+# When any guard fails the route returns 404.
+#
+# Leave this empty unless you are actively debugging locally.
+DEV_AUTH_BYPASS=
+
 # Bootstrap — el email que se seedeá como user 1 (tu cuenta de Google personal).
 # En el primer login con Google, el row existente se linkea al google_sub.
 # Corré `bun run db:seed` después de setear esto para crear el row.

--- a/src/app/api/dev/login/route.test.ts
+++ b/src/app/api/dev/login/route.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { decode } from "next-auth/jwt";
+import { db } from "@/lib/db";
+import { GET } from "./route";
+
+const SESSION_COOKIE = "authjs.session-token";
+const TEST_USER_EMAIL = "ing.amartinez94@gmail.com";
+const TEST_USER_ID = 1;
+const TEST_SECRET = "test-secret-for-vitest-only-do-not-use-elsewhere-ok-fine";
+
+function makeRequest(opts: { search?: string; host?: string } = {}): Request {
+  const qs = opts.search ?? `email=${encodeURIComponent(TEST_USER_EMAIL)}`;
+  return new Request(`http://localhost:3100/api/dev/login?${qs}`, {
+    method: "GET",
+    headers: { host: opts.host ?? "localhost:3100" },
+  });
+}
+
+describe("GET /api/dev/login", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("DEV_AUTH_BYPASS", "1");
+    vi.stubEnv("AUTH_SECRET", TEST_SECRET);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterAll(async () => {
+    await db.$client.end({ timeout: 1 });
+  });
+
+  it("returns 404 when NODE_ENV is production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when DEV_AUTH_BYPASS is unset", async () => {
+    vi.stubEnv("DEV_AUTH_BYPASS", "");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when DEV_AUTH_BYPASS is anything other than '1'", async () => {
+    vi.stubEnv("DEV_AUTH_BYPASS", "true");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when Host header is not local", async () => {
+    const res = await GET(makeRequest({ host: "findash.example.com" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("accepts 127.0.0.1 host", async () => {
+    const res = await GET(makeRequest({ host: "127.0.0.1:3100" }));
+    expect(res.status).toBe(303);
+  });
+
+  it("accepts IPv6 loopback host", async () => {
+    const res = await GET(makeRequest({ host: "[::1]:3100" }));
+    expect(res.status).toBe(303);
+  });
+
+  it("returns 500 when AUTH_SECRET is not set", async () => {
+    vi.stubEnv("AUTH_SECRET", "");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 400 when email query param is missing", async () => {
+    const res = await GET(makeRequest({ search: "" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when user does not exist", async () => {
+    const res = await GET(makeRequest({ search: "email=nobody@findash.local" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("issues a valid session cookie and 303 redirects on happy path", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toBe("http://localhost:3100/");
+
+    const setCookie = res.headers.get("set-cookie");
+    expect(setCookie).toBeTruthy();
+    expect(setCookie).toContain(`${SESSION_COOKIE}=`);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("Path=/");
+
+    const match = setCookie?.match(new RegExp(`${SESSION_COOKIE}=([^;]+)`));
+    const tokenValue = match?.[1];
+    expect(tokenValue).toBeTruthy();
+
+    const decoded = await decode({
+      token: tokenValue!,
+      secret: TEST_SECRET,
+      salt: SESSION_COOKIE,
+    });
+    expect(decoded?.email).toBe(TEST_USER_EMAIL);
+    expect(decoded?.sub).toBe(String(TEST_USER_ID));
+  });
+
+  it("honors the redirect query param", async () => {
+    const res = await GET(
+      makeRequest({
+        search: `email=${encodeURIComponent(TEST_USER_EMAIL)}&redirect=/transactions`,
+      }),
+    );
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toBe("http://localhost:3100/transactions");
+  });
+});

--- a/src/app/api/dev/login/route.test.ts
+++ b/src/app/api/dev/login/route.test.ts
@@ -1,12 +1,18 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { eq } from "drizzle-orm";
 import { decode } from "next-auth/jwt";
 import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
 import { GET } from "./route";
 
 const SESSION_COOKIE = "authjs.session-token";
-const TEST_USER_EMAIL = "ing.amartinez94@gmail.com";
 const TEST_USER_ID = 1;
 const TEST_SECRET = "test-secret-for-vitest-only-do-not-use-elsewhere-ok-fine";
+
+// Email of the bootstrap user (id=1) — varies by environment (local uses the
+// developer's email, CI uses BOOTSTRAP_USER_EMAIL). We resolve it from the DB
+// in beforeAll so the test is portable across seeds.
+let TEST_USER_EMAIL = "";
 
 function makeRequest(opts: { search?: string; host?: string } = {}): Request {
   const qs = opts.search ?? `email=${encodeURIComponent(TEST_USER_EMAIL)}`;
@@ -17,6 +23,18 @@ function makeRequest(opts: { search?: string; host?: string } = {}): Request {
 }
 
 describe("GET /api/dev/login", () => {
+  beforeAll(async () => {
+    const [row] = await db
+      .select({ email: users.email })
+      .from(users)
+      .where(eq(users.id, TEST_USER_ID))
+      .limit(1);
+    if (!row) {
+      throw new Error(`bootstrap user id=${TEST_USER_ID} not found — run db:seed:test`);
+    }
+    TEST_USER_EMAIL = row.email;
+  });
+
   beforeEach(() => {
     vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("DEV_AUTH_BYPASS", "1");

--- a/src/app/api/dev/login/route.ts
+++ b/src/app/api/dev/login/route.ts
@@ -1,0 +1,85 @@
+import { eq } from "drizzle-orm";
+import { encode } from "next-auth/jwt";
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+
+// Dev-only session bypass for local testing (chrome-devtools, curl, Playwright).
+// Triple-gated so it is impossible to reach in production: NODE_ENV check,
+// explicit DEV_AUTH_BYPASS=1 flag, and a Host-header localhost check. When any
+// guard fails the route returns 404 — never 403 — so the endpoint's existence
+// is not revealed.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const SESSION_COOKIE = "authjs.session-token";
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+const notFound = () => new NextResponse(null, { status: 404 });
+
+export async function GET(req: Request) {
+  if (process.env.NODE_ENV === "production") return notFound();
+  if (process.env.DEV_AUTH_BYPASS !== "1") return notFound();
+
+  const host = (req.headers.get("host") ?? "").toLowerCase();
+  const isLocalHost =
+    host.startsWith("localhost") || host.startsWith("127.0.0.1") || host.startsWith("[::1]");
+  if (!isLocalHost) return notFound();
+
+  const secret = process.env.AUTH_SECRET;
+  if (!secret) {
+    return new NextResponse("AUTH_SECRET not set", { status: 500 });
+  }
+
+  const url = new URL(req.url);
+  const email = url.searchParams.get("email");
+  if (!email) {
+    return new NextResponse("missing 'email' query param", { status: 400 });
+  }
+
+  const [row] = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      active: users.active,
+    })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+
+  if (!row) {
+    return new NextResponse(`user not found: ${email}`, { status: 404 });
+  }
+  if (!row.active) {
+    return new NextResponse(`user is inactive: ${email}`, { status: 403 });
+  }
+
+  const token = await encode({
+    token: {
+      email: row.email,
+      sub: String(row.id),
+      name: row.name,
+    },
+    secret,
+    salt: SESSION_COOKIE,
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+
+  console.warn(
+    `[dev-auth-bypass] issuing session for ${row.email} (id=${row.id}) — DEV_AUTH_BYPASS=1`,
+  );
+
+  const redirectTarget = url.searchParams.get("redirect") ?? "/";
+  const res = NextResponse.redirect(new URL(redirectTarget, req.url), 303);
+  res.cookies.set({
+    name: SESSION_COOKIE,
+    value: token,
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+  return res;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,6 +35,6 @@ export default auth((req) => {
 // /login before their own handler (or Next.js's static handler) ever runs.
 export const config = {
   matcher: [
-    "/((?!api/auth|api/telegram/webhook|api/ingest|api/fx/refresh|api/health|login|signup|_next/static|_next/image|favicon.ico|.*\\.(?:png|svg|ico|webmanifest)$).*)",
+    "/((?!api/auth|api/telegram/webhook|api/ingest|api/fx/refresh|api/health|api/dev/login|login|signup|_next/static|_next/image|favicon.ico|.*\\.(?:png|svg|ico|webmanifest)$).*)",
   ],
 };


### PR DESCRIPTION
## Summary

- New `GET /api/dev/login?email=<email>&redirect=<path>` that mints a valid NextAuth session cookie so headless clients (chrome-devtools MCP, curl, Playwright) can bypass the Google OAuth wall during local testing.
- Triple-gated — `NODE_ENV !== 'production'` + `DEV_AUTH_BYPASS === '1'` + Host header must be localhost/127.0.0.1/[::1]. Any guard fails → 404 (never 403, doesn't reveal existence).
- Missing `AUTH_SECRET` → 500 (fail closed). Inactive users → 403 (matches prod middleware). Every invocation logs `console.warn` with the issued user.

## How it works

The route encodes a JWT with `next-auth/jwt` `encode` using the same `AUTH_SECRET` + cookie-name salt NextAuth itself uses, then sets `authjs.session-token` as `HttpOnly; SameSite=lax; Path=/`. On the next request, `src/auth.ts`'s `jwt` callback hydrates `userId`/`role`/`active` from the DB exactly like a Google sign-in would — zero changes to the real auth path.

`src/proxy.ts` matcher also excludes `api/dev/login` so the session-gated middleware doesn't redirect it to /login before the guards run.

## Test plan

- [x] Unit tests — 11 vitest cases covering all three guards, AUTH_SECRET absence, email validation, user not found, inactive user, happy path + cookie decode roundtrip with the same salt/secret, and redirect query param.
- [x] E2E — started dev server with `DEV_AUTH_BYPASS=1`, navigated chrome-devtools MCP to `/api/dev/login?email=<seeded>&redirect=/transactions`. Chrome landed on `/transactions` fully authenticated (nav, user menu, 377 live transactions) — proxy middleware accepted the cookie.
- [x] Curl — `curl -L` followed 303 → /transactions returned 200 with 1 redirect (no re-login bounce).
- [x] Typecheck + lint clean.

## Safety

- `.env.example` documents `DEV_AUTH_BYPASS` with a loud "DEV-ONLY — DO NOT SET IN PRODUCTION" block.
- The route 404s the instant any guard fails, so a leaked flag in prod still produces no behavior change.
- Everything lives in one file that can be grepped, audited, or deleted without touching auth.ts.

Closes #241