### PR TITLE
feat(telemetry): populate divergence + unreconciled count; surface on /admin/health (#297)

### DIFF
--- a/src/app/(app)/admin/health/health-table.tsx
+++ b/src/app/(app)/admin/health/health-table.tsx
@@ -31,6 +31,10 @@ type UserHealthRow = {
 };
 
 const PARSER_WARN_THRESHOLD = 0.9;
+const UNRECONCILED_WARN = 20;
+// 50k COP — large enough that a consistently-same-direction drift is worth
+// investigating as a parser bug rather than dismissed as noise.
+const DIVERGENCE_WARN_CENTS = BigInt(50_000_00);
 
 export function HealthTable({ rows }: { rows: UserHealthRow[] }) {
   const [pending, startTransition] = useTransition();
@@ -107,7 +111,7 @@ function UserRowCard({ row }: { row: UserHealthRow }) {
           )}
         </div>
       </CardHeader>
-      <CardContent className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <CardContent className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
         <Metric label="Último capture" value={formatRelative(latest?.lastCaptureAt)} />
         <Metric label="Último SMS" value={formatRelative(latest?.lastSmsReceivedAt)} />
         <Metric
@@ -115,6 +119,16 @@ function UserRowCard({ row }: { row: UserHealthRow }) {
           value={formatRate(latest?.parserSuccessRate30d)}
           diff={diffRate(latest?.parserSuccessRate30d, weekAgo?.parserSuccessRate30d)}
           warn={lowRate}
+        />
+        <Metric
+          label="Unreconciled"
+          value={formatCount(latest?.unreconciledTxnCount)}
+          warn={(latest?.unreconciledTxnCount ?? 0) >= UNRECONCILED_WARN}
+        />
+        <Metric
+          label="Divergence 30d"
+          value={formatCents(latest?.divergenceCents)}
+          warn={isDivergenceLarge(latest?.divergenceCents)}
         />
         <Metric label="Sources 30d" value={formatSources(latest?.captureSources30d)} subtle />
       </CardContent>
@@ -170,6 +184,29 @@ function diffRate(now: number | null | undefined, prev: number | null | undefine
   if (Math.abs(delta) < 0.001) return "estable vs semana anterior";
   const sign = delta > 0 ? "+" : "";
   return `${sign}${(delta * 100).toFixed(1)}pp vs semana anterior`;
+}
+
+function formatCount(n: number | undefined): string {
+  if (n === undefined) return "—";
+  return String(n);
+}
+
+function formatCents(cents: string | null | undefined): string {
+  if (cents === null || cents === undefined) return "—";
+  const n = BigInt(cents);
+  const abs = n < BigInt(0) ? -n : n;
+  const major = abs / BigInt(100);
+  const sign = n < BigInt(0) ? "-" : "+";
+  // Format with thousands separators in Spanish-style
+  const grouped = major.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  return `${sign}$${grouped}`;
+}
+
+function isDivergenceLarge(cents: string | null | undefined): boolean {
+  if (cents === null || cents === undefined) return false;
+  const n = BigInt(cents);
+  const abs = n < BigInt(0) ? -n : n;
+  return abs >= DIVERGENCE_WARN_CENTS;
 }
 
 function formatSources(sources: Record<string, number | undefined> | undefined): string {

--- a/src/lib/telemetry/user-health.test.ts
+++ b/src/lib/telemetry/user-health.test.ts
@@ -39,15 +39,22 @@ async function seedTx(opts: {
   accountId: number;
   source: "sms" | "apple_pay" | "telegram" | "manual" | "csv";
   createdAt: Date;
+  channel?: "bank" | "manual" | "transfer";
+  isAdjustment?: boolean;
+  amountCents?: bigint;
+  reconciliationStatus?: "unreconciled" | "matched" | "flagged" | "imported_from_statement";
 }): Promise<void> {
   await db.insert(transactions).values({
     userId: TEST_USER_ID,
     accountId: opts.accountId,
     occurredAt: opts.createdAt,
-    amountCents: BigInt(-10000),
+    amountCents: opts.amountCents ?? BigInt(-10000),
     currency: "COP",
     descriptionRaw: `${TEST_TX_TAG}-${opts.source}`,
     source: opts.source,
+    channel: opts.channel ?? "bank",
+    isAdjustment: opts.isAdjustment ?? false,
+    reconciliationStatus: opts.reconciliationStatus ?? "unreconciled",
     createdAt: opts.createdAt,
     updatedAt: opts.createdAt,
   });
@@ -172,6 +179,88 @@ describe("computeUserHealthSnapshot", () => {
     const snap = await computeUserHealthSnapshot(TEST_USER_ID, NOW);
     expect(snap.churnSignalFlag).toBe(false);
   });
+
+  it("counts only unreconciled bank-channel non-adjustment txns as unreconciled", async () => {
+    const accountId = await seedAccount();
+    // 2 unreconciled bank rows → should be counted
+    await seedTx({
+      accountId,
+      source: "sms",
+      createdAt: ago(1),
+      reconciliationStatus: "unreconciled",
+    });
+    await seedTx({
+      accountId,
+      source: "sms",
+      createdAt: ago(2),
+      reconciliationStatus: "unreconciled",
+    });
+    // matched → excluded
+    await seedTx({
+      accountId,
+      source: "sms",
+      createdAt: ago(3),
+      reconciliationStatus: "matched",
+    });
+    // manual channel → excluded even when unreconciled
+    await seedTx({
+      accountId,
+      source: "manual",
+      createdAt: ago(4),
+      channel: "manual",
+      reconciliationStatus: "unreconciled",
+    });
+    // is_adjustment → excluded
+    await seedTx({
+      accountId,
+      source: "manual",
+      createdAt: ago(5),
+      isAdjustment: true,
+      reconciliationStatus: "unreconciled",
+    });
+
+    const snap = await computeUserHealthSnapshot(TEST_USER_ID, NOW);
+    expect(snap.unreconciledTxnCount).toBe(2);
+  });
+
+  it("sums is_adjustment txn amounts in the last 30 days for divergenceCents (signed)", async () => {
+    const accountId = await seedAccount();
+    // +50000 adjustment (findash was UNDER)
+    await seedTx({
+      accountId,
+      source: "manual",
+      createdAt: ago(1),
+      isAdjustment: true,
+      amountCents: BigInt(50_000_00),
+    });
+    // −10000 adjustment (findash was slightly OVER)
+    await seedTx({
+      accountId,
+      source: "manual",
+      createdAt: ago(5),
+      isAdjustment: true,
+      amountCents: BigInt(-10_000_00),
+    });
+    // outside the window → excluded
+    await seedTx({
+      accountId,
+      source: "manual",
+      createdAt: ago(40),
+      isAdjustment: true,
+      amountCents: BigInt(999_999_00),
+    });
+
+    const snap = await computeUserHealthSnapshot(TEST_USER_ID, NOW);
+    expect(snap.divergenceCents).toBe(BigInt(40_000_00));
+  });
+
+  it("returns divergenceCents=null when there are zero adjustments in the window", async () => {
+    const accountId = await seedAccount();
+    await seedTx({ accountId, source: "sms", createdAt: ago(1) });
+
+    const snap = await computeUserHealthSnapshot(TEST_USER_ID, NOW);
+    expect(snap.divergenceCents).toBeNull();
+  });
 });
 
 describe("saveUserHealthSnapshot + snapshotAllActiveUsers", () => {
@@ -193,7 +282,8 @@ describe("saveUserHealthSnapshot + snapshotAllActiveUsers", () => {
     expect(row.capturedAt.toISOString()).toBe(NOW.toISOString());
     expect(row.captureSources30d).toEqual({ sms: 1 });
     expect(row.parserSuccessRate30d).toBe("1.0000");
-    expect(row.unreconciledTxnCount).toBe(0);
+    // The seeded txn defaults to bank channel + unreconciled status, so it counts.
+    expect(row.unreconciledTxnCount).toBe(1);
     expect(row.divergenceCents).toBeNull();
     expect(row.churnSignalFlag).toBe(false);
   });

--- a/src/lib/telemetry/user-health.ts
+++ b/src/lib/telemetry/user-health.ts
@@ -86,14 +86,42 @@ export async function computeUserHealthSnapshot(
     now.getTime() - lastCaptureAt.getTime() > SEVEN_DAYS_MS &&
     now.getTime() - firstCaptureAt.getTime() > FOURTEEN_DAYS_MS;
 
+  const [unreconciledRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.channel, "bank"),
+        eq(transactions.isAdjustment, false),
+        eq(transactions.reconciliationStatus, "unreconciled"),
+      ),
+    );
+
+  const [divergenceRow] = await db
+    .select({
+      count: sql<number>`count(*)::int`,
+      sum: sql<string | null>`sum(${transactions.amountCents})::text`,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.isAdjustment, true),
+        gte(transactions.occurredAt, thirtyDaysAgo),
+      ),
+    );
+
+  const divergenceCents =
+    divergenceRow.count === 0 || divergenceRow.sum === null ? null : BigInt(divergenceRow.sum);
+
   return {
     lastSmsReceivedAt: smsRow.last ? new Date(smsRow.last) : null,
     lastCaptureAt,
     captureSources30d,
     parserSuccessRate30d,
-    // Both populated once Epic R (bank reconciliation) ships.
-    unreconciledTxnCount: 0,
-    divergenceCents: null,
+    unreconciledTxnCount: unreconciledRow.count,
+    divergenceCents,
     churnSignalFlag,
   };
 }


### PR DESCRIPTION
Closes #297. Wires up the two \`user_health_snapshots\` columns that were added in #248 as placeholders pending Epic R. Now that Epic R parsers + engine + endpoint are live, the numbers mean something.

## What

### \`computeUserHealthSnapshot\` (\`src/lib/telemetry/user-health.ts\`)
- **\`unreconciledTxnCount\`**: count of txns matching \`user_id=uid, channel='bank', is_adjustment=false, reconciliation_status='unreconciled'\`. Manual-channel rows and adjustments are excluded per PLAN.md reconciliation rules. Represents captures that haven't yet been confirmed by a statement — a drift-accumulation signal.
- **\`divergenceCents\`**: \`SUM(amount_cents)\` of \`is_adjustment=true\` txns whose \`occurred_at\` is within the last 30 days. Signed:
  - \`+\` → findash was UNDER-counting (user added money via adjustments)
  - \`−\` → findash was OVER-counting
  - \`null\` → zero adjustments in the window (no signal)

### \`/admin/health\` UI (\`health-table.tsx\`)
Two new metric cards on each \`UserRowCard\`:
- **Unreconciled** — raw count, warn-tinted when ≥ 20
- **Divergence 30d** — signed \`+$NNN\` / \`−$NNN\` COP, warn-tinted when \`|value| ≥ 50,000\` COP
- Grid bumped to 6 cards on xl viewports so nothing feels cramped

### Tests
\`user-health.test.ts\`:
- New test: unreconciled count excludes matched / manual-channel / is_adjustment rows
- New test: divergence sums signed amounts over the 30d window; adjustment outside window is excluded
- New test: divergence is \`null\` when zero adjustments
- Updated existing snapshot-shape test: the seeded sms txn now correctly counts as 1 unreconciled

## Out of scope
- Insight: "recurring same-direction adjustments" (parser bug detector + optional bot push) — separate follow-up

## Test plan
- [x] \`bun run test\` → 491 pass (3 new user-health cases)
- [x] \`bun run typecheck\` clean
- [x] \`bun run format:check\` clean
- [x] \`bun run lint\` clean (zero warnings)