### PR TITLE
feat(reconciliation): optional balance input on Apply + stmt divergence metric (#304)

### DIFF
--- a/drizzle/0030_nebulous_anita_blake.sql
+++ b/drizzle/0030_nebulous_anita_blake.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user_health_snapshots" ADD COLUMN "statement_divergence_cents" bigint;

--- a/drizzle/meta/0030_snapshot.json
+++ b/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,3476 @@
+{
+  "id": "635a468b-9425-4ce8-b30a-4ce721ebc9b8",
+  "prevId": "d89973fa-371e-4549-8444-7f6baa7d42e8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "ai",
+        "manual",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1776639400754,
       "tag": "0029_glamorous_zaladane",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1776645303374,
+      "tag": "0030_nebulous_anita_blake",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/admin/health/health-table.tsx
+++ b/src/app/(app)/admin/health/health-table.tsx
@@ -16,6 +16,7 @@ type SnapshotSummary = {
   parserSuccessRate30d: number | null;
   unreconciledTxnCount: number;
   divergenceCents: string | null;
+  statementDivergenceCents: string | null;
   churnSignalFlag: boolean;
 };
 
@@ -122,7 +123,7 @@ function UserRowCard({ row }: { row: UserHealthRow }) {
         </div>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-7">
           <Metric label="Último capture" value={formatRelative(latest?.lastCaptureAt)} />
           <Metric label="Último SMS" value={formatRelative(latest?.lastSmsReceivedAt)} />
           <Metric
@@ -140,6 +141,11 @@ function UserRowCard({ row }: { row: UserHealthRow }) {
             label="Divergence 30d"
             value={formatCents(latest?.divergenceCents)}
             warn={isDivergenceLarge(latest?.divergenceCents)}
+          />
+          <Metric
+            label="Stmt divergence"
+            value={formatCents(latest?.statementDivergenceCents)}
+            warn={isDivergenceLarge(latest?.statementDivergenceCents)}
           />
           <Metric label="Sources 30d" value={formatSources(latest?.captureSources30d)} subtle />
         </div>

--- a/src/app/(app)/admin/health/page.tsx
+++ b/src/app/(app)/admin/health/page.tsx
@@ -19,10 +19,12 @@ export default async function AdminHealthPage() {
         latest: row.latest && {
           ...row.latest,
           divergenceCents: row.latest.divergenceCents?.toString() ?? null,
+          statementDivergenceCents: row.latest.statementDivergenceCents?.toString() ?? null,
         },
         weekAgo: row.weekAgo && {
           ...row.weekAgo,
           divergenceCents: row.weekAgo.divergenceCents?.toString() ?? null,
+          statementDivergenceCents: row.weekAgo.statementDivergenceCents?.toString() ?? null,
         },
         insight: insight && {
           kind: insight.kind,

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
@@ -198,13 +198,18 @@ const applySchema = z.object({
   fileHash: z.string().regex(/^[0-9a-f]{64}$/),
   parsed: z.any(),
   plan: z.any(),
+  userBalanceAtEndCents: z
+    .string()
+    .regex(/^-?\d+$/)
+    .nullable()
+    .optional(),
 });
 
 export type ApplyReconcileInput = z.infer<typeof applySchema>;
 
 export async function applyReconcile(input: ApplyReconcileInput) {
   const session = await getSessionUser();
-  const { accountId, fileHash, parsed, plan } = applySchema.parse(input);
+  const { accountId, fileHash, parsed, plan, userBalanceAtEndCents } = applySchema.parse(input);
   const account = await loadAccount(session.id, accountId);
 
   const parsedStatement = deserializeParsed(parsed as SerializedParsed);
@@ -214,6 +219,7 @@ export async function applyReconcile(input: ApplyReconcileInput) {
     parsed: parsedStatement,
     plan: plan as MatchingPlan,
     fileHash,
+    userBalanceAtEndCents: userBalanceAtEndCents ? BigInt(userBalanceAtEndCents) : null,
   });
 
   log.info(

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/page.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/page.tsx
@@ -28,6 +28,7 @@ export default async function ReconcilePage({
       institutionSlug: accounts.institutionSlug,
       currency: accounts.currency,
       type: accounts.type,
+      balanceCents: accounts.balanceCents,
     })
     .from(accounts)
     .where(
@@ -97,6 +98,7 @@ export default async function ReconcilePage({
           accountId={account.id}
           accountCurrency={account.currency}
           accountInstitutionSlug={account.institutionSlug}
+          accountBalanceCents={account.balanceCents.toString()}
         />
       )}
 

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/reconcile-form.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/reconcile-form.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { formatMoney } from "@/lib/money";
+import { formatMoney, parseTolerantMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { applyReconcile, previewReconcile, type ReconcilePreview } from "./actions";
 
@@ -16,6 +16,7 @@ type Props = {
   accountId: number;
   accountCurrency: "COP" | "USD";
   accountInstitutionSlug: string;
+  accountBalanceCents: string;
 };
 
 const dateFmt = new Intl.DateTimeFormat("es-CO", {
@@ -23,11 +24,18 @@ const dateFmt = new Intl.DateTimeFormat("es-CO", {
   month: "short",
 });
 
-export function ReconcileForm({ accountId, accountCurrency, accountInstitutionSlug }: Props) {
+export function ReconcileForm({
+  accountId,
+  accountCurrency,
+  accountInstitutionSlug,
+  accountBalanceCents,
+}: Props) {
   const router = useRouter();
   const [parsing, startParsing] = useTransition();
   const [applying, startApplying] = useTransition();
   const [preview, setPreview] = useState<ReconcilePreview | null>(null);
+  const [balanceInput, setBalanceInput] = useState("");
+  const currentFindashBalance = BigInt(accountBalanceCents);
 
   async function onUpload(formData: FormData) {
     formData.set("accountId", String(accountId));
@@ -53,6 +61,15 @@ export function ReconcileForm({ accountId, accountCurrency, accountInstitutionSl
 
   function onApply() {
     if (!preview) return;
+    let userBalanceAtEndCents: string | null = null;
+    if (balanceInput.trim() !== "") {
+      try {
+        userBalanceAtEndCents = parseTolerantMoney(balanceInput).toString();
+      } catch {
+        toast.error("Couldn't parse the balance. Try plain digits, e.g. 1234567 or -4500000.");
+        return;
+      }
+    }
     startApplying(async () => {
       try {
         const result = await applyReconcile({
@@ -60,6 +77,7 @@ export function ReconcileForm({ accountId, accountCurrency, accountInstitutionSl
           fileHash: preview.fileHash,
           parsed: preview.parsed,
           plan: preview.plan,
+          userBalanceAtEndCents,
         });
         if (result.status === "already_imported") {
           toast.info("This statement was already imported — nothing changed.");
@@ -69,6 +87,7 @@ export function ReconcileForm({ accountId, accountCurrency, accountInstitutionSl
           );
         }
         setPreview(null);
+        setBalanceInput("");
         router.refresh();
       } catch (err) {
         toast.error(err instanceof Error ? err.message : "Apply failed");
@@ -192,6 +211,28 @@ export function ReconcileForm({ accountId, accountCurrency, accountInstitutionSl
               dual-currency card, upload separate statements for COP and USD against the linked
               accounts.
             </p>
+
+            <div className="flex flex-col gap-1.5 rounded-md border border-dashed p-3">
+              <Label htmlFor="recon-balance">Balance al cierre según el banco (opcional)</Label>
+              <Input
+                id="recon-balance"
+                name="balanceAtEnd"
+                type="text"
+                inputMode="decimal"
+                placeholder={accountCurrency === "USD" ? "1234.56" : "1234567"}
+                value={balanceInput}
+                onChange={(e) => setBalanceInput(e.target.value)}
+                disabled={applying}
+              />
+              <p className="text-muted-foreground text-xs">
+                Copialo del app del banco. Si lo ingresás, habilitamos la métrica de divergencia en{" "}
+                <code>/admin/health</code>. Findash actual:{" "}
+                <span className="tabular-nums">
+                  {formatMoney(currentFindashBalance, accountCurrency)}
+                </span>
+                .
+              </p>
+            </div>
 
             <div className="flex items-center justify-end gap-2">
               <Button variant="outline" onClick={() => setPreview(null)} disabled={applying}>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -757,8 +757,14 @@ export const userHealthSnapshots = pgTable(
     // painting green dashboards for dormant users.
     parserSuccessRate30d: numeric("parser_success_rate_30d", { precision: 5, scale: 4 }),
     unreconciledTxnCount: integer("unreconciled_txn_count").notNull().default(0),
-    // NULL until Epic R (bank reconciliation) lands.
+    // Sum of `is_adjustment = true` txn amounts in the last 30d — measures
+    // how much the user has corrected findash via balance adjustments.
     divergenceCents: bigint("divergence_cents", { mode: "bigint" }),
+    // Sum of (accounts.balance_cents − latest statement_imports.balance_at_end_cents)
+    // across accounts whose most recent 30d statement import carries a balance —
+    // measures the remaining gap between findash and reality per #304.
+    // NULL until a statement import with a user-provided balance lands.
+    statementDivergenceCents: bigint("statement_divergence_cents", { mode: "bigint" }),
     churnSignalFlag: boolean("churn_signal_flag").notNull().default(false),
   },
   (t) => [

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { decimalStringToCents } from "./money";
+import { decimalStringToCents, parseTolerantMoney } from "./money";
 
 describe("decimalStringToCents", () => {
   it("parses single-digit cent values", () => {
@@ -44,5 +44,43 @@ describe("decimalStringToCents", () => {
   it("rejects thousand separators and scientific notation", () => {
     expect(() => decimalStringToCents("1,000")).toThrow(/Invalid decimal/);
     expect(() => decimalStringToCents("1e5")).toThrow(/Invalid decimal/);
+  });
+});
+
+describe("parseTolerantMoney", () => {
+  it("parses plain integers", () => {
+    expect(parseTolerantMoney("1234567")).toBe(BigInt(123456700));
+    expect(parseTolerantMoney("0")).toBe(BigInt(0));
+  });
+
+  it("parses es-CO grouping ('.' thousand, ',' decimal)", () => {
+    expect(parseTolerantMoney("1.234.567,89")).toBe(BigInt(123456789));
+    expect(parseTolerantMoney("1.234.567")).toBe(BigInt(123456700));
+  });
+
+  it("parses en-US grouping (',' thousand, '.' decimal)", () => {
+    expect(parseTolerantMoney("1,234,567.89")).toBe(BigInt(123456789));
+    expect(parseTolerantMoney("1,234.56")).toBe(BigInt(123456));
+  });
+
+  it("handles negatives (credit card balances)", () => {
+    expect(parseTolerantMoney("-4.500.000")).toBe(BigInt(-450000000));
+    expect(parseTolerantMoney("-1234.56")).toBe(BigInt(-123456));
+  });
+
+  it("strips whitespace and currency symbols", () => {
+    expect(parseTolerantMoney("  $ 1.000 ")).toBe(BigInt(100000));
+    expect(parseTolerantMoney("$1,000.50")).toBe(BigInt(100050));
+  });
+
+  it("accepts single-cent decimals", () => {
+    expect(parseTolerantMoney("100,5")).toBe(BigInt(10050));
+    expect(parseTolerantMoney("100.5")).toBe(BigInt(10050));
+  });
+
+  it("rejects garbage input", () => {
+    expect(() => parseTolerantMoney("abc")).toThrow(/Invalid money/);
+    expect(() => parseTolerantMoney("")).toThrow(/Empty money/);
+    expect(() => parseTolerantMoney("1e5")).toThrow(/Invalid money/);
   });
 });

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -45,3 +45,33 @@ export function formatMoney(amountCents: bigint, currency: Currency): string {
     maximumFractionDigits: currency === "USD" ? 2 : 0,
   }).format(value);
 }
+
+/**
+ * Tolerant parser for user-entered money. Accepts negatives and both
+ * es-CO ("1.234.567,89") and en-US ("1,234,567.89") grouping styles, plus
+ * plain forms ("1234567", "1234.56"). Returns signed bigint cents.
+ *
+ * Heuristic for decimal separator: the LAST `.` or `,` followed by 1-2
+ * digits is treated as the decimal; anything else is a thousand separator
+ * and stripped. Matches how humans write money across locales without
+ * making the caller pass a locale.
+ */
+export function parseTolerantMoney(input: string): bigint {
+  const trimmed = input.trim();
+  if (trimmed === "") throw new Error("Empty money input");
+  const negative = trimmed.startsWith("-");
+  const body = (negative ? trimmed.slice(1) : trimmed).replace(/[\s$]/g, "");
+  if (!/^[\d.,]+$/.test(body)) {
+    throw new Error(`Invalid money input: ${JSON.stringify(input)}`);
+  }
+  const decimalMatch = body.match(/[.,](\d{1,2})$/);
+  let normalized: string;
+  if (decimalMatch) {
+    const whole = body.slice(0, -decimalMatch[0].length).replace(/[.,]/g, "");
+    normalized = `${whole || "0"}.${decimalMatch[1]}`;
+  } else {
+    normalized = body.replace(/[.,]/g, "");
+  }
+  const cents = decimalStringToCents(normalized);
+  return negative ? -cents : cents;
+}

--- a/src/lib/reconciliation/commit.test.ts
+++ b/src/lib/reconciliation/commit.test.ts
@@ -303,6 +303,63 @@ describe("commitReconciliation — integration against findash_test", () => {
     expect(rows).toHaveLength(1);
   });
 
+  it("persists userBalanceAtEndCents when provided, falls back to parsed otherwise", async () => {
+    const date = new Date("2026-04-15T05:00:00Z");
+    const buildRun = (tag: string) =>
+      buildParsed([
+        {
+          occurredAt: date,
+          amountCents: BigInt(1_000_00),
+          currency: "COP",
+          direction: "in",
+          descriptionRaw: `${TAG} ${tag}`,
+          rawData: {},
+          isMetadata: false,
+        },
+      ]);
+    const plan: MatchingPlan = {
+      decisions: [
+        {
+          statementRowIndex: 0,
+          action: "insert_new",
+          matchedTxnId: null,
+          matchScore: 0,
+          matchReason: "no_match",
+        },
+      ],
+      flaggedExisting: [],
+      summary: { matched: 0, newInserts: 1, flaggedExisting: 0 },
+    };
+
+    const withUserBalance = await commitReconciliation({
+      userId,
+      account: { id: accountId, currency: "COP" },
+      parsed: buildRun("user-balance"),
+      plan,
+      fileHash: hashFileBuffer(Buffer.from(`${TAG}-user-balance`)),
+      userBalanceAtEndCents: BigInt(12_345_678_00),
+    });
+    const [impWithUser] = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.id, withUserBalance.statementImportId));
+    expect(impWithUser.balanceAtEndCents).toBe(BigInt(12_345_678_00));
+
+    const noUserBalance = await commitReconciliation({
+      userId,
+      account: { id: accountId, currency: "COP" },
+      parsed: buildRun("no-user-balance"),
+      plan,
+      fileHash: hashFileBuffer(Buffer.from(`${TAG}-no-user-balance`)),
+      userBalanceAtEndCents: null,
+    });
+    const [impNoUser] = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.id, noUserBalance.statementImportId));
+    expect(impNoUser.balanceAtEndCents).toBeNull();
+  });
+
   it("preserves sign at persistence: direction='in' → positive cents, 'out' → negative", async () => {
     const date = new Date("2026-04-14T05:00:00Z");
     const parsed = buildParsed([

--- a/src/lib/reconciliation/commit.ts
+++ b/src/lib/reconciliation/commit.ts
@@ -26,6 +26,13 @@ export interface CommitInput {
   parsed: ParsedStatement;
   plan: MatchingPlan;
   fileHash: string;
+  /**
+   * Optional user-provided closing balance. When present, overrides whatever
+   * `parsed.balanceAtEndCents` held (parsers for most banks can't extract
+   * this — see #302 / #304). Null = no balance captured for this import;
+   * divergence stays blank on /admin/health.
+   */
+  userBalanceAtEndCents?: bigint | null;
 }
 
 /**
@@ -63,6 +70,10 @@ export async function commitReconciliation(input: CommitInput): Promise<CommitRe
       };
     }
 
+    const balanceAtEndCents =
+      input.userBalanceAtEndCents !== undefined && input.userBalanceAtEndCents !== null
+        ? input.userBalanceAtEndCents
+        : input.parsed.balanceAtEndCents;
     const [imp] = await tx
       .insert(statementImports)
       .values({
@@ -72,7 +83,7 @@ export async function commitReconciliation(input: CommitInput): Promise<CommitRe
         periodStart: toIsoDate(input.parsed.periodStart),
         periodEnd: toIsoDate(input.parsed.periodEnd),
         txnCount: 0,
-        balanceAtEndCents: input.parsed.balanceAtEndCents,
+        balanceAtEndCents,
       })
       .returning({ id: statementImports.id });
 

--- a/src/lib/telemetry/queries.ts
+++ b/src/lib/telemetry/queries.ts
@@ -23,6 +23,7 @@ export type SnapshotSummary = {
   parserSuccessRate30d: number | null;
   unreconciledTxnCount: number;
   divergenceCents: bigint | null;
+  statementDivergenceCents: bigint | null;
   churnSignalFlag: boolean;
 };
 
@@ -36,6 +37,7 @@ function toSummary(row: typeof userHealthSnapshots.$inferSelect): SnapshotSummar
       row.parserSuccessRate30d === null ? null : Number(row.parserSuccessRate30d),
     unreconciledTxnCount: row.unreconciledTxnCount,
     divergenceCents: row.divergenceCents,
+    statementDivergenceCents: row.statementDivergenceCents,
     churnSignalFlag: row.churnSignalFlag,
   };
 }

--- a/src/lib/telemetry/user-health.test.ts
+++ b/src/lib/telemetry/user-health.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, ingestionLogs, transactions, userHealthSnapshots } from "@/lib/db/schema";
+import {
+  accounts,
+  ingestionLogs,
+  statementImports,
+  transactions,
+  userHealthSnapshots,
+} from "@/lib/db/schema";
 import {
   computeUserHealthSnapshot,
   saveUserHealthSnapshot,
@@ -18,6 +24,7 @@ async function cleanup() {
   // Wipe all ingestion_logs for the test user — the test DB doesn't seed any
   // baseline logs, so this is safe and avoids cross-test pollution.
   await db.execute(sql`DELETE FROM ingestion_logs WHERE user_id = ${TEST_USER_ID}`);
+  await db.execute(sql`DELETE FROM statement_imports WHERE user_id = ${TEST_USER_ID}`);
   await db.execute(sql`DELETE FROM accounts WHERE name = ${TEST_ACCOUNT}`);
 }
 
@@ -95,6 +102,7 @@ describe("computeUserHealthSnapshot", () => {
     expect(snap.parserSuccessRate30d).toBeNull();
     expect(snap.unreconciledTxnCount).toBe(0);
     expect(snap.divergenceCents).toBeNull();
+    expect(snap.statementDivergenceCents).toBeNull();
     expect(snap.churnSignalFlag).toBe(false);
   });
 
@@ -261,6 +269,85 @@ describe("computeUserHealthSnapshot", () => {
     const snap = await computeUserHealthSnapshot(TEST_USER_ID, NOW);
     expect(snap.divergenceCents).toBeNull();
   });
+
+  it("statementDivergenceCents sums (findash − latest statement) per account in the 30d window", async () => {
+    const accountId = await seedAccount();
+    // Set findash's account balance.
+    await db
+      .update(accounts)
+      .set({ balanceCents: BigInt(1_200_000_00) })
+      .where(sql`${accounts.id} = ${accountId}`);
+
+    // Two imports for the same account — the later one should win.
+    const periodEndRecent = new Date(NOW.getTime() - 2 * 86_400_000).toISOString().slice(0, 10);
+    const periodEndOlder = new Date(NOW.getTime() - 15 * 86_400_000).toISOString().slice(0, 10);
+    await db.insert(statementImports).values({
+      userId: TEST_USER_ID,
+      accountId,
+      fileHash: "a".repeat(64),
+      periodStart: periodEndOlder,
+      periodEnd: periodEndOlder,
+      txnCount: 0,
+      balanceAtEndCents: BigInt(999_999_99),
+    });
+    await db.insert(statementImports).values({
+      userId: TEST_USER_ID,
+      accountId,
+      fileHash: "b".repeat(64),
+      periodStart: periodEndRecent,
+      periodEnd: periodEndRecent,
+      txnCount: 0,
+      balanceAtEndCents: BigInt(1_000_000_00),
+    });
+
+    const snap = await computeUserHealthSnapshot(TEST_USER_ID, NOW);
+    // findash 1_200_000.00 − latest stmt 1_000_000.00 = +200_000.00 (findash overstates)
+    expect(snap.statementDivergenceCents).toBe(BigInt(200_000_00));
+  });
+
+  it("statementDivergenceCents ignores imports older than 30 days", async () => {
+    const accountId = await seedAccount();
+    await db
+      .update(accounts)
+      .set({ balanceCents: BigInt(500_000_00) })
+      .where(sql`${accounts.id} = ${accountId}`);
+
+    const stale = new Date(NOW.getTime() - 40 * 86_400_000).toISOString().slice(0, 10);
+    await db.insert(statementImports).values({
+      userId: TEST_USER_ID,
+      accountId,
+      fileHash: "c".repeat(64),
+      periodStart: stale,
+      periodEnd: stale,
+      txnCount: 0,
+      balanceAtEndCents: BigInt(999_999_99),
+    });
+
+    const snap = await computeUserHealthSnapshot(TEST_USER_ID, NOW);
+    expect(snap.statementDivergenceCents).toBeNull();
+  });
+
+  it("statementDivergenceCents ignores imports whose balance_at_end is NULL", async () => {
+    const accountId = await seedAccount();
+    await db
+      .update(accounts)
+      .set({ balanceCents: BigInt(100_000_00) })
+      .where(sql`${accounts.id} = ${accountId}`);
+
+    const recent = new Date(NOW.getTime() - 2 * 86_400_000).toISOString().slice(0, 10);
+    await db.insert(statementImports).values({
+      userId: TEST_USER_ID,
+      accountId,
+      fileHash: "d".repeat(64),
+      periodStart: recent,
+      periodEnd: recent,
+      txnCount: 0,
+      balanceAtEndCents: null,
+    });
+
+    const snap = await computeUserHealthSnapshot(TEST_USER_ID, NOW);
+    expect(snap.statementDivergenceCents).toBeNull();
+  });
 });
 
 describe("saveUserHealthSnapshot + snapshotAllActiveUsers", () => {
@@ -285,6 +372,7 @@ describe("saveUserHealthSnapshot + snapshotAllActiveUsers", () => {
     // The seeded txn defaults to bank channel + unreconciled status, so it counts.
     expect(row.unreconciledTxnCount).toBe(1);
     expect(row.divergenceCents).toBeNull();
+    expect(row.statementDivergenceCents).toBeNull();
     expect(row.churnSignalFlag).toBe(false);
   });
 

--- a/src/lib/telemetry/user-health.ts
+++ b/src/lib/telemetry/user-health.ts
@@ -1,12 +1,15 @@
-import { and, eq, gte, sql } from "drizzle-orm";
+import { and, desc, eq, gte, isNotNull, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
+  accounts,
   ingestionLogs,
+  statementImports,
   transactions,
   userHealthSnapshots,
   users,
   type CaptureSources30d,
 } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
 
 const MS_PER_DAY = 86_400_000;
 const THIRTY_DAYS_MS = 30 * MS_PER_DAY;
@@ -22,6 +25,7 @@ export type UserHealthSnapshotData = {
   parserSuccessRate30d: number | null;
   unreconciledTxnCount: number;
   divergenceCents: bigint | null;
+  statementDivergenceCents: bigint | null;
   churnSignalFlag: boolean;
 };
 
@@ -115,6 +119,8 @@ export async function computeUserHealthSnapshot(
   const divergenceCents =
     divergenceRow.count === 0 || divergenceRow.sum === null ? null : BigInt(divergenceRow.sum);
 
+  const statementDivergenceCents = await computeStatementDivergence(userId, thirtyDaysAgo);
+
   return {
     lastSmsReceivedAt: smsRow.last ? new Date(smsRow.last) : null,
     lastCaptureAt,
@@ -122,8 +128,60 @@ export async function computeUserHealthSnapshot(
     parserSuccessRate30d,
     unreconciledTxnCount: unreconciledRow.count,
     divergenceCents,
+    statementDivergenceCents,
     churnSignalFlag,
   };
+}
+
+/**
+ * For each account with a statement import in the last 30 days that carries
+ * a user-provided balance, compares findash's stored balance against the
+ * most recent statement balance and sums the signed deltas. Null when no
+ * account has a qualifying statement — the column stays blank rather than
+ * showing a misleading zero.
+ */
+async function computeStatementDivergence(
+  userId: number,
+  thirtyDaysAgo: Date,
+): Promise<bigint | null> {
+  const windowStart = thirtyDaysAgo.toISOString().slice(0, 10);
+  const imports = await db
+    .select({
+      accountId: statementImports.accountId,
+      balanceAtEndCents: statementImports.balanceAtEndCents,
+    })
+    .from(statementImports)
+    .where(
+      and(
+        eq(statementImports.userId, userId),
+        gte(statementImports.periodEnd, windowStart),
+        isNotNull(statementImports.balanceAtEndCents),
+      ),
+    )
+    .orderBy(desc(statementImports.periodEnd));
+
+  const latestPerAccount = new Map<number, bigint>();
+  for (const imp of imports) {
+    if (imp.balanceAtEndCents === null) continue;
+    if (!latestPerAccount.has(imp.accountId)) {
+      latestPerAccount.set(imp.accountId, imp.balanceAtEndCents);
+    }
+  }
+  if (latestPerAccount.size === 0) return null;
+
+  const accountRows = await db
+    .select({ id: accounts.id, balanceCents: accounts.balanceCents })
+    .from(accounts)
+    .where(and(eq(accounts.userId, userId), notDeleted(accounts.deletedAt)));
+
+  let total = BigInt(0);
+  for (const acc of accountRows) {
+    const stmtBalance = latestPerAccount.get(acc.id);
+    if (stmtBalance !== undefined) {
+      total += acc.balanceCents - stmtBalance;
+    }
+  }
+  return total;
 }
 
 export async function saveUserHealthSnapshot(
@@ -141,6 +199,7 @@ export async function saveUserHealthSnapshot(
       data.parserSuccessRate30d === null ? null : data.parserSuccessRate30d.toFixed(4),
     unreconciledTxnCount: data.unreconciledTxnCount,
     divergenceCents: data.divergenceCents,
+    statementDivergenceCents: data.statementDivergenceCents,
     churnSignalFlag: data.churnSignalFlag,
   });
 }


### PR DESCRIPTION
## Summary

- Closed #302 (wrong premise — Bancolombia XLSX doesn't contain closing balance) and opened #304 with a corrected approach: ask the user for the balance at Apply time.
- Adds optional **\"Balance al cierre según el banco\"** input on the reconcile preview. Empty = current behavior (statement_imports.balance_at_end_cents stays NULL). Filled = persisted to DB.
- New \`/admin/health\` column **Stmt divergence** computes \`sum(accounts.balance_cents − latest statement_imports.balance_at_end_cents)\` per account within last 30d.
- Introduces a tolerant money parser (\`parseTolerantMoney\`) that handles es-CO / en-US groupings, negatives, and currency symbols.

Kept the existing \`divergence_cents\` column (sum of \`is_adjustment=true\` txns from #252) — it measures corrections made, while the new metric measures remaining gap. Different signals, both useful.

Schema: one migration (\`0030_nebulous_anita_blake.sql\`) adds \`statement_divergence_cents bigint NULL\` to \`user_health_snapshots\`.

## Test plan

- [x] Unit tests for \`parseTolerantMoney\` (7 cases covering es-CO, en-US, negatives, whitespace, rejects)
- [x] Commit integration test asserts \`userBalanceAtEndCents\` overrides parser value + NULL fallback preserved
- [x] Telemetry integration tests (3): computes divergence, ignores imports older than 30d, ignores NULL balance imports
- [x] Full suite: 509/509 pass, \`tsc --noEmit\` clean, \`eslint\` clean
- [x] Manual browser smoke: uploaded real Bancolombia savings statement, entered \`1.234.567\`, clicked Apply — DB shows \`balance_at_end_cents = 123456700\` and \`/admin/health\` renders \`STMT DIVERGENCE: -\$1.234.567\` after manual snapshot

Closes #304