### PR TITLE
feat(reconciliation): insight — recurring same-direction adjustments (#299)

### DIFF
--- a/src/app/(app)/admin/health/health-table.tsx
+++ b/src/app/(app)/admin/health/health-table.tsx
@@ -19,6 +19,15 @@ type SnapshotSummary = {
   churnSignalFlag: boolean;
 };
 
+type RecurringAdjustmentInsight = {
+  kind: "recurring_same_direction_adjustments";
+  direction: "in" | "out";
+  count: number;
+  totalCents: string;
+  message: string;
+  windowDays: number;
+};
+
 type UserHealthRow = {
   userId: number;
   email: string;
@@ -28,6 +37,7 @@ type UserHealthRow = {
   active: boolean;
   latest: SnapshotSummary | null;
   weekAgo: SnapshotSummary | null;
+  insight?: RecurringAdjustmentInsight | null;
 };
 
 const PARSER_WARN_THRESHOLD = 0.9;
@@ -111,26 +121,37 @@ function UserRowCard({ row }: { row: UserHealthRow }) {
           )}
         </div>
       </CardHeader>
-      <CardContent className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
-        <Metric label="Último capture" value={formatRelative(latest?.lastCaptureAt)} />
-        <Metric label="Último SMS" value={formatRelative(latest?.lastSmsReceivedAt)} />
-        <Metric
-          label="Parser success 30d"
-          value={formatRate(latest?.parserSuccessRate30d)}
-          diff={diffRate(latest?.parserSuccessRate30d, weekAgo?.parserSuccessRate30d)}
-          warn={lowRate}
-        />
-        <Metric
-          label="Unreconciled"
-          value={formatCount(latest?.unreconciledTxnCount)}
-          warn={(latest?.unreconciledTxnCount ?? 0) >= UNRECONCILED_WARN}
-        />
-        <Metric
-          label="Divergence 30d"
-          value={formatCents(latest?.divergenceCents)}
-          warn={isDivergenceLarge(latest?.divergenceCents)}
-        />
-        <Metric label="Sources 30d" value={formatSources(latest?.captureSources30d)} subtle />
+      <CardContent className="flex flex-col gap-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
+          <Metric label="Último capture" value={formatRelative(latest?.lastCaptureAt)} />
+          <Metric label="Último SMS" value={formatRelative(latest?.lastSmsReceivedAt)} />
+          <Metric
+            label="Parser success 30d"
+            value={formatRate(latest?.parserSuccessRate30d)}
+            diff={diffRate(latest?.parserSuccessRate30d, weekAgo?.parserSuccessRate30d)}
+            warn={lowRate}
+          />
+          <Metric
+            label="Unreconciled"
+            value={formatCount(latest?.unreconciledTxnCount)}
+            warn={(latest?.unreconciledTxnCount ?? 0) >= UNRECONCILED_WARN}
+          />
+          <Metric
+            label="Divergence 30d"
+            value={formatCents(latest?.divergenceCents)}
+            warn={isDivergenceLarge(latest?.divergenceCents)}
+          />
+          <Metric label="Sources 30d" value={formatSources(latest?.captureSources30d)} subtle />
+        </div>
+        {row.insight ? (
+          <div className="flex gap-2 rounded-md border border-amber-300 bg-amber-50/60 p-3 text-sm text-amber-900">
+            <AlertTriangleIcon className="mt-0.5 size-4 shrink-0" />
+            <div>
+              <div className="font-medium">Parser bug suspected</div>
+              <div className="text-xs">{row.insight.message}</div>
+            </div>
+          </div>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/src/app/(app)/admin/health/page.tsx
+++ b/src/app/(app)/admin/health/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { getSessionUser } from "@/lib/auth/session";
 import { listUserHealthRows } from "@/lib/telemetry/queries";
+import { detectRecurringAdjustmentInsight } from "@/lib/reconciliation/insights";
 import { HealthTable } from "./health-table";
 
 export const dynamic = "force-dynamic";
@@ -10,17 +11,30 @@ export default async function AdminHealthPage() {
   if (session.role !== "admin") notFound();
 
   const rows = await listUserHealthRows();
-  const payload = rows.map((row) => ({
-    ...row,
-    latest: row.latest && {
-      ...row.latest,
-      divergenceCents: row.latest.divergenceCents?.toString() ?? null,
-    },
-    weekAgo: row.weekAgo && {
-      ...row.weekAgo,
-      divergenceCents: row.weekAgo.divergenceCents?.toString() ?? null,
-    },
-  }));
+  const payload = await Promise.all(
+    rows.map(async (row) => {
+      const insight = await detectRecurringAdjustmentInsight(row.userId);
+      return {
+        ...row,
+        latest: row.latest && {
+          ...row.latest,
+          divergenceCents: row.latest.divergenceCents?.toString() ?? null,
+        },
+        weekAgo: row.weekAgo && {
+          ...row.weekAgo,
+          divergenceCents: row.weekAgo.divergenceCents?.toString() ?? null,
+        },
+        insight: insight && {
+          kind: insight.kind,
+          direction: insight.direction,
+          count: insight.count,
+          totalCents: insight.totalCents.toString(),
+          message: insight.message,
+          windowDays: insight.windowDays,
+        },
+      };
+    }),
+  );
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">

--- a/src/lib/reconciliation/insights.test.ts
+++ b/src/lib/reconciliation/insights.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, transactions, users } from "@/lib/db/schema";
+import { copyCategorySeedsToUser } from "@/lib/auth/signup";
+import { detectRecurringAdjustmentInsight } from "./insights";
+
+const TAG = "RECURRING_INSIGHT_TEST";
+const NOW = new Date("2026-04-19T12:00:00Z");
+const DAY_MS = 86_400_000;
+
+function ago(days: number): Date {
+  return new Date(NOW.getTime() - days * DAY_MS);
+}
+
+async function seedUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  return row.id;
+}
+
+async function seedAccount(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} acct`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function seedAdjustment(
+  userId: number,
+  accountId: number,
+  amountCents: bigint,
+  occurredAt: Date,
+): Promise<void> {
+  await db.insert(transactions).values({
+    userId,
+    accountId,
+    occurredAt,
+    amountCents,
+    currency: "COP",
+    descriptionRaw: `${TAG} adj`,
+    source: "balance_adjustment",
+    channel: "manual",
+    isAdjustment: true,
+  });
+}
+
+describe("detectRecurringAdjustmentInsight", () => {
+  let userId!: number;
+  let accountId!: number;
+
+  beforeAll(async () => {
+    userId = await seedUser(`${TAG.toLowerCase()}.${Date.now()}@test.local`);
+    accountId = await seedAccount(userId);
+  });
+
+  beforeEach(async () => {
+    await db.delete(transactions).where(eq(transactions.userId, userId));
+  });
+
+  afterAll(async () => {
+    await db.delete(transactions).where(eq(transactions.userId, userId));
+    await db.delete(accounts).where(eq(accounts.userId, userId));
+    await db.delete(users).where(eq(users.id, userId));
+  });
+
+  it("returns null when the user has zero adjustments", async () => {
+    expect(await detectRecurringAdjustmentInsight(userId, NOW)).toBeNull();
+  });
+
+  it("returns null when there are fewer than 3 adjustments", async () => {
+    await seedAdjustment(userId, accountId, BigInt(10_000), ago(1));
+    await seedAdjustment(userId, accountId, BigInt(10_000), ago(2));
+    expect(await detectRecurringAdjustmentInsight(userId, NOW)).toBeNull();
+  });
+
+  it("fires when 3+ adjustments are all positive (in-direction)", async () => {
+    await seedAdjustment(userId, accountId, BigInt(10_000_00), ago(1));
+    await seedAdjustment(userId, accountId, BigInt(5_000_00), ago(5));
+    await seedAdjustment(userId, accountId, BigInt(3_000_00), ago(15));
+
+    const signal = await detectRecurringAdjustmentInsight(userId, NOW);
+    expect(signal).not.toBeNull();
+    expect(signal?.direction).toBe("in");
+    expect(signal?.count).toBe(3);
+    expect(signal?.totalCents).toBe(BigInt(18_000_00));
+    expect(signal?.message).toContain("3 adjustments");
+    expect(signal?.message).toMatch(/adding/);
+    expect(signal?.windowDays).toBe(30);
+  });
+
+  it("fires when 3+ adjustments are all negative (out-direction)", async () => {
+    await seedAdjustment(userId, accountId, BigInt(-10_000_00), ago(1));
+    await seedAdjustment(userId, accountId, BigInt(-5_000_00), ago(5));
+    await seedAdjustment(userId, accountId, BigInt(-3_000_00), ago(15));
+
+    const signal = await detectRecurringAdjustmentInsight(userId, NOW);
+    expect(signal?.direction).toBe("out");
+    expect(signal?.totalCents).toBe(BigInt(-18_000_00));
+    expect(signal?.message).toMatch(/subtracting/);
+  });
+
+  it("returns null when adjustments mix direction", async () => {
+    await seedAdjustment(userId, accountId, BigInt(10_000_00), ago(1));
+    await seedAdjustment(userId, accountId, BigInt(-5_000_00), ago(5));
+    await seedAdjustment(userId, accountId, BigInt(3_000_00), ago(15));
+    expect(await detectRecurringAdjustmentInsight(userId, NOW)).toBeNull();
+  });
+
+  it("ignores adjustments older than the 30-day window", async () => {
+    await seedAdjustment(userId, accountId, BigInt(10_000_00), ago(40));
+    await seedAdjustment(userId, accountId, BigInt(5_000_00), ago(45));
+    await seedAdjustment(userId, accountId, BigInt(3_000_00), ago(50));
+    expect(await detectRecurringAdjustmentInsight(userId, NOW)).toBeNull();
+  });
+
+  it("counts only inside-window adjustments when the window overlaps old data", async () => {
+    // 2 inside, 1 outside → only 2 count → below threshold → null
+    await seedAdjustment(userId, accountId, BigInt(10_000_00), ago(5));
+    await seedAdjustment(userId, accountId, BigInt(5_000_00), ago(10));
+    await seedAdjustment(userId, accountId, BigInt(3_000_00), ago(40));
+    expect(await detectRecurringAdjustmentInsight(userId, NOW)).toBeNull();
+  });
+});

--- a/src/lib/reconciliation/insights.ts
+++ b/src/lib/reconciliation/insights.ts
@@ -1,0 +1,81 @@
+import { and, eq, gte } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { transactions } from "@/lib/db/schema";
+
+const MS_PER_DAY = 86_400_000;
+const WINDOW_DAYS = 30;
+const MIN_SAME_DIRECTION = 3;
+
+export interface RecurringAdjustmentInsight {
+  kind: "recurring_same_direction_adjustments";
+  direction: "in" | "out";
+  count: number;
+  totalCents: bigint;
+  message: string;
+  windowDays: number;
+}
+
+/**
+ * Fires when a user has ≥3 adjustments in the last 30 days that are ALL
+ * in the same direction. That's a strong signal that the parser is
+ * systematically dropping or double-counting a specific pattern, and
+ * the user keeps nudging findash back into reality through balance
+ * adjustments.
+ *
+ * Mixed-direction adjustments are noise (normal correction traffic);
+ * only uniform-direction streaks get promoted to an insight.
+ *
+ * Returns `null` when there's no signal.
+ */
+export async function detectRecurringAdjustmentInsight(
+  userId: number,
+  now: Date = new Date(),
+): Promise<RecurringAdjustmentInsight | null> {
+  const cutoff = new Date(now.getTime() - WINDOW_DAYS * MS_PER_DAY);
+
+  const rows = await db
+    .select({ amountCents: transactions.amountCents })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.isAdjustment, true),
+        gte(transactions.occurredAt, cutoff),
+      ),
+    );
+
+  if (rows.length < MIN_SAME_DIRECTION) return null;
+
+  let allPositive = true;
+  let allNegative = true;
+  let total = BigInt(0);
+  for (const row of rows) {
+    total += row.amountCents;
+    if (row.amountCents <= BigInt(0)) allPositive = false;
+    if (row.amountCents >= BigInt(0)) allNegative = false;
+  }
+
+  if (!allPositive && !allNegative) return null;
+
+  const direction: "in" | "out" = allPositive ? "in" : "out";
+  const absolute = total < BigInt(0) ? -total : total;
+  const message = buildMessage(direction, rows.length, absolute);
+
+  return {
+    kind: "recurring_same_direction_adjustments",
+    direction,
+    count: rows.length,
+    totalCents: total,
+    message,
+    windowDays: WINDOW_DAYS,
+  };
+}
+
+function buildMessage(direction: "in" | "out", count: number, absoluteCents: bigint): string {
+  const major = (absoluteCents / BigInt(100)).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  const arrow = direction === "in" ? "↑ adding" : "↓ subtracting";
+  return (
+    `${count} adjustments in 30 days, all ${arrow} money (total $${major}).` +
+    ` Findash is likely ${direction === "in" ? "missing inbound" : "double-counting outbound"} traffic — check recent parser behavior.`
+  );
+}


### PR DESCRIPTION
Closes #299. Last Epic R (#253) sub-task — parser bug detector via adjustment-pattern analysis.

## What

### Detector (\`src/lib/reconciliation/insights.ts\`)
\`detectRecurringAdjustmentInsight(userId, now?)\` — pure(ish) function:
- Pulls adjustments (\`is_adjustment=true\`) from the last 30 days
- If count < 3 → \`null\` (no signal)
- If adjustments are **all** positive → \`{ direction: 'in', ... }\` — findash is missing inbound traffic
- If adjustments are **all** negative → \`{ direction: 'out', ... }\` — findash is double-counting or missing outbound
- Mixed signs → \`null\` (normal correction noise, not systematic)

Returns \`{ count, totalCents (signed bigint), message, direction, windowDays }\`.

### /admin/health UI
- Per-user card renders an amber "Parser bug suspected" callout (with \`AlertTriangleIcon\`) under the metrics grid when the detector returns non-null
- Amber-toned (informational), not destructive — it's a hint worth investigating, not an outage
- Page component awaits \`detectRecurringAdjustmentInsight\` per user (parallel fetch via \`Promise.all\`)

### Tests
\`insights.test.ts\` (7 integration tests against \`findash_test\`):
- Zero adjustments → null
- Fewer than 3 → null
- 3+ all positive → "in" direction signal
- 3+ all negative → "out" direction signal
- Mixed signs → null
- Adjustments outside 30d window → null
- Window boundary: 2 inside + 1 outside → null (only inside-window counts)

## Out of scope / deferred
- Telegram bot push when insight fires — belongs to Epic T (bot expansion); the admin-facing signal is useful standalone
- Per-user dismissal / "I investigated this" acknowledgment — defer until insights accumulate

## Epic R status
**Complete.** All sub-tasks from #253 shipped:
- ✅ Schema (#283)
- ✅ Institution enum (#284)
- ✅ TC parser (#287)
- ✅ Savings parser (#289)
- ✅ Engine (#291)
- ✅ Endpoint + dispatch + commit (#293)
- ✅ UI + legacy retirement (#295)
- ✅ Divergence tracking (#297)
- ✅ Insight: recurring adjustments (this PR)

## Test plan
- [x] \`bun run test\` → 498 pass (7 new insight cases)
- [x] \`bun run typecheck\` clean
- [x] \`bun run format:check\` clean
- [x] \`bun run lint\` clean