### PR TITLE
feat(reconciliation): matching engine (pure function) (#291)

### DIFF
--- a/src/lib/reconciliation/engine/match.test.ts
+++ b/src/lib/reconciliation/engine/match.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import { jaccard, matchStatement, tokenize } from "./match";
+import type { ExistingTxnForMatch } from "./types";
+import type { ParsedStatementRow } from "../parsers/types";
+
+const DAY_MS = 86_400_000;
+
+function parsedRow(
+  overrides: Partial<ParsedStatementRow> & Pick<ParsedStatementRow, "occurredAt">,
+): ParsedStatementRow {
+  return {
+    amountCents: BigInt(10_000),
+    currency: "COP",
+    direction: "out",
+    descriptionRaw: "SOME CHARGE",
+    rawData: {},
+    isMetadata: false,
+    ...overrides,
+  };
+}
+
+function existingTxn(
+  overrides: Partial<ExistingTxnForMatch> & Pick<ExistingTxnForMatch, "id" | "occurredAt">,
+): ExistingTxnForMatch {
+  return {
+    amountCents: BigInt(-10_000),
+    currency: "COP",
+    descriptionRaw: "SOME CHARGE",
+    merchant: null,
+    channel: "bank",
+    isAdjustment: false,
+    reconciliationStatus: "unreconciled",
+    ...overrides,
+  };
+}
+
+describe("tokenize", () => {
+  it("lowercases, strips accents + punct, drops tokens <3 chars", () => {
+    expect(tokenize("DLO*DIDI FOOD — CO.PAYIN")).toEqual(new Set(["dlo", "didi", "food", "payin"]));
+  });
+  it("handles empty strings", () => {
+    expect(tokenize("")).toEqual(new Set());
+  });
+});
+
+describe("jaccard", () => {
+  it("is 1 for identical sets", () => {
+    expect(jaccard(new Set(["a", "b"]), new Set(["a", "b"]))).toBe(1);
+  });
+  it("is 0 for disjoint sets", () => {
+    expect(jaccard(new Set(["a"]), new Set(["b"]))).toBe(0);
+  });
+  it("returns intersect / union for partial overlap", () => {
+    expect(jaccard(new Set(["a", "b", "c"]), new Set(["b", "c", "d"]))).toBeCloseTo(2 / 4);
+  });
+  it("returns 0 for two empty sets", () => {
+    expect(jaccard(new Set(), new Set())).toBe(0);
+  });
+});
+
+describe("matchStatement — happy paths", () => {
+  const date = new Date("2026-04-10T05:00:00Z");
+
+  it("exact match when amount + date + currency + direction all line up", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date, descriptionRaw: "DLO DIDI FOOD" })],
+      existingTxns: [existingTxn({ id: 1, occurredAt: date, descriptionRaw: "DLO DIDI FOOD" })],
+    });
+    expect(plan.decisions).toEqual([
+      {
+        statementRowIndex: 0,
+        action: "match",
+        matchedTxnId: 1,
+        matchScore: 100,
+        matchReason: "amount_date_fuzzy_merchant",
+      },
+    ]);
+    expect(plan.summary).toEqual({ matched: 1, newInserts: 0, flaggedExisting: 0 });
+    expect(plan.flaggedExisting).toEqual([]);
+  });
+
+  it("near match (2 days apart) still accepted with reduced score", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date })],
+      existingTxns: [existingTxn({ id: 1, occurredAt: new Date(date.getTime() - 2 * DAY_MS) })],
+    });
+    expect(plan.decisions[0].action).toBe("match");
+    expect(plan.decisions[0].matchScore).toBeLessThan(100);
+  });
+
+  it("out of tolerance (5 days apart) → insert_new", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date })],
+      existingTxns: [existingTxn({ id: 1, occurredAt: new Date(date.getTime() - 5 * DAY_MS) })],
+    });
+    expect(plan.decisions[0].action).toBe("insert_new");
+    expect(plan.decisions[0].matchedTxnId).toBeNull();
+  });
+});
+
+describe("matchStatement — currency / amount / direction rules", () => {
+  const date = new Date("2026-04-10T05:00:00Z");
+
+  it("different currency never matches", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date, currency: "USD" })],
+      existingTxns: [existingTxn({ id: 1, occurredAt: date, currency: "COP" })],
+    });
+    expect(plan.decisions[0].action).toBe("insert_new");
+  });
+
+  it("different magnitude never matches", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date, amountCents: BigInt(10_000) })],
+      existingTxns: [existingTxn({ id: 1, occurredAt: date, amountCents: BigInt(-9_900) })],
+    });
+    expect(plan.decisions[0].action).toBe("insert_new");
+  });
+
+  it("direction mismatch (same magnitude, opposite sign) never matches", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date, direction: "out" })],
+      existingTxns: [existingTxn({ id: 1, occurredAt: date, amountCents: BigInt(10_000) })],
+    });
+    expect(plan.decisions[0].action).toBe("insert_new");
+  });
+
+  it("in-direction parsed row matches positive-signed existing", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date, direction: "in" })],
+      existingTxns: [existingTxn({ id: 1, occurredAt: date, amountCents: BigInt(10_000) })],
+    });
+    expect(plan.decisions[0].action).toBe("match");
+  });
+});
+
+describe("matchStatement — candidate selection", () => {
+  const date = new Date("2026-04-10T05:00:00Z");
+
+  it("multiple candidates with same amount+date → picks highest merchant similarity", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date, descriptionRaw: "RAPPI COLOMBIA" })],
+      existingTxns: [
+        existingTxn({ id: 1, occurredAt: date, descriptionRaw: "UNRELATED MERCHANT" }),
+        existingTxn({ id: 2, occurredAt: date, descriptionRaw: "RAPPI COLOMBIA FOOD" }),
+      ],
+    });
+    expect(plan.decisions[0].matchedTxnId).toBe(2);
+  });
+
+  it("ties on merchant score → picks earlier (by date proximity / first in list)", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date, descriptionRaw: "NEUTRAL DESC" })],
+      existingTxns: [
+        existingTxn({ id: 1, occurredAt: date, descriptionRaw: "OTHER" }),
+        existingTxn({ id: 2, occurredAt: date, descriptionRaw: "OTHER" }),
+      ],
+    });
+    expect(plan.decisions[0].matchedTxnId).toBe(1);
+  });
+
+  it("two parsed rows compete for same existing — first one wins; second one inserts new", () => {
+    const plan = matchStatement({
+      parsedRows: [
+        parsedRow({ occurredAt: date, descriptionRaw: "first" }),
+        parsedRow({ occurredAt: date, descriptionRaw: "second" }),
+      ],
+      existingTxns: [existingTxn({ id: 1, occurredAt: date })],
+    });
+    expect(plan.decisions[0].action).toBe("match");
+    expect(plan.decisions[0].matchedTxnId).toBe(1);
+    expect(plan.decisions[1].action).toBe("insert_new");
+  });
+});
+
+describe("matchStatement — exclusion rules", () => {
+  const date = new Date("2026-04-10T05:00:00Z");
+
+  it("channel='manual' existing is neither matched nor flagged", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date })],
+      existingTxns: [existingTxn({ id: 1, occurredAt: date, channel: "manual" })],
+    });
+    expect(plan.decisions[0].action).toBe("insert_new");
+    expect(plan.flaggedExisting).toEqual([]);
+  });
+
+  it("is_adjustment=true existing is neither matched nor flagged", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date })],
+      existingTxns: [existingTxn({ id: 1, occurredAt: date, isAdjustment: true })],
+    });
+    expect(plan.decisions[0].action).toBe("insert_new");
+    expect(plan.flaggedExisting).toEqual([]);
+  });
+
+  it("already 'matched' existing doesn't get re-flagged", () => {
+    const plan = matchStatement({
+      parsedRows: [],
+      existingTxns: [existingTxn({ id: 1, occurredAt: date, reconciliationStatus: "matched" })],
+    });
+    expect(plan.flaggedExisting).toEqual([]);
+  });
+
+  it("'imported_from_statement' existing doesn't get re-flagged", () => {
+    const plan = matchStatement({
+      parsedRows: [],
+      existingTxns: [
+        existingTxn({
+          id: 1,
+          occurredAt: date,
+          reconciliationStatus: "imported_from_statement",
+        }),
+      ],
+    });
+    expect(plan.flaggedExisting).toEqual([]);
+  });
+
+  it("'unreconciled' bank-channel existing NOT matched → flagged", () => {
+    const plan = matchStatement({
+      parsedRows: [],
+      existingTxns: [existingTxn({ id: 1, occurredAt: date })],
+    });
+    expect(plan.flaggedExisting).toEqual([{ txnId: 1, reason: "no_statement_match" }]);
+    expect(plan.summary.flaggedExisting).toBe(1);
+  });
+});
+
+describe("matchStatement — invariants", () => {
+  const date = new Date("2026-04-10T05:00:00Z");
+
+  it("is deterministic: same input → identical output (twice)", () => {
+    const input = {
+      parsedRows: [
+        parsedRow({ occurredAt: date, descriptionRaw: "a" }),
+        parsedRow({ occurredAt: date, descriptionRaw: "b" }),
+      ],
+      existingTxns: [
+        existingTxn({ id: 1, occurredAt: date, descriptionRaw: "a" }),
+        existingTxn({ id: 2, occurredAt: date, descriptionRaw: "b" }),
+      ],
+    };
+    const a = matchStatement(input);
+    const b = matchStatement(input);
+    expect(a).toEqual(b);
+  });
+
+  it("summary counts agree with decisions + flaggedExisting arrays", () => {
+    const plan = matchStatement({
+      parsedRows: [
+        parsedRow({ occurredAt: date, descriptionRaw: "matched" }),
+        parsedRow({ occurredAt: date, descriptionRaw: "new" }),
+      ],
+      existingTxns: [
+        existingTxn({ id: 1, occurredAt: date, descriptionRaw: "matched" }),
+        existingTxn({ id: 2, occurredAt: date, descriptionRaw: "unmatched existing" }),
+      ],
+    });
+    expect(plan.summary.matched).toBe(plan.decisions.filter((d) => d.action === "match").length);
+    expect(plan.summary.newInserts).toBe(
+      plan.decisions.filter((d) => d.action === "insert_new").length,
+    );
+    expect(plan.summary.flaggedExisting).toBe(plan.flaggedExisting.length);
+  });
+
+  it("dateToleranceDays config is honored", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date })],
+      existingTxns: [existingTxn({ id: 1, occurredAt: new Date(date.getTime() - 5 * DAY_MS) })],
+      config: { dateToleranceDays: 7 },
+    });
+    expect(plan.decisions[0].action).toBe("match");
+  });
+});

--- a/src/lib/reconciliation/engine/match.ts
+++ b/src/lib/reconciliation/engine/match.ts
@@ -1,0 +1,117 @@
+import type { ParsedStatementRow } from "../parsers/types";
+import type { ExistingTxnForMatch, MatchDecision, MatchingInput, MatchingPlan } from "./types";
+
+const DEFAULT_DATE_TOLERANCE_DAYS = 3;
+const DEFAULT_MERCHANT_FUZZ_THRESHOLD = 0.5;
+const MS_PER_DAY = 86_400_000;
+
+export function matchStatement(input: MatchingInput): MatchingPlan {
+  const dateToleranceDays = input.config?.dateToleranceDays ?? DEFAULT_DATE_TOLERANCE_DAYS;
+  const merchantFuzzThreshold =
+    input.config?.merchantFuzzThreshold ?? DEFAULT_MERCHANT_FUZZ_THRESHOLD;
+  const toleranceMs = dateToleranceDays * MS_PER_DAY;
+
+  const eligibleExisting = input.existingTxns.filter(
+    (e) => e.channel !== "manual" && !e.isAdjustment,
+  );
+  const consumed = new Set<number>();
+  const decisions: MatchDecision[] = [];
+
+  for (let i = 0; i < input.parsedRows.length; i++) {
+    const parsed = input.parsedRows[i];
+    const parsedSignedCents = parsed.direction === "in" ? parsed.amountCents : -parsed.amountCents;
+    const parsedTokens = tokenize(parsed.descriptionRaw);
+
+    let best: { txnId: number; score: number; reason: MatchDecision["matchReason"] } | null = null;
+
+    for (const candidate of eligibleExisting) {
+      if (consumed.has(candidate.id)) continue;
+      if (candidate.currency !== parsed.currency) continue;
+      if (candidate.amountCents !== parsedSignedCents) continue;
+
+      const deltaMs = Math.abs(candidate.occurredAt.getTime() - parsed.occurredAt.getTime());
+      if (deltaMs > toleranceMs) continue;
+
+      const candidateTokens = tokenize(`${candidate.descriptionRaw} ${candidate.merchant ?? ""}`);
+      const similarity = jaccard(parsedTokens, candidateTokens);
+      const reason: MatchDecision["matchReason"] =
+        similarity >= merchantFuzzThreshold ? "amount_date_fuzzy_merchant" : "amount_date_exact";
+      const score = scoreMatch(deltaMs, similarity);
+
+      if (!best || score > best.score) {
+        best = { txnId: candidate.id, score, reason };
+      }
+    }
+
+    if (best) {
+      consumed.add(best.txnId);
+      decisions.push({
+        statementRowIndex: i,
+        action: "match",
+        matchedTxnId: best.txnId,
+        matchScore: best.score,
+        matchReason: best.reason,
+      });
+    } else {
+      decisions.push({
+        statementRowIndex: i,
+        action: "insert_new",
+        matchedTxnId: null,
+        matchScore: 0,
+        matchReason: "no_match",
+      });
+    }
+  }
+
+  const flaggedExisting = eligibleExisting
+    .filter((e) => !consumed.has(e.id) && e.reconciliationStatus === "unreconciled")
+    .map((e) => ({ txnId: e.id, reason: "no_statement_match" as const }));
+
+  const matched = decisions.filter((d) => d.action === "match").length;
+  const newInserts = decisions.length - matched;
+
+  return {
+    decisions,
+    flaggedExisting,
+    summary: {
+      matched,
+      newInserts,
+      flaggedExisting: flaggedExisting.length,
+    },
+  };
+}
+
+/**
+ * Score in [0, 100]: date proximity dominates (up to 50), merchant
+ * similarity fills the rest (up to 50). Same-day gets the full 50;
+ * each additional day drops 10 points until 0.
+ */
+function scoreMatch(deltaMs: number, similarity: number): number {
+  const deltaDays = Math.round(deltaMs / MS_PER_DAY);
+  const dateScore = Math.max(0, 50 - deltaDays * 10);
+  const merchantScore = Math.round(similarity * 50);
+  return Math.min(100, dateScore + merchantScore);
+}
+
+export function tokenize(input: string): Set<string> {
+  const cleaned = input
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^\p{L}\p{N}\s]+/gu, " ");
+  const out = new Set<string>();
+  for (const token of cleaned.split(/\s+/)) {
+    if (token.length >= 3) out.add(token);
+  }
+  return out;
+}
+
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  let intersectionSize = 0;
+  for (const t of a) if (b.has(t)) intersectionSize++;
+  const unionSize = a.size + b.size - intersectionSize;
+  return unionSize === 0 ? 0 : intersectionSize / unionSize;
+}
+
+export type { ParsedStatementRow, ExistingTxnForMatch };

--- a/src/lib/reconciliation/engine/types.ts
+++ b/src/lib/reconciliation/engine/types.ts
@@ -1,0 +1,56 @@
+import type { ParsedStatementRow } from "../parsers/types";
+
+/**
+ * Shape the engine expects for an existing transaction when deciding
+ * matches. The caller (upload endpoint) projects the full tx row into
+ * this subset. `amountCents` is SIGNED per findash's DB convention:
+ * positive = ingreso, negative = gasto.
+ */
+export interface ExistingTxnForMatch {
+  id: number;
+  occurredAt: Date;
+  amountCents: bigint;
+  currency: "COP" | "USD";
+  descriptionRaw: string;
+  merchant: string | null;
+  channel: "bank" | "manual" | "transfer";
+  isAdjustment: boolean;
+  reconciliationStatus: "unreconciled" | "matched" | "flagged" | "imported_from_statement";
+}
+
+export type MatchAction = "match" | "insert_new";
+export type MatchReason = "amount_date_exact" | "amount_date_fuzzy_merchant" | "no_match";
+
+export interface MatchDecision {
+  statementRowIndex: number;
+  action: MatchAction;
+  matchedTxnId: number | null;
+  matchScore: number;
+  matchReason: MatchReason;
+}
+
+export interface FlaggedExistingTxn {
+  txnId: number;
+  reason: "no_statement_match";
+}
+
+export interface MatchingPlan {
+  decisions: MatchDecision[];
+  flaggedExisting: FlaggedExistingTxn[];
+  summary: {
+    matched: number;
+    newInserts: number;
+    flaggedExisting: number;
+  };
+}
+
+export interface MatchingConfig {
+  dateToleranceDays?: number;
+  merchantFuzzThreshold?: number;
+}
+
+export interface MatchingInput {
+  parsedRows: ParsedStatementRow[];
+  existingTxns: ExistingTxnForMatch[];
+  config?: MatchingConfig;
+}


### PR DESCRIPTION
Closes #291. Core matching algorithm — pure function with 24 tests. No DB, no I/O. Feeds upload endpoint (next PR).

## What

- **`types.ts`** — `ExistingTxnForMatch`, `MatchDecision`, `MatchingPlan`, `MatchingInput`, `MatchingConfig`. `ExistingTxnForMatch.amountCents` is SIGNED (findash DB convention: positive = ingreso, negative = gasto). Engine translates parser-side magnitude+direction at boundary.
- **`match.ts`** — `matchStatement(input) → MatchingPlan`:
  - Greedy: iterates parsed rows in order; matched existing txns are consumed and not reconsidered
  - Match criteria (all required): same currency, exact magnitude, direction derivable from signed amountCents matches, `|Δt| ≤ dateToleranceDays` (default 3)
  - Excluded from matching + flagging: `channel='manual'` and `isAdjustment=true` (they can't appear in a bank statement)
  - Already-matched and `imported_from_statement` existing txns don't get re-flagged
  - Scoring (0-100): date proximity dominates (up to 50, drops 10/day), merchant Jaccard fills the rest (up to 50)
  - `tokenize()` + `jaccard()` exported for reuse + direct testing
- **`match.test.ts`** — 24 tests across 6 suites: happy paths, currency/amount/direction rules, candidate selection (ties, competition), exclusion rules, invariants (determinism, summary consistency, config honored)

## Design notes

- **Sign convention at the boundary**: parsers emit magnitude + `direction: 'in' | 'out'`. Engine converts to signed cents inside `matchStatement` before comparison. Downstream (endpoint) also translates parser output → signed before writing to `transactions.amount_cents`.
- **Determinism**: greedy first-seen-wins. Same input → same output, every time. Verified by a test.
- **No minimum score threshold** for matching. Amount match is authoritative per the PLAN.md algorithm. Merchant similarity only breaks ties among multiple same-amount candidates. This is intentionally permissive — the engine prefers a match over insert+flag when the bank data supports it.

## Out of scope (follow-ups)
- Upload endpoint that wires parser + engine + DB writes (+ retires the legacy `/settings/import` flow)
- UI reconcile page
- Divergence tracking
- Insight detection

## Test plan
- [x] `bun run test` → 480 pass (24 new engine tests on top of 456)
- [x] `bun run typecheck` clean
- [x] `bun run format:check` clean
- [x] `bun run lint` clean (one pre-existing warning unrelated to this PR)