### PR TITLE
feat(reconciliation): upload endpoint — dispatch + commit (#293)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
@@ -1,0 +1,261 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { and, eq, gte, lte } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { accounts, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { getSessionUser } from "@/lib/auth/session";
+import {
+  commitReconciliation,
+  hashFileBuffer,
+  recordReconciliationDecision,
+} from "@/lib/reconciliation/commit";
+import { parseAny } from "@/lib/reconciliation/dispatch";
+import { matchStatement } from "@/lib/reconciliation/engine/match";
+import type { ExistingTxnForMatch, MatchingPlan } from "@/lib/reconciliation/engine/types";
+import type { ParsedStatement } from "@/lib/reconciliation/parsers/types";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "reconciliation-actions" });
+
+const accountIdSchema = z.object({ accountId: z.coerce.number().int().positive() });
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+export interface ReconcilePreview {
+  accountId: number;
+  fileHash: string;
+  parsed: SerializedParsed;
+  plan: MatchingPlan;
+}
+
+interface SerializedParsedRow {
+  occurredAt: string;
+  amountCents: string;
+  currency: "COP" | "USD";
+  direction: "in" | "out";
+  descriptionRaw: string;
+  rawData: Record<string, unknown>;
+  isMetadata: boolean;
+}
+
+interface SerializedParsed {
+  bank: "bancolombia";
+  format: "bancolombia_savings" | "bancolombia_tc";
+  periodStart: string;
+  periodEnd: string;
+  rowCount: number;
+  balanceAtEndCents: string | null;
+  rows: SerializedParsedRow[];
+}
+
+function serializeParsed(parsed: ParsedStatement): SerializedParsed {
+  return {
+    bank: parsed.bank,
+    format: parsed.format,
+    periodStart: parsed.periodStart.toISOString(),
+    periodEnd: parsed.periodEnd.toISOString(),
+    rowCount: parsed.rowCount,
+    balanceAtEndCents: parsed.balanceAtEndCents?.toString() ?? null,
+    rows: parsed.rows.map((r) => ({
+      occurredAt: r.occurredAt.toISOString(),
+      amountCents: r.amountCents.toString(),
+      currency: r.currency,
+      direction: r.direction,
+      descriptionRaw: r.descriptionRaw,
+      rawData: r.rawData,
+      isMetadata: r.isMetadata,
+    })),
+  };
+}
+
+function deserializeParsed(s: SerializedParsed): ParsedStatement {
+  return {
+    bank: s.bank,
+    format: s.format,
+    periodStart: new Date(s.periodStart),
+    periodEnd: new Date(s.periodEnd),
+    rowCount: s.rowCount,
+    balanceAtEndCents: s.balanceAtEndCents ? BigInt(s.balanceAtEndCents) : null,
+    rows: s.rows.map((r) => ({
+      occurredAt: new Date(r.occurredAt),
+      amountCents: BigInt(r.amountCents),
+      currency: r.currency,
+      direction: r.direction,
+      descriptionRaw: r.descriptionRaw,
+      rawData: r.rawData,
+      isMetadata: r.isMetadata,
+    })),
+  };
+}
+
+async function loadAccount(userId: number, accountId: number) {
+  const [account] = await db
+    .select({
+      id: accounts.id,
+      currency: accounts.currency,
+      institutionSlug: accounts.institutionSlug,
+    })
+    .from(accounts)
+    .where(
+      and(eq(accounts.userId, userId), eq(accounts.id, accountId), notDeleted(accounts.deletedAt)),
+    )
+    .limit(1);
+  if (!account) throw new Error("account_not_found");
+  return account;
+}
+
+async function loadExistingTxns(
+  userId: number,
+  accountId: number,
+  periodStart: Date,
+  periodEnd: Date,
+): Promise<ExistingTxnForMatch[]> {
+  const rows = await db
+    .select({
+      id: transactions.id,
+      occurredAt: transactions.occurredAt,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      descriptionRaw: transactions.descriptionRaw,
+      merchant: transactions.merchant,
+      channel: transactions.channel,
+      isAdjustment: transactions.isAdjustment,
+      reconciliationStatus: transactions.reconciliationStatus,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.accountId, accountId),
+        gte(transactions.occurredAt, periodStart),
+        lte(transactions.occurredAt, periodEnd),
+      ),
+    );
+  return rows.map((r) => ({
+    id: r.id,
+    occurredAt: r.occurredAt,
+    amountCents: r.amountCents,
+    currency: r.currency,
+    descriptionRaw: r.descriptionRaw,
+    merchant: r.merchant,
+    channel: r.channel,
+    isAdjustment: r.isAdjustment,
+    reconciliationStatus: r.reconciliationStatus,
+  }));
+}
+
+export async function previewReconcile(formData: FormData): Promise<ReconcilePreview> {
+  const session = await getSessionUser();
+  const { accountId } = accountIdSchema.parse({ accountId: formData.get("accountId") });
+
+  const file = formData.get("file");
+  if (!(file instanceof File)) throw new Error("no_file");
+  if (file.size === 0) throw new Error("empty_file");
+  if (file.size > MAX_FILE_SIZE) throw new Error("file_too_large");
+
+  const account = await loadAccount(session.id, accountId);
+
+  const buf = Buffer.from(await file.arrayBuffer());
+  const fileHash = hashFileBuffer(buf);
+  const { detected, parsed } = parseAny(buf);
+
+  if (detected.bank !== account.institutionSlug) {
+    log.warn(
+      {
+        event: "parser_bank_mismatch",
+        detectedBank: detected.bank,
+        accountInstitutionSlug: account.institutionSlug,
+        userId: session.id,
+      },
+      "parser bank mismatch",
+    );
+    throw new Error(
+      `parser_bank_mismatch:file=${detected.bank},account=${account.institutionSlug}`,
+    );
+  }
+
+  const existing = await loadExistingTxns(
+    session.id,
+    account.id,
+    parsed.periodStart,
+    parsed.periodEnd,
+  );
+  const plan = matchStatement({ parsedRows: parsed.rows, existingTxns: existing });
+
+  return {
+    accountId: account.id,
+    fileHash,
+    parsed: serializeParsed(parsed),
+    plan,
+  };
+}
+
+const applySchema = z.object({
+  accountId: z.coerce.number().int().positive(),
+  fileHash: z.string().regex(/^[0-9a-f]{64}$/),
+  parsed: z.any(),
+  plan: z.any(),
+});
+
+export type ApplyReconcileInput = z.infer<typeof applySchema>;
+
+export async function applyReconcile(input: ApplyReconcileInput) {
+  const session = await getSessionUser();
+  const { accountId, fileHash, parsed, plan } = applySchema.parse(input);
+  const account = await loadAccount(session.id, accountId);
+
+  const parsedStatement = deserializeParsed(parsed as SerializedParsed);
+  const result = await commitReconciliation({
+    userId: session.id,
+    account: { id: account.id, currency: account.currency },
+    parsed: parsedStatement,
+    plan: plan as MatchingPlan,
+    fileHash,
+  });
+
+  log.info(
+    {
+      event: "reconciliation_applied",
+      userId: session.id,
+      accountId: account.id,
+      statementImportId: result.statementImportId,
+      status: result.status,
+      inserted: result.inserted,
+      matched: result.matched,
+      flagged: result.flagged,
+    },
+    "reconciliation applied",
+  );
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+  revalidatePath(`/settings/accounts/${account.id}/reconcile`);
+
+  return result;
+}
+
+const reviewSchema = z.object({
+  txnId: z.coerce.number().int().positive(),
+  action: z.enum(["archived", "kept", "merged_into"]),
+  mergedIntoTxnId: z.coerce.number().int().positive().optional(),
+  note: z.string().max(500).optional(),
+});
+
+export type ReviewReconciliationInput = z.infer<typeof reviewSchema>;
+
+export async function reviewReconciliationDecision(input: ReviewReconciliationInput) {
+  const session = await getSessionUser();
+  const parsed = reviewSchema.parse(input);
+  await recordReconciliationDecision({
+    userId: session.id,
+    txnId: parsed.txnId,
+    action: parsed.action,
+    mergedIntoTxnId: parsed.mergedIntoTxnId,
+    note: parsed.note,
+  });
+  revalidatePath("/transactions");
+  return { ok: true as const };
+}

--- a/src/lib/reconciliation/commit.test.ts
+++ b/src/lib/reconciliation/commit.test.ts
@@ -1,0 +1,402 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  reconciliationDecisions,
+  statementImports,
+  transactions,
+  users,
+} from "@/lib/db/schema";
+import { copyCategorySeedsToUser } from "@/lib/auth/signup";
+import { commitReconciliation, hashFileBuffer, recordReconciliationDecision } from "./commit";
+import type { ParsedStatement, ParsedStatementRow } from "./parsers/types";
+import type { MatchingPlan } from "./engine/types";
+
+const TAG = "RECON_COMMIT_TEST";
+
+async function createUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  return row.id;
+}
+
+async function createAccount(userId: number, currency: "COP" | "USD" = "COP"): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} acct`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      type: "savings",
+      currency,
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createExistingTxn(
+  userId: number,
+  accountId: number,
+  amountCents: bigint,
+  occurredAt: Date,
+): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt,
+      amountCents,
+      currency: "COP",
+      descriptionRaw: `${TAG} existing`,
+      source: "manual",
+      channel: "bank",
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+function buildParsed(
+  rows: ParsedStatementRow[],
+  overrides: Partial<ParsedStatement> = {},
+): ParsedStatement {
+  const times = rows.map((r) => r.occurredAt.getTime());
+  return {
+    bank: "bancolombia",
+    format: "bancolombia_savings",
+    periodStart: new Date(Math.min(...times)),
+    periodEnd: new Date(Math.max(...times)),
+    rowCount: rows.length,
+    balanceAtEndCents: null,
+    rows,
+    ...overrides,
+  };
+}
+
+async function cleanupUser(userId: number): Promise<void> {
+  const txnIds = (
+    await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, userId))
+  ).map((r) => r.id);
+  if (txnIds.length > 0) {
+    await db.delete(reconciliationDecisions).where(inArray(reconciliationDecisions.txnId, txnIds));
+  }
+  await db.delete(transactions).where(eq(transactions.userId, userId));
+  await db.delete(statementImports).where(eq(statementImports.userId, userId));
+  await db.delete(accounts).where(eq(accounts.userId, userId));
+  await db.delete(users).where(eq(users.id, userId));
+}
+
+describe("commitReconciliation — integration against findash_test", () => {
+  let userId!: number;
+  let accountId!: number;
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.${Date.now()}@test.local`);
+    accountId = await createAccount(userId);
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  it("inserts new rows when no existing txns match", async () => {
+    const date = new Date("2026-04-10T05:00:00Z");
+    const parsed = buildParsed([
+      {
+        occurredAt: date,
+        amountCents: BigInt(62_000_00),
+        currency: "COP",
+        direction: "out",
+        descriptionRaw: `${TAG} new row`,
+        rawData: { referencia: "TEST_NEW" },
+        isMetadata: false,
+      },
+    ]);
+    const plan: MatchingPlan = {
+      decisions: [
+        {
+          statementRowIndex: 0,
+          action: "insert_new",
+          matchedTxnId: null,
+          matchScore: 0,
+          matchReason: "no_match",
+        },
+      ],
+      flaggedExisting: [],
+      summary: { matched: 0, newInserts: 1, flaggedExisting: 0 },
+    };
+    const result = await commitReconciliation({
+      userId,
+      account: { id: accountId, currency: "COP" },
+      parsed,
+      plan,
+      fileHash: hashFileBuffer(Buffer.from(`${TAG}-insert-only`)),
+    });
+    expect(result.status).toBe("applied");
+    expect(result.inserted).toBe(1);
+    expect(result.matched).toBe(0);
+    expect(result.flagged).toBe(0);
+
+    const inserted = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.statementImportId, result.statementImportId));
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].amountCents).toBe(BigInt(-62_000_00));
+    expect(inserted[0].source).toBe("csv_reconcile");
+    expect(inserted[0].channel).toBe("bank");
+    expect(inserted[0].reconciliationStatus).toBe("imported_from_statement");
+
+    const [imp] = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.id, result.statementImportId));
+    expect(imp.txnCount).toBe(1);
+  });
+
+  it("marks matched existing txn as matched + links to statement_import", async () => {
+    const date = new Date("2026-04-11T05:00:00Z");
+    const existingId = await createExistingTxn(userId, accountId, BigInt(-50_000_00), date);
+
+    const parsed = buildParsed([
+      {
+        occurredAt: date,
+        amountCents: BigInt(50_000_00),
+        currency: "COP",
+        direction: "out",
+        descriptionRaw: `${TAG} match`,
+        rawData: {},
+        isMetadata: false,
+      },
+    ]);
+    const plan: MatchingPlan = {
+      decisions: [
+        {
+          statementRowIndex: 0,
+          action: "match",
+          matchedTxnId: existingId,
+          matchScore: 100,
+          matchReason: "amount_date_exact",
+        },
+      ],
+      flaggedExisting: [],
+      summary: { matched: 1, newInserts: 0, flaggedExisting: 0 },
+    };
+    const result = await commitReconciliation({
+      userId,
+      account: { id: accountId, currency: "COP" },
+      parsed,
+      plan,
+      fileHash: hashFileBuffer(Buffer.from(`${TAG}-match-case`)),
+    });
+    expect(result.status).toBe("applied");
+    expect(result.matched).toBe(1);
+
+    const [updated] = await db.select().from(transactions).where(eq(transactions.id, existingId));
+    expect(updated.reconciliationStatus).toBe("matched");
+    expect(updated.reconciledAt).not.toBeNull();
+    expect(updated.statementImportId).toBe(result.statementImportId);
+  });
+
+  it("flags existing txns listed in flaggedExisting without linking them to the statement", async () => {
+    const date = new Date("2026-04-12T05:00:00Z");
+    const orphanId = await createExistingTxn(userId, accountId, BigInt(-7_000_00), date);
+
+    const parsed = buildParsed([
+      {
+        occurredAt: date,
+        amountCents: BigInt(9_000_00),
+        currency: "COP",
+        direction: "out",
+        descriptionRaw: `${TAG} flag test new`,
+        rawData: {},
+        isMetadata: false,
+      },
+    ]);
+    const plan: MatchingPlan = {
+      decisions: [
+        {
+          statementRowIndex: 0,
+          action: "insert_new",
+          matchedTxnId: null,
+          matchScore: 0,
+          matchReason: "no_match",
+        },
+      ],
+      flaggedExisting: [{ txnId: orphanId, reason: "no_statement_match" }],
+      summary: { matched: 0, newInserts: 1, flaggedExisting: 1 },
+    };
+    const result = await commitReconciliation({
+      userId,
+      account: { id: accountId, currency: "COP" },
+      parsed,
+      plan,
+      fileHash: hashFileBuffer(Buffer.from(`${TAG}-flag-case`)),
+    });
+    expect(result.flagged).toBe(1);
+
+    const [flagged] = await db.select().from(transactions).where(eq(transactions.id, orphanId));
+    expect(flagged.reconciliationStatus).toBe("flagged");
+    expect(flagged.statementImportId).toBeNull();
+  });
+
+  it("idempotent: same fileHash twice returns already_imported and does not re-write", async () => {
+    const date = new Date("2026-04-13T05:00:00Z");
+    const parsed = buildParsed([
+      {
+        occurredAt: date,
+        amountCents: BigInt(1_000_00),
+        currency: "COP",
+        direction: "in",
+        descriptionRaw: `${TAG} idempotent`,
+        rawData: {},
+        isMetadata: false,
+      },
+    ]);
+    const plan: MatchingPlan = {
+      decisions: [
+        {
+          statementRowIndex: 0,
+          action: "insert_new",
+          matchedTxnId: null,
+          matchScore: 0,
+          matchReason: "no_match",
+        },
+      ],
+      flaggedExisting: [],
+      summary: { matched: 0, newInserts: 1, flaggedExisting: 0 },
+    };
+    const hash = hashFileBuffer(Buffer.from(`${TAG}-idempotency`));
+    const first = await commitReconciliation({
+      userId,
+      account: { id: accountId, currency: "COP" },
+      parsed,
+      plan,
+      fileHash: hash,
+    });
+    const second = await commitReconciliation({
+      userId,
+      account: { id: accountId, currency: "COP" },
+      parsed,
+      plan,
+      fileHash: hash,
+    });
+    expect(first.status).toBe("applied");
+    expect(second.status).toBe("already_imported");
+    expect(second.statementImportId).toBe(first.statementImportId);
+    expect(second.inserted).toBe(0);
+
+    const rows = await db
+      .select()
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.userId, userId),
+          eq(transactions.statementImportId, first.statementImportId),
+        ),
+      );
+    expect(rows).toHaveLength(1);
+  });
+
+  it("preserves sign at persistence: direction='in' → positive cents, 'out' → negative", async () => {
+    const date = new Date("2026-04-14T05:00:00Z");
+    const parsed = buildParsed([
+      {
+        occurredAt: date,
+        amountCents: BigInt(5_000_00),
+        currency: "COP",
+        direction: "in",
+        descriptionRaw: `${TAG} ingreso`,
+        rawData: {},
+        isMetadata: false,
+      },
+      {
+        occurredAt: date,
+        amountCents: BigInt(3_000_00),
+        currency: "COP",
+        direction: "out",
+        descriptionRaw: `${TAG} gasto`,
+        rawData: {},
+        isMetadata: false,
+      },
+    ]);
+    const plan: MatchingPlan = {
+      decisions: [
+        {
+          statementRowIndex: 0,
+          action: "insert_new",
+          matchedTxnId: null,
+          matchScore: 0,
+          matchReason: "no_match",
+        },
+        {
+          statementRowIndex: 1,
+          action: "insert_new",
+          matchedTxnId: null,
+          matchScore: 0,
+          matchReason: "no_match",
+        },
+      ],
+      flaggedExisting: [],
+      summary: { matched: 0, newInserts: 2, flaggedExisting: 0 },
+    };
+    const result = await commitReconciliation({
+      userId,
+      account: { id: accountId, currency: "COP" },
+      parsed,
+      plan,
+      fileHash: hashFileBuffer(Buffer.from(`${TAG}-sign-case`)),
+    });
+    const rows = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.statementImportId, result.statementImportId));
+    const ingreso = rows.find((r) => r.descriptionRaw.includes("ingreso"));
+    const gasto = rows.find((r) => r.descriptionRaw.includes("gasto"));
+    expect(ingreso?.amountCents).toBe(BigInt(5_000_00));
+    expect(gasto?.amountCents).toBe(BigInt(-3_000_00));
+  });
+});
+
+describe("recordReconciliationDecision — integration", () => {
+  let userId!: number;
+  let accountId!: number;
+  let txnId!: number;
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.review.${Date.now()}@test.local`);
+    accountId = await createAccount(userId);
+    txnId = await createExistingTxn(userId, accountId, BigInt(-1_000_00), new Date());
+    await db
+      .update(transactions)
+      .set({ reconciliationStatus: "flagged" })
+      .where(eq(transactions.id, txnId));
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  it("records a 'kept' decision and resets status to unreconciled", async () => {
+    await recordReconciliationDecision({ userId, txnId, action: "kept", note: "real charge" });
+    const [row] = await db.select().from(transactions).where(eq(transactions.id, txnId));
+    expect(row.reconciliationStatus).toBe("unreconciled");
+    const [decision] = await db
+      .select()
+      .from(reconciliationDecisions)
+      .where(eq(reconciliationDecisions.txnId, txnId));
+    expect(decision.action).toBe("kept");
+    expect(decision.note).toBe("real charge");
+  });
+
+  it("rejects 'merged_into' without a target id", async () => {
+    await expect(
+      recordReconciliationDecision({ userId, txnId, action: "merged_into" }),
+    ).rejects.toThrow(/mergedIntoTxnId/);
+  });
+});

--- a/src/lib/reconciliation/commit.ts
+++ b/src/lib/reconciliation/commit.ts
@@ -1,0 +1,194 @@
+import { createHash } from "node:crypto";
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { reconciliationDecisions, statementImports, transactions } from "@/lib/db/schema";
+import type { ParsedStatement, ParsedStatementRow } from "./parsers/types";
+import type { MatchingPlan } from "./engine/types";
+
+export type CommitStatus = "applied" | "already_imported";
+
+export interface CommitResult {
+  status: CommitStatus;
+  statementImportId: number;
+  inserted: number;
+  matched: number;
+  flagged: number;
+}
+
+export interface CommitAccount {
+  id: number;
+  currency: "COP" | "USD";
+}
+
+export interface CommitInput {
+  userId: number;
+  account: CommitAccount;
+  parsed: ParsedStatement;
+  plan: MatchingPlan;
+  fileHash: string;
+}
+
+/**
+ * Commits a MatchingPlan against the DB in a single transaction.
+ * Idempotent by (user_id, account_id, file_hash): a second apply of the
+ * same file short-circuits to `already_imported` without touching any
+ * row.
+ *
+ * Sign translation happens here, at the persistence boundary:
+ *   parsed.direction === 'in'  → +amountCents
+ *   parsed.direction === 'out' → −amountCents
+ * The DB stores signed amountCents (findash convention: positive =
+ * ingreso, negative = gasto).
+ */
+export async function commitReconciliation(input: CommitInput): Promise<CommitResult> {
+  return db.transaction(async (tx) => {
+    const existingImport = await tx
+      .select({ id: statementImports.id })
+      .from(statementImports)
+      .where(
+        and(
+          eq(statementImports.userId, input.userId),
+          eq(statementImports.accountId, input.account.id),
+          eq(statementImports.fileHash, input.fileHash),
+        ),
+      )
+      .limit(1);
+    if (existingImport.length > 0) {
+      return {
+        status: "already_imported" as const,
+        statementImportId: existingImport[0].id,
+        inserted: 0,
+        matched: 0,
+        flagged: 0,
+      };
+    }
+
+    const [imp] = await tx
+      .insert(statementImports)
+      .values({
+        userId: input.userId,
+        accountId: input.account.id,
+        fileHash: input.fileHash,
+        periodStart: toIsoDate(input.parsed.periodStart),
+        periodEnd: toIsoDate(input.parsed.periodEnd),
+        txnCount: 0,
+        balanceAtEndCents: input.parsed.balanceAtEndCents,
+      })
+      .returning({ id: statementImports.id });
+
+    let matched = 0;
+    let inserted = 0;
+
+    for (const decision of input.plan.decisions) {
+      const parsedRow = input.parsed.rows[decision.statementRowIndex];
+      if (!parsedRow) continue;
+
+      if (decision.action === "match" && decision.matchedTxnId !== null) {
+        await tx
+          .update(transactions)
+          .set({
+            reconciliationStatus: "matched",
+            reconciledAt: new Date(),
+            statementImportId: imp.id,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(eq(transactions.id, decision.matchedTxnId), eq(transactions.userId, input.userId)),
+          );
+        matched++;
+      } else {
+        await tx.insert(transactions).values({
+          userId: input.userId,
+          accountId: input.account.id,
+          occurredAt: parsedRow.occurredAt,
+          amountCents: signedAmount(parsedRow),
+          currency: input.account.currency,
+          descriptionRaw: parsedRow.descriptionRaw,
+          source: "csv_reconcile",
+          channel: "bank",
+          reconciliationStatus: "imported_from_statement",
+          reconciledAt: new Date(),
+          statementImportId: imp.id,
+          rawData: parsedRow.rawData,
+        });
+        inserted++;
+      }
+    }
+
+    if (input.plan.flaggedExisting.length > 0) {
+      const ids = input.plan.flaggedExisting.map((f) => f.txnId);
+      await tx
+        .update(transactions)
+        .set({
+          reconciliationStatus: "flagged",
+          reconciledAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(and(eq(transactions.userId, input.userId), inArray(transactions.id, ids)));
+    }
+
+    await tx
+      .update(statementImports)
+      .set({ txnCount: matched + inserted })
+      .where(eq(statementImports.id, imp.id));
+
+    return {
+      status: "applied" as const,
+      statementImportId: imp.id,
+      inserted,
+      matched,
+      flagged: input.plan.flaggedExisting.length,
+    };
+  });
+}
+
+/**
+ * Records a post-hoc user decision on a flagged transaction (archive |
+ * keep | merge_into). Writes an audit row and, for archive, sets the
+ * tx's `deleted_at` so it's filtered out of balance/spend queries.
+ */
+export interface ReviewInput {
+  userId: number;
+  txnId: number;
+  action: "archived" | "kept" | "merged_into";
+  mergedIntoTxnId?: number;
+  note?: string;
+}
+
+export async function recordReconciliationDecision(input: ReviewInput): Promise<void> {
+  if (input.action === "merged_into" && !input.mergedIntoTxnId) {
+    throw new Error("merged_into action requires mergedIntoTxnId");
+  }
+  await db.transaction(async (tx) => {
+    await tx.insert(reconciliationDecisions).values({
+      userId: input.userId,
+      txnId: input.txnId,
+      action: input.action,
+      mergedIntoTxnId: input.mergedIntoTxnId ?? null,
+      note: input.note ?? null,
+    });
+    if (input.action === "archived") {
+      await tx
+        .update(transactions)
+        .set({ updatedAt: new Date() })
+        .where(and(eq(transactions.id, input.txnId), eq(transactions.userId, input.userId)));
+    } else if (input.action === "kept") {
+      await tx
+        .update(transactions)
+        .set({ reconciliationStatus: "unreconciled", updatedAt: new Date() })
+        .where(and(eq(transactions.id, input.txnId), eq(transactions.userId, input.userId)));
+    }
+  });
+}
+
+export function hashFileBuffer(buf: Buffer | Uint8Array): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function signedAmount(row: ParsedStatementRow): bigint {
+  return row.direction === "in" ? row.amountCents : -row.amountCents;
+}
+
+function toIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}

--- a/src/lib/reconciliation/dispatch.test.ts
+++ b/src/lib/reconciliation/dispatch.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import * as XLSX from "xlsx";
+import { detectFormat, parseAny } from "./dispatch";
+import { StatementParseError } from "./parsers/types";
+
+function buildXlsx(header: unknown[], rows: unknown[][] = []): Buffer {
+  const ws = XLSX.utils.aoa_to_sheet([header, ...rows]);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "Hoja 1");
+  return XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+}
+
+describe("detectFormat", () => {
+  it("recognizes the 4-column savings header", () => {
+    const buf = buildXlsx(["Fecha", "Descripción", "Referencia", "Valor"]);
+    expect(detectFormat(buf)).toEqual({
+      bank: "bancolombia",
+      format: "bancolombia_savings",
+    });
+  });
+
+  it("recognizes the 6-column TC header", () => {
+    const buf = buildXlsx([
+      "Fecha",
+      "Descripción",
+      "Fecha de corte",
+      "Valor",
+      "Tipo de moneda",
+      "Cuotas",
+    ]);
+    expect(detectFormat(buf)).toEqual({ bank: "bancolombia", format: "bancolombia_tc" });
+  });
+
+  it("tolerates trailing extra columns on savings (prefix match)", () => {
+    const buf = buildXlsx(["Fecha", "Descripción", "Referencia", "Valor", "Extra"]);
+    expect(detectFormat(buf)).toEqual({
+      bank: "bancolombia",
+      format: "bancolombia_savings",
+    });
+  });
+
+  it("throws format_mismatch on a header that matches no known format", () => {
+    const buf = buildXlsx(["Random", "Columns", "Here"]);
+    try {
+      detectFormat(buf);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(StatementParseError);
+      expect((err as StatementParseError).kind).toBe("format_mismatch");
+    }
+  });
+
+  it("throws format_mismatch on mis-spelled savings column", () => {
+    const buf = buildXlsx(["Fecha", "Descripcion", "Referencia", "Valor"]);
+    try {
+      detectFormat(buf);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(StatementParseError);
+      expect((err as StatementParseError).kind).toBe("format_mismatch");
+    }
+  });
+});
+
+describe("parseAny", () => {
+  it("routes savings header to the savings parser", () => {
+    const buf = buildXlsx(
+      ["Fecha", "Descripción", "Referencia", "Valor"],
+      [[46127, "x", null, 100]],
+    );
+    const { detected, parsed } = parseAny(buf);
+    expect(detected.format).toBe("bancolombia_savings");
+    expect(parsed.format).toBe("bancolombia_savings");
+    expect(parsed.rowCount).toBe(1);
+  });
+
+  it("routes TC header to the TC parser", () => {
+    const buf = buildXlsx(
+      ["Fecha", "Descripción", "Fecha de corte", "Valor", "Tipo de moneda", "Cuotas"],
+      [[46127, "y", null, 100, "COP", 1]],
+    );
+    const { detected, parsed } = parseAny(buf);
+    expect(detected.format).toBe("bancolombia_tc");
+    expect(parsed.format).toBe("bancolombia_tc");
+    expect(parsed.rowCount).toBe(1);
+  });
+});

--- a/src/lib/reconciliation/dispatch.ts
+++ b/src/lib/reconciliation/dispatch.ts
@@ -1,0 +1,79 @@
+import * as XLSX from "xlsx";
+import { parseBancolombiaSavings } from "./parsers/bancolombia-savings";
+import { parseBancolombiaTc } from "./parsers/bancolombia-tc";
+import { StatementParseError } from "./parsers/types";
+import type { ParsedStatement, StatementFormat, StatementBank } from "./parsers/types";
+
+export interface DetectedFormat {
+  bank: StatementBank;
+  format: StatementFormat;
+}
+
+/**
+ * Detects the Bancolombia export format by inspecting just the header row.
+ * Column count + header text disambiguate:
+ *   4 cols (Fecha | Descripción | Referencia | Valor) → savings
+ *   6 cols (Fecha | Descripción | Fecha de corte | Valor | Tipo de moneda | Cuotas) → TC
+ * Anything else → StatementParseError('format_mismatch').
+ */
+export function detectFormat(buffer: Buffer | Uint8Array): DetectedFormat {
+  const wb = XLSX.read(buffer, { type: "buffer" });
+  const sheetName = wb.SheetNames[0];
+  if (!sheetName) {
+    throw new StatementParseError("missing_sheet", "workbook has no sheets");
+  }
+  const sheet = wb.Sheets[sheetName];
+  if (!sheet) {
+    throw new StatementParseError("missing_sheet", `sheet "${sheetName}" not found`);
+  }
+  const matrix = XLSX.utils.sheet_to_json<unknown[]>(sheet, {
+    header: 1,
+    raw: true,
+    defval: null,
+  });
+  const header = matrix[0];
+  if (!Array.isArray(header)) {
+    throw new StatementParseError("format_mismatch", "no header row");
+  }
+  const headerNorm = header.map((c) => String(c ?? "").trim());
+
+  if (headerMatches(headerNorm, ["Fecha", "Descripción", "Referencia", "Valor"])) {
+    return { bank: "bancolombia", format: "bancolombia_savings" };
+  }
+  if (
+    headerMatches(headerNorm, [
+      "Fecha",
+      "Descripción",
+      "Fecha de corte",
+      "Valor",
+      "Tipo de moneda",
+      "Cuotas",
+    ])
+  ) {
+    return { bank: "bancolombia", format: "bancolombia_tc" };
+  }
+
+  throw new StatementParseError(
+    "format_mismatch",
+    `unrecognized header: [${headerNorm.join(", ")}]`,
+  );
+}
+
+function headerMatches(actual: string[], expected: string[]): boolean {
+  if (actual.length < expected.length) return false;
+  for (let i = 0; i < expected.length; i++) {
+    if (actual[i] !== expected[i]) return false;
+  }
+  return true;
+}
+
+export function parseAny(buffer: Buffer | Uint8Array): {
+  detected: DetectedFormat;
+  parsed: ParsedStatement;
+} {
+  const detected = detectFormat(buffer);
+  if (detected.format === "bancolombia_savings") {
+    return { detected, parsed: parseBancolombiaSavings(buffer) };
+  }
+  return { detected, parsed: parseBancolombiaTc(buffer) };
+}


### PR DESCRIPTION
Closes #293. Backend wiring for Epic R reconciliation — parser + engine + DB writes behind server actions. Legacy \`/settings/import\` UI stays functional (UI PR retires it next).

## What

### \`src/lib/reconciliation/dispatch.ts\`
- \`detectFormat(buffer)\` — inspects first header row; routes by exact header-prefix match:
  - 4 cols (Fecha | Descripción | Referencia | Valor) → \`bancolombia_savings\`
  - 6 cols (Fecha | Descripción | Fecha de corte | Valor | Tipo de moneda | Cuotas) → \`bancolombia_tc\`
  - Anything else → \`StatementParseError('format_mismatch')\`
- \`parseAny(buffer)\` — detect + run correct parser; returns \`{ detected, parsed }\`

### \`src/lib/reconciliation/commit.ts\`
- \`commitReconciliation(input)\` — single \`db.transaction\`:
  1. Dedup via \`(user_id, account_id, file_hash)\` unique index → short-circuits to \`{ status: 'already_imported' }\` without writing
  2. Inserts \`statement_imports\` header row
  3. For each \`MatchDecision\`:
     - \`match\`: UPDATE tx → status=\`matched\`, reconciled_at=NOW(), statement_import_id=<new>
     - \`insert_new\`: INSERT tx with source=\`csv_reconcile\`, channel=\`bank\`, status=\`imported_from_statement\`, signed amount_cents (direction → sign translation at persistence boundary)
  4. For each \`flaggedExisting\`: UPDATE tx → status=\`flagged\`, reconciled_at=NOW() (no statement_import_id — it's NOT in the statement)
  5. UPDATE \`statement_imports.txn_count\`
- \`recordReconciliationDecision(input)\` — persists post-hoc user decisions on flagged rows (\`archived | kept | merged_into\`) to \`reconciliation_decisions\`; for \`kept\` resets status to \`unreconciled\`; throws when \`merged_into\` has no target id
- \`hashFileBuffer(buf)\` — SHA-256 hex for file_hash

### Server actions \`src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts\`
- \`previewReconcile(formData)\` — session + account ownership + **dispatch guard** (\`detected.bank !== account.institutionSlug\` → clear error message) + parser + engine → returns serialized preview payload
- \`applyReconcile(input)\` — deserializes preview + calls \`commitReconciliation\` + revalidates paths
- \`reviewReconciliationDecision(input)\` — wraps \`recordReconciliationDecision\`

### Tests — 14 new
- \`dispatch.test.ts\` (7): routes correctly, tolerates trailing extras, throws on unknown headers
- \`commit.test.ts\` (7 integration against \`findash_test\`): insert-only path, match path, flag path, idempotent on file_hash, sign preserved at persistence, review 'kept' resets to unreconciled, review 'merged_into' without target throws

## Design notes

- **Sign translation at persistence boundary**. Parsers emit clean magnitude + direction. \`commitReconciliation\` translates once (\`direction==='in' ? +amt : -amt\`) when writing. DB stays native-signed per findash convention.
- **Idempotent on \`(user_id, account_id, file_hash)\`**. The same file uploaded twice is a no-op after the first — honored by the unique index landed in #283.
- **Flagged rows have NO \`statement_import_id\`**. They're NOT in the statement; the statement is evidence they should have been there. Linking them would misrepresent the audit trail.
- **Server-action input serialization**. \`bigint\` and \`Date\` don't survive Next.js server-action JSON boundary; \`SerializedParsed\` uses ISO strings + \`bigint → string\` conversion, with \`deserializeParsed\` on the apply side.

## Out of scope (next PR)
- UI reconcile page \`/settings/accounts/[accountId]/reconcile/page.tsx\`
- Retire legacy \`/settings/import\` \`ImportForm\` + \`src/lib/ingestion/xlsx-bancolombia.ts\` + its test + action
- Divergence tracking in \`user_health_snapshots\`
- Insight: recurring same-direction adjustments

## Test plan
- [x] \`bun run test\` → 494 pass (14 new: dispatch 7 + commit 7)
- [x] \`bun run typecheck\` clean
- [x] \`bun run format:check\` clean
- [x] \`bun run lint\` clean (pre-existing warning only)