### PR TITLE
feat(ui): polish iOS Shortcut onboarding — gotcha banner + troubleshooting + video slot (#250)

### DIFF
--- a/src/app/(app)/settings/webhooks/ios-gotcha-banner.tsx
+++ b/src/app/(app)/settings/webhooks/ios-gotcha-banner.tsx
@@ -1,0 +1,49 @@
+import { AlertTriangleIcon } from "lucide-react";
+
+const RULES = [
+  {
+    icon: "❌",
+    title: "No guardes “Bancolombia” como contacto",
+    why: "iOS ignora los SMS de contactos en el trigger de automation — perdés la captura.",
+  },
+  {
+    icon: "❌",
+    title: "No respondas los SMS del banco",
+    why: "Abrir o responder el hilo rompe el patrón de Apple para captura nativa (relevante para la app iOS futura).",
+  },
+  {
+    icon: "✅",
+    title: "Dejá “Run Immediately” activado",
+    why: "Sin esto, iOS pide confirmación cada vez que llega un SMS y la captura falla en la práctica.",
+  },
+];
+
+export function IosGotchaBanner() {
+  return (
+    <aside
+      role="note"
+      aria-label="Atajos de iOS — reglas importantes"
+      className="flex flex-col gap-3 rounded-lg border border-amber-300 bg-amber-50/60 p-4 dark:border-amber-900/40 dark:bg-amber-950/20"
+    >
+      <header className="flex items-center gap-2">
+        <AlertTriangleIcon className="size-4 text-amber-700 dark:text-amber-300" />
+        <h2 className="text-sm font-semibold tracking-tight text-amber-900 dark:text-amber-100">
+          Antes de configurar — 3 reglas que no podés olvidar
+        </h2>
+      </header>
+      <ul className="flex flex-col gap-2 text-sm">
+        {RULES.map((r) => (
+          <li key={r.title} className="flex gap-2">
+            <span aria-hidden className="shrink-0 select-none">
+              {r.icon}
+            </span>
+            <div className="flex flex-col">
+              <span className="font-medium text-amber-900 dark:text-amber-100">{r.title}</span>
+              <span className="text-xs text-amber-900/70 dark:text-amber-100/70">{r.why}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/src/app/(app)/settings/webhooks/ios-troubleshooting.tsx
+++ b/src/app/(app)/settings/webhooks/ios-troubleshooting.tsx
@@ -1,0 +1,81 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type Entry = {
+  symptom: string;
+  checklist: string[];
+  note?: string;
+};
+
+const ENTRIES: Entry[] = [
+  {
+    symptom: "No estoy recibiendo transacciones",
+    checklist: [
+      "¿La Shortcut está instalada? Shortcuts app → debería aparecer “Findash SMS Prod”.",
+      "¿La automatización está habilitada? Shortcuts app → Automation → tu atajo → verificá el toggle.",
+      "¿Tocaste “Run Immediately”? Si pide confirmación cada vez, está en manual.",
+      "¿Tenés “Bancolombia” como contacto? iOS filtra SMS de contactos — sacá ese contacto.",
+      "¿Tu token sigue activo? Revisá la lista de tokens arriba — si lo revocaste, mintá uno nuevo y reemplazá en el Shortcut.",
+    ],
+    note: "Si el checklist pasa completo y seguís sin captura, mirá `/settings/inbox` — un SMS que llegó sin cuenta asociada aparece ahí como error.",
+  },
+  {
+    symptom: "La automatización me pide confirmación cada vez",
+    checklist: [
+      "Shortcuts app → Automation → abrí tu atajo.",
+      "En la configuración de la automatización, activá Run Immediately.",
+      "Guardá. Desde el próximo SMS, corre sin pedir tap.",
+    ],
+    note: "En iOS 17+ puede requerir también “Notify When Run” = OFF para evitar banners de notificación ruidosos.",
+  },
+  {
+    symptom: "Recibo transacciones duplicadas",
+    checklist: [
+      "¿Tenés Shortcut Dev y Prod activos al mismo tiempo? Desactivá Dev en producción.",
+      "¿Instalaste la Shortcut dos veces? Borrá la vieja desde Shortcuts app.",
+      "Si el SMS llegó dos veces real (iMessage + SMS), el pipeline de dedup debería rechazarlo como “duplicated” — mirá en `/settings/inbox` si hay errores.",
+    ],
+    note: "Findash usa `externalId` determinístico (kind + monto + fecha + cuenta) para dedup. Si el duplicado persiste, reportalo como bug con el raw SMS.",
+  },
+  {
+    symptom: "El Shortcut falla con 401 / 403",
+    checklist: [
+      "El token venció o fue revocado. Mintá un nuevo token SMS arriba.",
+      "Copiá el plaintext (solo se muestra una vez).",
+      "Editá el Shortcut → Get Contents of URL → reemplazá `PASTE-TOKEN` con el nuevo.",
+    ],
+  },
+];
+
+export function IosTroubleshooting() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Troubleshooting</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {ENTRIES.map((e) => (
+          <details
+            key={e.symptom}
+            className="border-border bg-muted/20 hover:bg-muted/30 group open:bg-muted/40 rounded-md border p-3"
+          >
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-2 text-sm font-medium">
+              <span>{e.symptom}</span>
+              <span
+                aria-hidden
+                className="text-muted-foreground text-xs transition-transform group-open:rotate-90"
+              >
+                ›
+              </span>
+            </summary>
+            <ol className="text-body mt-3 list-decimal space-y-1 pl-5">
+              {e.checklist.map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ol>
+            {e.note ? <p className="text-muted-foreground mt-2 text-xs italic">{e.note}</p> : null}
+          </details>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(app)/settings/webhooks/ios-video-demo.tsx
+++ b/src/app/(app)/settings/webhooks/ios-video-demo.tsx
@@ -1,0 +1,48 @@
+import { PlayCircleIcon } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * Renders the embedded onboarding walkthrough. Pass `videoUrl=null` to show a
+ * styled placeholder until the recording is dropped into /public/ios-shortcut/.
+ * Kept as a pure presentational component so the page decides whether the
+ * asset exists (server-side `existsSync` check in the page).
+ */
+export function IosVideoDemo({
+  videoUrl,
+  posterUrl,
+}: {
+  videoUrl: string | null;
+  posterUrl?: string;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Video demo — setup en 45 segundos</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {videoUrl ? (
+          <video
+            src={videoUrl}
+            poster={posterUrl}
+            controls
+            playsInline
+            preload="metadata"
+            className="border-border w-full rounded-md border"
+          >
+            Tu navegador no soporta video embebido. Usá el link directo:{" "}
+            <a href={videoUrl}>{videoUrl}</a>.
+          </video>
+        ) : (
+          <div className="border-border/60 bg-muted/40 flex aspect-video w-full flex-col items-center justify-center gap-2 rounded-md border border-dashed text-center">
+            <PlayCircleIcon className="text-muted-foreground size-10" />
+            <p className="text-muted-foreground text-sm font-medium">Video demo en producción</p>
+            <p className="text-muted-foreground max-w-sm text-xs">
+              Mientras tanto, seguí los pasos escritos abajo. Los screenshots cubren los 4 pasos
+              críticos.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(app)/settings/webhooks/page.tsx
+++ b/src/app/(app)/settings/webhooks/page.tsx
@@ -1,13 +1,30 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { getSessionUser } from "@/lib/auth/session";
 import { listWebhookTokensForUser } from "@/lib/webhook-tokens";
+import { IosGotchaBanner } from "./ios-gotcha-banner";
 import { IosShortcutCard } from "./ios-shortcut-card";
+import { IosTroubleshooting } from "./ios-troubleshooting";
+import { IosVideoDemo } from "./ios-video-demo";
 import { WebhookTokensManager } from "./webhook-tokens-manager";
 
 export const dynamic = "force-dynamic";
 
+// Pulled from disk once per render — if the file lands later, no code change
+// needed to light up the embedded player.
+const VIDEO_FILE = "ios-shortcut/onboarding.mp4";
+const POSTER_FILE = "ios-shortcut/onboarding-poster.jpg";
+
+function publicAssetUrl(relative: string): string | null {
+  const abs = join(process.cwd(), "public", relative);
+  return existsSync(abs) ? `/${relative}` : null;
+}
+
 export default async function WebhooksPage() {
   const session = await getSessionUser();
   const tokens = await listWebhookTokensForUser(session.id);
+  const videoUrl = publicAssetUrl(VIDEO_FILE);
+  const posterUrl = publicAssetUrl(POSTER_FILE) ?? undefined;
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
@@ -21,6 +38,7 @@ export default async function WebhooksPage() {
           <strong>once</strong> at mint time — store it before leaving the page.
         </p>
       </header>
+      <IosGotchaBanner />
       <WebhookTokensManager
         tokens={tokens.map((t) => ({
           id: t.id,
@@ -31,7 +49,9 @@ export default async function WebhooksPage() {
           revokedAt: t.revokedAt ? t.revokedAt.toISOString() : null,
         }))}
       />
+      <IosVideoDemo videoUrl={videoUrl} posterUrl={posterUrl} />
       <IosShortcutCard />
+      <IosTroubleshooting />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Reduces beta onboarding dropout on `/settings/webhooks`. Adds 3 polish sections:

1. **Gotcha banner** (top of page, amber callout) — the 3 rules that cause silent capture failure: don't save Bancolombia as contact, don't reply to the thread, keep Run Immediately on. Same rules apply to the future iOS native app (per PLAN.md §"iOS SMS capture findings").

2. **Video demo slot** — `<video>` renders when `/public/ios-shortcut/onboarding.mp4` is present, styled placeholder otherwise. Server-side `existsSync` check lights it up automatically once the recording lands — no code change needed. Recording itself is a user-TODO (can't be done from the agent).

3. **Troubleshooting accordion** — 4 symptoms with actionable checklists:
   - No estoy recibiendo transacciones → 5-point checklist + drill-down to `/settings/inbox` for silent errors
   - La automatización pide confirmación cada vez → Run Immediately fix
   - Recibo duplicados → Dev vs Prod double-install + dedup pipeline explanation
   - 401/403 → token rotation workflow

## Files
- `src/app/(app)/settings/webhooks/ios-gotcha-banner.tsx` (new)
- `src/app/(app)/settings/webhooks/ios-troubleshooting.tsx` (new)
- `src/app/(app)/settings/webhooks/ios-video-demo.tsx` (new)
- `src/app/(app)/settings/webhooks/page.tsx` — composes them + `existsSync` for video

## Test plan
- [x] `bun run typecheck` green
- [x] `bun run lint` green
- [x] `bun run format:check` green
- [x] `bun run test` — 39 files / 401 tests green (no new tests — UI copy + structure)
- [ ] Manual: `/settings/webhooks` renders gotcha banner, placeholder video card, troubleshooting accordion on desktop + mobile

## Follow-up
- User records 30–45s walkthrough video and drops it at `public/ios-shortcut/onboarding.mp4` (plus optional `onboarding-poster.jpg`). The page picks it up automatically on next render.

Closes #250