### PR TITLE
fix(deploy): use relative imports in signup.ts so migrate-prod.ts works (#268)

### DIFF
--- a/src/lib/auth/signup.ts
+++ b/src/lib/auth/signup.ts
@@ -1,11 +1,15 @@
 import { sql } from "drizzle-orm";
-import { db as defaultDb, type DB } from "@/lib/db";
+// Relative imports (not `@/lib/...` aliases) are required because this file
+// is copied verbatim into the prod release by deploy.yml and executed there
+// by bun, which has no tsconfig to resolve path aliases. Keeping these
+// relative makes the same file work in dev and on the droplet.
+import { db as defaultDb, type DB } from "../db";
 import {
   categories,
   categorySeeds,
   classificationRuleSeeds,
   classificationRules,
-} from "@/lib/db/schema";
+} from "../db/schema";
 
 /**
  * Copy every row from `category_seeds` into `categories` with the new user's


### PR DESCRIPTION
Closes #268

## Summary

Hotfix for the failed deploy of PR #267. `signup.ts` is copied verbatim into the release stage so `scripts/migrate-prod.ts` can import its per-user hooks, but the file was using `@/lib/db` and `@/lib/db/schema` path aliases. Bun on the droplet has no tsconfig → can't resolve `@/*` → deploy failed at the migrate step.

Fix: swap the two aliased imports for relative ones (`../db`, `../db/schema`). The directory layout is identical in dev and on the stage (both have `src/lib/auth/signup.ts` + `src/lib/db/`), so relative paths resolve in both contexts.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 377/377 pass
- [ ] Deploy workflow succeeds on merge (the real test)

## Why not add tsconfig to the stage

Considered. Adding tsconfig + wiring bun's path-alias resolution would work, but it introduces another moving part that can break silently. Every other file we copy to prod already uses relative imports (seed-reference-data.ts, backfill-users-reference.ts, migrate-prod.ts); making signup.ts consistent with that convention is the lower-risk fix.