### PR TITLE
feat(reconciliation): "Merge into" action on flagged review (#301)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/flagged-review.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/flagged-review.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import type { Currency } from "@/lib/types";
@@ -19,16 +26,33 @@ export type FlaggedRow = {
   merchant: string | null;
 };
 
+export type MergeCandidate = {
+  id: number;
+  occurredAt: string;
+  amountCents: string;
+  currency: "COP" | "USD";
+  descriptionRaw: string;
+};
+
 const dateFmt = new Intl.DateTimeFormat("es-CO", {
   day: "2-digit",
   month: "short",
   year: "2-digit",
 });
 
-export function FlaggedReview({ rows, currency }: { rows: FlaggedRow[]; currency: Currency }) {
+export function FlaggedReview({
+  rows,
+  currency,
+  mergeCandidates,
+}: {
+  rows: FlaggedRow[];
+  currency: Currency;
+  mergeCandidates: MergeCandidate[];
+}) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [busy, setBusy] = useState<number | null>(null);
+  const [mergePicker, setMergePicker] = useState<FlaggedRow | null>(null);
 
   function handle(rowId: number, action: "archived" | "kept") {
     setBusy(rowId);
@@ -43,6 +67,26 @@ export function FlaggedReview({ rows, currency }: { rows: FlaggedRow[]; currency
         router.refresh();
       } catch (err) {
         toast.error(err instanceof Error ? err.message : "Action failed");
+      } finally {
+        setBusy(null);
+      }
+    });
+  }
+
+  function handleMerge(flaggedId: number, targetId: number) {
+    setBusy(flaggedId);
+    startTransition(async () => {
+      try {
+        await reviewReconciliationDecision({
+          txnId: flaggedId,
+          action: "merged_into",
+          mergedIntoTxnId: targetId,
+        });
+        toast.success("Merged — flagged row inherits the statement amount & date");
+        setMergePicker(null);
+        router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Merge failed");
       } finally {
         setBusy(null);
       }
@@ -113,6 +157,19 @@ export function FlaggedReview({ rows, currency }: { rows: FlaggedRow[]; currency
                         >
                           Keep
                         </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setMergePicker(r)}
+                          disabled={pending || isBusy || mergeCandidates.length === 0}
+                          title={
+                            mergeCandidates.length === 0
+                              ? "No statement-imported rows available to merge with"
+                              : "Merge into a statement-imported row"
+                          }
+                        >
+                          Merge into…
+                        </Button>
                       </div>
                     </td>
                   </tr>
@@ -122,6 +179,99 @@ export function FlaggedReview({ rows, currency }: { rows: FlaggedRow[]; currency
           </table>
         </div>
       </CardContent>
+      <MergePickerDialog
+        open={mergePicker !== null}
+        flagged={mergePicker}
+        candidates={mergeCandidates}
+        currency={currency}
+        disabled={pending}
+        onClose={() => setMergePicker(null)}
+        onPick={handleMerge}
+      />
     </Card>
+  );
+}
+
+function MergePickerDialog({
+  open,
+  flagged,
+  candidates,
+  currency,
+  disabled,
+  onClose,
+  onPick,
+}: {
+  open: boolean;
+  flagged: FlaggedRow | null;
+  candidates: MergeCandidate[];
+  currency: Currency;
+  disabled: boolean;
+  onClose: () => void;
+  onPick: (flaggedId: number, targetId: number) => void;
+}) {
+  const sorted = useMemo(() => {
+    if (!flagged) return candidates;
+    const flaggedMs = new Date(flagged.occurredAt).getTime();
+    return [...candidates].sort((a, b) => {
+      const da = Math.abs(new Date(a.occurredAt).getTime() - flaggedMs);
+      const db = Math.abs(new Date(b.occurredAt).getTime() - flaggedMs);
+      return da - db;
+    });
+  }, [flagged, candidates]);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Merge flagged into…</DialogTitle>
+          <DialogDescription>
+            {flagged
+              ? `Pick the statement-imported row that corresponds to "${flagged.descriptionRaw}" (${formatMoney(BigInt(flagged.amountCents), currency)}, ${dateFmt.format(new Date(flagged.occurredAt))}). The flagged row keeps its category and adopts the statement's amount + date.`
+              : null}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-y-auto rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-muted-foreground text-xs uppercase">
+              <tr>
+                <th className="p-2 text-left">Date</th>
+                <th className="p-2 text-left">Description</th>
+                <th className="p-2 text-right">Amount</th>
+                <th className="p-2 text-right"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((c) => {
+                const cents = BigInt(c.amountCents);
+                return (
+                  <tr key={c.id} className="border-t">
+                    <td className="p-2 tabular-nums">{dateFmt.format(new Date(c.occurredAt))}</td>
+                    <td className="max-w-[22rem] truncate p-2">{c.descriptionRaw}</td>
+                    <td
+                      className={cn(
+                        "p-2 text-right font-medium tabular-nums",
+                        cents < BigInt(0) ? "text-rose-600" : "text-emerald-600",
+                      )}
+                    >
+                      {formatMoney(cents, currency)}
+                    </td>
+                    <td className="p-2 text-right">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={disabled}
+                        onClick={() => flagged && onPick(flagged.id, c.id)}
+                      >
+                        Merge
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/page.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/page.tsx
@@ -6,7 +6,7 @@ import { accounts, transactions } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { getSessionUser } from "@/lib/auth/session";
 import { ReconcileForm } from "./reconcile-form";
-import { FlaggedReview, type FlaggedRow } from "./flagged-review";
+import { FlaggedReview, type FlaggedRow, type MergeCandidate } from "./flagged-review";
 
 export const dynamic = "force-dynamic";
 
@@ -70,6 +70,36 @@ export default async function ReconcilePage({
     merchant: r.merchant,
   }));
 
+  const mergeCandidateRows =
+    flagged.length > 0
+      ? await db
+          .select({
+            id: transactions.id,
+            occurredAt: transactions.occurredAt,
+            amountCents: transactions.amountCents,
+            currency: transactions.currency,
+            descriptionRaw: transactions.descriptionRaw,
+          })
+          .from(transactions)
+          .where(
+            and(
+              eq(transactions.userId, session.id),
+              eq(transactions.accountId, accountId),
+              eq(transactions.reconciliationStatus, "imported_from_statement"),
+            ),
+          )
+          .orderBy(desc(transactions.occurredAt))
+          .limit(500)
+      : [];
+
+  const mergeCandidates: MergeCandidate[] = mergeCandidateRows.map((r) => ({
+    id: r.id,
+    occurredAt: r.occurredAt.toISOString(),
+    amountCents: r.amountCents.toString(),
+    currency: r.currency,
+    descriptionRaw: r.descriptionRaw,
+  }));
+
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
       <header className="flex items-center justify-between gap-2">
@@ -102,7 +132,13 @@ export default async function ReconcilePage({
         />
       )}
 
-      {flagged.length > 0 ? <FlaggedReview rows={flagged} currency={account.currency} /> : null}
+      {flagged.length > 0 ? (
+        <FlaggedReview
+          rows={flagged}
+          currency={account.currency}
+          mergeCandidates={mergeCandidates}
+        />
+      ) : null}
     </main>
   );
 }

--- a/src/lib/reconciliation/commit.test.ts
+++ b/src/lib/reconciliation/commit.test.ts
@@ -457,3 +457,126 @@ describe("recordReconciliationDecision — integration", () => {
     ).rejects.toThrow(/mergedIntoTxnId/);
   });
 });
+
+describe("recordReconciliationDecision — merge_into path", () => {
+  let userId!: number;
+  let accountId!: number;
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.merge.${Date.now()}@test.local`);
+    accountId = await createAccount(userId);
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  it("merges flagged into target: flagged survives with statement data, target is deleted", async () => {
+    // Set up: one flagged row (with its category) and one statement-imported target.
+    const flaggedDate = new Date("2026-04-10T05:00:00Z");
+    const [flaggedRow] = await db
+      .insert(transactions)
+      .values({
+        userId,
+        accountId,
+        occurredAt: flaggedDate,
+        amountCents: BigInt(-25_448_00),
+        currency: "COP",
+        descriptionRaw: `${TAG} sms-captured`,
+        source: "sms",
+        channel: "bank",
+        categorySlug: "mercado",
+        reconciliationStatus: "flagged",
+      })
+      .returning({ id: transactions.id });
+
+    const targetDate = new Date("2026-04-10T05:00:00Z");
+    const [imp] = await db
+      .insert(statementImports)
+      .values({
+        userId,
+        accountId,
+        fileHash: hashFileBuffer(Buffer.from(`${TAG}-merge`)),
+        periodStart: "2026-04-01",
+        periodEnd: "2026-04-18",
+        txnCount: 1,
+      })
+      .returning({ id: statementImports.id });
+
+    const [targetRow] = await db
+      .insert(transactions)
+      .values({
+        userId,
+        accountId,
+        occurredAt: targetDate,
+        amountCents: BigInt(-25_573_00), // ← different amount (FX rounding)
+        currency: "COP",
+        descriptionRaw: `${TAG} bank-description`,
+        source: "csv_reconcile",
+        channel: "bank",
+        statementImportId: imp.id,
+        reconciliationStatus: "imported_from_statement",
+      })
+      .returning({ id: transactions.id });
+
+    await recordReconciliationDecision({
+      userId,
+      txnId: flaggedRow.id,
+      action: "merged_into",
+      mergedIntoTxnId: targetRow.id,
+      note: "FX rounding on intl txn",
+    });
+
+    // Flagged row survived, adopted statement amount/description, status=matched, kept category.
+    const [survivor] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, flaggedRow.id));
+    expect(survivor).toBeDefined();
+    expect(survivor.amountCents).toBe(BigInt(-25_573_00));
+    expect(survivor.descriptionRaw).toBe(`${TAG} bank-description`);
+    expect(survivor.reconciliationStatus).toBe("matched");
+    expect(survivor.statementImportId).toBe(imp.id);
+    expect(survivor.categorySlug).toBe("mercado");
+
+    // Target was deleted.
+    const targetAfter = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, targetRow.id));
+    expect(targetAfter).toHaveLength(0);
+
+    // Decision row recorded. mergedIntoTxnId is now NULL because of ON DELETE SET NULL.
+    const [decision] = await db
+      .select()
+      .from(reconciliationDecisions)
+      .where(eq(reconciliationDecisions.txnId, flaggedRow.id));
+    expect(decision.action).toBe("merged_into");
+    expect(decision.mergedIntoTxnId).toBeNull();
+    expect(decision.note).toBe("FX rounding on intl txn");
+  });
+
+  it("rejects merge when target is not imported_from_statement", async () => {
+    const flagged = await createExistingTxn(userId, accountId, BigInt(-1000_00), new Date());
+    await db
+      .update(transactions)
+      .set({ reconciliationStatus: "flagged" })
+      .where(eq(transactions.id, flagged));
+
+    const nonImported = await createExistingTxn(userId, accountId, BigInt(-1000_00), new Date());
+    // default reconciliationStatus is 'unreconciled'
+
+    await expect(
+      recordReconciliationDecision({
+        userId,
+        txnId: flagged,
+        action: "merged_into",
+        mergedIntoTxnId: nonImported,
+      }),
+    ).rejects.toThrow(/merge_target_not_importable/);
+
+    // Flagged row unchanged
+    const [still] = await db.select().from(transactions).where(eq(transactions.id, flagged));
+    expect(still.reconciliationStatus).toBe("flagged");
+  });
+});

--- a/src/lib/reconciliation/commit.ts
+++ b/src/lib/reconciliation/commit.ts
@@ -171,6 +171,64 @@ export async function recordReconciliationDecision(input: ReviewInput): Promise<
     throw new Error("merged_into action requires mergedIntoTxnId");
   }
   await db.transaction(async (tx) => {
+    if (input.action === "merged_into") {
+      const targetId = input.mergedIntoTxnId!;
+      const [target] = await tx
+        .select({
+          id: transactions.id,
+          occurredAt: transactions.occurredAt,
+          amountCents: transactions.amountCents,
+          currency: transactions.currency,
+          descriptionRaw: transactions.descriptionRaw,
+          statementImportId: transactions.statementImportId,
+          rawData: transactions.rawData,
+          reconciliationStatus: transactions.reconciliationStatus,
+        })
+        .from(transactions)
+        .where(and(eq(transactions.id, targetId), eq(transactions.userId, input.userId)))
+        .limit(1);
+      if (!target) throw new Error("merge_target_not_found");
+      if (target.reconciliationStatus !== "imported_from_statement") {
+        throw new Error("merge_target_not_importable");
+      }
+
+      // The flagged row survives (keeps category_slug / counterparty / notes
+      // from prior classification) and adopts the bank-authoritative fields
+      // from the statement-imported target.
+      const updated = await tx
+        .update(transactions)
+        .set({
+          occurredAt: target.occurredAt,
+          amountCents: target.amountCents,
+          currency: target.currency,
+          descriptionRaw: target.descriptionRaw,
+          statementImportId: target.statementImportId,
+          rawData: target.rawData,
+          reconciliationStatus: "matched",
+          reconciledAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(and(eq(transactions.id, input.txnId), eq(transactions.userId, input.userId)))
+        .returning({ id: transactions.id });
+      if (updated.length === 0) throw new Error("flagged_txn_not_found");
+
+      // Record the decision before deleting the target so the FK is populated.
+      // mergedIntoTxnId has ON DELETE SET NULL — acceptable loss of detail on
+      // the audit row in exchange for no duplicate txn in balance queries.
+      await tx.insert(reconciliationDecisions).values({
+        userId: input.userId,
+        txnId: input.txnId,
+        action: input.action,
+        mergedIntoTxnId: targetId,
+        note: input.note ?? null,
+      });
+
+      await tx
+        .delete(transactions)
+        .where(and(eq(transactions.id, targetId), eq(transactions.userId, input.userId)));
+      return;
+    }
+
     await tx.insert(reconciliationDecisions).values({
       userId: input.userId,
       txnId: input.txnId,


### PR DESCRIPTION
## Summary

Completes the originally-scoped \`archive | keep | merge\` triple from Epic R (#253). The shipped UI in #295 only had archive + keep.

Smoke test today on a real Bancolombia savings statement showed **2 of 3 flagged rows were FX-rounding near-matches to \"will insert\" rows** (1 peso + 125 pesos off) — merge is the common case, not the edge.

## What it does

- Adds a **Merge into…** button to each flagged row (alongside Archive / Keep).
- Clicking opens a Dialog with all \`imported_from_statement\` txns for the account, sorted by date proximity to the flagged row. Disabled when no candidates exist.
- On Merge: flagged row keeps its \`category_slug\`, \`counterparty_id\`, and \`notes\` (prior classification preserved) and adopts the bank-authoritative fields from the target (date, amount, description, \`statement_import_id\`, raw_data). Status → \`matched\`. Target row is deleted.
- Decision row records \`action='merged_into'\`, \`mergedIntoTxnId\` (the FK resolves to NULL after target delete via \`ON DELETE SET NULL\`, acceptable audit loss in exchange for no duplicate in balance queries).

## Test plan

- [x] 2 new integration tests in \`commit.test.ts\`: happy path + refuses non-importable target
- [x] Full suite: 511/511 pass; \`tsc --noEmit\` clean; \`eslint\` clean
- [x] Manual browser smoke on real data: opened picker on flagged \"Pago TC *7291 -\$1.320.564\", selected \"PAGO SUC VIRT TC MASTER DOLAR -\$1.320.565\" (the near-match), got success toast + DB shows survivor with merged fields, target deleted, decision recorded.

Closes #301