### PR TITLE
feat(reconciliation): shared Bancolombia TC parser (formats B+C) (#287)

### DIFF
--- a/src/lib/reconciliation/parsers/bancolombia-tc.test.ts
+++ b/src/lib/reconciliation/parsers/bancolombia-tc.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import * as XLSX from "xlsx";
+import { parseBancolombiaTc } from "./bancolombia-tc";
+import { StatementParseError, excelSerialToBogotaUtc } from "./types";
+
+type Row = [
+  number | string | null, // Fecha (serial)
+  string | null, // Descripción
+  number | string | null, // Fecha de corte (serial or null)
+  number | null, // Valor (signed)
+  "COP" | "USD" | null, // Tipo de moneda
+  number | null, // Cuotas
+];
+
+const CORRECT_HEADER = [
+  "Fecha",
+  "Descripción",
+  "Fecha de corte",
+  "Valor",
+  "Tipo de moneda",
+  "Cuotas",
+];
+
+function buildXlsx(header: unknown[], rows: Row[]): Buffer {
+  const ws = XLSX.utils.aoa_to_sheet([header, ...rows]);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "Hoja 1");
+  return XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+}
+
+describe("parseBancolombiaTc", () => {
+  it("parses a Visa-like fixture (all COP) with correct shape", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127, "DLO*DIDI FOOD", null, 35450, "COP", 1],
+      [46127, "RAPPI COLOMBIA", null, 71950, "COP", 1],
+      [46126, "ABONO SUCURSAL VIRTUAL", null, -4351431, "COP", 0],
+      [46126, "SPRED", null, 36641.38, "COP", 36],
+    ]);
+    const out = parseBancolombiaTc(buf);
+    expect(out.bank).toBe("bancolombia");
+    expect(out.format).toBe("bancolombia_tc");
+    expect(out.rowCount).toBe(4);
+    expect(out.balanceAtEndCents).toBeNull();
+    expect(out.rows.every((r) => r.currency === "COP")).toBe(true);
+  });
+
+  it("parses a Mastercard-like fixture with mixed COP and USD", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127, "ANTHROPIC", null, 10, "USD", 36],
+      [46127, "CLAUDE.AI", null, 195.26, "USD", 36],
+      [46126, "ABONO SUC VIRTUAL", null, -130469, "COP", 0],
+      [46126, "ABONO SUC VIRTUAL", null, -366, "USD", 0],
+      [46111, "INTERESES", 46111, 26470.92, "COP", 0],
+    ]);
+    const out = parseBancolombiaTc(buf);
+    const currencies = out.rows.map((r) => r.currency);
+    expect(currencies).toEqual(["USD", "USD", "COP", "USD", "COP"]);
+  });
+
+  it("normalizes sign: positive Valor → direction='out', negative → 'in', amountCents always positive", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127, "charge", null, 5000, "COP", 1],
+      [46127, "abono", null, -5000, "COP", 0],
+    ]);
+    const out = parseBancolombiaTc(buf);
+    expect(out.rows[0].direction).toBe("out");
+    expect(out.rows[0].amountCents).toBe(BigInt(500_000));
+    expect(out.rows[1].direction).toBe("in");
+    expect(out.rows[1].amountCents).toBe(BigInt(500_000));
+  });
+
+  it("converts USD decimals to cents without precision loss", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127, "usd small", null, 195.26, "USD", 36],
+      [46127, "usd tiny", null, 0.18, "USD", 0],
+      [46127, "usd large", null, 4099523.37, "COP", 60],
+    ]);
+    const out = parseBancolombiaTc(buf);
+    expect(out.rows[0].amountCents).toBe(BigInt(19526));
+    expect(out.rows[1].amountCents).toBe(BigInt(18));
+    expect(out.rows[2].amountCents).toBe(BigInt(409_952_337));
+  });
+
+  it("flags cuotas=0 rows as metadata; non-zero as regular", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127, "fee", null, 35672, "COP", 0],
+      [46127, "single", null, 5000, "COP", 1],
+      [46127, "installments", null, 60000, "COP", 12],
+    ]);
+    const out = parseBancolombiaTc(buf);
+    expect(out.rows[0].isMetadata).toBe(true);
+    expect(out.rows[1].isMetadata).toBe(false);
+    expect(out.rows[2].isMetadata).toBe(false);
+    expect(out.rows[2].rawData.cuotas).toBe(12);
+  });
+
+  it("converts Excel serial to Bogotá midnight UTC (05:00Z)", () => {
+    // Serial 46127 → 2026-04-16 UTC date by Excel convention
+    // Bogotá midnight on 2026-04-16 == 2026-04-16T05:00:00Z
+    const ref = excelSerialToBogotaUtc(46127);
+    const buf = buildXlsx(CORRECT_HEADER, [[46127, "x", null, 100, "COP", 1]]);
+    const out = parseBancolombiaTc(buf);
+    expect(out.rows[0].occurredAt.toISOString()).toBe(ref.toISOString());
+    expect(out.rows[0].occurredAt.getUTCHours()).toBe(5);
+    expect(out.rows[0].occurredAt.getUTCMinutes()).toBe(0);
+  });
+
+  it("captures periodStart/periodEnd from min/max of rows", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127, "latest", null, 100, "COP", 1],
+      [46120, "earliest", null, 200, "COP", 1],
+      [46124, "middle", null, 300, "COP", 1],
+    ]);
+    const out = parseBancolombiaTc(buf);
+    expect(out.periodStart.toISOString()).toBe(excelSerialToBogotaUtc(46120).toISOString());
+    expect(out.periodEnd.toISOString()).toBe(excelSerialToBogotaUtc(46127).toISOString());
+  });
+
+  it("captures fechaDeCorte when present, null when NaN/blank", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127, "pending", null, 100, "COP", 1],
+      [46111, "billed", 46111, 200, "COP", 0],
+    ]);
+    const out = parseBancolombiaTc(buf);
+    expect(out.rows[0].rawData.fechaDeCorte).toBeNull();
+    expect(out.rows[1].rawData.fechaDeCorte).toBe(excelSerialToBogotaUtc(46111).toISOString());
+  });
+
+  it("throws format_mismatch when columns are wrong", () => {
+    const buf = buildXlsx(
+      ["Fecha", "Descripcion", "Fecha de corte", "Valor", "Tipo", "Cuotas"],
+      [[46127, "x", null, 100, "COP", 1]],
+    );
+    expect(() => parseBancolombiaTc(buf)).toThrow(StatementParseError);
+    try {
+      parseBancolombiaTc(buf);
+    } catch (err) {
+      expect((err as StatementParseError).kind).toBe("format_mismatch");
+    }
+  });
+
+  it("throws empty when there are no data rows", () => {
+    const buf = buildXlsx(CORRECT_HEADER, []);
+    expect(() => parseBancolombiaTc(buf)).toThrow(StatementParseError);
+    try {
+      parseBancolombiaTc(buf);
+    } catch (err) {
+      expect((err as StatementParseError).kind).toBe("empty");
+    }
+  });
+
+  it("throws bad_row when Valor is non-numeric", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127, "x", null, "not-a-number" as unknown as number, "COP", 1],
+    ]);
+    try {
+      parseBancolombiaTc(buf);
+    } catch (err) {
+      expect(err).toBeInstanceOf(StatementParseError);
+      expect((err as StatementParseError).kind).toBe("bad_row");
+    }
+  });
+
+  it("skips fully-blank rows mid-sheet", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127, "real", null, 100, "COP", 1],
+      [null, null, null, null, null, null],
+      [46126, "also real", null, 200, "COP", 1],
+    ]);
+    const out = parseBancolombiaTc(buf);
+    expect(out.rowCount).toBe(2);
+  });
+});

--- a/src/lib/reconciliation/parsers/bancolombia-tc.ts
+++ b/src/lib/reconciliation/parsers/bancolombia-tc.ts
@@ -1,0 +1,140 @@
+import * as XLSX from "xlsx";
+import {
+  StatementParseError,
+  excelSerialToBogotaUtc,
+  type ParsedStatement,
+  type ParsedStatementRow,
+} from "./types";
+
+const EXPECTED_HEADERS = [
+  "Fecha",
+  "Descripción",
+  "Fecha de corte",
+  "Valor",
+  "Tipo de moneda",
+  "Cuotas",
+] as const;
+
+/**
+ * Parses a Bancolombia credit card statement (shared across Visa and
+ * Mastercard exports — structurally identical; currency is per-row).
+ *
+ * Sign convention in Bancolombia TC exports is inverted vs. savings:
+ *   `+` Valor = charge to card (direction='out')
+ *   `−` Valor = abono/payment received (direction='in')
+ * The caller gets `amountCents` ALWAYS positive with the semantic in
+ * `direction`, so downstream code never has to reason about the file's
+ * signed representation.
+ */
+export function parseBancolombiaTc(buffer: Buffer | Uint8Array): ParsedStatement {
+  const wb = XLSX.read(buffer, { type: "buffer" });
+  const firstSheetName = wb.SheetNames[0];
+  if (!firstSheetName) {
+    throw new StatementParseError("missing_sheet", "workbook has no sheets");
+  }
+  const ws = wb.Sheets[firstSheetName];
+  if (!ws) {
+    throw new StatementParseError("missing_sheet", `sheet "${firstSheetName}" not found`);
+  }
+
+  const matrix = XLSX.utils.sheet_to_json<unknown[]>(ws, {
+    header: 1,
+    raw: true,
+    defval: null,
+  });
+
+  const header = matrix[0];
+  if (!Array.isArray(header) || header.length < EXPECTED_HEADERS.length) {
+    throw new StatementParseError(
+      "format_mismatch",
+      `expected ${EXPECTED_HEADERS.length} columns, got ${header?.length ?? 0}`,
+    );
+  }
+  for (let i = 0; i < EXPECTED_HEADERS.length; i++) {
+    const actual = String(header[i] ?? "").trim();
+    if (actual !== EXPECTED_HEADERS[i]) {
+      throw new StatementParseError(
+        "format_mismatch",
+        `column ${i}: expected "${EXPECTED_HEADERS[i]}", got "${actual}"`,
+      );
+    }
+  }
+
+  const dataRows = matrix.slice(1);
+  const rows: ParsedStatementRow[] = [];
+  let minMs = Number.POSITIVE_INFINITY;
+  let maxMs = Number.NEGATIVE_INFINITY;
+
+  for (let i = 0; i < dataRows.length; i++) {
+    const raw = dataRows[i];
+    if (!Array.isArray(raw) || raw.length === 0) continue;
+    const [fecha, descripcion, fechaCorte, valor, tipoMoneda, cuotas] = raw;
+    if (fecha === null || fecha === undefined || fecha === "") continue;
+
+    const fechaNum = Number(fecha);
+    if (!Number.isFinite(fechaNum)) {
+      throw new StatementParseError(
+        "bad_row",
+        `row ${i + 2}: Fecha is not numeric (got "${String(fecha)}")`,
+      );
+    }
+    const occurredAt = excelSerialToBogotaUtc(fechaNum);
+
+    const valorNum = Number(valor);
+    if (!Number.isFinite(valorNum)) {
+      throw new StatementParseError(
+        "bad_row",
+        `row ${i + 2}: Valor is not numeric (got "${String(valor)}")`,
+      );
+    }
+    const direction: "in" | "out" = valorNum < 0 ? "in" : "out";
+    const amountCents = BigInt(Math.round(Math.abs(valorNum) * 100));
+
+    const currency: "COP" | "USD" =
+      String(tipoMoneda).trim().toUpperCase() === "USD" ? "USD" : "COP";
+
+    const cuotasNum = Number(cuotas ?? 0);
+    const isMetadata = Number.isFinite(cuotasNum) && cuotasNum === 0;
+
+    const fechaCorteNum =
+      fechaCorte === null || fechaCorte === undefined || fechaCorte === ""
+        ? null
+        : Number(fechaCorte);
+    const fechaCorteIso =
+      fechaCorteNum !== null && Number.isFinite(fechaCorteNum)
+        ? excelSerialToBogotaUtc(fechaCorteNum).toISOString()
+        : null;
+
+    rows.push({
+      occurredAt,
+      amountCents,
+      currency,
+      direction,
+      descriptionRaw: String(descripcion ?? "").trim(),
+      rawData: {
+        cuotas: Number.isFinite(cuotasNum) ? cuotasNum : null,
+        fechaDeCorte: fechaCorteIso,
+        tipoMoneda: currency,
+      },
+      isMetadata,
+    });
+
+    const ms = occurredAt.getTime();
+    if (ms < minMs) minMs = ms;
+    if (ms > maxMs) maxMs = ms;
+  }
+
+  if (rows.length === 0) {
+    throw new StatementParseError("empty", "no valid data rows");
+  }
+
+  return {
+    bank: "bancolombia",
+    format: "bancolombia_tc",
+    periodStart: new Date(minMs),
+    periodEnd: new Date(maxMs),
+    rowCount: rows.length,
+    balanceAtEndCents: null,
+    rows,
+  };
+}

--- a/src/lib/reconciliation/parsers/types.ts
+++ b/src/lib/reconciliation/parsers/types.ts
@@ -1,0 +1,49 @@
+export type ParseDirection = "in" | "out";
+
+export type StatementFormat = "bancolombia_tc" | "bancolombia_savings";
+
+export type StatementBank = "bancolombia";
+
+export interface ParsedStatementRow {
+  occurredAt: Date;
+  amountCents: bigint;
+  currency: "COP" | "USD";
+  direction: ParseDirection;
+  descriptionRaw: string;
+  rawData: Record<string, unknown>;
+  isMetadata: boolean;
+}
+
+export interface ParsedStatement {
+  bank: StatementBank;
+  format: StatementFormat;
+  periodStart: Date;
+  periodEnd: Date;
+  rowCount: number;
+  balanceAtEndCents: bigint | null;
+  rows: ParsedStatementRow[];
+}
+
+export type StatementParseErrorKind = "format_mismatch" | "missing_sheet" | "bad_row" | "empty";
+
+export class StatementParseError extends Error {
+  constructor(
+    public readonly kind: StatementParseErrorKind,
+    message: string,
+  ) {
+    super(message);
+    this.name = "StatementParseError";
+  }
+}
+
+/**
+ * Excel stores dates as serial days since 1899-12-30 (accounting for the
+ * legacy 1900 leap-year bug — day 1 = 1900-01-01). Bancolombia TC exports
+ * give us integer serials (date only, no time). Bogotá is UTC-5 with no
+ * DST, so "midnight Bogotá" on a given calendar date == 05:00 UTC.
+ */
+export function excelSerialToBogotaUtc(serial: number): Date {
+  const days = Math.floor(serial);
+  const utcMidnightMs = Date.UTC(1899, 11, 30) + days * 86_400_000;
+  return new Date(utcMidnightMs + 5 * 60 * 60 * 1000);
+}


### PR DESCRIPTION
Closes #287. First actual parser for Epic R (#253). Shared across Bancolombia TC Visa (COP-only) and TC Mastercard (dual-currency COP+USD) because both exports are **structurally identical** — currency is per-row.

## What

New module at `src/lib/reconciliation/parsers/`:

- **`types.ts`** — canonical shapes for all future parsers:
  - `ParsedStatement`, `ParsedStatementRow`, `ParseDirection`, `StatementFormat`
  - `StatementParseError` with discriminated `kind` (`format_mismatch | missing_sheet | bad_row | empty`)
  - `excelSerialToBogotaUtc()` helper — Bogotá is UTC-5 with no DST so midnight Bogotá == 05:00 UTC on that calendar date
- **`bancolombia-tc.ts`** — `parseBancolombiaTc(buffer): ParsedStatement`:
  - Signature detection on the 6 expected headers (`Fecha | Descripción | Fecha de corte | Valor | Tipo de moneda | Cuotas`). Mismatch → throws before parsing any row.
  - Sign normalization: Bancolombia TC uses `+` for charges and `−` for abonos/payments (inverted vs. savings). Parser emits `amountCents` ALWAYS positive and captures the semantic in `direction: 'in' | 'out'`, so downstream code never reasons about the file's signed representation.
  - Per-row currency (COP/USD coexist in the same Mastercard sheet).
  - `cuotas=0` → `isMetadata=true` (intereses, cuotas de manejo, abonos, refinanciación). These rows are structurally different from real spend and the engine will treat them accordingly.
  - `fechaDeCorte` preserved in `rawData` (`null` for pending / ISO string for billed rows).
  - `balanceAtEndCents: null` — Bancolombia TC exports do not expose a closing balance. The engine will derive divergence from the saved tx balance, not from the file.
- **`bancolombia-tc.test.ts`** — 12 tests. Fixtures are generated programmatically with `XLSX.utils.aoa_to_sheet` inside the test (no binary blobs committed, no real sample data leaks).

## Sanity check against real samples

Ran the parser locally against the two real Bancolombia exports (kept outside the repo):

- **Visa** — 20 rows, all COP, 19 charges + 1 abono, 1 cuotas=0 row
- **Mastercard** — 20 rows, 14 USD + 6 COP, 15 charges + 5 abonos, 8 cuotas=0 rows

Totals, period, and metadata counts line up with manual inspection of the XLSX contents.

## Out of scope (follow-ups)
- Parser for format A (savings) — different 4-column shape, separate issue
- Parser dispatch at upload time (`account.institutionSlug` guard) — lands with the upload endpoint/UI
- Reconciliation matching engine
- DB writes, file hash dedup, UI

## Test plan
- [x] `bun run test` → 447 pass (12 new parser tests)
- [x] `bun run typecheck` clean
- [x] `bun run format:check` clean
- [x] `bun run lint` clean (one pre-existing warning unrelated to this PR)
- [x] Local sanity run against the two real Bancolombia samples → coherent totals + period