### PR TITLE
feat(observability): /admin/slos dashboard — 6 SLOs aggregated cross-user (#249)

### DIFF
--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -22,6 +22,12 @@ const LINKS = [
     description:
       "Telemetría diaria: último SMS, último capture, fuentes activas, tasa de éxito del parser y señales de churn.",
   },
+  {
+    href: "/admin/slos",
+    title: "SLOs del parser",
+    description:
+      "6 métricas agregadas cross-user (parse success, clasificación, dedup, onboarding, data loss, detection lag). Gatean Phase 8.",
+  },
 ];
 
 export default async function AdminPage() {

--- a/src/app/(app)/admin/slos/page.tsx
+++ b/src/app/(app)/admin/slos/page.tsx
@@ -1,0 +1,146 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getSessionUser } from "@/lib/auth/session";
+import {
+  computeAllSlos,
+  type SloResult,
+  type SloStatus,
+  type SloWindow,
+} from "@/lib/telemetry/slos";
+import { Sparkline } from "./sparkline";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_WINDOWS: SloWindow[] = [7, 30, 90];
+
+function parseWindow(value: string | undefined): SloWindow {
+  const n = Number(value);
+  if (ALLOWED_WINDOWS.includes(n as SloWindow)) return n as SloWindow;
+  return 30;
+}
+
+export default async function AdminSlosPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ window?: string }>;
+}) {
+  const session = await getSessionUser();
+  if (session.role !== "admin") notFound();
+
+  const params = await searchParams;
+  const windowDays = parseWindow(params.window);
+  const slos = await computeAllSlos(windowDays);
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-h1">SLOs del parser</h1>
+          <p className="text-body text-muted-foreground">
+            6 métricas agregadas cross-user. Gatean Phase 8 (segundo banco) — sin verde sostenido,
+            no agregamos más complejidad.
+          </p>
+        </div>
+        <WindowPicker current={windowDays} />
+      </header>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {slos.map((slo) => (
+          <SloCard key={slo.key} slo={slo} />
+        ))}
+      </div>
+    </main>
+  );
+}
+
+function WindowPicker({ current }: { current: SloWindow }) {
+  return (
+    <nav className="flex items-center gap-1 text-xs">
+      <span className="text-muted-foreground mr-1">Ventana:</span>
+      {ALLOWED_WINDOWS.map((w) => {
+        const active = w === current;
+        return (
+          <Link
+            key={w}
+            href={`?window=${w}`}
+            className={
+              active
+                ? "bg-foreground text-background rounded px-2 py-1 font-medium"
+                : "text-muted-foreground hover:text-foreground rounded px-2 py-1"
+            }
+          >
+            {w}d
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+const STATUS_STYLES: Record<SloStatus, { label: string; className: string; dot: string }> = {
+  green: {
+    label: "OK",
+    className:
+      "border-emerald-300 bg-emerald-50/60 dark:border-emerald-900/40 dark:bg-emerald-950/20",
+    dot: "bg-emerald-500",
+  },
+  yellow: {
+    label: "Atención",
+    className: "border-amber-300 bg-amber-50/60 dark:border-amber-900/40 dark:bg-amber-950/20",
+    dot: "bg-amber-500",
+  },
+  red: {
+    label: "Crítico",
+    className: "border-red-300 bg-red-50/60 dark:border-red-900/40 dark:bg-red-950/20",
+    dot: "bg-red-500",
+  },
+  "no-signal": {
+    label: "Sin señal",
+    className: "border-border bg-muted/30",
+    dot: "bg-muted-foreground",
+  },
+};
+
+function SloCard({ slo }: { slo: SloResult }) {
+  const style = STATUS_STYLES[slo.status];
+  return (
+    <Card className={style.className}>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-0.5">
+            <CardTitle className="text-base">{slo.label}</CardTitle>
+            <CardDescription className="text-xs">{slo.description}</CardDescription>
+          </div>
+          <span
+            className="inline-flex items-center gap-1.5 rounded-full bg-white/60 px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase dark:bg-black/20"
+            title={style.label}
+          >
+            <span className={`size-2 rounded-full ${style.dot}`} />
+            {style.label}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <span className="font-heading text-3xl font-semibold tabular-nums">{slo.display}</span>
+          <span className="text-muted-foreground text-xs">Target {slo.target}</span>
+        </div>
+        {slo.trend.length > 0 ? (
+          <Sparkline points={slo.trend} />
+        ) : (
+          <p className="text-muted-foreground text-[11px] italic">
+            Trend no disponible para esta métrica todavía.
+          </p>
+        )}
+        {slo.drilldown ? (
+          <Link
+            href={slo.drilldown}
+            className="text-xs font-medium underline-offset-4 hover:underline"
+          >
+            Ver detalle →
+          </Link>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(app)/admin/slos/sparkline.tsx
+++ b/src/app/(app)/admin/slos/sparkline.tsx
@@ -1,0 +1,47 @@
+import type { TrendPoint } from "@/lib/telemetry/slos";
+
+const WIDTH = 240;
+const HEIGHT = 40;
+
+export function Sparkline({ points }: { points: TrendPoint[] }) {
+  const numericValues = points
+    .map((p) => p.value)
+    .filter((v): v is number => v !== null && Number.isFinite(v));
+
+  if (numericValues.length === 0) {
+    return <p className="text-muted-foreground text-[11px] italic">Sin datos en la ventana.</p>;
+  }
+
+  const min = Math.min(...numericValues);
+  const max = Math.max(...numericValues);
+  const range = max - min || 1;
+  const step = WIDTH / Math.max(points.length - 1, 1);
+
+  // Build the path — skip null gaps by lifting the pen (`M` after a gap).
+  let d = "";
+  let prevWasNull = true;
+  points.forEach((p, i) => {
+    if (p.value === null || !Number.isFinite(p.value)) {
+      prevWasNull = true;
+      return;
+    }
+    const x = i * step;
+    const y = HEIGHT - ((p.value - min) / range) * HEIGHT;
+    d += `${prevWasNull ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)} `;
+    prevWasNull = false;
+  });
+
+  return (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      width="100%"
+      height={HEIGHT}
+      preserveAspectRatio="none"
+      className="text-foreground/70"
+      role="img"
+      aria-label={`Sparkline trend con ${numericValues.length} puntos`}
+    >
+      <path d={d.trim()} fill="none" stroke="currentColor" strokeWidth={1.5} />
+    </svg>
+  );
+}

--- a/src/lib/telemetry/slos.test.ts
+++ b/src/lib/telemetry/slos.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, ingestionLogs, transactions } from "@/lib/db/schema";
+import {
+  sloClassificationRate,
+  sloDataLoss,
+  sloDetectionLag,
+  sloOnboardingTime,
+  sloParseSuccess,
+  computeAllSlos,
+} from "./slos";
+
+const TEST_USER_ID = 1;
+const TEST_ACCOUNT = "__slos_test_account__";
+const TEST_TX_TAG = "__slos_test_tx__";
+
+// Freeze "now" so windowed queries are deterministic.
+const NOW = new Date(Date.UTC(2026, 3, 20, 12, 0, 0));
+const ago = (days: number, hours = 0) =>
+  new Date(NOW.getTime() - days * 86_400_000 - hours * 3_600_000);
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE '__slos_test_tx__%'`);
+  await db.execute(sql`DELETE FROM ingestion_logs WHERE user_id = ${TEST_USER_ID}`);
+  await db.execute(sql`DELETE FROM accounts WHERE name = ${TEST_ACCOUNT}`);
+}
+
+async function seedAccount(): Promise<number> {
+  const [a] = await db
+    .insert(accounts)
+    .values({
+      userId: TEST_USER_ID,
+      name: TEST_ACCOUNT,
+      institution: "Test",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return a.id;
+}
+
+async function seedTx(opts: {
+  accountId: number;
+  source: "sms" | "telegram" | "manual" | "csv";
+  classificationMethod: "rule" | "ai" | "manual" | "unclassified";
+  createdAt: Date;
+}): Promise<void> {
+  await db.insert(transactions).values({
+    userId: TEST_USER_ID,
+    accountId: opts.accountId,
+    occurredAt: opts.createdAt,
+    amountCents: BigInt(-10_000),
+    currency: "COP",
+    descriptionRaw: `${TEST_TX_TAG}-${opts.source}-${Math.random()}`,
+    classificationMethod: opts.classificationMethod,
+    source: opts.source,
+    createdAt: opts.createdAt,
+    updatedAt: opts.createdAt,
+  });
+}
+
+async function seedLog(opts: {
+  source: "sms" | "csv" | "apple_pay" | "manual" | "telegram";
+  status: "inserted" | "duplicated" | "error" | "skipped";
+  startedAt: Date;
+  resolvedAt?: Date | null;
+  kind?: string;
+}): Promise<number> {
+  const [row] = await db
+    .insert(ingestionLogs)
+    .values({
+      userId: TEST_USER_ID,
+      source: opts.source,
+      status: opts.status,
+      itemsReceived: 1,
+      payload: { kind: opts.kind ?? "slo-test" },
+      startedAt: opts.startedAt,
+      finishedAt: opts.startedAt,
+      resolvedAt: opts.resolvedAt ?? null,
+    })
+    .returning({ id: ingestionLogs.id });
+  return row.id;
+}
+
+describe("sloParseSuccess", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("green when success rate ≥ 95%", async () => {
+    for (let i = 0; i < 19; i++)
+      await seedLog({ source: "sms", status: "inserted", startedAt: ago(1) });
+    await seedLog({ source: "sms", status: "error", startedAt: ago(1) });
+
+    const r = await sloParseSuccess(30, NOW);
+    expect(r.raw).toBeCloseTo(0.95, 5);
+    expect(r.status).toBe("green");
+    expect(r.drilldown).toBe("/settings/inbox");
+  });
+
+  it("red when success rate <95% by more than 5%", async () => {
+    for (let i = 0; i < 5; i++)
+      await seedLog({ source: "sms", status: "error", startedAt: ago(1) });
+    for (let i = 0; i < 5; i++)
+      await seedLog({ source: "sms", status: "inserted", startedAt: ago(1) });
+
+    const r = await sloParseSuccess(30, NOW);
+    expect(r.raw).toBeCloseTo(0.5, 5);
+    expect(r.status).toBe("red");
+  });
+
+  it("excludes ai-classify and debug-capture rows", async () => {
+    await seedLog({ source: "sms", status: "inserted", startedAt: ago(1) });
+    await seedLog({ source: "manual", status: "inserted", startedAt: ago(1), kind: "ai-classify" });
+    await seedLog({
+      source: "apple_pay",
+      status: "error",
+      startedAt: ago(1),
+      kind: "debug-capture",
+    });
+
+    const r = await sloParseSuccess(30, NOW);
+    expect(r.raw).toBe(1);
+  });
+
+  it("no-signal when window is empty", async () => {
+    const r = await sloParseSuccess(7, NOW);
+    expect(r.raw).toBeNull();
+    expect(r.status).toBe("no-signal");
+    expect(r.display).toBe("—");
+  });
+
+  it("trend has one point per day in the window", async () => {
+    await seedLog({ source: "sms", status: "inserted", startedAt: ago(1) });
+    const r = await sloParseSuccess(7, NOW);
+    expect(r.trend).toHaveLength(7);
+  });
+});
+
+describe("sloClassificationRate", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("green when (rule+ai)/total ≥ 90%", async () => {
+    const accountId = await seedAccount();
+    for (let i = 0; i < 9; i++) {
+      await seedTx({ accountId, source: "sms", classificationMethod: "rule", createdAt: ago(1) });
+    }
+    await seedTx({
+      accountId,
+      source: "sms",
+      classificationMethod: "unclassified",
+      createdAt: ago(1),
+    });
+
+    const r = await sloClassificationRate(30, NOW);
+    expect(r.raw).toBeCloseTo(0.9, 5);
+    expect(r.status).toBe("green");
+  });
+
+  it("counts ai as automated", async () => {
+    const accountId = await seedAccount();
+    await seedTx({ accountId, source: "sms", classificationMethod: "ai", createdAt: ago(1) });
+    await seedTx({ accountId, source: "sms", classificationMethod: "rule", createdAt: ago(1) });
+    await seedTx({
+      accountId,
+      source: "manual",
+      classificationMethod: "manual",
+      createdAt: ago(1),
+    });
+
+    const r = await sloClassificationRate(30, NOW);
+    expect(r.raw).toBeCloseTo(2 / 3, 5);
+  });
+
+  it("no-signal on empty window", async () => {
+    const r = await sloClassificationRate(7, NOW);
+    expect(r.raw).toBeNull();
+    expect(r.status).toBe("no-signal");
+  });
+});
+
+describe("sloDataLoss", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("green when zero unresolved errors", async () => {
+    const r = await sloDataLoss();
+    expect(r.raw).toBe(0);
+    expect(r.status).toBe("green");
+  });
+
+  it("yellow when 1-4 unresolved", async () => {
+    await seedLog({ source: "sms", status: "error", startedAt: ago(1) });
+    await seedLog({ source: "sms", status: "error", startedAt: ago(1) });
+
+    const r = await sloDataLoss();
+    expect(r.raw).toBe(2);
+    expect(r.status).toBe("yellow");
+  });
+
+  it("red when 5+ unresolved", async () => {
+    for (let i = 0; i < 5; i++) {
+      await seedLog({ source: "sms", status: "error", startedAt: ago(1) });
+    }
+    const r = await sloDataLoss();
+    expect(r.raw).toBe(5);
+    expect(r.status).toBe("red");
+  });
+
+  it("resolved errors don't count", async () => {
+    await seedLog({
+      source: "sms",
+      status: "error",
+      startedAt: ago(1),
+      resolvedAt: NOW,
+    });
+    const r = await sloDataLoss();
+    expect(r.raw).toBe(0);
+    expect(r.status).toBe("green");
+  });
+});
+
+describe("sloDetectionLag", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("green when no unresolved errors exist", async () => {
+    const r = await sloDetectionLag(30, NOW);
+    expect(r.raw).toBe(0);
+    expect(r.status).toBe("green");
+  });
+
+  it("green when oldest unresolved is <24h", async () => {
+    await seedLog({ source: "sms", status: "error", startedAt: ago(0, 2) }); // 2h ago
+    const r = await sloDetectionLag(30, NOW);
+    expect(r.raw).toBeGreaterThan(0);
+    expect(r.raw).toBeLessThan(24 * 3600);
+    expect(r.status).toBe("green");
+  });
+
+  it("red when oldest unresolved is >24h by margin", async () => {
+    await seedLog({ source: "sms", status: "error", startedAt: ago(3) }); // 3 days ago
+    const r = await sloDetectionLag(30, NOW);
+    expect(r.status).toBe("red");
+  });
+
+  it("only counts unresolved — resolved old errors don't drag the lag", async () => {
+    await seedLog({
+      source: "sms",
+      status: "error",
+      startedAt: ago(30),
+      resolvedAt: ago(29),
+    });
+    const r = await sloDetectionLag(30, NOW);
+    expect(r.raw).toBe(0);
+    expect(r.status).toBe("green");
+  });
+});
+
+describe("sloOnboardingTime + computeAllSlos", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("sloOnboardingTime returns no-signal when no users were created in the window", async () => {
+    // Bootstrap user id=1 was created long before; using a 7-day window it
+    // won't appear in the onboarding-time sample.
+    const r = await sloOnboardingTime(7, NOW);
+    expect(r.raw).toBeNull();
+    expect(r.status).toBe("no-signal");
+  });
+
+  it("computeAllSlos fans out and returns 6 results", async () => {
+    const results = await computeAllSlos(30, NOW);
+    expect(results).toHaveLength(6);
+    expect(results.map((r) => r.key).sort()).toEqual(
+      [
+        "classification_rate",
+        "data_loss",
+        "dedup_success",
+        "detection_lag",
+        "onboarding_time",
+        "parse_success",
+      ].sort(),
+    );
+  });
+});

--- a/src/lib/telemetry/slos.ts
+++ b/src/lib/telemetry/slos.ts
@@ -1,0 +1,404 @@
+import { and, eq, gte, isNull, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { ingestionLogs, transactions } from "@/lib/db/schema";
+
+// Bancolombia Parser SLOs (PLAN.md §"Bancolombia Parser SLOs"). System-wide
+// aggregates across all users — NOT per-user (that is /admin/health).
+//
+// These gate Phase 8 (second bank). "Bancolombia works well" must be
+// measurable, not aspirational.
+
+export type SloWindow = 7 | 30 | 90;
+
+export type SloKey =
+  | "parse_success"
+  | "classification_rate"
+  | "dedup_success"
+  | "onboarding_time"
+  | "data_loss"
+  | "detection_lag";
+
+export type SloStatus = "green" | "yellow" | "red" | "no-signal";
+
+export type SloResult = {
+  key: SloKey;
+  label: string;
+  description: string;
+  target: string;
+  /** Display-ready value, e.g. "97.3%" or "4m 12s" or "0". */
+  display: string;
+  /** Raw value; null = "no signal" (no data in window). */
+  raw: number | null;
+  status: SloStatus;
+  /** Optional link to drill into the failing events. */
+  drilldown?: string;
+  /** Daily trend points over the window; value=null when the day had no signal. */
+  trend: TrendPoint[];
+};
+
+export type TrendPoint = { date: string; value: number | null };
+
+const MS_PER_DAY = 86_400_000;
+
+function windowStart(windowDays: SloWindow, now: Date): Date {
+  return new Date(now.getTime() - windowDays * MS_PER_DAY);
+}
+
+function percent(n: number): string {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+function statusFor(raw: number | null, target: number, higherIsBetter: boolean): SloStatus {
+  if (raw === null) return "no-signal";
+  if (higherIsBetter) {
+    if (raw >= target) return "green";
+    if (raw >= target * 0.95) return "yellow";
+    return "red";
+  }
+  if (raw <= target) return "green";
+  if (raw <= target * 1.2) return "yellow";
+  return "red";
+}
+
+// ---------------------------------------------------------------------------
+// SLO #1 — SMS parse success rate (target ≥ 95%)
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregates across ALL users, filters out ai-classify + debug-capture rows
+ * (same semantics as `computeUserHealthSnapshot`). success = inserted|duplicated.
+ */
+export async function sloParseSuccess(
+  windowDays: SloWindow,
+  now: Date = new Date(),
+): Promise<SloResult> {
+  const start = windowStart(windowDays, now);
+
+  const [row] = await db
+    .select({
+      success: sql<number>`count(*) FILTER (WHERE ${ingestionLogs.status} IN ('inserted', 'duplicated'))::int`,
+      total: sql<number>`count(*)::int`,
+    })
+    .from(ingestionLogs)
+    .where(
+      and(
+        gte(ingestionLogs.startedAt, start),
+        sql`(${ingestionLogs.payload} ->> 'kind') NOT IN ('ai-classify', 'debug-capture') OR (${ingestionLogs.payload} ->> 'kind') IS NULL`,
+      ),
+    );
+
+  const raw = row.total === 0 ? null : row.success / row.total;
+  const trend = await dailyParseSuccessTrend(windowDays, now);
+
+  return {
+    key: "parse_success",
+    label: "SMS parse success",
+    description:
+      "Ingests terminados sin error (inserted o duplicated) / total. Excluye ai-classify y debug.",
+    target: "≥ 95%",
+    display: raw === null ? "—" : percent(raw),
+    raw,
+    status: statusFor(raw, 0.95, true),
+    drilldown: "/settings/inbox",
+    trend,
+  };
+}
+
+async function dailyParseSuccessTrend(windowDays: SloWindow, now: Date): Promise<TrendPoint[]> {
+  const start = windowStart(windowDays, now);
+  const rows = await db
+    .select({
+      day: sql<string>`to_char(date_trunc('day', ${ingestionLogs.startedAt} AT TIME ZONE 'America/Bogota'), 'YYYY-MM-DD')`,
+      success: sql<number>`count(*) FILTER (WHERE ${ingestionLogs.status} IN ('inserted', 'duplicated'))::int`,
+      total: sql<number>`count(*)::int`,
+    })
+    .from(ingestionLogs)
+    .where(
+      and(
+        gte(ingestionLogs.startedAt, start),
+        sql`(${ingestionLogs.payload} ->> 'kind') NOT IN ('ai-classify', 'debug-capture') OR (${ingestionLogs.payload} ->> 'kind') IS NULL`,
+      ),
+    )
+    .groupBy(sql`1`)
+    .orderBy(sql`1`);
+
+  return fillDailyTrend(
+    rows.map((r) => ({ date: r.day, value: r.total === 0 ? null : r.success / r.total })),
+    windowDays,
+    now,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SLO #2 — Classification rate (rule + ai) / total (target ≥ 90%)
+// ---------------------------------------------------------------------------
+
+export async function sloClassificationRate(
+  windowDays: SloWindow,
+  now: Date = new Date(),
+): Promise<SloResult> {
+  const start = windowStart(windowDays, now);
+
+  const [row] = await db
+    .select({
+      auto: sql<number>`count(*) FILTER (WHERE ${transactions.classificationMethod} IN ('rule', 'ai'))::int`,
+      total: sql<number>`count(*)::int`,
+    })
+    .from(transactions)
+    .where(gte(transactions.createdAt, start));
+
+  const raw = row.total === 0 ? null : row.auto / row.total;
+
+  const trendRows = await db
+    .select({
+      day: sql<string>`to_char(date_trunc('day', ${transactions.createdAt} AT TIME ZONE 'America/Bogota'), 'YYYY-MM-DD')`,
+      auto: sql<number>`count(*) FILTER (WHERE ${transactions.classificationMethod} IN ('rule', 'ai'))::int`,
+      total: sql<number>`count(*)::int`,
+    })
+    .from(transactions)
+    .where(gte(transactions.createdAt, start))
+    .groupBy(sql`1`)
+    .orderBy(sql`1`);
+
+  const trend = fillDailyTrend(
+    trendRows.map((r) => ({ date: r.day, value: r.total === 0 ? null : r.auto / r.total })),
+    windowDays,
+    now,
+  );
+
+  return {
+    key: "classification_rate",
+    label: "Clasificación automática",
+    description:
+      "Transacciones categorizadas por regla o AI / total. Excluye manual y unclassified.",
+    target: "≥ 90%",
+    display: raw === null ? "—" : percent(raw),
+    raw,
+    status: statusFor(raw, 0.9, true),
+    trend,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SLO #3 — Dedup success (target ≥ 98%)
+//
+// MVP: we have no ground truth for "silent wrong dedup" until Epic R ships
+// bank-statement reconciliation. Report duplicate-rejection count as a leading
+// indicator with status='no-signal' so the dashboard shows "not yet measurable"
+// instead of faking a number.
+// ---------------------------------------------------------------------------
+
+export async function sloDedupSuccess(
+  windowDays: SloWindow,
+  now: Date = new Date(),
+): Promise<SloResult> {
+  const start = windowStart(windowDays, now);
+
+  const [row] = await db
+    .select({
+      duplicated: sql<number>`count(*) FILTER (WHERE ${ingestionLogs.status} = 'duplicated')::int`,
+      total: sql<number>`count(*)::int`,
+    })
+    .from(ingestionLogs)
+    .where(
+      and(
+        gte(ingestionLogs.startedAt, start),
+        sql`(${ingestionLogs.payload} ->> 'kind') NOT IN ('ai-classify', 'debug-capture') OR (${ingestionLogs.payload} ->> 'kind') IS NULL`,
+      ),
+    );
+
+  return {
+    key: "dedup_success",
+    label: "Dedup correctness",
+    description:
+      "Requiere ground truth de extractos bancarios (Epic R) para medir correctness real. Por ahora: duplicate-rejection count como leading indicator.",
+    target: "≥ 98%",
+    display: `${row.duplicated} rejected / ${row.total}`,
+    raw: null,
+    status: "no-signal",
+    trend: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SLO #4 — Onboarding completion time (signup → first txn, target ≤ 5 min)
+// ---------------------------------------------------------------------------
+
+export async function sloOnboardingTime(
+  windowDays: SloWindow,
+  now: Date = new Date(),
+): Promise<SloResult> {
+  const start = windowStart(windowDays, now);
+
+  const rows = await db.execute<{ seconds: string | null }>(sql`
+    SELECT EXTRACT(EPOCH FROM (first_tx.first_at - u.created_at))::text AS seconds
+    FROM users u
+    JOIN LATERAL (
+      SELECT min(t.created_at) AS first_at
+      FROM transactions t
+      WHERE t.user_id = u.id
+    ) first_tx ON TRUE
+    WHERE u.created_at >= ${start.toISOString()}::timestamptz
+      AND first_tx.first_at IS NOT NULL
+      AND first_tx.first_at >= u.created_at
+  `);
+
+  const seconds = rows
+    .map((r) => (r.seconds === null ? null : Number(r.seconds)))
+    .filter((s): s is number => s !== null && Number.isFinite(s));
+
+  if (seconds.length === 0) {
+    return {
+      key: "onboarding_time",
+      label: "Tiempo de onboarding",
+      description:
+        "Mediana signup → primer transaction creada. Ventana: users creados en el rango.",
+      target: "≤ 5 min",
+      display: "—",
+      raw: null,
+      status: "no-signal",
+      trend: [],
+    };
+  }
+
+  seconds.sort((a, b) => a - b);
+  const median = seconds[Math.floor(seconds.length / 2)];
+
+  return {
+    key: "onboarding_time",
+    label: "Tiempo de onboarding (p50)",
+    description: `Mediana signup → primer transaction creada. N=${seconds.length} users en la ventana.`,
+    target: "≤ 5 min",
+    display: formatSeconds(median),
+    raw: median,
+    status: statusFor(median, 300, false),
+    trend: [],
+  };
+}
+
+function formatSeconds(s: number): string {
+  if (s < 60) return `${s.toFixed(0)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s - m * 60);
+  if (m < 60) return `${m}m ${rem}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+// ---------------------------------------------------------------------------
+// SLO #5 — Data loss incidents per user/month (target = 0)
+//
+// Measured as: unresolved error logs. After #261 (Ingestion Inbox) landed,
+// any errored ingest has a resolve/dismiss path. An unresolved error is a
+// data-loss incident until the user acts.
+// ---------------------------------------------------------------------------
+
+export async function sloDataLoss(): Promise<SloResult> {
+  const [row] = await db
+    .select({
+      unresolved: sql<number>`count(*)::int`,
+      affectedUsers: sql<number>`count(DISTINCT ${ingestionLogs.userId})::int`,
+    })
+    .from(ingestionLogs)
+    .where(and(eq(ingestionLogs.status, "error"), isNull(ingestionLogs.resolvedAt)));
+
+  return {
+    key: "data_loss",
+    label: "Data loss pendiente",
+    description:
+      "Logs de ingesta en error sin resolver (retry/dismiss). Cada uno es un ingest que no creó tx.",
+    target: "= 0",
+    display: `${row.unresolved} en ${row.affectedUsers} user${row.affectedUsers === 1 ? "" : "s"}`,
+    raw: row.unresolved,
+    status: row.unresolved === 0 ? "green" : row.unresolved < 5 ? "yellow" : "red",
+    drilldown: "/settings/inbox",
+    trend: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SLO #6 — Time-to-detect parser break (target ≤ 24h)
+//
+// MVP: age of the oldest unresolved error log. If any error has been unresolved
+// for >24h, we've failed to detect. When alerting lands, this becomes lag from
+// drop to operator ack.
+// ---------------------------------------------------------------------------
+
+export async function sloDetectionLag(
+  _windowDays: SloWindow,
+  now: Date = new Date(),
+): Promise<SloResult> {
+  const [row] = await db
+    .select({
+      oldest: sql<string | null>`min(${ingestionLogs.startedAt})`,
+    })
+    .from(ingestionLogs)
+    .where(and(eq(ingestionLogs.status, "error"), isNull(ingestionLogs.resolvedAt)));
+
+  if (!row.oldest) {
+    return {
+      key: "detection_lag",
+      label: "Detection lag",
+      description: "Edad del error más viejo sin resolver. Si supera 24h, no detectamos a tiempo.",
+      target: "≤ 24h",
+      display: "0 (sin errores pendientes)",
+      raw: 0,
+      status: "green",
+      trend: [],
+    };
+  }
+
+  const oldestDate = new Date(row.oldest);
+  const ageSeconds = (now.getTime() - oldestDate.getTime()) / 1000;
+
+  return {
+    key: "detection_lag",
+    label: "Detection lag",
+    description: "Edad del error más viejo sin resolver. Si supera 24h, no detectamos a tiempo.",
+    target: "≤ 24h",
+    display: formatSeconds(ageSeconds),
+    raw: ageSeconds,
+    status: statusFor(ageSeconds, 24 * 3600, false),
+    drilldown: "/settings/inbox",
+    trend: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration — fetch all 6 in parallel
+// ---------------------------------------------------------------------------
+
+export async function computeAllSlos(
+  windowDays: SloWindow,
+  now: Date = new Date(),
+): Promise<SloResult[]> {
+  return Promise.all([
+    sloParseSuccess(windowDays, now),
+    sloClassificationRate(windowDays, now),
+    sloDedupSuccess(windowDays, now),
+    sloOnboardingTime(windowDays, now),
+    sloDataLoss(),
+    sloDetectionLag(windowDays, now),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Pads a day-keyed trend series to include every day in the window, so the
+ * sparkline has stable width regardless of data density.
+ */
+function fillDailyTrend(points: TrendPoint[], windowDays: SloWindow, now: Date): TrendPoint[] {
+  const map = new Map(points.map((p) => [p.date, p.value]));
+  const out: TrendPoint[] = [];
+  for (let i = windowDays - 1; i >= 0; i--) {
+    const d = new Date(now.getTime() - i * MS_PER_DAY);
+    // YYYY-MM-DD in the Bogota offset used by the SQL. For sparkline alignment
+    // the exact TZ is low-stakes — what matters is density + order.
+    const key = d.toISOString().slice(0, 10);
+    out.push({ date: key, value: map.has(key) ? (map.get(key) ?? null) : null });
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Exposes the 6 Bancolombia Parser SLOs from PLAN.md as a live operator dashboard at `/admin/slos`. System-wide aggregates, not per-user. **These gate Phase 8** (second bank) — without green sustained, we don't add more complexity.

### Design choice: no `parser_events` table

The issue suggested a new `parser_events` append-only table. I pushed back (and the user agreed): `ingestion_logs` + `transactions` + `users` already hold every signal needed, and after #261 landed we have a measurable "data loss = 0" surface via the inbox. Adding `parser_events` would duplicate data without new capability.

### What the 6 SLOs measure

| SLO | Source | MVP notes |
|-----|--------|-----------|
| #1 Parse success ≥ 95% | `ingestion_logs` `inserted/duplicated` vs total | Excludes `ai-classify` + `debug-capture` payload kinds |
| #2 Classification ≥ 90% | `transactions.classification_method` in `(rule, ai)` | |
| #3 Dedup ≥ 98% | — | no-signal until Epic R ground truth; displays duplicate-rejection count as leading indicator |
| #4 Onboarding ≤ 5 min | `users.created_at` → first `transactions.created_at` | Median (p50) across users created in window |
| #5 Data loss = 0 | Unresolved error logs (`resolved_at IS NULL`) | Direct reuse of #261 inbox surface |
| #6 Detection lag ≤ 24h | Age of oldest unresolved error | Becomes "alert-to-ack" lag when alerting lands |

### Dashboard features

- Window selector (7d / 30d / 90d) via `?window=N` searchParam.
- 4 status levels: green / yellow / red / no-signal, color-coded cards.
- Per-metric sparkline (SVG, no deps) for #1 and #2; handles null gaps.
- Drill-down link to `/settings/inbox` for #1, #5, #6 (data loss surfaces).

### Deferred (follow-up issues)
- Alerting (48h-sustained threshold → email/Telegram to operator).
- Dedup ground truth (gated on Epic R — #253).
- Per-SLO sparkline for #5/#6 (needs snapshot infra or live aggregation).

## Test plan
- [x] `bun run typecheck` green
- [x] `bun run lint` green
- [x] `bun run format:check` green
- [x] `bun run test` — 39 files / 401 tests green (18 new SLO tests)
- [ ] Manual smoke: `/admin/slos` renders with bootstrap data; window switcher works; sparklines draw.

Closes #249