### PR TITLE
fix(deploy): overlay src/lib/logger.ts for migrate-prod (#281)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,7 @@ jobs:
           cp src/lib/db/schema.ts "$STAGE/src/lib/db/schema.ts"
           cp src/lib/db/seed-reference-data.ts "$STAGE/src/lib/db/seed-reference-data.ts"
           cp src/lib/auth/signup.ts "$STAGE/src/lib/auth/signup.ts"
+          cp src/lib/logger.ts "$STAGE/src/lib/logger.ts"
           echo "$GIT_SHA" > "$STAGE/GIT_SHA"
           tar -czf release.tar.gz -C "$STAGE" .
           ls -lh release.tar.gz

--- a/src/lib/db/seed-reference-data.ts
+++ b/src/lib/db/seed-reference-data.ts
@@ -14,7 +14,7 @@
 // Those are populated per-user by the signup flow or the one-shot backfill
 // scripts under scripts/backfill-*.ts — never globally.
 
-import { createLogger } from "@/lib/logger";
+import { createLogger } from "../logger";
 import { db as defaultDb, type DB } from "./index";
 import { categorySeeds, classificationRuleSeeds } from "./schema";
 


### PR DESCRIPTION
## Summary

- Add `cp src/lib/logger.ts` to the deploy overlay so the migrate-prod entrypoint can resolve `../src/lib/logger` on prod.
- Switch `seed-reference-data.ts` from the `@/lib/logger` alias to a relative `../logger` import to keep the overlay self-contained (matches `scripts/*` convention; no tsconfig path resolution at runtime).

Fixes the failure introduced by #280 — last deploy ([run 24640470037](https://github.com/ingamartinez/personal-financial-dashboard/actions/runs/24640470037)) errored with:

```
error: Cannot find module '../src/lib/logger' from '/srv/findash/app/releases/<sha>/scripts/migrate-prod.ts'
```

Pino itself is already in the standalone trace via app routes that import the logger — no node_modules overlay needed.

## Test plan

- [x] Local: `PGDATABASE=findash_test bun scripts/migrate-prod.ts` → migrations + reference seeding + per-user backfill all complete; logger emits structured JSON
- [x] Lint + format pass via lint-staged on commit
- [ ] Next CD run after merge re-applies migrations idempotently

Closes #281