### PR TITLE
feat(ui): category editor UX polish — color picker, icon picker, drag-n-drop reorder (#270)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # testing
 /coverage
 /e2e/screenshots/
+/.screenshots/
 /test-results/
 /playwright-report/
 /playwright/.cache/

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,9 @@
     "": {
       "name": "personal-financial-dashboard",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
         "@number-flow/react": "^0.6.0",
         "class-variance-authority": "^0.7.1",
@@ -21,6 +24,7 @@
         "postgres": "^3.4.9",
         "radix-ui": "^1.4.3",
         "react": "19.2.5",
+        "react-colorful": "^5.6.1",
         "react-dom": "19.2.5",
         "react-hook-form": "^7.72.1",
         "react-markdown": "^10.1.0",
@@ -121,6 +125,14 @@
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.61.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-utL3cpZoFzflyqUkjYbxYujI6STBTmO5LFn4bbin/NZnRWN6wQ7eErhr3/Vpa5h/jicPFC6kTa42r940mQftJQ=="],
 
@@ -1603,6 +1615,8 @@
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "react-colorful": ["react-colorful@5.6.1", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw=="],
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     ]
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@number-flow/react": "^0.6.0",
     "class-variance-authority": "^0.7.1",
@@ -54,6 +57,7 @@
     "postgres": "^3.4.9",
     "radix-ui": "^1.4.3",
     "react": "19.2.5",
+    "react-colorful": "^5.6.1",
     "react-dom": "19.2.5",
     "react-hook-form": "^7.72.1",
     "react-markdown": "^10.1.0",

--- a/src/app/(app)/settings/categories/actions.ts
+++ b/src/app/(app)/settings/categories/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray, isNull, max } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { categories } from "@/lib/db/schema";
@@ -23,7 +23,6 @@ const createSchema = z.object({
   parentSlug: slugSchema.nullable(),
   icon: z.string().max(40).nullable(),
   color: hexColorSchema.nullable(),
-  sortOrder: z.coerce.number().int().min(0).max(9999).default(500),
 });
 
 const updateSchema = z.object({
@@ -32,10 +31,16 @@ const updateSchema = z.object({
   parentSlug: slugSchema.nullable(),
   icon: z.string().max(40).nullable(),
   color: hexColorSchema.nullable(),
-  sortOrder: z.coerce.number().int().min(0).max(9999),
 });
 
 const archiveSchema = z.object({ slug: slugSchema });
+
+// Reorder payload: ordered list of root-or-sibling slugs sharing a parent.
+// Children reorder independently; leave `parentSlug` null for roots.
+const reorderSchema = z.object({
+  parentSlug: slugSchema.nullable(),
+  slugs: z.array(slugSchema).min(1).max(500),
+});
 
 export type CategoryActionResult = { status: "ok" } | { status: "error"; message: string };
 
@@ -62,6 +67,22 @@ export async function createCategory(
     }
   }
 
+  // sortOrder is owned by drag-and-drop; for new rows we just park them at
+  // the end of their sibling group.
+  const [{ current }] = await db
+    .select({ current: max(categories.sortOrder) })
+    .from(categories)
+    .where(
+      and(
+        eq(categories.userId, session.id),
+        parsed.data.parentSlug
+          ? eq(categories.parentSlug, parsed.data.parentSlug)
+          : isNull(categories.parentSlug),
+        notDeleted(categories.deletedAt),
+      ),
+    );
+  const nextSortOrder = (current ?? 0) + 10;
+
   await db.insert(categories).values({
     userId: session.id,
     slug: parsed.data.slug,
@@ -69,7 +90,7 @@ export async function createCategory(
     parentSlug: parsed.data.parentSlug,
     icon: parsed.data.icon,
     color: parsed.data.color,
-    sortOrder: parsed.data.sortOrder,
+    sortOrder: nextSortOrder,
   });
 
   revalidatePath("/settings/categories");
@@ -106,7 +127,6 @@ export async function updateCategory(
       parentSlug: parsed.data.parentSlug,
       icon: parsed.data.icon,
       color: parsed.data.color,
-      sortOrder: parsed.data.sortOrder,
       updatedAt: new Date(),
     })
     .where(
@@ -116,6 +136,62 @@ export async function updateCategory(
         notDeleted(categories.deletedAt),
       ),
     );
+
+  revalidatePath("/settings/categories");
+  return { status: "ok" };
+}
+
+export async function reorderCategories(
+  input: z.input<typeof reorderSchema>,
+): Promise<CategoryActionResult> {
+  const session = await getSessionUser();
+  const parsed = reorderSchema.safeParse(input);
+  if (!parsed.success) {
+    return { status: "error", message: parsed.error.issues[0]?.message ?? "Input inválido." };
+  }
+
+  // Validate all slugs belong to the user + share the expected parent.
+  const rows = await db
+    .select({ slug: categories.slug, parentSlug: categories.parentSlug })
+    .from(categories)
+    .where(
+      and(
+        eq(categories.userId, session.id),
+        inArray(categories.slug, parsed.data.slugs),
+        notDeleted(categories.deletedAt),
+      ),
+    );
+
+  if (rows.length !== parsed.data.slugs.length) {
+    return { status: "error", message: "Alguna categoría no existe o está archivada." };
+  }
+
+  const expected = parsed.data.parentSlug;
+  const mismatch = rows.find((r) => (r.parentSlug ?? null) !== (expected ?? null));
+  if (mismatch) {
+    return {
+      status: "error",
+      message: "No se puede reordenar entre categorías de distinto padre.",
+    };
+  }
+
+  // One round-trip: rebuild sort_order via VALUES-join so all siblings update
+  // atomically at 10/20/30… Matches the FK-safe pattern used elsewhere.
+  const now = new Date();
+  await db.transaction(async (tx) => {
+    for (const [index, slug] of parsed.data.slugs.entries()) {
+      await tx
+        .update(categories)
+        .set({ sortOrder: (index + 1) * 10, updatedAt: now })
+        .where(
+          and(
+            eq(categories.userId, session.id),
+            eq(categories.slug, slug),
+            notDeleted(categories.deletedAt),
+          ),
+        );
+    }
+  });
 
   revalidatePath("/settings/categories");
   return { status: "ok" };

--- a/src/app/(app)/settings/categories/categories-manager.tsx
+++ b/src/app/(app)/settings/categories/categories-manager.tsx
@@ -1,8 +1,27 @@
 "use client";
 
-import { useMemo, useState, useTransition } from "react";
-import { ArchiveIcon, PencilIcon, PlusIcon } from "lucide-react";
+import { useEffect, useMemo, useState, useTransition } from "react";
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { ArchiveIcon, GripVerticalIcon, PencilIcon, PlusIcon } from "lucide-react";
 import { toast } from "sonner";
+import { ColorPicker } from "@/components/categories/color-picker";
+import { CategoryIcon, IconPicker } from "@/components/categories/icon-picker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -16,7 +35,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { archiveCategory, createCategory, updateCategory } from "./actions";
+import { cn } from "@/lib/utils";
+import { archiveCategory, createCategory, reorderCategories, updateCategory } from "./actions";
 
 export type CategoryRow = {
   id: number;
@@ -35,7 +55,6 @@ type FormState = {
   parentSlug: string;
   icon: string;
   color: string;
-  sortOrder: string;
   // Whether the slug field is editable. Slugs become immutable after
   // creation to protect composite FKs.
   slugLocked: boolean;
@@ -48,7 +67,6 @@ const EMPTY_FORM: FormState = {
   parentSlug: "",
   icon: "",
   color: "",
-  sortOrder: "500",
   slugLocked: false,
 };
 
@@ -68,7 +86,28 @@ export function CategoriesManager({ rows }: { rows: CategoryRow[] }) {
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
 
-  const roots = useMemo(() => rows.filter((r) => r.parentSlug === null), [rows]);
+  // Server-ordered root slugs. Local state so drag-and-drop can reorder
+  // optimistically; we re-sync when the server sends new props.
+  const serverRootSlugs = useMemo(
+    () => rows.filter((r) => r.parentSlug === null).map((r) => r.slug),
+    [rows],
+  );
+  const [rootOrder, setRootOrder] = useState<string[]>(serverRootSlugs);
+  useEffect(() => {
+    setRootOrder(serverRootSlugs);
+  }, [serverRootSlugs]);
+
+  const rowBySlug = useMemo(() => {
+    const map = new Map<string, CategoryRow>();
+    for (const r of rows) map.set(r.slug, r);
+    return map;
+  }, [rows]);
+
+  const orderedRoots = useMemo(
+    () => rootOrder.map((slug) => rowBySlug.get(slug)).filter((r): r is CategoryRow => !!r),
+    [rootOrder, rowBySlug],
+  );
+
   const childrenByParent = useMemo(() => {
     const map = new Map<string, CategoryRow[]>();
     for (const r of rows) {
@@ -80,6 +119,11 @@ export function CategoriesManager({ rows }: { rows: CategoryRow[] }) {
     }
     return map;
   }, [rows]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   function openCreate() {
     setForm(EMPTY_FORM);
@@ -94,7 +138,6 @@ export function CategoriesManager({ rows }: { rows: CategoryRow[] }) {
       parentSlug: row.parentSlug ?? "",
       icon: row.icon ?? "",
       color: row.color ?? "",
-      sortOrder: row.sortOrder.toString(),
       slugLocked: true,
     });
     setOpen(true);
@@ -107,7 +150,6 @@ export function CategoriesManager({ rows }: { rows: CategoryRow[] }) {
       parentSlug: form.parentSlug.trim() || null,
       icon: form.icon.trim() || null,
       color: form.color.trim() || null,
-      sortOrder: Number(form.sortOrder),
     };
 
     startTransition(async () => {
@@ -137,6 +179,27 @@ export function CategoriesManager({ rows }: { rows: CategoryRow[] }) {
     });
   }
 
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = rootOrder.indexOf(String(active.id));
+    const newIndex = rootOrder.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const next = arrayMove(rootOrder, oldIndex, newIndex);
+    setRootOrder(next);
+
+    startTransition(async () => {
+      const result = await reorderCategories({ parentSlug: null, slugs: next });
+      if (result.status === "error") {
+        toast.error(result.message);
+        // Revert optimistic order — server rejected the change.
+        setRootOrder(rootOrder);
+      }
+    });
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-end">
@@ -145,79 +208,22 @@ export function CategoriesManager({ rows }: { rows: CategoryRow[] }) {
         </Button>
       </div>
 
-      <div className="flex flex-col gap-3">
-        {roots.map((root) => {
-          const children = childrenByParent.get(root.slug) ?? [];
-          return (
-            <Card key={root.id}>
-              <CardHeader className="flex flex-row items-center justify-between gap-2">
-                <div className="flex items-center gap-3">
-                  {root.color && (
-                    <span
-                      aria-hidden
-                      className="size-5 rounded"
-                      style={{ background: root.color }}
-                    />
-                  )}
-                  <CardTitle className="text-base">{root.name}</CardTitle>
-                  <Badge variant="outline" className="font-mono text-xs">
-                    {root.slug}
-                  </Badge>
-                </div>
-                <div className="flex gap-1">
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    disabled={pending}
-                    onClick={() => openEdit(root)}
-                  >
-                    <PencilIcon className="size-4" />
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    disabled={pending}
-                    onClick={() => archive(root.slug)}
-                  >
-                    <ArchiveIcon className="size-4" />
-                  </Button>
-                </div>
-              </CardHeader>
-              {children.length > 0 && (
-                <CardContent className="flex flex-wrap gap-2 border-t pt-3">
-                  {children.map((c) => (
-                    <div
-                      key={c.id}
-                      className="bg-muted/40 flex items-center gap-2 rounded-full border px-3 py-1 text-sm"
-                    >
-                      <span>{c.name}</span>
-                      <span className="text-muted-foreground font-mono text-xs">{c.slug}</span>
-                      <button
-                        type="button"
-                        className="text-muted-foreground hover:text-foreground"
-                        disabled={pending}
-                        onClick={() => openEdit(c)}
-                        aria-label={`Editar ${c.name}`}
-                      >
-                        <PencilIcon className="size-3" />
-                      </button>
-                      <button
-                        type="button"
-                        className="text-muted-foreground hover:text-destructive"
-                        disabled={pending}
-                        onClick={() => archive(c.slug)}
-                        aria-label={`Archivar ${c.name}`}
-                      >
-                        <ArchiveIcon className="size-3" />
-                      </button>
-                    </div>
-                  ))}
-                </CardContent>
-              )}
-            </Card>
-          );
-        })}
-      </div>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={rootOrder} strategy={verticalListSortingStrategy}>
+          <div className="flex flex-col gap-3">
+            {orderedRoots.map((root) => (
+              <SortableRootCard
+                key={root.slug}
+                root={root}
+                childRows={childrenByParent.get(root.slug) ?? []}
+                pending={pending}
+                onEdit={openEdit}
+                onArchive={archive}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent>
@@ -268,7 +274,7 @@ export function CategoriesManager({ rows }: { rows: CategoryRow[] }) {
                 className="border-input bg-background focus:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus:ring-2"
               >
                 <option value="">— Ninguna (categoría raíz)</option>
-                {roots
+                {orderedRoots
                   .filter((r) => r.slug !== form.slug)
                   .map((r) => (
                     <option key={r.id} value={r.slug}>
@@ -277,33 +283,21 @@ export function CategoriesManager({ rows }: { rows: CategoryRow[] }) {
                   ))}
               </select>
             </div>
-            <div className="flex gap-2">
+            <div className="flex gap-3">
               <div className="flex-1">
-                <Label htmlFor="cat-color">Color hex</Label>
-                <Input
+                <Label htmlFor="cat-color">Color</Label>
+                <ColorPicker
                   id="cat-color"
                   value={form.color}
-                  onChange={(e) => setForm((f) => ({ ...f, color: e.target.value }))}
-                  placeholder="#0ea5e9"
-                  className="font-mono"
+                  onChange={(color) => setForm((f) => ({ ...f, color }))}
                 />
               </div>
               <div className="flex-1">
-                <Label htmlFor="cat-icon">Icono (lucide)</Label>
-                <Input
+                <Label htmlFor="cat-icon">Icono</Label>
+                <IconPicker
                   id="cat-icon"
                   value={form.icon}
-                  onChange={(e) => setForm((f) => ({ ...f, icon: e.target.value }))}
-                  placeholder="home"
-                />
-              </div>
-              <div className="w-24">
-                <Label htmlFor="cat-order">Orden</Label>
-                <Input
-                  id="cat-order"
-                  type="number"
-                  value={form.sortOrder}
-                  onChange={(e) => setForm((f) => ({ ...f, sortOrder: e.target.value }))}
+                  onChange={(icon) => setForm((f) => ({ ...f, icon }))}
                 />
               </div>
             </div>
@@ -318,6 +312,107 @@ export function CategoriesManager({ rows }: { rows: CategoryRow[] }) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+    </div>
+  );
+}
+
+function SortableRootCard({
+  root,
+  childRows,
+  pending,
+  onEdit,
+  onArchive,
+}: {
+  root: CategoryRow;
+  childRows: CategoryRow[];
+  pending: boolean;
+  onEdit: (row: CategoryRow) => void;
+  onArchive: (slug: string) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: root.slug,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className={cn(isDragging && "z-10 opacity-80")}>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-2">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              aria-label={`Arrastrar ${root.name}`}
+              className="text-muted-foreground hover:text-foreground cursor-grab touch-none active:cursor-grabbing"
+              // dnd-kit generates aria-describedby="DndDescribedBy-N" via an
+              // internal counter that can differ between SSR and hydration
+              // (upstream issue). The attribute is otherwise stable, so we
+              // silence the hydration warning on this one element only.
+              suppressHydrationWarning
+              {...attributes}
+              {...listeners}
+            >
+              <GripVerticalIcon className="size-4" />
+            </button>
+            {root.color && (
+              <span aria-hidden className="size-5 rounded" style={{ background: root.color }} />
+            )}
+            {root.icon && <CategoryIcon name={root.icon} className="text-muted-foreground" />}
+            <CardTitle className="text-base">{root.name}</CardTitle>
+            <Badge variant="outline" className="font-mono text-xs">
+              {root.slug}
+            </Badge>
+          </div>
+          <div className="flex gap-1">
+            <Button size="sm" variant="ghost" disabled={pending} onClick={() => onEdit(root)}>
+              <PencilIcon className="size-4" />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={pending}
+              onClick={() => onArchive(root.slug)}
+            >
+              <ArchiveIcon className="size-4" />
+            </Button>
+          </div>
+        </CardHeader>
+        {childRows.length > 0 && (
+          <CardContent className="flex flex-wrap gap-2 border-t pt-3">
+            {childRows.map((c) => (
+              <div
+                key={c.id}
+                className="bg-muted/40 flex items-center gap-2 rounded-full border px-3 py-1 text-sm"
+              >
+                {c.icon && <CategoryIcon name={c.icon} className="text-muted-foreground size-3" />}
+                <span>{c.name}</span>
+                <span className="text-muted-foreground font-mono text-xs">{c.slug}</span>
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-foreground"
+                  disabled={pending}
+                  onClick={() => onEdit(c)}
+                  aria-label={`Editar ${c.name}`}
+                >
+                  <PencilIcon className="size-3" />
+                </button>
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-destructive"
+                  disabled={pending}
+                  onClick={() => onArchive(c.slug)}
+                  aria-label={`Archivar ${c.name}`}
+                >
+                  <ArchiveIcon className="size-3" />
+                </button>
+              </div>
+            ))}
+          </CardContent>
+        )}
+      </Card>
     </div>
   );
 }

--- a/src/components/categories/color-picker.tsx
+++ b/src/components/categories/color-picker.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { HexColorPicker } from "react-colorful";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+export type ColorPickerProps = {
+  value: string;
+  onChange: (hex: string) => void;
+  id?: string;
+  className?: string;
+};
+
+export function ColorPicker({ value, onChange, id, className }: ColorPickerProps) {
+  const [open, setOpen] = useState(false);
+  const isValid = HEX_RE.test(value);
+  const swatchBg = isValid ? value : "transparent";
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label="Elegir color"
+            className={cn(
+              "border-input ring-ring/50 relative size-8 shrink-0 rounded-lg border transition-colors outline-none focus-visible:ring-3",
+              !isValid &&
+                "bg-[repeating-conic-gradient(theme(colors.muted)_0%_25%,transparent_0%_50%)_50%/8px_8px]",
+            )}
+            style={isValid ? { background: swatchBg } : undefined}
+          />
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-3" align="start">
+          <HexColorPicker color={isValid ? value : "#0ea5e9"} onChange={onChange} />
+        </PopoverContent>
+      </Popover>
+      <Input
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="#0ea5e9"
+        className="font-mono"
+        maxLength={7}
+        aria-invalid={value.length > 0 && !isValid}
+      />
+    </div>
+  );
+}

--- a/src/components/categories/icon-picker.tsx
+++ b/src/components/categories/icon-picker.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useMemo, useState, type ComponentType } from "react";
+import {
+  Baby,
+  Beer,
+  BookOpen,
+  Briefcase,
+  Bus,
+  Car,
+  Coffee,
+  Coins,
+  CreditCard,
+  Cross,
+  Dog,
+  Dumbbell,
+  Film,
+  Flame,
+  Fuel,
+  Gamepad2,
+  Gift,
+  GraduationCap,
+  HandCoins,
+  Hammer,
+  HeartPulse,
+  Home,
+  Landmark,
+  Laptop,
+  MoreHorizontal,
+  Music,
+  PartyPopper,
+  PawPrint,
+  PiggyBank,
+  Pill,
+  Pizza,
+  Plane,
+  Plus,
+  Receipt,
+  Scissors,
+  Shirt,
+  ShoppingCart,
+  Smartphone,
+  Sofa,
+  Sparkles,
+  TrendingUp,
+  Trophy,
+  Utensils,
+  Wallet,
+  Wifi,
+  Wine,
+  Wrench,
+  Zap,
+  HelpCircle,
+  type LucideIcon,
+} from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+// Curated finance-relevant lucide set. Keys are the lucide kebab-case name
+// so they round-trip with the existing `icon` string column.
+export const CURATED_ICONS: Record<string, LucideIcon> = {
+  home: Home,
+  "shopping-cart": ShoppingCart,
+  utensils: Utensils,
+  pizza: Pizza,
+  coffee: Coffee,
+  wine: Wine,
+  beer: Beer,
+  car: Car,
+  bus: Bus,
+  plane: Plane,
+  fuel: Fuel,
+  "heart-pulse": HeartPulse,
+  pill: Pill,
+  cross: Cross,
+  dumbbell: Dumbbell,
+  "graduation-cap": GraduationCap,
+  "book-open": BookOpen,
+  baby: Baby,
+  "paw-print": PawPrint,
+  dog: Dog,
+  gift: Gift,
+  film: Film,
+  music: Music,
+  gamepad: Gamepad2,
+  "party-popper": PartyPopper,
+  sparkles: Sparkles,
+  trophy: Trophy,
+  shirt: Shirt,
+  scissors: Scissors,
+  briefcase: Briefcase,
+  smartphone: Smartphone,
+  laptop: Laptop,
+  wifi: Wifi,
+  zap: Zap,
+  flame: Flame,
+  sofa: Sofa,
+  hammer: Hammer,
+  wrench: Wrench,
+  "piggy-bank": PiggyBank,
+  "trending-up": TrendingUp,
+  landmark: Landmark,
+  receipt: Receipt,
+  "credit-card": CreditCard,
+  wallet: Wallet,
+  "hand-coins": HandCoins,
+  coins: Coins,
+  plus: Plus,
+  more: MoreHorizontal,
+};
+
+export function CategoryIcon({
+  name,
+  className,
+}: {
+  name: string | null | undefined;
+  className?: string;
+}) {
+  const Icon = (name && CURATED_ICONS[name]) || HelpCircle;
+  return <Icon className={cn("size-4", className)} />;
+}
+
+export type IconPickerProps = {
+  value: string;
+  onChange: (name: string) => void;
+  id?: string;
+};
+
+export function IconPicker({ value, onChange, id }: IconPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const entries = Object.entries(CURATED_ICONS);
+    if (!q) return entries;
+    return entries.filter(([name]) => name.includes(q));
+  }, [query]);
+
+  const Selected = (value && CURATED_ICONS[value]) as
+    | ComponentType<{ className?: string }>
+    | undefined;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label="Elegir icono"
+            className="border-input ring-ring/50 text-muted-foreground hover:text-foreground flex size-8 shrink-0 items-center justify-center rounded-lg border bg-transparent transition-colors outline-none focus-visible:ring-3"
+          >
+            {Selected ? <Selected className="size-4" /> : <HelpCircle className="size-4" />}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-64 p-2" align="start">
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Buscar icono…"
+            className="border-input bg-background focus:ring-ring mb-2 h-8 w-full rounded-md border px-2 text-sm outline-none focus:ring-2"
+            autoFocus
+          />
+          <div className="grid max-h-56 grid-cols-6 gap-1 overflow-y-auto">
+            {filtered.map(([name, Icon]) => {
+              const isSelected = name === value;
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  title={name}
+                  onClick={() => {
+                    onChange(name);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    "hover:bg-muted flex size-8 items-center justify-center rounded-md transition-colors",
+                    isSelected && "bg-muted ring-ring ring-2",
+                  )}
+                >
+                  <Icon className="size-4" />
+                </button>
+              );
+            })}
+            {filtered.length === 0 && (
+              <div className="text-muted-foreground col-span-6 py-4 text-center text-xs">
+                Sin resultados
+              </div>
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+      <Input
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="home"
+        className="font-mono"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Swatch + popover color picker (`react-colorful`) replaces the bare hex input.
- Searchable grid icon picker with ~50 curated lucide finance icons (free text still accepted for anything outside the set).
- Removes the manual `Orden` number field — root categories reorder via `@dnd-kit` drag handle; new server action `reorderCategories` rebuilds `sort_order` atomically in a transaction.
- List rows now render the configured icon next to the color swatch on both root and child rows.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run test` — 377 pass / 0 fail
- [x] Manual smoke in Chrome via dev-login bypass:
  - [x] Open edit dialog → Color popover renders with saturation/hue pickers; hex input syncs with picker.
  - [x] Icon popover renders 6-col grid with search; selected icon shows ring state; home icon persists back to list row.
  - [x] Keyboard drag-and-drop: focus handle → Space → ArrowUp/Down → Space reorders the list; hard reload preserves the new order; DB shows `sort_order` rebuilt at 10/20/30… for roots.
  - [x] No console errors; the one dnd-kit `aria-describedby` hydration mismatch is scoped-silenced via `suppressHydrationWarning` on the drag handle only.

## Screenshots

Captured locally in `.screenshots/` (gitignored). Before: single-row form with `Color hex | Icono (lucide) | Orden`. After: dialog has `Color` (swatch + hex) and `Icono` (preview button + name), list cards show grip handle + icon next to the color chip.

Closes #270