### PR TITLE
feat(reconciliation): Bancolombia savings (format A) parser (#289)

### DIFF
--- a/src/lib/reconciliation/parsers/bancolombia-savings.test.ts
+++ b/src/lib/reconciliation/parsers/bancolombia-savings.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import * as XLSX from "xlsx";
+import { parseBancolombiaSavings } from "./bancolombia-savings";
+import { StatementParseError, excelSerialToBogotaUtc } from "./types";
+
+type Row = [
+  number | string | null, // Fecha (serial, typically fractional)
+  string | null, // Descripción
+  string | null, // Referencia
+  number | null, // Valor (signed, native)
+];
+
+const CORRECT_HEADER = ["Fecha", "Descripción", "Referencia", "Valor"];
+
+function buildXlsx(header: unknown[], rows: Row[]): Buffer {
+  const ws = XLSX.utils.aoa_to_sheet([header, ...rows]);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "Hoja 1");
+  return XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+}
+
+describe("parseBancolombiaSavings", () => {
+  it("parses a savings-like fixture with correct shape", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46130.20833, "ABONO INTERESES AHORROS", "", 0.18],
+      [46130.20833, "PAGO QR PELUQUERIA", "0090860726", -62000],
+      [46129.20833, "TRANSFERENCIA CTA SUC VIRTUAL", "91241521350", 1000],
+    ]);
+    const out = parseBancolombiaSavings(buf);
+    expect(out.bank).toBe("bancolombia");
+    expect(out.format).toBe("bancolombia_savings");
+    expect(out.rowCount).toBe(3);
+    expect(out.balanceAtEndCents).toBeNull();
+    expect(out.rows.every((r) => r.currency === "COP")).toBe(true);
+    expect(out.rows.every((r) => r.isMetadata === false)).toBe(true);
+  });
+
+  it("normalizes sign natively: positive → 'in', negative → 'out', amountCents always positive", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127.20833, "ingreso", null, 100000],
+      [46127.20833, "gasto", null, -62000],
+    ]);
+    const out = parseBancolombiaSavings(buf);
+    expect(out.rows[0].direction).toBe("in");
+    expect(out.rows[0].amountCents).toBe(BigInt(10_000_000));
+    expect(out.rows[1].direction).toBe("out");
+    expect(out.rows[1].amountCents).toBe(BigInt(6_200_000));
+  });
+
+  it("normalizes Referencia: empty string, 'null' literal, null → null; real strings pass through", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127.20833, "empty", "", 100],
+      [46127.20833, "null literal", "null", 100],
+      [46127.20833, "nil", null, 100],
+      [46127.20833, "real", "91218413213", 100],
+      [46127.20833, "whitespace", "   ", 100],
+    ]);
+    const out = parseBancolombiaSavings(buf);
+    expect(out.rows[0].rawData.referencia).toBeNull();
+    expect(out.rows[1].rawData.referencia).toBeNull();
+    expect(out.rows[2].rawData.referencia).toBeNull();
+    expect(out.rows[3].rawData.referencia).toBe("91218413213");
+    expect(out.rows[4].rawData.referencia).toBeNull();
+  });
+
+  it("handles fractional .20833 date serials (strips time → Bogotá midnight UTC)", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [[46130.20833, "x", "", 100]]);
+    const out = parseBancolombiaSavings(buf);
+    const expected = excelSerialToBogotaUtc(46130);
+    expect(out.rows[0].occurredAt.toISOString()).toBe(expected.toISOString());
+    expect(out.rows[0].occurredAt.getUTCHours()).toBe(5);
+  });
+
+  it("captures periodStart/periodEnd from min/max of rows", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46130.20833, "newest", "", 100],
+      [46113.20833, "oldest", "", 200],
+      [46120.20833, "middle", "", 300],
+    ]);
+    const out = parseBancolombiaSavings(buf);
+    expect(out.periodStart.toISOString()).toBe(excelSerialToBogotaUtc(46113).toISOString());
+    expect(out.periodEnd.toISOString()).toBe(excelSerialToBogotaUtc(46130).toISOString());
+  });
+
+  it("throws format_mismatch when columns are wrong", () => {
+    const buf = buildXlsx(["Fecha", "Descripcion", "Referencia", "Valor"], [[46127, "x", "", 100]]);
+    try {
+      parseBancolombiaSavings(buf);
+    } catch (err) {
+      expect(err).toBeInstanceOf(StatementParseError);
+      expect((err as StatementParseError).kind).toBe("format_mismatch");
+    }
+  });
+
+  it("throws empty when there are no data rows", () => {
+    const buf = buildXlsx(CORRECT_HEADER, []);
+    try {
+      parseBancolombiaSavings(buf);
+    } catch (err) {
+      expect(err).toBeInstanceOf(StatementParseError);
+      expect((err as StatementParseError).kind).toBe("empty");
+    }
+  });
+
+  it("throws bad_row when Valor is non-numeric", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [[46127, "x", "", "not-a-number" as unknown as number]]);
+    try {
+      parseBancolombiaSavings(buf);
+    } catch (err) {
+      expect(err).toBeInstanceOf(StatementParseError);
+      expect((err as StatementParseError).kind).toBe("bad_row");
+    }
+  });
+
+  it("skips fully-blank rows mid-sheet", () => {
+    const buf = buildXlsx(CORRECT_HEADER, [
+      [46127, "real", "", 100],
+      [null, null, null, null],
+      [46126, "also real", "", 200],
+    ]);
+    const out = parseBancolombiaSavings(buf);
+    expect(out.rowCount).toBe(2);
+  });
+});

--- a/src/lib/reconciliation/parsers/bancolombia-savings.ts
+++ b/src/lib/reconciliation/parsers/bancolombia-savings.ts
@@ -1,0 +1,125 @@
+import * as XLSX from "xlsx";
+import {
+  StatementParseError,
+  excelSerialToBogotaUtc,
+  type ParsedStatement,
+  type ParsedStatementRow,
+} from "./types";
+
+const EXPECTED_HEADERS = ["Fecha", "Descripción", "Referencia", "Valor"] as const;
+
+/**
+ * Parses a Bancolombia savings-account statement (format A — 4 columns).
+ *
+ * Sign is NATIVE here — opposite of TC:
+ *   `+` Valor = ingreso (direction='in')
+ *   `−` Valor = gasto (direction='out')
+ * `amountCents` is ALWAYS positive; the semantic is in `direction`.
+ *
+ * Savings exports use a fractional serial (`46130.20833`) where `.20833`
+ * encodes 05:00 UTC (= midnight Bogotá). The fraction is constant across
+ * rows and redundant — we strip it and interpret as a calendar date in
+ * Bogotá, same as the TC parser.
+ */
+export function parseBancolombiaSavings(buffer: Buffer | Uint8Array): ParsedStatement {
+  const wb = XLSX.read(buffer, { type: "buffer" });
+  const firstSheetName = wb.SheetNames[0];
+  if (!firstSheetName) {
+    throw new StatementParseError("missing_sheet", "workbook has no sheets");
+  }
+  const ws = wb.Sheets[firstSheetName];
+  if (!ws) {
+    throw new StatementParseError("missing_sheet", `sheet "${firstSheetName}" not found`);
+  }
+
+  const matrix = XLSX.utils.sheet_to_json<unknown[]>(ws, {
+    header: 1,
+    raw: true,
+    defval: null,
+  });
+
+  const header = matrix[0];
+  if (!Array.isArray(header) || header.length < EXPECTED_HEADERS.length) {
+    throw new StatementParseError(
+      "format_mismatch",
+      `expected ${EXPECTED_HEADERS.length} columns, got ${header?.length ?? 0}`,
+    );
+  }
+  for (let i = 0; i < EXPECTED_HEADERS.length; i++) {
+    const actual = String(header[i] ?? "").trim();
+    if (actual !== EXPECTED_HEADERS[i]) {
+      throw new StatementParseError(
+        "format_mismatch",
+        `column ${i}: expected "${EXPECTED_HEADERS[i]}", got "${actual}"`,
+      );
+    }
+  }
+
+  const dataRows = matrix.slice(1);
+  const rows: ParsedStatementRow[] = [];
+  let minMs = Number.POSITIVE_INFINITY;
+  let maxMs = Number.NEGATIVE_INFINITY;
+
+  for (let i = 0; i < dataRows.length; i++) {
+    const raw = dataRows[i];
+    if (!Array.isArray(raw) || raw.length === 0) continue;
+    const [fecha, descripcion, referencia, valor] = raw;
+    if (fecha === null || fecha === undefined || fecha === "") continue;
+
+    const fechaNum = Number(fecha);
+    if (!Number.isFinite(fechaNum)) {
+      throw new StatementParseError(
+        "bad_row",
+        `row ${i + 2}: Fecha is not numeric (got "${String(fecha)}")`,
+      );
+    }
+    const occurredAt = excelSerialToBogotaUtc(fechaNum);
+
+    const valorNum = Number(valor);
+    if (!Number.isFinite(valorNum)) {
+      throw new StatementParseError(
+        "bad_row",
+        `row ${i + 2}: Valor is not numeric (got "${String(valor)}")`,
+      );
+    }
+    const direction: "in" | "out" = valorNum < 0 ? "out" : "in";
+    const amountCents = BigInt(Math.round(Math.abs(valorNum) * 100));
+
+    const referenciaStr = normalizeReferencia(referencia);
+
+    rows.push({
+      occurredAt,
+      amountCents,
+      currency: "COP",
+      direction,
+      descriptionRaw: String(descripcion ?? "").trim(),
+      rawData: { referencia: referenciaStr },
+      isMetadata: false,
+    });
+
+    const ms = occurredAt.getTime();
+    if (ms < minMs) minMs = ms;
+    if (ms > maxMs) maxMs = ms;
+  }
+
+  if (rows.length === 0) {
+    throw new StatementParseError("empty", "no valid data rows");
+  }
+
+  return {
+    bank: "bancolombia",
+    format: "bancolombia_savings",
+    periodStart: new Date(minMs),
+    periodEnd: new Date(maxMs),
+    rowCount: rows.length,
+    balanceAtEndCents: null,
+    rows,
+  };
+}
+
+function normalizeReferencia(raw: unknown): string | null {
+  if (raw === null || raw === undefined) return null;
+  const s = String(raw).trim();
+  if (s === "" || s.toLowerCase() === "null") return null;
+  return s;
+}


### PR DESCRIPTION
Closes #289. Second parser for Epic R (#253). Reuses the shared `types.ts` + `excelSerialToBogotaUtc()` helper from #287 — pure additive work.

## What

- **`bancolombia-savings.ts`** — `parseBancolombiaSavings(buffer): ParsedStatement`:
  - 4-column signature detection (`Fecha | Descripción | Referencia | Valor`)
  - Sign convention is **native** (opposite of TC): `+` = ingreso → `direction='in'`, `−` = gasto → `direction='out'`. `amountCents` always positive.
  - Currency hardcoded `'COP'` (no column in this format — implicit)
  - `isMetadata: false` for every row (no cuotas column; savings has no metadata rows)
  - `Referencia` normalized in `rawData`: `""`, `"null"` literal, blank, whitespace-only → `null`; real strings pass through
  - `balanceAtEndCents: null` (not exposed by Bancolombia savings exports)
  - Fractional `.20833` date serials: the fraction encodes 05:00 UTC (midnight Bogotá) and is redundant — stripped, same Bogotá-calendar-day treatment as TC
- **`bancolombia-savings.test.ts`** — 9 tests, programmatic fixtures (no binary blobs)

## Sanity check against real sample

Ran locally against `/home/alejo/findash-samples/bancolombia/MovimientosTusCuentasBancolombia*-Ahorros*.xlsx`:
- 70 rows, period 2026-04-01 → 2026-04-18
- 42 non-null Referencia + 28 null (matches manual inspection)
- Totals: 6.97M COP in, 8.19M COP out — coherent monthly cashflow

## Out of scope
- Parser dispatch / upload endpoint
- Reconciliation matching engine
- DB writes, file hash dedup, UI
- e-card format (PLAN.md mentioned 3 formats; we've only observed 2 physical shapes — TC + savings)

## Test plan
- [x] `bun run test` → 456 pass (9 new savings tests on top of 447)
- [x] `bun run typecheck` clean
- [x] `bun run format:check` clean
- [x] `bun run lint` clean (one pre-existing warning unrelated to this PR)
- [x] Local sanity run against real savings sample → coherent totals