### PR TITLE
feat(api): canIngest(userId) seam in ingest routes (#247)

### DIFF
--- a/src/app/api/ingest/ocr/route.ts
+++ b/src/app/api/ingest/ocr/route.ts
@@ -1,10 +1,20 @@
 import { NextResponse } from "next/server";
 import { previewScreenshotOcr } from "@/app/(app)/settings/import/actions";
+import { canIngest, paywallResponse } from "@/lib/auth/can-ingest";
+import { getSessionUserOrNull } from "@/lib/auth/session";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
+  const session = await getSessionUserOrNull();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const gate = await canIngest(session.id);
+  if (!gate.allowed) return paywallResponse(gate.reason);
+
   const contentType = req.headers.get("content-type") ?? "";
   if (!contentType.includes("multipart/form-data")) {
     return NextResponse.json(

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { canIngest, paywallResponse } from "@/lib/auth/can-ingest";
 import { db } from "@/lib/db";
 import { ingestionLogs } from "@/lib/db/schema";
 import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
@@ -20,6 +21,9 @@ export async function POST(req: Request) {
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const gate = await canIngest(auth.userId);
+  if (!gate.allowed) return paywallResponse(gate.reason);
 
   const rawBody = await req.text();
   if (rawBody.length > MAX_BODY_BYTES) {

--- a/src/app/api/telegram/webhook/[botId]/route.ts
+++ b/src/app/api/telegram/webhook/[botId]/route.ts
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from "node:crypto";
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
+import { canIngest, paywallResponse } from "@/lib/auth/can-ingest";
 import { db } from "@/lib/db";
 import { telegramBots } from "@/lib/db/schema";
 import { decrypt } from "@/lib/crypto/symmetric";
@@ -42,6 +43,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ botId: 
   if (!provided || !constantTimeEquals(provided, bot.webhookSecret)) {
     return unauthorized();
   }
+
+  const gate = await canIngest(bot.userId);
+  if (!gate.allowed) return paywallResponse(gate.reason);
 
   let update: TelegramUpdate;
   try {

--- a/src/lib/auth/can-ingest.test.ts
+++ b/src/lib/auth/can-ingest.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { canIngest, paywallResponse } from "./can-ingest";
+
+describe("canIngest", () => {
+  it("allows in v1 (no-op seam) — any userId returns allowed: true", async () => {
+    await expect(canIngest(1)).resolves.toEqual({ allowed: true });
+    await expect(canIngest(999)).resolves.toEqual({ allowed: true });
+  });
+});
+
+describe("paywallResponse", () => {
+  it("returns HTTP 402 with { ok: false, status: 'paywall', reason }", async () => {
+    const res = paywallResponse("subscription_past_due");
+    expect(res.status).toBe(402);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      status: "paywall",
+      reason: "subscription_past_due",
+    });
+  });
+});

--- a/src/lib/auth/can-ingest.ts
+++ b/src/lib/auth/can-ingest.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export type CanIngestResult = { allowed: true } | { allowed: false; reason: string };
+
+// Phase 7 (SaaS productization) seam. v1 is a no-op — every ingest is allowed.
+// When Phase 7 flips, this reads users.subscription_status / trial_ends_at and
+// denies when the subscription is past_due or canceled past grace period.
+// See PLAN.md § Business Model & Pricing (Deferred) and issue #247.
+export async function canIngest(_userId: number): Promise<CanIngestResult> {
+  return { allowed: true };
+}
+
+export function paywallResponse(reason: string) {
+  return NextResponse.json({ ok: false, status: "paywall", reason }, { status: 402 });
+}


### PR DESCRIPTION
## Summary

Adds the Phase 7 soft-paywall seam. `canIngest(userId)` in `src/lib/auth/can-ingest.ts` is a no-op today (always returns `{ allowed: true }`). When Phase 7 flips, the implementation will read the columns added in #246 and deny when subscription is past_due / canceled.

Wired into every ingestion surface we have today:

- `/api/ingest/sms` — right after `resolveWebhookAuth`
- `/api/ingest/ocr` — after resolving the session user (this route had no user check at the route level; it now returns 401 for anonymous callers instead of a leaky 400 from the action — tight coupling with the action's own `getSessionUser` retained as defense-in-depth)
- `/api/telegram/webhook/[botId]` — after verifying the Telegram bot secret

Denied path returns HTTP 402 with `{ ok: false, status: "paywall", reason }` via the shared `paywallResponse()` helper.

Apple Pay route doesn't exist yet — listed in the issue as "when added". Will be wired in the same pattern when the endpoint lands.

## Test plan

- [x] `src/lib/auth/can-ingest.test.ts` — unit test for the allow path + paywallResponse shape (402, `{ ok: false, status: "paywall", reason }`)
- [x] Manual paywall shape verified via the `paywallResponse` unit test — wiring in each route is a single identical line `if (!gate.allowed) return paywallResponse(gate.reason)`
- [x] `bun run lint` green
- [x] `tsc --noEmit` green
- [x] `bun run test` green — 40 files / 409 tests (+2 new)

## Phase 7 follow-ups (not in this PR)

- Implement the denial branch (read `users.subscription_status`, `trial_ends_at` — columns added in #246)
- Telegram webhook denial: today 402 means Telegram retries forever. Phase 7 will decide between a bot message + 200 vs. 402 with a tight retry cap
- Wire `/api/ingest/apple-pay` once that endpoint exists

Closes #247