### PR TITLE
feat(ui): /settings/accounts page — create/edit accounts with multi-currency support (#245)

### DIFF
--- a/drizzle/0020_eager_micromax.sql
+++ b/drizzle/0020_eager_micromax.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "accounts" ADD COLUMN "physical_card_id" uuid;--> statement-breakpoint
+ALTER TABLE "accounts" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "accounts_user_live_idx" ON "accounts" USING btree ("user_id") WHERE "accounts"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "accounts_physical_card_live_idx" ON "accounts" USING btree ("physical_card_id") WHERE "accounts"."physical_card_id" IS NOT NULL AND "accounts"."deleted_at" IS NULL;

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,2465 @@
+{
+  "id": "ee6cbcff-a29b-4088-b2a7-65b437cc7c63",
+  "prevId": "f3950e75-a279-483a-a316-84e5258ba5bc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_category_slug_categories_slug_fk": {
+          "name": "budgets_category_slug_categories_slug_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_slug_categories_slug_fk": {
+          "name": "categories_parent_slug_categories_slug_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_categories_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_category_slug_categories_slug_fk": {
+          "name": "classification_rules_category_slug_categories_slug_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_default_category_slug_categories_slug_fk": {
+          "name": "counterparties_default_category_slug_categories_slug_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_category_slug_categories_slug_fk": {
+          "name": "recurring_transactions_category_slug_categories_slug_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_category_slug_categories_slug_fk": {
+          "name": "transactions_category_slug_categories_slug_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "ai",
+        "manual",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1776568400000,
       "tag": "0019_chief_layla_miller",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1776620189201,
+      "tag": "0020_eager_micromax",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -1,4 +1,6 @@
+import Link from "next/link";
 import { CreditCardIcon, LandmarkIcon, PiggyBankIcon, WalletIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { getSessionUser } from "@/lib/auth/session";
@@ -72,7 +74,12 @@ export default async function AccountsPage() {
           <EmptyState
             icon={<WalletIcon />}
             title="No accounts yet"
-            description="Run the seed script or add accounts through the database to see balances here."
+            description="Create your first account to start tracking balances and transactions."
+            action={
+              <Button asChild>
+                <Link href="/settings/accounts">Create account</Link>
+              </Button>
+            }
           />
         </Card>
       ) : null}

--- a/src/app/(app)/settings/accounts/accounts-manager.tsx
+++ b/src/app/(app)/settings/accounts/accounts-manager.tsx
@@ -1,0 +1,695 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { LinkIcon, PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { formatMoney } from "@/lib/money";
+import type { Currency } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import type { AccountMetadata } from "@/lib/db/schema";
+import { archiveAccount, toggleAccountActive, upsertAccount } from "./actions";
+
+type AccountType = "savings" | "credit_card" | "loan";
+
+export type AccountRow = {
+  id: number;
+  name: string;
+  institution: string;
+  type: AccountType;
+  currency: Currency;
+  balanceCents: string;
+  active: boolean;
+  metadata: AccountMetadata;
+  physicalCardId: string | null;
+};
+
+const TYPE_LABEL: Record<AccountType, string> = {
+  savings: "Savings",
+  credit_card: "Credit cards",
+  loan: "Loans",
+};
+
+const TYPE_ORDER: AccountType[] = ["savings", "credit_card", "loan"];
+
+type EditorState = { open: boolean; editing: AccountRow | null };
+
+export function AccountsManager({ items }: { items: AccountRow[] }) {
+  const [editor, setEditor] = useState<EditorState>({ open: false, editing: null });
+  const [pending, startTransition] = useTransition();
+
+  const grouped = useMemo(() => {
+    const byType: Record<AccountType, AccountRow[]> = {
+      savings: [],
+      credit_card: [],
+      loan: [],
+    };
+    for (const it of items) byType[it.type].push(it);
+    return byType;
+  }, [items]);
+
+  function openCreate() {
+    setEditor({ open: true, editing: null });
+  }
+  function openEdit(row: AccountRow) {
+    setEditor({ open: true, editing: row });
+  }
+  function close() {
+    setEditor({ open: false, editing: null });
+  }
+
+  function onToggle(row: AccountRow) {
+    startTransition(async () => {
+      try {
+        await toggleAccountActive(row.id, !row.active);
+        toast.success(row.active ? "Deactivated" : "Activated");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed");
+      }
+    });
+  }
+
+  function onArchive(row: AccountRow) {
+    if (!confirm(`Archive account "${row.name}"? This hides it from all views.`)) return;
+    startTransition(async () => {
+      try {
+        await archiveAccount(row.id);
+        toast.success("Archived");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed");
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex justify-end">
+        <Button onClick={openCreate}>
+          <PlusIcon className="size-4" />
+          New account
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <Card>
+          <CardContent className="text-muted-foreground flex flex-col items-center gap-2 py-12 text-center text-sm">
+            <p className="text-base font-medium">No accounts yet.</p>
+            <p>Add your first bank account, credit card, or loan to start tracking transactions.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {TYPE_ORDER.map((t) =>
+            grouped[t].length === 0 ? null : (
+              <Card key={t}>
+                <CardHeader>
+                  <CardTitle>
+                    {TYPE_LABEL[t]} ({grouped[t].length})
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="overflow-x-auto rounded-md border">
+                    <table className="w-full text-sm">
+                      <thead className="bg-muted/50 text-muted-foreground text-xs uppercase">
+                        <tr>
+                          <th className="p-2 text-left">Name</th>
+                          <th className="p-2 text-left">Institution</th>
+                          <th className="p-2 text-left">Currency</th>
+                          <th className="p-2 text-right">Balance</th>
+                          <th className="p-2 text-left">Status</th>
+                          <th className="p-2"></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {grouped[t].map((r) => {
+                          const cents = BigInt(r.balanceCents);
+                          return (
+                            <tr key={r.id} className={cn("border-t", !r.active && "opacity-50")}>
+                              <td className="p-2">
+                                <div className="flex items-center gap-1.5 font-medium">
+                                  {r.name}
+                                  {r.physicalCardId ? (
+                                    <span
+                                      title="Linked to a multi-currency physical card"
+                                      aria-label="multi-currency"
+                                    >
+                                      <LinkIcon className="text-muted-foreground size-3" />
+                                    </span>
+                                  ) : null}
+                                </div>
+                                {r.metadata.last4s && r.metadata.last4s.length > 0 ? (
+                                  <div className="text-muted-foreground text-xs tabular-nums">
+                                    •••• {r.metadata.last4s.join(" / ")}
+                                  </div>
+                                ) : null}
+                              </td>
+                              <td className="text-muted-foreground p-2 text-xs">{r.institution}</td>
+                              <td className="text-muted-foreground p-2 text-xs">{r.currency}</td>
+                              <td className="p-2 text-right font-medium tabular-nums">
+                                {formatMoney(cents, r.currency)}
+                              </td>
+                              <td className="p-2 text-xs">
+                                <button
+                                  type="button"
+                                  onClick={() => onToggle(r)}
+                                  disabled={pending}
+                                  className={cn(
+                                    "rounded px-1.5 py-0.5",
+                                    r.active
+                                      ? "bg-emerald-100 text-emerald-800"
+                                      : "bg-muted text-muted-foreground",
+                                  )}
+                                >
+                                  {r.active ? "active" : "paused"}
+                                </button>
+                              </td>
+                              <td className="p-2 text-right">
+                                <div className="flex justify-end gap-1">
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => openEdit(r)}
+                                    disabled={pending}
+                                    aria-label="Edit"
+                                  >
+                                    <PencilIcon className="size-4" />
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => onArchive(r)}
+                                    disabled={pending}
+                                    aria-label="Archive"
+                                  >
+                                    <Trash2Icon className="size-4" />
+                                  </Button>
+                                </div>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </CardContent>
+              </Card>
+            ),
+          )}
+        </div>
+      )}
+
+      <AccountEditor
+        key={editor.editing?.id ?? (editor.open ? "new" : "closed")}
+        open={editor.open}
+        editing={editor.editing}
+        onClose={close}
+      />
+    </div>
+  );
+}
+
+type SideMetadataKeys = Pick<
+  AccountMetadata,
+  | "last4s"
+  | "network"
+  | "creditLimitCents"
+  | "cutoffDay"
+  | "paymentDueDay"
+  | "interestRateMonthly"
+  | "termMonths"
+  | "loanOriginalCents"
+  | "monthlyPaymentCents"
+>;
+
+function metadataFromForm(values: {
+  network: string;
+  last4: string;
+  creditLimit: string;
+  cutoffDay: string;
+  paymentDueDay: string;
+  interestRateMonthly: string;
+  termMonths: string;
+  loanOriginal: string;
+  monthlyPayment: string;
+}): SideMetadataKeys {
+  const md: SideMetadataKeys = {};
+  if (values.network === "visa" || values.network === "mastercard" || values.network === "amex") {
+    md.network = values.network;
+  }
+  const last4Trimmed = values.last4.trim();
+  if (last4Trimmed) {
+    const parts = last4Trimmed.split(/[\s,]+/).filter((p) => /^\d{4}$/.test(p));
+    if (parts.length > 0) md.last4s = parts;
+  }
+  if (values.creditLimit) {
+    const n = Number(values.creditLimit);
+    if (Number.isFinite(n) && n >= 0) md.creditLimitCents = Math.round(n * 100);
+  }
+  if (values.cutoffDay) {
+    const n = Number(values.cutoffDay);
+    if (Number.isInteger(n) && n >= 1 && n <= 31) md.cutoffDay = n;
+  }
+  if (values.paymentDueDay) {
+    const n = Number(values.paymentDueDay);
+    if (Number.isInteger(n) && n >= 1 && n <= 31) md.paymentDueDay = n;
+  }
+  if (values.interestRateMonthly) {
+    const n = Number(values.interestRateMonthly);
+    if (Number.isFinite(n) && n >= 0) md.interestRateMonthly = n;
+  }
+  if (values.termMonths) {
+    const n = Number(values.termMonths);
+    if (Number.isInteger(n) && n > 0) md.termMonths = n;
+  }
+  if (values.loanOriginal) {
+    const n = Number(values.loanOriginal);
+    if (Number.isFinite(n) && n >= 0) md.loanOriginalCents = Math.round(n * 100);
+  }
+  if (values.monthlyPayment) {
+    const n = Number(values.monthlyPayment);
+    if (Number.isFinite(n) && n >= 0) md.monthlyPaymentCents = Math.round(n * 100);
+  }
+  return md;
+}
+
+function AccountEditor({
+  open,
+  editing,
+  onClose,
+}: {
+  open: boolean;
+  editing: AccountRow | null;
+  onClose: () => void;
+}) {
+  const [pending, startTransition] = useTransition();
+  const isEdit = !!editing;
+
+  const [name, setName] = useState(editing?.name ?? "");
+  const [institution, setInstitution] = useState(editing?.institution ?? "Bancolombia");
+  const [type, setType] = useState<AccountType>(editing?.type ?? "savings");
+  const [currency, setCurrency] = useState<Currency>(editing?.currency ?? "COP");
+  const [balance, setBalance] = useState(
+    editing ? (Number(BigInt(editing.balanceCents)) / 100).toString() : "0",
+  );
+
+  const initialMeta = editing?.metadata ?? {};
+  const [network, setNetwork] = useState<string>(initialMeta.network ?? "");
+  const [last4, setLast4] = useState((initialMeta.last4s ?? []).join(" "));
+  const [creditLimit, setCreditLimit] = useState(
+    initialMeta.creditLimitCents != null ? (initialMeta.creditLimitCents / 100).toString() : "",
+  );
+  const [cutoffDay, setCutoffDay] = useState(initialMeta.cutoffDay?.toString() ?? "");
+  const [paymentDueDay, setPaymentDueDay] = useState(initialMeta.paymentDueDay?.toString() ?? "");
+  const [interestRateMonthly, setInterestRateMonthly] = useState(
+    initialMeta.interestRateMonthly?.toString() ?? "",
+  );
+  const [termMonths, setTermMonths] = useState(initialMeta.termMonths?.toString() ?? "");
+  const [loanOriginal, setLoanOriginal] = useState(
+    initialMeta.loanOriginalCents != null ? (initialMeta.loanOriginalCents / 100).toString() : "",
+  );
+  const [monthlyPayment, setMonthlyPayment] = useState(
+    initialMeta.monthlyPaymentCents != null
+      ? (initialMeta.monthlyPaymentCents / 100).toString()
+      : "",
+  );
+
+  const [multiCurrency, setMultiCurrency] = useState(false);
+  const [secondaryCurrency, setSecondaryCurrency] = useState<Currency>(
+    currency === "COP" ? "USD" : "COP",
+  );
+  const [secondaryBalance, setSecondaryBalance] = useState("0");
+  const [secondaryCreditLimit, setSecondaryCreditLimit] = useState("");
+
+  const multiCurrencyAllowed = !isEdit && type === "credit_card";
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const balNum = Number(balance);
+    if (!Number.isFinite(balNum)) {
+      toast.error("Balance must be a number");
+      return;
+    }
+    const primaryMd = metadataFromForm({
+      network,
+      last4,
+      creditLimit,
+      cutoffDay,
+      paymentDueDay,
+      interestRateMonthly,
+      termMonths,
+      loanOriginal,
+      monthlyPayment,
+    });
+
+    let secondary: Parameters<typeof upsertAccount>[0]["secondary"];
+    if (multiCurrencyAllowed && multiCurrency) {
+      if (secondaryCurrency === currency) {
+        toast.error("Secondary currency must differ from primary");
+        return;
+      }
+      const secBal = Number(secondaryBalance);
+      if (!Number.isFinite(secBal)) {
+        toast.error("Secondary balance must be a number");
+        return;
+      }
+      secondary = {
+        currency: secondaryCurrency,
+        balance: secBal,
+        metadata: metadataFromForm({
+          network,
+          last4,
+          creditLimit: secondaryCreditLimit,
+          cutoffDay,
+          paymentDueDay,
+          interestRateMonthly: "",
+          termMonths: "",
+          loanOriginal: "",
+          monthlyPayment: "",
+        }),
+      };
+    }
+
+    startTransition(async () => {
+      try {
+        await upsertAccount({
+          id: editing?.id,
+          name: name.trim(),
+          institution: institution.trim(),
+          type,
+          primary: { currency, balance: balNum, metadata: primaryMd },
+          secondary,
+        });
+        toast.success(isEdit ? "Updated" : "Created");
+        onClose();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Save failed");
+      }
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? `Edit: ${editing.name}` : "New account"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={onSubmit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="acc-name">Name</Label>
+            <Input
+              id="acc-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Ahorros Principal"
+              required
+              maxLength={100}
+              autoFocus={!isEdit}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="acc-inst">Institution</Label>
+              <Input
+                id="acc-inst"
+                value={institution}
+                onChange={(e) => setInstitution(e.target.value)}
+                required
+                maxLength={50}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="acc-type">Type</Label>
+              <select
+                id="acc-type"
+                value={type}
+                onChange={(e) => setType(e.target.value as AccountType)}
+                disabled={isEdit}
+                className="bg-background h-9 rounded-md border px-2 text-sm disabled:opacity-60"
+              >
+                <option value="savings">Savings</option>
+                <option value="credit_card">Credit card</option>
+                <option value="loan">Loan</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="acc-currency">Currency</Label>
+              <select
+                id="acc-currency"
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value as Currency)}
+                disabled={isEdit}
+                className="bg-background h-9 rounded-md border px-2 text-sm disabled:opacity-60"
+              >
+                <option value="COP">COP</option>
+                <option value="USD">USD</option>
+              </select>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="acc-balance">
+                {type === "credit_card" ? "Current balance" : "Opening balance"} ({currency})
+              </Label>
+              <Input
+                id="acc-balance"
+                type="number"
+                inputMode="decimal"
+                step={currency === "USD" ? "0.01" : "1"}
+                value={balance}
+                onChange={(e) => setBalance(e.target.value)}
+                required
+                className="tabular-nums"
+              />
+            </div>
+          </div>
+
+          {multiCurrencyAllowed ? (
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={multiCurrency}
+                onChange={(e) => setMultiCurrency(e.target.checked)}
+              />
+              <span>
+                Multi-currency card (e.g. Mastercard Internacional, Amex — one plastic with separate
+                COP + USD cupos)
+              </span>
+            </label>
+          ) : null}
+
+          {multiCurrencyAllowed && multiCurrency ? (
+            <div className="bg-muted/30 flex flex-col gap-3 rounded-md border p-3">
+              <p className="text-xs font-medium">Secondary currency side</p>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="acc-currency-2">Currency</Label>
+                  <select
+                    id="acc-currency-2"
+                    value={secondaryCurrency}
+                    onChange={(e) => setSecondaryCurrency(e.target.value as Currency)}
+                    className="bg-background h-9 rounded-md border px-2 text-sm"
+                  >
+                    <option value="COP">COP</option>
+                    <option value="USD">USD</option>
+                  </select>
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="acc-balance-2">Balance ({secondaryCurrency})</Label>
+                  <Input
+                    id="acc-balance-2"
+                    type="number"
+                    inputMode="decimal"
+                    step={secondaryCurrency === "USD" ? "0.01" : "1"}
+                    value={secondaryBalance}
+                    onChange={(e) => setSecondaryBalance(e.target.value)}
+                    className="tabular-nums"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="acc-limit-2">Credit limit ({secondaryCurrency})</Label>
+                <Input
+                  id="acc-limit-2"
+                  type="number"
+                  inputMode="decimal"
+                  step={secondaryCurrency === "USD" ? "0.01" : "1"}
+                  value={secondaryCreditLimit}
+                  onChange={(e) => setSecondaryCreditLimit(e.target.value)}
+                  placeholder="Optional"
+                  className="tabular-nums"
+                />
+              </div>
+            </div>
+          ) : null}
+
+          <details className="group rounded-md border px-3 py-2">
+            <summary className="cursor-pointer text-sm font-medium">Advanced details</summary>
+            <div className="mt-3 flex flex-col gap-3">
+              {type === "credit_card" ? (
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="acc-network">Network</Label>
+                    <select
+                      id="acc-network"
+                      value={network}
+                      onChange={(e) => setNetwork(e.target.value)}
+                      className="bg-background h-9 rounded-md border px-2 text-sm"
+                    >
+                      <option value="">—</option>
+                      <option value="visa">Visa</option>
+                      <option value="mastercard">Mastercard</option>
+                      <option value="amex">Amex</option>
+                    </select>
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="acc-limit">Credit limit ({currency})</Label>
+                    <Input
+                      id="acc-limit"
+                      type="number"
+                      inputMode="decimal"
+                      step={currency === "USD" ? "0.01" : "1"}
+                      value={creditLimit}
+                      onChange={(e) => setCreditLimit(e.target.value)}
+                      placeholder="Optional"
+                      className="tabular-nums"
+                    />
+                  </div>
+                </div>
+              ) : null}
+
+              {(type === "credit_card" || type === "savings") && (
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="acc-last4">Last 4 digits (space-separated for multiple)</Label>
+                  <Input
+                    id="acc-last4"
+                    value={last4}
+                    onChange={(e) => setLast4(e.target.value)}
+                    placeholder="e.g. 1234 5678"
+                    inputMode="numeric"
+                  />
+                </div>
+              )}
+
+              {type === "credit_card" ? (
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="acc-cutoff">Cutoff day</Label>
+                    <Input
+                      id="acc-cutoff"
+                      type="number"
+                      min="1"
+                      max="31"
+                      value={cutoffDay}
+                      onChange={(e) => setCutoffDay(e.target.value)}
+                      placeholder="Optional"
+                      className="tabular-nums"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="acc-due">Payment due day</Label>
+                    <Input
+                      id="acc-due"
+                      type="number"
+                      min="1"
+                      max="31"
+                      value={paymentDueDay}
+                      onChange={(e) => setPaymentDueDay(e.target.value)}
+                      placeholder="Optional"
+                      className="tabular-nums"
+                    />
+                  </div>
+                </div>
+              ) : null}
+
+              {type === "loan" ? (
+                <>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="flex flex-col gap-1.5">
+                      <Label htmlFor="acc-loan-orig">Original amount ({currency})</Label>
+                      <Input
+                        id="acc-loan-orig"
+                        type="number"
+                        inputMode="decimal"
+                        step={currency === "USD" ? "0.01" : "1"}
+                        value={loanOriginal}
+                        onChange={(e) => setLoanOriginal(e.target.value)}
+                        placeholder="Optional"
+                        className="tabular-nums"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1.5">
+                      <Label htmlFor="acc-loan-monthly">Monthly payment ({currency})</Label>
+                      <Input
+                        id="acc-loan-monthly"
+                        type="number"
+                        inputMode="decimal"
+                        step={currency === "USD" ? "0.01" : "1"}
+                        value={monthlyPayment}
+                        onChange={(e) => setMonthlyPayment(e.target.value)}
+                        placeholder="Optional"
+                        className="tabular-nums"
+                      />
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="flex flex-col gap-1.5">
+                      <Label htmlFor="acc-rate">Monthly interest rate (%)</Label>
+                      <Input
+                        id="acc-rate"
+                        type="number"
+                        inputMode="decimal"
+                        step="0.01"
+                        value={interestRateMonthly}
+                        onChange={(e) => setInterestRateMonthly(e.target.value)}
+                        placeholder="Optional"
+                        className="tabular-nums"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1.5">
+                      <Label htmlFor="acc-term">Term (months)</Label>
+                      <Input
+                        id="acc-term"
+                        type="number"
+                        min="1"
+                        value={termMonths}
+                        onChange={(e) => setTermMonths(e.target.value)}
+                        placeholder="Optional"
+                        className="tabular-nums"
+                      />
+                    </div>
+                  </div>
+                </>
+              ) : null}
+            </div>
+          </details>
+
+          <DialogFooter className="mt-2">
+            <Button type="button" variant="outline" onClick={onClose} disabled={pending}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving…" : isEdit ? "Save" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(app)/settings/accounts/actions.test.ts
+++ b/src/app/(app)/settings/accounts/actions.test.ts
@@ -1,0 +1,247 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, users } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockResolvedValue({ id: 1, email: "test@test.local", name: "Test" }),
+}));
+
+const { upsertAccount, archiveAccount, toggleAccountActive } = await import("./actions");
+
+const TEST_USER_ID = 1;
+const MARKER = "__test_accounts_ui";
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM accounts WHERE name LIKE ${MARKER + "%"}`);
+}
+
+describe("accounts actions: single-currency", () => {
+  afterEach(cleanup);
+
+  it("creates a savings account then archives it (soft-delete)", async () => {
+    await upsertAccount({
+      name: `${MARKER}-savings`,
+      institution: "Bancolombia",
+      type: "savings",
+      active: true,
+      primary: { currency: "COP", balance: 1_200_000 },
+    });
+
+    const [row] = await db
+      .select()
+      .from(accounts)
+      .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${MARKER}-savings`)));
+    expect(row).toBeDefined();
+    expect(row.type).toBe("savings");
+    expect(row.currency).toBe("COP");
+    expect(row.balanceCents).toBe(BigInt(120_000_000));
+    expect(row.physicalCardId).toBeNull();
+    expect(row.deletedAt).toBeNull();
+
+    await archiveAccount(row.id);
+
+    const live = await db
+      .select()
+      .from(accounts)
+      .where(
+        and(
+          eq(accounts.userId, TEST_USER_ID),
+          eq(accounts.name, `${MARKER}-savings`),
+          notDeleted(accounts.deletedAt),
+        ),
+      );
+    expect(live).toHaveLength(0);
+
+    const archived = await db
+      .select()
+      .from(accounts)
+      .where(
+        and(
+          eq(accounts.userId, TEST_USER_ID),
+          eq(accounts.name, `${MARKER}-savings`),
+          isNotNull(accounts.deletedAt),
+        ),
+      );
+    expect(archived).toHaveLength(1);
+  });
+
+  it("updates an existing account via id", async () => {
+    await upsertAccount({
+      name: `${MARKER}-edit`,
+      institution: "Bancolombia",
+      type: "savings",
+      primary: { currency: "COP", balance: 500_000 },
+    });
+    const [before] = await db
+      .select()
+      .from(accounts)
+      .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${MARKER}-edit`)));
+
+    await upsertAccount({
+      id: before.id,
+      name: `${MARKER}-edit`,
+      institution: "Bancolombia",
+      type: "savings",
+      primary: { currency: "COP", balance: 750_000 },
+    });
+
+    const [after] = await db.select().from(accounts).where(eq(accounts.id, before.id));
+    expect(after.balanceCents).toBe(BigInt(75_000_000));
+  });
+
+  it("rejects secondary currency on non-credit_card types", async () => {
+    await expect(
+      upsertAccount({
+        name: `${MARKER}-bad`,
+        institution: "Bancolombia",
+        type: "savings",
+        primary: { currency: "COP", balance: 100_000 },
+        secondary: { currency: "USD", balance: 50 },
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("accounts actions: multi-currency credit card", () => {
+  afterEach(cleanup);
+
+  it("creates two linked rows sharing physical_card_id", async () => {
+    await upsertAccount({
+      name: `${MARKER}-amex`,
+      institution: "Bancolombia",
+      type: "credit_card",
+      primary: {
+        currency: "COP",
+        balance: 0,
+        metadata: { network: "amex", last4s: ["1234"], creditLimitCents: 500_000_000 },
+      },
+      secondary: {
+        currency: "USD",
+        balance: 0,
+        metadata: { network: "amex", last4s: ["1234"], creditLimitCents: 200_000 },
+      },
+    });
+
+    const rows = await db
+      .select()
+      .from(accounts)
+      .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${MARKER}-amex`)));
+    expect(rows).toHaveLength(2);
+    expect(rows[0].physicalCardId).not.toBeNull();
+    expect(rows[0].physicalCardId).toBe(rows[1].physicalCardId);
+    const currencies = rows.map((r) => r.currency).sort();
+    expect(currencies).toEqual(["COP", "USD"]);
+  });
+
+  it("archives each linked row independently (no cascade)", async () => {
+    await upsertAccount({
+      name: `${MARKER}-intl`,
+      institution: "Bancolombia",
+      type: "credit_card",
+      primary: { currency: "COP", balance: 0 },
+      secondary: { currency: "USD", balance: 0 },
+    });
+    const rows = await db
+      .select()
+      .from(accounts)
+      .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${MARKER}-intl`)));
+    expect(rows).toHaveLength(2);
+
+    const copRow = rows.find((r) => r.currency === "COP")!;
+    await archiveAccount(copRow.id);
+
+    const live = await db
+      .select()
+      .from(accounts)
+      .where(
+        and(
+          eq(accounts.userId, TEST_USER_ID),
+          eq(accounts.name, `${MARKER}-intl`),
+          notDeleted(accounts.deletedAt),
+        ),
+      );
+    expect(live).toHaveLength(1);
+    expect(live[0].currency).toBe("USD");
+  });
+
+  it("rejects secondary on edit (multi-currency only at create)", async () => {
+    await upsertAccount({
+      name: `${MARKER}-single-cc`,
+      institution: "Bancolombia",
+      type: "credit_card",
+      primary: { currency: "COP", balance: 0 },
+    });
+    const [row] = await db
+      .select()
+      .from(accounts)
+      .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${MARKER}-single-cc`)));
+
+    await expect(
+      upsertAccount({
+        id: row.id,
+        name: `${MARKER}-single-cc`,
+        institution: "Bancolombia",
+        type: "credit_card",
+        primary: { currency: "COP", balance: 0 },
+        secondary: { currency: "USD", balance: 0 },
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("accounts actions: auth scoping", () => {
+  const OTHER_USER_EMAIL = `${MARKER}-other@test.local`;
+  let otherUserId = 0;
+
+  beforeAll(async () => {
+    const [u] = await db
+      .insert(users)
+      .values({ email: OTHER_USER_EMAIL, name: "Other User" })
+      .returning({ id: users.id });
+    otherUserId = u.id;
+  });
+  afterAll(async () => {
+    await db.execute(sql`DELETE FROM users WHERE email = ${OTHER_USER_EMAIL}`);
+  });
+  afterEach(cleanup);
+
+  it("archive cannot target another user's account", async () => {
+    await db.insert(accounts).values({
+      userId: otherUserId,
+      name: `${MARKER}-other-user`,
+      institution: "Other",
+      type: "savings",
+      currency: "COP",
+      balanceCents: BigInt(0),
+    });
+    const [victim] = await db
+      .select()
+      .from(accounts)
+      .where(and(eq(accounts.userId, otherUserId), eq(accounts.name, `${MARKER}-other-user`)));
+
+    await archiveAccount(victim.id);
+
+    const [stillLive] = await db.select().from(accounts).where(eq(accounts.id, victim.id));
+    expect(stillLive.deletedAt).toBeNull();
+  });
+
+  it("toggleAccountActive flips the flag", async () => {
+    await upsertAccount({
+      name: `${MARKER}-toggle`,
+      institution: "Bancolombia",
+      type: "savings",
+      primary: { currency: "COP", balance: 0 },
+    });
+    const [row] = await db
+      .select()
+      .from(accounts)
+      .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${MARKER}-toggle`)));
+
+    await toggleAccountActive(row.id, false);
+    const [after] = await db.select().from(accounts).where(eq(accounts.id, row.id));
+    expect(after.active).toBe(false);
+  });
+});

--- a/src/app/(app)/settings/accounts/actions.ts
+++ b/src/app/(app)/settings/accounts/actions.ts
@@ -1,0 +1,150 @@
+"use server";
+
+import { randomUUID } from "node:crypto";
+import { revalidatePath } from "next/cache";
+import { and, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { accounts, type AccountMetadata } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { getSessionUser } from "@/lib/auth/session";
+
+const metadataSchema = z
+  .object({
+    last4s: z
+      .array(z.string().regex(/^\d{4}$/))
+      .max(8)
+      .optional(),
+    network: z.enum(["visa", "mastercard", "amex"]).optional(),
+    creditLimitCents: z.number().int().nonnegative().optional(),
+    availableCreditCents: z.number().int().nonnegative().optional(),
+    cutoffDay: z.number().int().min(1).max(31).optional(),
+    paymentDueDay: z.number().int().min(1).max(31).optional(),
+    interestRateMonthly: z.number().nonnegative().optional(),
+    termMonths: z.number().int().positive().optional(),
+    loanOriginalCents: z.number().int().nonnegative().optional(),
+    loanRemainingCents: z.number().int().nonnegative().optional(),
+    monthlyPaymentCents: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+const sideSchema = z.object({
+  currency: z.enum(["COP", "USD"]),
+  balance: z.coerce.number().finite(),
+  metadata: metadataSchema.optional(),
+});
+
+const upsertSchema = z
+  .object({
+    id: z.coerce.number().int().positive().optional(),
+    name: z.string().min(1).max(100),
+    institution: z.string().min(1).max(50),
+    type: z.enum(["savings", "credit_card", "loan"]),
+    active: z.coerce.boolean().default(true),
+    primary: sideSchema,
+    secondary: sideSchema.optional(),
+  })
+  .refine((v) => !v.secondary || v.type === "credit_card", {
+    message: "Multi-currency only supported for credit_card",
+    path: ["secondary"],
+  })
+  .refine((v) => !v.secondary || v.secondary.currency !== v.primary.currency, {
+    message: "Secondary currency must differ from primary",
+    path: ["secondary", "currency"],
+  })
+  .refine((v) => !v.secondary || !v.id, {
+    message: "Multi-currency can only be set on create",
+    path: ["secondary"],
+  });
+
+export type AccountUpsertInput = z.input<typeof upsertSchema>;
+
+function revalidate() {
+  revalidatePath("/");
+  revalidatePath("/accounts");
+  revalidatePath("/settings/accounts");
+}
+
+function sideToValues(side: z.infer<typeof sideSchema>) {
+  return {
+    currency: side.currency,
+    balanceCents: BigInt(Math.round(side.balance * 100)),
+    metadata: (side.metadata ?? {}) as AccountMetadata,
+  };
+}
+
+export async function upsertAccount(input: AccountUpsertInput) {
+  const session = await getSessionUser();
+  const parsed = upsertSchema.parse(input);
+
+  const base = {
+    userId: session.id,
+    name: parsed.name,
+    institution: parsed.institution,
+    type: parsed.type,
+    active: parsed.active,
+    updatedAt: new Date(),
+  };
+
+  if (parsed.id) {
+    const primaryValues = sideToValues(parsed.primary);
+    await db
+      .update(accounts)
+      .set({ ...base, ...primaryValues })
+      .where(
+        and(
+          eq(accounts.userId, session.id),
+          eq(accounts.id, parsed.id),
+          notDeleted(accounts.deletedAt),
+        ),
+      );
+    revalidate();
+    return;
+  }
+
+  if (parsed.secondary) {
+    const physicalCardId = randomUUID();
+    await db.transaction(async (trx) => {
+      await trx.insert(accounts).values([
+        { ...base, ...sideToValues(parsed.primary), physicalCardId },
+        { ...base, ...sideToValues(parsed.secondary!), physicalCardId },
+      ]);
+    });
+  } else {
+    await db.insert(accounts).values({ ...base, ...sideToValues(parsed.primary) });
+  }
+
+  revalidate();
+}
+
+export async function archiveAccount(id: number) {
+  const session = await getSessionUser();
+  const parsedId = z.coerce.number().int().positive().parse(id);
+  await db
+    .update(accounts)
+    .set({ deletedAt: sql`NOW()`, updatedAt: new Date() })
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        eq(accounts.id, parsedId),
+        notDeleted(accounts.deletedAt),
+      ),
+    );
+  revalidate();
+}
+
+export async function toggleAccountActive(id: number, active: boolean) {
+  const session = await getSessionUser();
+  const parsedId = z.coerce.number().int().positive().parse(id);
+  await db
+    .update(accounts)
+    .set({ active, updatedAt: new Date() })
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        eq(accounts.id, parsedId),
+        notDeleted(accounts.deletedAt),
+      ),
+    );
+  revalidate();
+}

--- a/src/app/(app)/settings/accounts/page.tsx
+++ b/src/app/(app)/settings/accounts/page.tsx
@@ -1,0 +1,46 @@
+import { asc } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { getSessionUser } from "@/lib/auth/session";
+import { AccountsManager, type AccountRow } from "./accounts-manager";
+
+export const dynamic = "force-dynamic";
+
+export default async function SettingsAccountsPage() {
+  const session = await getSessionUser();
+  const rows = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      institution: accounts.institution,
+      type: accounts.type,
+      currency: accounts.currency,
+      balanceCents: accounts.balanceCents,
+      active: accounts.active,
+      metadata: accounts.metadata,
+      physicalCardId: accounts.physicalCardId,
+    })
+    .from(accounts)
+    .where(and(eq(accounts.userId, session.id), notDeleted(accounts.deletedAt)))
+    .orderBy(asc(accounts.type), asc(accounts.name));
+
+  const items: AccountRow[] = rows.map((r) => ({
+    ...r,
+    balanceCents: r.balanceCents.toString(),
+  }));
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-h1">Accounts</h1>
+        <p className="text-body text-muted-foreground">
+          Create and manage your savings accounts, credit cards, and loans. These are the buckets
+          that your transactions are associated with.
+        </p>
+      </header>
+      <AccountsManager items={items} />
+    </main>
+  );
+}

--- a/src/app/(app)/settings/import/actions.ts
+++ b/src/app/(app)/settings/import/actions.ts
@@ -5,6 +5,7 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { accounts, ingestionLogs, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
 import { getSessionUser } from "@/lib/auth/session";
 import { classifyByRule } from "@/lib/classification/rules";
 import { parseBancolombiaXlsx, type ParsedRow } from "@/lib/ingestion/xlsx-bancolombia";
@@ -39,7 +40,13 @@ export async function previewBancolombiaXlsx(formData: FormData): Promise<Previe
   const [account] = await db
     .select({ id: accounts.id })
     .from(accounts)
-    .where(and(eq(accounts.userId, session.id), eq(accounts.id, accountId)))
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        eq(accounts.id, accountId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
     .limit(1);
   if (!account) throw new Error("Account not found");
 
@@ -105,7 +112,13 @@ export async function confirmBancolombiaImport(input: ConfirmInput): Promise<Con
   const [account] = await db
     .select({ id: accounts.id, currency: accounts.currency })
     .from(accounts)
-    .where(and(eq(accounts.userId, session.id), eq(accounts.id, parsed.accountId)))
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        eq(accounts.id, parsed.accountId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
     .limit(1);
   if (!account) throw new Error("Account not found");
 
@@ -200,7 +213,13 @@ export async function previewScreenshotOcr(formData: FormData): Promise<OcrPrevi
   const [account] = await db
     .select({ id: accounts.id })
     .from(accounts)
-    .where(and(eq(accounts.userId, session.id), eq(accounts.id, accountId)))
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        eq(accounts.id, accountId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
     .limit(1);
   if (!account) throw new Error("Account not found");
 
@@ -269,7 +288,13 @@ export async function confirmOcrImport(input: ConfirmOcrInput): Promise<ConfirmR
   const [account] = await db
     .select({ id: accounts.id, currency: accounts.currency })
     .from(accounts)
-    .where(and(eq(accounts.userId, session.id), eq(accounts.id, parsed.accountId)))
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        eq(accounts.id, parsed.accountId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
     .limit(1);
   if (!account) throw new Error("Account not found");
 

--- a/src/app/(app)/settings/import/page.tsx
+++ b/src/app/(app)/settings/import/page.tsx
@@ -1,6 +1,7 @@
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
 import { ScreenshotUpload } from "@/components/import/screenshot-upload";
 import { ImportForm } from "./import-form";
 
@@ -10,7 +11,7 @@ export default async function ImportPage() {
   const accs = await db
     .select({ id: accounts.id, name: accounts.name, currency: accounts.currency })
     .from(accounts)
-    .where(eq(accounts.active, true))
+    .where(and(eq(accounts.active, true), notDeleted(accounts.deletedAt)))
     .orderBy(asc(accounts.name));
 
   return (

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -4,6 +4,12 @@ import { getSessionUser } from "@/lib/auth/session";
 
 const LINKS = [
   {
+    href: "/settings/accounts",
+    title: "Accounts",
+    description:
+      "Create and manage savings, credit cards, and loans. Required before any transaction can land.",
+  },
+  {
     href: "/settings/import",
     title: "Import",
     description: "Bulk-import from XLSX or drop a screenshot for OCR.",

--- a/src/app/(app)/settings/recurring/actions.ts
+++ b/src/app/(app)/settings/recurring/actions.ts
@@ -45,7 +45,13 @@ export async function upsertRecurring(input: RecurringInput) {
   const [account] = await db
     .select({ id: accounts.id, currency: accounts.currency })
     .from(accounts)
-    .where(and(eq(accounts.userId, session.id), eq(accounts.id, parsed.accountId)))
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        eq(accounts.id, parsed.accountId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
     .limit(1);
   if (!account) throw new Error("Account not found");
 

--- a/src/app/(app)/settings/recurring/page.tsx
+++ b/src/app/(app)/settings/recurring/page.tsx
@@ -1,4 +1,4 @@
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, categories, recurringTransactions } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
@@ -15,7 +15,7 @@ export default async function RecurringPage() {
         currency: accounts.currency,
       })
       .from(accounts)
-      .where(eq(accounts.active, true))
+      .where(and(eq(accounts.active, true), notDeleted(accounts.deletedAt)))
       .orderBy(asc(accounts.name)),
     db
       .select({

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -11,6 +11,7 @@ import {
   counterpartyType,
   transactions,
 } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
 import { getSessionUser } from "@/lib/auth/session";
 import { classifySingleWithAi as classifySingleWithAiLib } from "@/lib/classification/ai";
 import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
@@ -102,7 +103,13 @@ export async function createManualExpense(input: {
   const [account] = await db
     .select({ id: accounts.id, currency: accounts.currency })
     .from(accounts)
-    .where(and(eq(accounts.userId, session.id), eq(accounts.id, parsed.accountId)))
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        eq(accounts.id, parsed.accountId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
     .limit(1);
 
   if (!account) throw new Error("Account not found");

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { db, type DB } from "@/lib/db";
 import { accounts, ingestionLogs, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
 import { classifyByRule } from "@/lib/classification/rules";
 import { emit } from "@/lib/events/bus";
 import { autoLinkTransaction } from "@/lib/recurring/auto-link";
@@ -115,7 +116,7 @@ export async function ingestParsed(userId: number, parsed: ParseResult): Promise
       type: accounts.type,
     })
     .from(accounts)
-    .where(eq(accounts.userId, userId))) as Array<
+    .where(and(eq(accounts.userId, userId), notDeleted(accounts.deletedAt)))) as Array<
     RoutableAccount & { institution: string; type: string }
   >;
 

--- a/src/components/transactions/quick-expense-fab.tsx
+++ b/src/components/transactions/quick-expense-fab.tsx
@@ -1,6 +1,7 @@
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, categories } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
 import { QuickExpenseDialog } from "./quick-expense-dialog";
 
 export async function QuickExpenseFab() {
@@ -8,7 +9,7 @@ export async function QuickExpenseFab() {
     db
       .select({ id: accounts.id, name: accounts.name, currency: accounts.currency })
       .from(accounts)
-      .where(eq(accounts.active, true))
+      .where(and(eq(accounts.active, true), notDeleted(accounts.deletedAt)))
       .orderBy(asc(accounts.name)),
     db
       .select({

--- a/src/lib/accounts/queries.ts
+++ b/src/lib/accounts/queries.ts
@@ -1,6 +1,7 @@
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, type AccountMetadata } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
 import type { AccountType, Currency } from "@/lib/types";
 
 export type AccountDetail = {
@@ -27,6 +28,6 @@ export async function listAccountsDetailed(userId: number): Promise<AccountDetai
       metadata: accounts.metadata,
     })
     .from(accounts)
-    .where(eq(accounts.userId, userId))
+    .where(and(eq(accounts.userId, userId), notDeleted(accounts.deletedAt)))
     .orderBy(asc(accounts.type), asc(accounts.institution), asc(accounts.name));
 }

--- a/src/lib/ai/insights.ts
+++ b/src/lib/ai/insights.ts
@@ -91,7 +91,13 @@ export async function buildInsightsSummary(
           balanceCents: accounts.balanceCents,
         })
         .from(accounts)
-        .where(and(eq(accounts.userId, userId), eq(accounts.active, true)))
+        .where(
+          and(
+            eq(accounts.userId, userId),
+            eq(accounts.active, true),
+            notDeleted(accounts.deletedAt),
+          ),
+        )
         .orderBy(asc(accounts.name)),
       db
         .select({

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -1,6 +1,7 @@
 import { aliasedTable, and, asc, eq, gte, lt, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, categories, counterparties, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
 import { toCop } from "@/lib/money";
 import type { AccountType, CounterpartyType, Currency } from "@/lib/types";
 
@@ -30,7 +31,9 @@ export async function getAccountStatuses(userId: number): Promise<AccountStatus[
       balanceCents: accounts.balanceCents,
     })
     .from(accounts)
-    .where(and(eq(accounts.userId, userId), eq(accounts.active, true)))
+    .where(
+      and(eq(accounts.userId, userId), eq(accounts.active, true), notDeleted(accounts.deletedAt)),
+    )
     .orderBy(asc(accounts.name));
 }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -14,6 +14,7 @@ import {
   text,
   timestamp,
   uniqueIndex,
+  uuid,
   varchar,
   type AnyPgColumn,
 } from "drizzle-orm/pg-core";
@@ -119,10 +120,20 @@ export const accounts = pgTable(
       .default(sql`0`),
     active: boolean("active").notNull().default(true),
     metadata: jsonb("metadata").$type<AccountMetadata>().notNull().default({}),
+    physicalCardId: uuid("physical_card_id"),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (t) => [index("accounts_user_active_idx").on(t.userId, t.active)],
+  (t) => [
+    index("accounts_user_active_idx").on(t.userId, t.active),
+    index("accounts_user_live_idx")
+      .on(t.userId)
+      .where(sql`${t.deletedAt} IS NULL`),
+    index("accounts_physical_card_live_idx")
+      .on(t.physicalCardId)
+      .where(sql`${t.physicalCardId} IS NOT NULL AND ${t.deletedAt} IS NULL`),
+  ],
 );
 
 export type AccountMetadata = {

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -1,4 +1,5 @@
 import { and, asc, desc, eq, ilike, lt, lte, gte, ne, or, sql } from "drizzle-orm";
+import { notDeleted } from "@/lib/db/helpers";
 import { db } from "@/lib/db";
 import {
   accounts,
@@ -184,7 +185,9 @@ export async function listAccounts(userId: number) {
   return db
     .select({ id: accounts.id, name: accounts.name })
     .from(accounts)
-    .where(and(eq(accounts.userId, userId), eq(accounts.active, true)))
+    .where(
+      and(eq(accounts.userId, userId), eq(accounts.active, true), notDeleted(accounts.deletedAt)),
+    )
     .orderBy(asc(accounts.name));
 }
 


### PR DESCRIPTION
## Summary

- New page at \`/settings/accounts\` — list grouped by type, Dialog editor with create/edit/archive, multi-currency toggle for credit cards
- Schema: adds \`accounts.physical_card_id UUID\` + \`accounts.deleted_at TIMESTAMPTZ\` (nullable), plus partial indexes; migration 0020
- Filters \`notDeleted(accounts.deletedAt)\` across 10+ downstream queries (dashboard, transactions, ai/insights, recurring, import, SMS ingest, quick-expense FAB) so archived accounts stop surfacing anywhere, including ingest routing
- Updates \`/accounts\` empty state to link to the new page; adds nav entry in \`/settings\`
- 8 new passing integration tests covering single-currency, multi-currency dual-insert, independent archive, edit-locked multi-currency toggle, auth scoping

### UX decisions (confirmed with user)

- **Advanced metadata** (network, last4s, cutoff/due day, loan amortization) lives behind an \`<details>\` accordion so the base form stays friendly for non-technical users
- **Archive is per-row** on multi-currency cards — no sibling cascade; the UUID is a logical grouping, not a hard FK
- **Multi-currency toggle is lock-on-edit** — convert mono↔multi is out of scope for v1; historical transactions complicate the edge cases

## Test plan

- [x] prettier + eslint --fix via lint-staged on commit
- [x] \`tsc --noEmit\` passes
- [x] \`vitest run\` — 36 files, 364 tests all green (8 new)
- [x] Migration 0020 applied to \`findash\` + \`findash_test\`, \`_journal.json\` monotonic
- [ ] CI green on PR (lint + format + typecheck + tests + next build)
- [ ] Manual smoke in browser: sign in → /settings/accounts → create → edit → archive → confirm empty state on /accounts links back correctly

Closes #245