### PR TITLE
feat(observability): AI canary for SMS parser drift detection (#258)

### DIFF
--- a/drizzle/0027_happy_tomas.sql
+++ b/drizzle/0027_happy_tomas.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "canary_alerts" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"fired_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"resolved_at" timestamp with time zone,
+	"rate" numeric(5, 4) NOT NULL,
+	"samples" integer NOT NULL,
+	"top_divergences" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"notification_status" varchar(40) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "parser_canary_events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer,
+	"sms_body_hash" varchar(64) NOT NULL,
+	"sender" varchar(100),
+	"regex_result" jsonb NOT NULL,
+	"ai_result" jsonb NOT NULL,
+	"agreement" boolean NOT NULL,
+	"divergence_fields" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"ai_model" varchar(50) NOT NULL,
+	"ai_input_tokens" integer DEFAULT 0 NOT NULL,
+	"ai_output_tokens" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "parser_canary_events" ADD CONSTRAINT "parser_canary_events_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "canary_alerts_unresolved_idx" ON "canary_alerts" USING btree ("fired_at") WHERE "canary_alerts"."resolved_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "parser_canary_events_created_idx" ON "parser_canary_events" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "parser_canary_events_disagree_idx" ON "parser_canary_events" USING btree ("created_at") WHERE "parser_canary_events"."agreement" = false;

--- a/drizzle/meta/0027_snapshot.json
+++ b/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,3065 @@
+{
+  "id": "9475aafd-a2e7-4e61-a3d3-4b5daa15ed7f",
+  "prevId": "5a23a472-c8d8-4dc5-b066-c34cb86e09c4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "ai",
+        "manual",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1776632846337,
       "tag": "0026_many_daredevil",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1776633826377,
+      "tag": "0027_happy_tomas",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/admin/slos/canary/page.tsx
+++ b/src/app/(app)/admin/slos/canary/page.tsx
@@ -1,0 +1,187 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { desc, eq } from "drizzle-orm";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { db } from "@/lib/db";
+import { canaryAlerts, parserCanaryEvents, type CanaryProjection } from "@/lib/db/schema";
+import { getSessionUser } from "@/lib/auth/session";
+
+export const dynamic = "force-dynamic";
+
+const FIELD_LABELS: Record<keyof CanaryProjection, string> = {
+  amountCents: "Monto (cents)",
+  currency: "Moneda",
+  merchant: "Merchant",
+  occurredOn: "Fecha",
+};
+
+export default async function CanaryDrilldownPage() {
+  const session = await getSessionUser();
+  if (session.role !== "admin") notFound();
+
+  const [disagrees, alerts] = await Promise.all([
+    db
+      .select({
+        id: parserCanaryEvents.id,
+        createdAt: parserCanaryEvents.createdAt,
+        sender: parserCanaryEvents.sender,
+        smsBodyHash: parserCanaryEvents.smsBodyHash,
+        regexResult: parserCanaryEvents.regexResult,
+        aiResult: parserCanaryEvents.aiResult,
+        divergenceFields: parserCanaryEvents.divergenceFields,
+        aiModel: parserCanaryEvents.aiModel,
+      })
+      .from(parserCanaryEvents)
+      .where(eq(parserCanaryEvents.agreement, false))
+      .orderBy(desc(parserCanaryEvents.createdAt))
+      .limit(25),
+    db.select().from(canaryAlerts).orderBy(desc(canaryAlerts.firedAt)).limit(10),
+  ]);
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 sm:p-6">
+      <header className="flex flex-col gap-1">
+        <Link href="/admin/slos" className="text-muted-foreground text-xs hover:underline">
+          ← Volver a SLOs
+        </Link>
+        <h1 className="text-h1">AI Canary — eventos recientes</h1>
+        <p className="text-body text-muted-foreground">
+          Eventos donde regex y Haiku discrepan. Solo guardamos hash del SMS — los projections son
+          el debugging feedback.
+        </p>
+      </header>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-h2">Últimos disagree ({disagrees.length})</h2>
+        {disagrees.length === 0 ? (
+          <p className="text-muted-foreground text-sm italic">
+            No hay disagreements registrados todavía.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {disagrees.map((ev) => (
+              <DisagreeCard key={ev.id} event={ev} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-h2">Historial de alertas</h2>
+        {alerts.length === 0 ? (
+          <p className="text-muted-foreground text-sm italic">Ninguna alerta disparada todavía.</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {alerts.map((a) => (
+              <div
+                key={a.id}
+                className="border-border flex items-center justify-between rounded border px-3 py-2 text-xs"
+              >
+                <div className="flex flex-col">
+                  <span className="font-medium">
+                    {a.firedAt.toISOString()} · rate {(Number(a.rate) * 100).toFixed(1)}% ·{" "}
+                    {a.samples} samples
+                  </span>
+                  <span className="text-muted-foreground">
+                    notification: {a.notificationStatus}
+                  </span>
+                </div>
+                <span
+                  className={
+                    a.resolvedAt
+                      ? "text-emerald-700 dark:text-emerald-400"
+                      : "text-red-700 dark:text-red-400"
+                  }
+                >
+                  {a.resolvedAt ? `resolved ${a.resolvedAt.toISOString()}` : "active"}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function DisagreeCard({
+  event,
+}: {
+  event: {
+    id: number;
+    createdAt: Date;
+    sender: string | null;
+    smsBodyHash: string;
+    regexResult: CanaryProjection;
+    aiResult: CanaryProjection;
+    divergenceFields: string[];
+    aiModel: string;
+  };
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <CardTitle className="text-sm">
+            {event.createdAt.toISOString()} · {event.sender ?? "sender desconocido"}
+          </CardTitle>
+          <span className="text-muted-foreground text-[10px] tabular-nums">
+            hash: {event.smsBodyHash.slice(0, 12)}… · {event.aiModel}
+          </span>
+        </div>
+        <div className="flex flex-wrap gap-1.5 pt-1">
+          {event.divergenceFields.map((f) => (
+            <span
+              key={f}
+              className="inline-flex items-center rounded bg-red-100 px-2 py-0.5 text-[10px] font-medium text-red-900 dark:bg-red-900/30 dark:text-red-200"
+            >
+              {FIELD_LABELS[f as keyof CanaryProjection] ?? f}
+            </span>
+          ))}
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <div className="flex flex-col gap-1">
+            <span className="text-muted-foreground text-[10px] tracking-wide uppercase">Regex</span>
+            <ProjectionTable projection={event.regexResult} divergence={event.divergenceFields} />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-muted-foreground text-[10px] tracking-wide uppercase">Haiku</span>
+            <ProjectionTable projection={event.aiResult} divergence={event.divergenceFields} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ProjectionTable({
+  projection,
+  divergence,
+}: {
+  projection: CanaryProjection;
+  divergence: string[];
+}) {
+  const fields = Object.keys(FIELD_LABELS) as (keyof CanaryProjection)[];
+  const div = new Set(divergence);
+  return (
+    <div className="border-border rounded border text-xs">
+      {fields.map((f, i) => (
+        <div
+          key={f}
+          className={
+            "flex items-baseline justify-between gap-2 px-2 py-1.5 " +
+            (i > 0 ? "border-border border-t " : "") +
+            (div.has(f) ? "bg-red-50/60 dark:bg-red-950/20" : "")
+          }
+        >
+          <span className="text-muted-foreground">{FIELD_LABELS[f]}</span>
+          <span className="max-w-[60%] truncate text-right tabular-nums">
+            {projection[f] ?? "—"}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(app)/admin/slos/page.tsx
+++ b/src/app/(app)/admin/slos/page.tsx
@@ -3,6 +3,12 @@ import { notFound } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { getSessionUser } from "@/lib/auth/session";
 import {
+  CANARY_AGREEMENT_THRESHOLD,
+  CANARY_MIN_SAMPLES,
+  computeAgreementRate24h,
+  computeAgreementTrend30d,
+} from "@/lib/observability/canary-alerts";
+import {
   computeAllSlos,
   type SloResult,
   type SloStatus,
@@ -30,7 +36,11 @@ export default async function AdminSlosPage({
 
   const params = await searchParams;
   const windowDays = parseWindow(params.window);
-  const slos = await computeAllSlos(windowDays);
+  const [slos, canaryStats, canaryTrend] = await Promise.all([
+    computeAllSlos(windowDays),
+    computeAgreementRate24h(),
+    computeAgreementTrend30d(),
+  ]);
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
@@ -49,7 +59,78 @@ export default async function AdminSlosPage({
           <SloCard key={slo.key} slo={slo} />
         ))}
       </div>
+      <section className="flex flex-col gap-2">
+        <h2 className="text-h2">AI Canary</h2>
+        <p className="text-body text-muted-foreground">
+          Shadow-parse por Haiku del 1% del tráfico — detecta drift de formato antes que el usuario.
+          Alerta cuando agreement &lt; {(CANARY_AGREEMENT_THRESHOLD * 100).toFixed(0)}% sostenido
+          24h (mínimo {CANARY_MIN_SAMPLES} muestras).
+        </p>
+        <div className="grid grid-cols-1 gap-4">
+          <CanaryCard stats={canaryStats} trend={canaryTrend} />
+        </div>
+      </section>
     </main>
+  );
+}
+
+function CanaryCard({
+  stats,
+  trend,
+}: {
+  stats: { rate: number | null; total: number; disagrees: number };
+  trend: { date: string; value: number | null }[];
+}) {
+  const status: SloStatus =
+    stats.rate === null || stats.total < CANARY_MIN_SAMPLES
+      ? "no-signal"
+      : stats.rate >= CANARY_AGREEMENT_THRESHOLD
+        ? "green"
+        : stats.rate >= CANARY_AGREEMENT_THRESHOLD - 0.05
+          ? "yellow"
+          : "red";
+  const style = STATUS_STYLES[status];
+  const display = stats.rate === null ? "—" : `${(stats.rate * 100).toFixed(1)}%`;
+  return (
+    <Card className={style.className}>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-0.5">
+            <CardTitle className="text-base">Agreement rate (24h)</CardTitle>
+            <CardDescription className="text-xs">
+              {stats.total} muestra{stats.total === 1 ? "" : "s"} · {stats.disagrees} disagree
+              {stats.disagrees === 1 ? "" : "s"}
+            </CardDescription>
+          </div>
+          <span
+            className="inline-flex items-center gap-1.5 rounded-full bg-white/60 px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase dark:bg-black/20"
+            title={style.label}
+          >
+            <span className={`size-2 rounded-full ${style.dot}`} />
+            {style.label}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <span className="font-heading text-3xl font-semibold tabular-nums">{display}</span>
+          <span className="text-muted-foreground text-xs">
+            Target ≥ {(CANARY_AGREEMENT_THRESHOLD * 100).toFixed(0)}%
+          </span>
+        </div>
+        {trend.length > 0 ? (
+          <Sparkline points={trend} />
+        ) : (
+          <p className="text-muted-foreground text-[11px] italic">Trend no disponible todavía.</p>
+        )}
+        <Link
+          href="/admin/slos/canary"
+          className="text-xs font-medium underline-offset-4 hover:underline"
+        >
+          Ver eventos de disagree →
+        </Link>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/app/api/cron/canary-check/route.ts
+++ b/src/app/api/cron/canary-check/route.ts
@@ -1,0 +1,33 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import { checkAndAlertCanary } from "@/lib/observability/canary-alerts";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+function resolveToken(req: Request): string | null {
+  const header = req.headers.get("authorization");
+  if (!header?.startsWith("Bearer ")) return null;
+  return header.slice(7).trim() || null;
+}
+
+export async function POST(req: Request) {
+  const expected = process.env.CRON_TOKEN;
+  if (!expected) {
+    return NextResponse.json({ error: "CRON_TOKEN not configured" }, { status: 500 });
+  }
+  const provided = resolveToken(req);
+  if (!provided || !constantTimeEquals(provided, expected)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const decision = await checkAndAlertCanary();
+  return NextResponse.json({ ok: true, decision });
+}

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -1,9 +1,10 @@
-import { NextResponse } from "next/server";
+import { after, NextResponse } from "next/server";
 import { canIngest, paywallResponse } from "@/lib/auth/can-ingest";
 import { db } from "@/lib/db";
 import { ingestionLogs } from "@/lib/db/schema";
 import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
 import { ingestParsed, serializeParsed } from "@/lib/ingestion/sms-pipeline";
+import { runCanaryForSms } from "@/lib/observability/canary";
 import { resolveWebhookAuth } from "@/lib/webhook-tokens";
 
 export const runtime = "nodejs";
@@ -70,6 +71,20 @@ export async function POST(req: Request) {
     startedAt,
     finishedAt: new Date(),
   });
+
+  // Fire-and-forget: shadow-parse a 1% sample via Haiku and persist the
+  // comparison. Runs after the response is sent — no hot-path latency.
+  // after() requires a request scope, so unit tests that call POST() directly
+  // would throw — swallow so the test harness doesn't care.
+  try {
+    after(async () => {
+      await runCanaryForSms({ userId: auth.userId, body, sender });
+    });
+  } catch (err) {
+    if (process.env.NODE_ENV !== "test") {
+      console.error("[canary] after() registration failed", err);
+    }
+  }
 
   return NextResponse.json({ ok: true, ...outcome });
 }

--- a/src/app/api/ingest/sms/route.ts
+++ b/src/app/api/ingest/sms/route.ts
@@ -4,7 +4,7 @@ import { db } from "@/lib/db";
 import { ingestionLogs } from "@/lib/db/schema";
 import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
 import { ingestParsed, serializeParsed } from "@/lib/ingestion/sms-pipeline";
-import { runCanaryForSms } from "@/lib/observability/canary";
+import { runCanaryForSms, safeLogDetail } from "@/lib/observability/canary";
 import { resolveWebhookAuth } from "@/lib/webhook-tokens";
 
 export const runtime = "nodejs";
@@ -82,7 +82,7 @@ export async function POST(req: Request) {
     });
   } catch (err) {
     if (process.env.NODE_ENV !== "test") {
-      console.error("[canary] after() registration failed", err);
+      console.error("[canary] after() registration failed:", safeLogDetail(err));
     }
   }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -597,6 +597,65 @@ export const telegramSessions = pgTable(
 
 export type CaptureSources30d = Partial<Record<(typeof txSource.enumValues)[number], number>>;
 
+// AI canary — shadow-parses a deterministic 1% sample of incoming SMS via
+// Haiku and compares against the regex result. Detects Bancolombia format
+// drift before users notice. See PLAN.md § AI Strategy + issue #258.
+//
+// regexResult / aiResult shape is CanaryProjection — { amountCents, currency,
+// merchant, occurredOn } — see src/lib/observability/canary.ts.
+export type CanaryProjection = {
+  amountCents: string | null;
+  currency: "COP" | "USD" | null;
+  merchant: string | null;
+  occurredOn: string | null;
+};
+
+export const parserCanaryEvents = pgTable(
+  "parser_canary_events",
+  {
+    id: serial("id").primaryKey(),
+    userId: integer("user_id").references(() => users.id, { onDelete: "cascade" }),
+    smsBodyHash: varchar("sms_body_hash", { length: 64 }).notNull(),
+    sender: varchar("sender", { length: 100 }),
+    regexResult: jsonb("regex_result").$type<CanaryProjection>().notNull(),
+    aiResult: jsonb("ai_result").$type<CanaryProjection>().notNull(),
+    agreement: boolean("agreement").notNull(),
+    divergenceFields: jsonb("divergence_fields").$type<string[]>().notNull().default([]),
+    aiModel: varchar("ai_model", { length: 50 }).notNull(),
+    aiInputTokens: integer("ai_input_tokens").notNull().default(0),
+    aiOutputTokens: integer("ai_output_tokens").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("parser_canary_events_created_idx").on(t.createdAt),
+    index("parser_canary_events_disagree_idx")
+      .on(t.createdAt)
+      .where(sql`${t.agreement} = false`),
+  ],
+);
+
+// Insert-only alert log with built-in dedup. Rules for the dispatcher:
+//   - Never fire a new alert if another is unresolved (resolvedAt IS NULL)
+//   - When rate recovers ≥ threshold, mark the most recent unresolved row as resolved
+// This gives us history + natural dedup without a separate state table.
+export const canaryAlerts = pgTable(
+  "canary_alerts",
+  {
+    id: serial("id").primaryKey(),
+    firedAt: timestamp("fired_at", { withTimezone: true }).notNull().defaultNow(),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    rate: numeric("rate", { precision: 5, scale: 4 }).notNull(),
+    samples: integer("samples").notNull(),
+    topDivergences: jsonb("top_divergences").notNull().default([]),
+    notificationStatus: varchar("notification_status", { length: 40 }).notNull(),
+  },
+  (t) => [
+    index("canary_alerts_unresolved_idx")
+      .on(t.firedAt)
+      .where(sql`${t.resolvedAt} IS NULL`),
+  ],
+);
+
 export const userHealthSnapshots = pgTable(
   "user_health_snapshots",
   {

--- a/src/lib/observability/canary-alerts.test.ts
+++ b/src/lib/observability/canary-alerts.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  CANARY_AGREEMENT_THRESHOLD,
+  CANARY_MIN_SAMPLES,
+  decideCanaryAction,
+} from "./canary-alerts";
+
+function stats(rate: number | null, total: number) {
+  const agrees = rate === null ? 0 : Math.round(rate * total);
+  return { rate, total, disagrees: total - agrees };
+}
+
+describe("decideCanaryAction", () => {
+  it("no-ops when there are no samples", () => {
+    const d = decideCanaryAction(stats(null, 0), null);
+    expect(d.action).toBe("noop");
+    if (d.action === "noop") expect(d.reason).toBe("insufficient_samples");
+  });
+
+  it("no-ops when samples are below minimum", () => {
+    const d = decideCanaryAction(stats(0.5, CANARY_MIN_SAMPLES - 1), null);
+    expect(d.action).toBe("noop");
+    if (d.action === "noop") expect(d.reason).toBe("insufficient_samples");
+  });
+
+  it("no-ops when healthy and no active alert", () => {
+    const d = decideCanaryAction(stats(0.98, 50), null);
+    expect(d.action).toBe("noop");
+    if (d.action === "noop") expect(d.reason).toBe("healthy");
+  });
+
+  it("fires when rate dips below threshold and no alert is active", () => {
+    const d = decideCanaryAction(stats(0.9, 50), null);
+    expect(d.action).toBe("fire");
+  });
+
+  it("does not re-fire when an alert is already active (dedup)", () => {
+    const d = decideCanaryAction(stats(0.9, 50), { id: 42 });
+    expect(d.action).toBe("noop");
+    if (d.action === "noop") expect(d.reason).toBe("already_alerted");
+  });
+
+  it("resolves an active alert when rate recovers to threshold", () => {
+    const d = decideCanaryAction(stats(CANARY_AGREEMENT_THRESHOLD, 50), { id: 42 });
+    expect(d.action).toBe("resolve");
+    if (d.action === "resolve") expect(d.alertId).toBe(42);
+  });
+
+  it("resolves when rate recovers above threshold", () => {
+    const d = decideCanaryAction(stats(0.99, 50), { id: 7 });
+    expect(d.action).toBe("resolve");
+  });
+
+  it("treats rate exactly at threshold as healthy", () => {
+    const d = decideCanaryAction(stats(CANARY_AGREEMENT_THRESHOLD, 100), null);
+    expect(d.action).toBe("noop");
+  });
+
+  it("fires at exact min-samples boundary when below threshold", () => {
+    const d = decideCanaryAction(stats(0.5, CANARY_MIN_SAMPLES), null);
+    expect(d.action).toBe("fire");
+  });
+});

--- a/src/lib/observability/canary-alerts.ts
+++ b/src/lib/observability/canary-alerts.ts
@@ -1,0 +1,192 @@
+import { and, desc, eq, gte, isNull, sql } from "drizzle-orm";
+import { db, type DB } from "@/lib/db";
+import {
+  canaryAlerts,
+  parserCanaryEvents,
+  telegramBots,
+  telegramSessions,
+  users,
+} from "@/lib/db/schema";
+import { decrypt } from "@/lib/crypto/symmetric";
+import { createTelegramClient } from "@/lib/telegram/client";
+import type { TrendPoint } from "@/lib/telemetry/slos";
+
+export const CANARY_AGREEMENT_THRESHOLD = 0.97;
+export const CANARY_MIN_SAMPLES = 5;
+
+export type AgreementStats = {
+  rate: number | null;
+  total: number;
+  disagrees: number;
+};
+
+export async function computeAgreementRate24h(database: DB = db): Promise<AgreementStats> {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const [row] = await database
+    .select({
+      total: sql<number>`count(*)::int`,
+      disagrees: sql<number>`count(*) filter (where ${parserCanaryEvents.agreement} = false)::int`,
+    })
+    .from(parserCanaryEvents)
+    .where(gte(parserCanaryEvents.createdAt, since));
+  const total = row?.total ?? 0;
+  const disagrees = row?.disagrees ?? 0;
+  const rate = total === 0 ? null : (total - disagrees) / total;
+  return { rate, total, disagrees };
+}
+
+export async function computeAgreementTrend30d(database: DB = db): Promise<TrendPoint[]> {
+  const sinceMs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+  const since = new Date(sinceMs);
+  const rows = await database
+    .select({
+      day: sql<string>`to_char(date_trunc('day', ${parserCanaryEvents.createdAt}), 'YYYY-MM-DD')`,
+      total: sql<number>`count(*)::int`,
+      agrees: sql<number>`count(*) filter (where ${parserCanaryEvents.agreement} = true)::int`,
+    })
+    .from(parserCanaryEvents)
+    .where(gte(parserCanaryEvents.createdAt, since))
+    .groupBy(sql`date_trunc('day', ${parserCanaryEvents.createdAt})`);
+  const byDay = new Map(rows.map((r) => [r.day, r]));
+  const out: TrendPoint[] = [];
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date(sinceMs + (29 - i) * 24 * 60 * 60 * 1000);
+    const key = d.toISOString().slice(0, 10);
+    const r = byDay.get(key);
+    out.push({ date: key, value: r && r.total > 0 ? r.agrees / r.total : null });
+  }
+  return out;
+}
+
+export async function fetchTopDivergences(
+  database: DB = db,
+  limit = 3,
+): Promise<Array<{ id: number; divergenceFields: string[]; smsBodyHash: string }>> {
+  const rows = await database
+    .select({
+      id: parserCanaryEvents.id,
+      divergenceFields: parserCanaryEvents.divergenceFields,
+      smsBodyHash: parserCanaryEvents.smsBodyHash,
+    })
+    .from(parserCanaryEvents)
+    .where(eq(parserCanaryEvents.agreement, false))
+    .orderBy(desc(parserCanaryEvents.createdAt))
+    .limit(limit);
+  return rows;
+}
+
+export type CheckDecision =
+  | { action: "fire"; stats: AgreementStats }
+  | { action: "resolve"; stats: AgreementStats; alertId: number }
+  | { action: "noop"; stats: AgreementStats; reason: string };
+
+// Pure decision function — testable without hitting the DB transport.
+// `latestUnresolved` is null when there's no open alert.
+export function decideCanaryAction(
+  stats: AgreementStats,
+  latestUnresolved: { id: number } | null,
+  thresholds = {
+    agreementThreshold: CANARY_AGREEMENT_THRESHOLD,
+    minSamples: CANARY_MIN_SAMPLES,
+  },
+): CheckDecision {
+  if (stats.rate === null || stats.total < thresholds.minSamples) {
+    return { action: "noop", stats, reason: "insufficient_samples" };
+  }
+  if (stats.rate >= thresholds.agreementThreshold) {
+    if (latestUnresolved) return { action: "resolve", stats, alertId: latestUnresolved.id };
+    return { action: "noop", stats, reason: "healthy" };
+  }
+  // rate < threshold
+  if (latestUnresolved) return { action: "noop", stats, reason: "already_alerted" };
+  return { action: "fire", stats };
+}
+
+export async function checkAndAlertCanary(database: DB = db): Promise<CheckDecision> {
+  const stats = await computeAgreementRate24h(database);
+  const [latestUnresolved] = await database
+    .select({ id: canaryAlerts.id })
+    .from(canaryAlerts)
+    .where(isNull(canaryAlerts.resolvedAt))
+    .orderBy(desc(canaryAlerts.firedAt))
+    .limit(1);
+  const decision = decideCanaryAction(stats, latestUnresolved ?? null);
+
+  if (decision.action === "fire") {
+    const topDivergences = await fetchTopDivergences(database, 3);
+    const telegramStatus = await dispatchTelegramAlert(database, stats, topDivergences).catch(
+      (err) => {
+        console.error("[canary] telegram dispatch failed", err);
+        return "telegram_error";
+      },
+    );
+    await database.insert(canaryAlerts).values({
+      rate: stats.rate!.toFixed(4),
+      samples: stats.total,
+      topDivergences,
+      notificationStatus: telegramStatus,
+    });
+  } else if (decision.action === "resolve") {
+    await database
+      .update(canaryAlerts)
+      .set({ resolvedAt: new Date() })
+      .where(eq(canaryAlerts.id, decision.alertId));
+  }
+
+  return decision;
+}
+
+async function dispatchTelegramAlert(
+  database: DB,
+  stats: AgreementStats,
+  topDivergences: Array<{ id: number; divergenceFields: string[]; smsBodyHash: string }>,
+): Promise<string> {
+  const [admin] = await database
+    .select({ id: users.id })
+    .from(users)
+    .where(and(eq(users.role, "admin"), eq(users.active, true)))
+    .limit(1);
+  if (!admin) return "no_admin";
+
+  const [bot] = await database
+    .select()
+    .from(telegramBots)
+    .where(eq(telegramBots.userId, admin.id))
+    .limit(1);
+  if (!bot) return "no_bot";
+
+  const [session] = await database
+    .select({ chatId: telegramSessions.chatId })
+    .from(telegramSessions)
+    .where(eq(telegramSessions.userId, admin.id))
+    .orderBy(desc(telegramSessions.updatedAt))
+    .limit(1);
+  if (!session) return "no_session";
+
+  let token: string;
+  try {
+    token = decrypt(bot.tokenEncrypted);
+  } catch {
+    return "token_decrypt_failed";
+  }
+
+  const client = createTelegramClient({ token });
+  const ratePct = (stats.rate! * 100).toFixed(1);
+  const divergenceSummary = topDivergences.length
+    ? topDivergences.map((d) => `• ${d.divergenceFields.join(", ")}`).join("\n")
+    : "—";
+  const text = [
+    `🐤 Canary alert — parser drift detected`,
+    ``,
+    `Agreement rate (24h): ${ratePct}% (${stats.total - stats.disagrees}/${stats.total})`,
+    `Disagrees: ${stats.disagrees}`,
+    ``,
+    `Top divergence fields:`,
+    divergenceSummary,
+    ``,
+    `Details: /admin/slos/canary`,
+  ].join("\n");
+
+  await client.sendMessage({ chat_id: Number(session.chatId), text });
+  return "telegram_sent";
+}

--- a/src/lib/observability/canary-alerts.ts
+++ b/src/lib/observability/canary-alerts.ts
@@ -8,6 +8,7 @@ import {
   users,
 } from "@/lib/db/schema";
 import { decrypt } from "@/lib/crypto/symmetric";
+import { safeLogDetail } from "@/lib/observability/canary";
 import { createTelegramClient } from "@/lib/telegram/client";
 import type { TrendPoint } from "@/lib/telemetry/slos";
 
@@ -116,7 +117,7 @@ export async function checkAndAlertCanary(database: DB = db): Promise<CheckDecis
     const topDivergences = await fetchTopDivergences(database, 3);
     const telegramStatus = await dispatchTelegramAlert(database, stats, topDivergences).catch(
       (err) => {
-        console.error("[canary] telegram dispatch failed", err);
+        console.error("[canary] telegram dispatch failed:", safeLogDetail(err));
         return "telegram_error";
       },
     );

--- a/src/lib/observability/canary.test.ts
+++ b/src/lib/observability/canary.test.ts
@@ -4,6 +4,7 @@ import {
   hashSmsBody,
   parseProjectionJson,
   projectFromRegex,
+  safeLogDetail,
   sampleForCanary,
 } from "./canary";
 import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
@@ -104,6 +105,28 @@ describe("compareProjections", () => {
     });
     expect(agreement).toBe(false);
     expect(divergenceFields).toEqual(["currency", "occurredOn"]);
+  });
+});
+
+describe("safeLogDetail", () => {
+  it("strips newlines, carriage returns, and control chars so log lines can't be forged", () => {
+    const tainted = new Error("parse failed\nFAKE LOG\rERROR: admin hijacked\x00bytes");
+    const out = safeLogDetail(tainted);
+    expect(out).not.toContain("\n");
+    expect(out).not.toContain("\r");
+    expect(out).not.toContain("\x00");
+    expect(out).toContain("parse failed");
+  });
+
+  it("truncates very long messages to 500 chars", () => {
+    const long = new Error("x".repeat(5000));
+    expect(safeLogDetail(long)).toHaveLength(500);
+  });
+
+  it("coerces non-Error values to string", () => {
+    expect(safeLogDetail("plain string")).toBe("plain string");
+    expect(safeLogDetail(42)).toBe("42");
+    expect(safeLogDetail(null)).toBe("null");
   });
 });
 

--- a/src/lib/observability/canary.test.ts
+++ b/src/lib/observability/canary.test.ts
@@ -109,29 +109,21 @@ describe("compareProjections", () => {
 });
 
 describe("safeLogDetail", () => {
-  it("encodes newlines and control chars so log lines can't be forged", () => {
+  it("returns the Error class name, never the message (defeats log-injection)", () => {
     const tainted = new Error("parse failed\nFAKE LOG\rERROR: admin hijacked\x00bytes");
-    const out = safeLogDetail(tainted);
-    expect(out).not.toContain("\n");
-    expect(out).not.toContain("\r");
-    expect(out).not.toContain("\x00");
-    // encodeURIComponent preserves the semantic payload — the operator can
-    // still decode it for debugging if they need to.
-    expect(out).toContain("parse%20failed");
-    expect(out).toContain("%0A"); // \n
-    expect(out).toContain("%0D"); // \r
+    expect(safeLogDetail(tainted)).toBe("Error");
   });
 
-  it("truncates the pre-encode message to 500 chars", () => {
-    const long = new Error("x".repeat(5000));
-    // After encoding "x"*500 is still 500 chars (x doesn't need escaping).
-    expect(safeLogDetail(long)).toHaveLength(500);
+  it("returns the constructor name for subclasses of Error", () => {
+    class CanaryBoom extends Error {}
+    expect(safeLogDetail(new CanaryBoom("x"))).toBe("CanaryBoom");
+    expect(safeLogDetail(new SyntaxError("y"))).toBe("SyntaxError");
   });
 
-  it("coerces non-Error values to string", () => {
-    expect(safeLogDetail("plain string")).toBe("plain%20string");
-    expect(safeLogDetail(42)).toBe("42");
-    expect(safeLogDetail(null)).toBe("null");
+  it("returns the typeof for non-Error values", () => {
+    expect(safeLogDetail("plain string")).toBe("string");
+    expect(safeLogDetail(42)).toBe("number");
+    expect(safeLogDetail(null)).toBe("object");
   });
 });
 

--- a/src/lib/observability/canary.test.ts
+++ b/src/lib/observability/canary.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import {
+  compareProjections,
+  hashSmsBody,
+  parseProjectionJson,
+  projectFromRegex,
+  sampleForCanary,
+} from "./canary";
+import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
+
+describe("sampleForCanary", () => {
+  it("is deterministic — same body always returns the same verdict", () => {
+    const body = "Bancolombia: Compra de $50,000 en EXITO...";
+    const a = sampleForCanary(body);
+    const b = sampleForCanary(body);
+    const c = sampleForCanary(body);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it("returns roughly 1% across a large corpus of unique bodies", () => {
+    let positives = 0;
+    const N = 5000;
+    for (let i = 0; i < N; i++) {
+      if (sampleForCanary(`msg-${i}`)) positives++;
+    }
+    // Expected ~50. Allow [20, 100] — catches regression to 0% or 10%+.
+    expect(positives).toBeGreaterThan(20);
+    expect(positives).toBeLessThan(100);
+  });
+
+  it("hashSmsBody returns a stable sha256 hex", () => {
+    const h = hashSmsBody("hello");
+    expect(h).toBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    expect(h).toHaveLength(64);
+  });
+});
+
+describe("projectFromRegex", () => {
+  it("projects a real purchase SMS into { amountCents, currency, merchant, occurredOn }", () => {
+    const sms =
+      "Bancolombia: Compraste COP35.450,00 en DLO*DiDi Food CO Pay con tu T.Cred *2575, el 15/04/2026 a las 20:34. Si tienes dudas, encuentranos aqui: 6045109095 o 018000931987. Estamos cerca.";
+    const parsed = parseSmsBancolombia(sms);
+    const projection = projectFromRegex(parsed);
+    expect(projection.amountCents).toBe("3545000");
+    expect(projection.currency).toBe("COP");
+    expect(projection.merchant).toBe("DLO*DiDi Food CO Pay");
+    expect(projection.occurredOn).toBe("2026-04-15");
+  });
+
+  it("returns all-null projection for skip results", () => {
+    const parsed = parseSmsBancolombia("Tu clave está lista. Descárgala en la app.");
+    const projection = projectFromRegex(parsed);
+    expect(projection).toEqual({
+      amountCents: null,
+      currency: null,
+      merchant: null,
+      occurredOn: null,
+    });
+  });
+});
+
+describe("compareProjections", () => {
+  const base = {
+    amountCents: "5000000",
+    currency: "COP" as const,
+    merchant: "EXITO CHIA",
+    occurredOn: "2026-04-15",
+  };
+
+  it("agrees when all fields match", () => {
+    const { agreement, divergenceFields } = compareProjections(base, { ...base });
+    expect(agreement).toBe(true);
+    expect(divergenceFields).toEqual([]);
+  });
+
+  it("disagrees on amount", () => {
+    const { agreement, divergenceFields } = compareProjections(base, {
+      ...base,
+      amountCents: "9999",
+    });
+    expect(agreement).toBe(false);
+    expect(divergenceFields).toEqual(["amountCents"]);
+  });
+
+  it("ignores case + punctuation + whitespace in merchant", () => {
+    const { agreement } = compareProjections(base, { ...base, merchant: "  éxito,  chía!  " });
+    expect(agreement).toBe(true);
+  });
+
+  it("null === null agrees; null vs value disagrees", () => {
+    const allNull = { amountCents: null, currency: null, merchant: null, occurredOn: null };
+    expect(compareProjections(allNull, allNull).agreement).toBe(true);
+    const r = compareProjections(allNull, { ...allNull, merchant: "X" });
+    expect(r.agreement).toBe(false);
+    expect(r.divergenceFields).toEqual(["merchant"]);
+  });
+
+  it("reports multiple divergence fields", () => {
+    const { agreement, divergenceFields } = compareProjections(base, {
+      ...base,
+      currency: "USD",
+      occurredOn: "2026-04-16",
+    });
+    expect(agreement).toBe(false);
+    expect(divergenceFields).toEqual(["currency", "occurredOn"]);
+  });
+});
+
+describe("parseProjectionJson", () => {
+  it("extracts the JSON object even with prose wrapping", () => {
+    const text = `Sure, here's the extraction:
+{"amountCents": "5000000", "currency": "COP", "merchant": "EXITO", "occurredOn": "2026-04-15"}
+Hope that helps!`;
+    const p = parseProjectionJson(text);
+    expect(p.amountCents).toBe("5000000");
+    expect(p.currency).toBe("COP");
+    expect(p.merchant).toBe("EXITO");
+  });
+
+  it("coerces nulls + unknown currency to null", () => {
+    const p = parseProjectionJson(
+      `{"amountCents": null, "currency": "BRL", "merchant": "", "occurredOn": null}`,
+    );
+    expect(p).toEqual({
+      amountCents: null,
+      currency: null,
+      merchant: null,
+      occurredOn: null,
+    });
+  });
+
+  it("throws when there is no JSON object in the response", () => {
+    expect(() => parseProjectionJson("I cannot parse this SMS.")).toThrow();
+  });
+});

--- a/src/lib/observability/canary.test.ts
+++ b/src/lib/observability/canary.test.ts
@@ -109,22 +109,27 @@ describe("compareProjections", () => {
 });
 
 describe("safeLogDetail", () => {
-  it("strips newlines, carriage returns, and control chars so log lines can't be forged", () => {
+  it("encodes newlines and control chars so log lines can't be forged", () => {
     const tainted = new Error("parse failed\nFAKE LOG\rERROR: admin hijacked\x00bytes");
     const out = safeLogDetail(tainted);
     expect(out).not.toContain("\n");
     expect(out).not.toContain("\r");
     expect(out).not.toContain("\x00");
-    expect(out).toContain("parse failed");
+    // encodeURIComponent preserves the semantic payload — the operator can
+    // still decode it for debugging if they need to.
+    expect(out).toContain("parse%20failed");
+    expect(out).toContain("%0A"); // \n
+    expect(out).toContain("%0D"); // \r
   });
 
-  it("truncates very long messages to 500 chars", () => {
+  it("truncates the pre-encode message to 500 chars", () => {
     const long = new Error("x".repeat(5000));
+    // After encoding "x"*500 is still 500 chars (x doesn't need escaping).
     expect(safeLogDetail(long)).toHaveLength(500);
   });
 
   it("coerces non-Error values to string", () => {
-    expect(safeLogDetail("plain string")).toBe("plain string");
+    expect(safeLogDetail("plain string")).toBe("plain%20string");
     expect(safeLogDetail(42)).toBe("42");
     expect(safeLogDetail(null)).toBe("null");
   });

--- a/src/lib/observability/canary.ts
+++ b/src/lib/observability/canary.ts
@@ -1,0 +1,194 @@
+import { createHash } from "node:crypto";
+import { db } from "@/lib/db";
+import { parserCanaryEvents, type CanaryProjection } from "@/lib/db/schema";
+import { parseSmsBancolombia, type ParseResult } from "@/lib/ingestion/sms-bancolombia";
+
+const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+const SAMPLE_NUMERATOR = 1;
+const SAMPLE_DENOMINATOR = 100;
+const PROJECTION_FIELDS = ["amountCents", "currency", "merchant", "occurredOn"] as const;
+type ProjectionField = (typeof PROJECTION_FIELDS)[number];
+
+export function hashSmsBody(body: string): string {
+  return createHash("sha256").update(body, "utf8").digest("hex");
+}
+
+// Deterministic 1% sampling — derived from the sha256 of the body so the same
+// SMS always gets the same verdict (reproducible in tests, replayable).
+export function sampleForCanary(smsBody: string): boolean {
+  const hash = hashSmsBody(smsBody);
+  const bucket = parseInt(hash.slice(0, 8), 16) % SAMPLE_DENOMINATOR;
+  return bucket < SAMPLE_NUMERATOR;
+}
+
+export function projectFromRegex(parsed: ParseResult): CanaryProjection {
+  if (parsed.kind === "skip") {
+    return { amountCents: null, currency: null, merchant: null, occurredOn: null };
+  }
+  return {
+    amountCents: parsed.amountCents.toString(),
+    currency: parsed.currency,
+    merchant: merchantFromParsed(parsed),
+    occurredOn: parsed.occurredOn,
+  };
+}
+
+function merchantFromParsed(parsed: Exclude<ParseResult, { kind: "skip" }>): string | null {
+  switch (parsed.kind) {
+    case "purchase":
+      return parsed.merchant;
+    case "provider_payment":
+    case "transfer_received":
+    case "tc_credit_received":
+      return parsed.senderName;
+    case "provider_payment_sent":
+      return parsed.providerName;
+    case "bre_b_transfer":
+      return parsed.recipientName;
+    default:
+      return null;
+  }
+}
+
+export function compareProjections(
+  regex: CanaryProjection,
+  ai: CanaryProjection,
+): { agreement: boolean; divergenceFields: ProjectionField[] } {
+  const divergenceFields: ProjectionField[] = [];
+  for (const field of PROJECTION_FIELDS) {
+    if (!fieldsEqual(field, regex[field], ai[field])) divergenceFields.push(field);
+  }
+  return { agreement: divergenceFields.length === 0, divergenceFields };
+}
+
+function fieldsEqual(field: ProjectionField, a: string | null, b: string | null): boolean {
+  if (a === null && b === null) return true;
+  if (a === null || b === null) return false;
+  if (field === "merchant") return normalizeMerchant(a) === normalizeMerchant(b);
+  return a === b;
+}
+
+function normalizeMerchant(s: string): string {
+  return s
+    .normalize("NFD")
+    .replace(/\p{M}/gu, "")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N} ]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const AI_PROMPT_HEADER = `You are parsing a single Bancolombia SMS notification. Extract these fields as strict JSON.
+
+- amountCents: integer as string, amount × 100 (e.g. "$50,000 COP" → "5000000"). null if no amount.
+- currency: "COP" | "USD" | null
+- merchant: name of the other party — store name, person, provider. null if it's a transfer/withdrawal/ATM with no counterparty name.
+- occurredOn: date as YYYY-MM-DD from the SMS (assume current year if only month/day shown). null if not present.
+
+Return ONLY valid JSON with exactly these 4 keys. No prose.
+
+SMS:
+`;
+
+export async function shadowParseSms(
+  smsBody: string,
+  opts?: { apiKey?: string; model?: string; fetchImpl?: typeof fetch },
+): Promise<{
+  projection: CanaryProjection;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+}> {
+  const apiKey = opts?.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
+  const model = opts?.model ?? DEFAULT_MODEL;
+  const doFetch = opts?.fetchImpl ?? fetch;
+
+  const res = await doFetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 256,
+      messages: [{ role: "user", content: AI_PROMPT_HEADER + smsBody }],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Anthropic API error ${res.status}: ${body.slice(0, 300)}`);
+  }
+
+  const payload = (await res.json()) as {
+    content: Array<{ type: string; text?: string }>;
+    usage?: { input_tokens: number; output_tokens: number };
+  };
+  const text = payload.content?.find((c) => c.type === "text")?.text ?? "";
+  return {
+    projection: parseProjectionJson(text),
+    model,
+    inputTokens: payload.usage?.input_tokens ?? 0,
+    outputTokens: payload.usage?.output_tokens ?? 0,
+  };
+}
+
+export function parseProjectionJson(text: string): CanaryProjection {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) throw new Error("shadowParseSms: no JSON object in response");
+  const raw = JSON.parse(match[0]) as Record<string, unknown>;
+  return {
+    amountCents: coerceStringOrNull(raw.amountCents),
+    currency:
+      raw.currency === "COP" || raw.currency === "USD" ? (raw.currency as "COP" | "USD") : null,
+    merchant: coerceStringOrNull(raw.merchant),
+    occurredOn: coerceStringOrNull(raw.occurredOn),
+  };
+}
+
+function coerceStringOrNull(v: unknown): string | null {
+  if (v === null || v === undefined) return null;
+  if (typeof v === "string") return v.trim() || null;
+  if (typeof v === "number" || typeof v === "bigint") return String(v);
+  return null;
+}
+
+// Entry point used by the SMS route's after() hook. Swallows errors — a
+// canary failure must NEVER surface to the user or retry the ingestion.
+export async function runCanaryForSms(params: {
+  userId: number;
+  body: string;
+  sender: string | null;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<void> {
+  try {
+    if (!sampleForCanary(params.body)) return;
+
+    const regexParsed = parseSmsBancolombia(params.body);
+    const regexProjection = projectFromRegex(regexParsed);
+    const ai = await shadowParseSms(params.body, {
+      apiKey: params.apiKey,
+      fetchImpl: params.fetchImpl,
+    });
+    const { agreement, divergenceFields } = compareProjections(regexProjection, ai.projection);
+
+    await db.insert(parserCanaryEvents).values({
+      userId: params.userId,
+      smsBodyHash: hashSmsBody(params.body),
+      sender: params.sender,
+      regexResult: regexProjection,
+      aiResult: ai.projection,
+      agreement,
+      divergenceFields,
+      aiModel: ai.model,
+      aiInputTokens: ai.inputTokens,
+      aiOutputTokens: ai.outputTokens,
+    });
+  } catch (err) {
+    console.error("[canary] shadow parse failed", err);
+  }
+}

--- a/src/lib/observability/canary.ts
+++ b/src/lib/observability/canary.ts
@@ -156,14 +156,14 @@ function coerceStringOrNull(v: unknown): string | null {
   return null;
 }
 
-// Sanitize an error (possibly wrapping user-controlled SMS bytes) before
-// writing to console — encodes CR / LF / control chars via encodeURIComponent
-// so a malicious payload can't forge fake log lines. encodeURIComponent is
-// the CodeQL-recognized sanitizer for js/log-injection (our prior regex-strip
-// was effectively equivalent but CodeQL couldn't prove it).
+// Returns the error CLASS only — never message content. Defeats log-injection
+// by construction: no user-controlled bytes reach the logger. Diagnostic
+// value is "which kind of failure happened", not "what was the exact text".
+// When we introduce a centralized logger (Pino), it will serialize the full
+// err object with safe encoding and this helper can retire.
 export function safeLogDetail(err: unknown): string {
-  const msg = err instanceof Error ? err.message : String(err);
-  return encodeURIComponent(msg.slice(0, 500));
+  if (err instanceof Error) return err.constructor.name;
+  return typeof err;
 }
 
 // Entry point used by the SMS route's after() hook. Swallows errors — a

--- a/src/lib/observability/canary.ts
+++ b/src/lib/observability/canary.ts
@@ -157,11 +157,13 @@ function coerceStringOrNull(v: unknown): string | null {
 }
 
 // Sanitize an error (possibly wrapping user-controlled SMS bytes) before
-// writing to console — strips control chars / CR / LF so a malicious payload
-// can't inject fake log lines. Flagged by CodeQL js/log-injection otherwise.
+// writing to console — encodes CR / LF / control chars via encodeURIComponent
+// so a malicious payload can't forge fake log lines. encodeURIComponent is
+// the CodeQL-recognized sanitizer for js/log-injection (our prior regex-strip
+// was effectively equivalent but CodeQL couldn't prove it).
 export function safeLogDetail(err: unknown): string {
   const msg = err instanceof Error ? err.message : String(err);
-  return msg.replace(/[\r\n\x00-\x1f\x7f]/g, " ").slice(0, 500);
+  return encodeURIComponent(msg.slice(0, 500));
 }
 
 // Entry point used by the SMS route's after() hook. Swallows errors — a

--- a/src/lib/observability/canary.ts
+++ b/src/lib/observability/canary.ts
@@ -156,6 +156,14 @@ function coerceStringOrNull(v: unknown): string | null {
   return null;
 }
 
+// Sanitize an error (possibly wrapping user-controlled SMS bytes) before
+// writing to console — strips control chars / CR / LF so a malicious payload
+// can't inject fake log lines. Flagged by CodeQL js/log-injection otherwise.
+export function safeLogDetail(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.replace(/[\r\n\x00-\x1f\x7f]/g, " ").slice(0, 500);
+}
+
 // Entry point used by the SMS route's after() hook. Swallows errors — a
 // canary failure must NEVER surface to the user or retry the ingestion.
 export async function runCanaryForSms(params: {
@@ -189,6 +197,6 @@ export async function runCanaryForSms(params: {
       aiOutputTokens: ai.outputTokens,
     });
   } catch (err) {
-    console.error("[canary] shadow parse failed", err);
+    console.error("[canary] shadow parse failed:", safeLogDetail(err));
   }
 }


### PR DESCRIPTION
## Summary

Closes #258. Adds an AI canary that shadow-parses a deterministic 1% sample of incoming SMS via Haiku and compares against the regex result — detects Bancolombia format drift within 24-48h instead of waiting for users to report data gaps.

### Pieces in this PR

**Capture** (`src/lib/observability/canary.ts`)
- `sampleForCanary(body)` — sha256 of body → first 4 bytes → mod 100 < 1. Deterministic, reproducible, testable.
- `projectFromRegex(parsed)` — extracts `{amountCents, currency, merchant, occurredOn}` from any `ParseResult` kind
- `shadowParseSms(body)` — HTTP `fetch` to `api.anthropic.com/v1/messages` with `claude-haiku-4-5-20251001`; strict JSON output prompt
- `compareProjections(regex, ai)` — field-by-field comparison; merchant normalized (NFD strip accents + lowercase + strip non-alnum)
- `runCanaryForSms(...)` — swallows errors so canary failures NEVER leak to the SMS ingestion path

**Hot-path wiring** (`src/app/api/ingest/sms/route.ts`)
- Fires `runCanaryForSms` inside `after()` from `next/server` — zero added latency on the user-facing request
- Wrapped in try/catch so unit tests calling `POST()` directly (outside a request scope) don't break

**Alerting** (`src/lib/observability/canary-alerts.ts`)
- `computeAgreementRate24h()` + `computeAgreementTrend30d()` — the rolling aggregates
- `decideCanaryAction(stats, latestUnresolved)` — PURE decision function (heavily unit-tested): `fire` / `resolve` / `noop` with reason
- `checkAndAlertCanary()` — applies the decision, dispatches Telegram DM to admin, writes to `canary_alerts` table
- Thresholds: `CANARY_AGREEMENT_THRESHOLD = 0.97`, `CANARY_MIN_SAMPLES = 5` (avoid noise on low traffic)
- Dedup: insert-only `canary_alerts` table. Won't re-fire while an `unresolvedAt IS NULL` row exists; marks resolved when rate recovers.

**Cron seam** (`src/app/api/cron/canary-check/route.ts`)
- POST with `Authorization: Bearer <CRON_TOKEN>` (timing-safe compare). Calls `checkAndAlertCanary`.
- Env read inside the handler, not at module load — doesn't break `next build` per the prior `nextjs16-build-imports-route-modules` gotcha.

**Schema** (`drizzle/0027_happy_tomas.sql`)
- `parser_canary_events` (+2 indexes incl. partial on `agreement = false`)
- `canary_alerts` (+ partial index on unresolved)
- Journal `when` monotonic ✅

**Dashboard** (`src/app/(app)/admin/slos/*`)
- Canary card on `/admin/slos` — 24h rate, 30d sparkline, drilldown link. Status colors tied to threshold ± 5%.
- `/admin/slos/canary` — side-by-side regex vs Haiku projection for last 25 disagrees, divergence fields highlighted, plus alert history.

### Scope decisions (explicit)

| Piece | Decision | Why |
|---|---|---|
| Email alerting | **Skipped** | No SMTP / Resend infra exists. Follow-up issue recommended. |
| Cron trigger | `/api/cron/canary-check` route + `CRON_TOKEN` | No scheduler in the repo. External cron (systemd timer / Vercel Cron / GH Action) can drive it. |
| Telegram channel | Admin's own bot via `telegramBots` + most-recent `telegramSessions.chatId` | Reuses existing infra. Logs `no_session`/`no_bot`/`no_admin`/`token_decrypt_failed` as `notificationStatus`. |
| PII | Store only `sha256(body)` — per issue spec | Projections give enough debug signal; the SMS body itself isn't needed to diagnose drift. |

### Test plan

- [x] `bun run lint` — 0 errors (1 pre-existing warning from `_userId` in `can-ingest.ts`, merged in #247)
- [x] `tsc --noEmit` — green
- [x] `bun run test` — 42 files / 431 tests (+24 new)
  - `canary.test.ts` — sampling determinism (~1% across 5k unique bodies), `projectFromRegex` on real Bancolombia SMS, `compareProjections` including accent-insensitive merchant matching, `parseProjectionJson` with prose wrapping
  - `canary-alerts.test.ts` — pure `decideCanaryAction` covering all 5 action branches (fire / resolve / noop healthy / noop already_alerted / noop insufficient_samples)
- [x] `db:migrate` + `db:migrate:test` — applied cleanly to both DBs
- [x] Drizzle journal `when` monotonic (verified with jq)

### Follow-ups (not blocking merge)

- **Email alert channel** — requires picking an email provider (Resend / SMTP). File a new issue.
- **Real cron scheduling** — decide between systemd timer on ia-server, GitHub scheduled workflow, or Vercel Cron. Document in `docs/deploy.md`.
- **Sampling rate tunable via env** — currently hardcoded 1/100. Worth making it `CANARY_SAMPLE_RATE` once we see real traffic volume.
- **Admin must have an active Telegram session** for alerts to deliver today. Once the bot is part of daily use this is fine; before then alerts log `no_session` and stay visible in the dashboard alert history.

Closes #258