### PR TITLE
feat(reconciliation): engine near-match detection → merge suggestions (#303)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/reconcile-form.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/reconcile-form.tsx
@@ -44,7 +44,7 @@ export function ReconcileForm({
         const result = await previewReconcile(formData);
         setPreview(result);
         toast.success(
-          `Preview ready · ${result.plan.summary.matched} matched, ${result.plan.summary.newInserts} new, ${result.plan.summary.flaggedExisting} flagged`,
+          `Preview ready · ${result.plan.summary.matched} matched, ${result.plan.summary.newInserts} new${result.plan.summary.nearMatches > 0 ? `, ${result.plan.summary.nearMatches} near-match` : ""}, ${result.plan.summary.flaggedExisting} flagged`,
         );
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Parse failed";
@@ -130,8 +130,11 @@ export function ReconcileForm({
         <Card>
           <CardHeader>
             <CardTitle>
-              Preview · {preview.plan.summary.matched + preview.plan.summary.newInserts} statement
-              rows
+              Preview ·{" "}
+              {preview.plan.summary.matched +
+                preview.plan.summary.newInserts +
+                preview.plan.summary.nearMatches}{" "}
+              statement rows
             </CardTitle>
             <CardDescription>
               Format: <code>{preview.parsed.format}</code> · Period{" "}
@@ -147,6 +150,11 @@ export function ReconcileForm({
               <Badge variant="outline" className="bg-sky-50 text-sky-900">
                 {preview.plan.summary.newInserts} new
               </Badge>
+              {preview.plan.summary.nearMatches > 0 ? (
+                <Badge variant="outline" className="bg-amber-50 text-amber-900">
+                  {preview.plan.summary.nearMatches} near-match
+                </Badge>
+              ) : null}
               <Badge variant="outline" className="bg-amber-50 text-amber-900">
                 {preview.plan.summary.flaggedExisting} flagged (not in statement)
               </Badge>
@@ -188,6 +196,17 @@ export function ReconcileForm({
                               title={`score ${decision.matchScore} (${decision.matchReason})`}
                             >
                               match · #{decision.matchedTxnId}
+                            </span>
+                          ) : decision?.action === "near_match" ? (
+                            <span
+                              className="rounded bg-amber-100 px-1.5 py-0.5 text-amber-900"
+                              title={`score ${decision.matchScore} (${decision.matchReason})`}
+                            >
+                              near-match ·{" "}
+                              {decision.amountDiffCents !== undefined
+                                ? formatMoney(BigInt(decision.amountDiffCents), row.currency)
+                                : "?"}{" "}
+                              off · merge with #{decision.matchedTxnId} post-Apply
                             </span>
                           ) : (
                             <span className="rounded bg-sky-100 px-1.5 py-0.5 text-sky-900">
@@ -241,7 +260,7 @@ export function ReconcileForm({
               <Button onClick={onApply} disabled={applying}>
                 {applying
                   ? "Applying…"
-                  : `Apply (${preview.plan.summary.matched} match + ${preview.plan.summary.newInserts} new + ${preview.plan.summary.flaggedExisting} flag)`}
+                  : `Apply (${preview.plan.summary.matched} match + ${preview.plan.summary.newInserts} new${preview.plan.summary.nearMatches > 0 ? ` + ${preview.plan.summary.nearMatches} near` : ""} + ${preview.plan.summary.flaggedExisting} flag)`}
               </Button>
             </div>
           </CardContent>

--- a/src/lib/reconciliation/commit.test.ts
+++ b/src/lib/reconciliation/commit.test.ts
@@ -128,7 +128,7 @@ describe("commitReconciliation — integration against findash_test", () => {
         },
       ],
       flaggedExisting: [],
-      summary: { matched: 0, newInserts: 1, flaggedExisting: 0 },
+      summary: { matched: 0, newInserts: 1, nearMatches: 0, flaggedExisting: 0 },
     };
     const result = await commitReconciliation({
       userId,
@@ -185,7 +185,7 @@ describe("commitReconciliation — integration against findash_test", () => {
         },
       ],
       flaggedExisting: [],
-      summary: { matched: 1, newInserts: 0, flaggedExisting: 0 },
+      summary: { matched: 1, newInserts: 0, nearMatches: 0, flaggedExisting: 0 },
     };
     const result = await commitReconciliation({
       userId,
@@ -229,7 +229,7 @@ describe("commitReconciliation — integration against findash_test", () => {
         },
       ],
       flaggedExisting: [{ txnId: orphanId, reason: "no_statement_match" }],
-      summary: { matched: 0, newInserts: 1, flaggedExisting: 1 },
+      summary: { matched: 0, newInserts: 1, nearMatches: 0, flaggedExisting: 1 },
     };
     const result = await commitReconciliation({
       userId,
@@ -269,7 +269,7 @@ describe("commitReconciliation — integration against findash_test", () => {
         },
       ],
       flaggedExisting: [],
-      summary: { matched: 0, newInserts: 1, flaggedExisting: 0 },
+      summary: { matched: 0, newInserts: 1, nearMatches: 0, flaggedExisting: 0 },
     };
     const hash = hashFileBuffer(Buffer.from(`${TAG}-idempotency`));
     const first = await commitReconciliation({
@@ -328,7 +328,7 @@ describe("commitReconciliation — integration against findash_test", () => {
         },
       ],
       flaggedExisting: [],
-      summary: { matched: 0, newInserts: 1, flaggedExisting: 0 },
+      summary: { matched: 0, newInserts: 1, nearMatches: 0, flaggedExisting: 0 },
     };
 
     const withUserBalance = await commitReconciliation({
@@ -400,7 +400,7 @@ describe("commitReconciliation — integration against findash_test", () => {
         },
       ],
       flaggedExisting: [],
-      summary: { matched: 0, newInserts: 2, flaggedExisting: 0 },
+      summary: { matched: 0, newInserts: 2, nearMatches: 0, flaggedExisting: 0 },
     };
     const result = await commitReconciliation({
       userId,

--- a/src/lib/reconciliation/engine/match.test.ts
+++ b/src/lib/reconciliation/engine/match.test.ts
@@ -75,7 +75,7 @@ describe("matchStatement — happy paths", () => {
         matchReason: "amount_date_fuzzy_merchant",
       },
     ]);
-    expect(plan.summary).toEqual({ matched: 1, newInserts: 0, flaggedExisting: 0 });
+    expect(plan.summary).toEqual({ matched: 1, newInserts: 0, nearMatches: 0, flaggedExisting: 0 });
     expect(plan.flaggedExisting).toEqual([]);
   });
 
@@ -109,10 +109,22 @@ describe("matchStatement — currency / amount / direction rules", () => {
     expect(plan.decisions[0].action).toBe("insert_new");
   });
 
-  it("different magnitude never matches", () => {
+  it("different magnitude never reaches exact match (can fall through to near_match)", () => {
     const plan = matchStatement({
       parsedRows: [parsedRow({ occurredAt: date, amountCents: BigInt(10_000) })],
       existingTxns: [existingTxn({ id: 1, occurredAt: date, amountCents: BigInt(-9_900) })],
+    });
+    // Exact match is rejected on amount mismatch. The near-match fallback
+    // may or may not pick it up depending on thresholds; we only care that
+    // it's NOT classified as an exact match.
+    expect(plan.decisions[0].action).not.toBe("match");
+  });
+
+  it("very different magnitude (outside both exact and near thresholds) becomes insert_new", () => {
+    const plan = matchStatement({
+      parsedRows: [parsedRow({ occurredAt: date, amountCents: BigInt(10_000_00) })],
+      // $9000 off on a $10k txn — way outside 1% ($100) and the $500 floor.
+      existingTxns: [existingTxn({ id: 1, occurredAt: date, amountCents: BigInt(-1_000_00) })],
     });
     expect(plan.decisions[0].action).toBe("insert_new");
   });
@@ -270,5 +282,168 @@ describe("matchStatement — invariants", () => {
       config: { dateToleranceDays: 7 },
     });
     expect(plan.decisions[0].action).toBe("match");
+  });
+});
+
+describe("matchStatement — near-match fallback", () => {
+  const date = new Date("2026-04-14T05:00:00Z");
+
+  it("emits near_match when amount is 1 peso off but date + description align (FX rounding case)", () => {
+    // Real shape from smoke-test today: bank statement has "COMPRA INTL POLAR
+    // TONNOZ SER" and the SMS-captured findash row has "POLAR TONNOZ SERVIC"
+    // — decent token overlap + 1-peso amount drift from FX rounding.
+    const plan = matchStatement({
+      parsedRows: [
+        parsedRow({
+          occurredAt: date,
+          amountCents: BigInt(1_320_565_00),
+          direction: "out",
+          descriptionRaw: "COMPRA INTL POLAR TONNOZ SERVIC",
+        }),
+      ],
+      existingTxns: [
+        existingTxn({
+          id: 42,
+          occurredAt: date,
+          amountCents: BigInt(-1_320_564_00), // ← 1 peso off
+          descriptionRaw: "POLAR TONNOZ SERVIC",
+        }),
+      ],
+    });
+    expect(plan.decisions).toHaveLength(1);
+    expect(plan.decisions[0].action).toBe("near_match");
+    expect(plan.decisions[0].matchedTxnId).toBe(42);
+    expect(plan.decisions[0].matchReason).toBe("near_match_fuzzy_amount");
+    expect(plan.decisions[0].amountDiffCents).toBe("100");
+    expect(plan.decisions[0].dateDiffDays).toBe(0);
+    expect(plan.summary.nearMatches).toBe(1);
+    expect(plan.summary.newInserts).toBe(0);
+    // Candidate is NOT consumed — it flows to flaggedExisting so the user
+    // can resolve via merge-into post-Apply.
+    expect(plan.flaggedExisting).toEqual([{ txnId: 42, reason: "no_statement_match" }]);
+  });
+
+  it("does NOT emit near_match when amount differs by more than 1% + absolute floor", () => {
+    const plan = matchStatement({
+      parsedRows: [
+        parsedRow({
+          occurredAt: date,
+          amountCents: BigInt(100_000_00), // $100k, 1% = $1k, floor $500
+          direction: "out",
+          descriptionRaw: "SHARED DESCRIPTION",
+        }),
+      ],
+      existingTxns: [
+        existingTxn({
+          id: 1,
+          occurredAt: date,
+          amountCents: BigInt(-90_000_00), // $10k off → well above $1k threshold
+          descriptionRaw: "SHARED DESCRIPTION",
+        }),
+      ],
+    });
+    expect(plan.decisions[0].action).toBe("insert_new");
+    expect(plan.summary.nearMatches).toBe(0);
+  });
+
+  it("does NOT emit near_match for opposite signs (debit vs credit)", () => {
+    const plan = matchStatement({
+      parsedRows: [
+        parsedRow({
+          occurredAt: date,
+          amountCents: BigInt(1_320_564_00),
+          direction: "in", // credit in the statement
+          descriptionRaw: "ABONO",
+        }),
+      ],
+      existingTxns: [
+        existingTxn({
+          id: 1,
+          occurredAt: date,
+          amountCents: BigInt(-1_320_565_00), // debit in findash
+          descriptionRaw: "ABONO",
+        }),
+      ],
+    });
+    expect(plan.decisions[0].action).toBe("insert_new");
+  });
+
+  it("does NOT emit near_match when description overlap is below threshold", () => {
+    const plan = matchStatement({
+      parsedRows: [
+        parsedRow({
+          occurredAt: date,
+          amountCents: BigInt(100_00),
+          direction: "out",
+          descriptionRaw: "ONE TWO THREE FOUR",
+        }),
+      ],
+      existingTxns: [
+        existingTxn({
+          id: 1,
+          occurredAt: date,
+          amountCents: BigInt(-99_00), // $1 off, within threshold
+          descriptionRaw: "ALPHA BETA GAMMA DELTA", // zero overlap
+        }),
+      ],
+    });
+    expect(plan.decisions[0].action).toBe("insert_new");
+  });
+
+  it("prefers exact match over near-match when both candidates are available", () => {
+    const plan = matchStatement({
+      parsedRows: [
+        parsedRow({
+          occurredAt: date,
+          amountCents: BigInt(1_320_565_00),
+          direction: "out",
+          descriptionRaw: "PAGO TC",
+        }),
+      ],
+      existingTxns: [
+        // near-match candidate (amount differs by 1 peso)
+        existingTxn({
+          id: 1,
+          occurredAt: date,
+          amountCents: BigInt(-1_320_564_00),
+          descriptionRaw: "PAGO TC",
+        }),
+        // exact match candidate
+        existingTxn({
+          id: 2,
+          occurredAt: date,
+          amountCents: BigInt(-1_320_565_00),
+          descriptionRaw: "PAGO TC",
+        }),
+      ],
+    });
+    expect(plan.decisions[0].action).toBe("match");
+    expect(plan.decisions[0].matchedTxnId).toBe(2);
+    // The near-match candidate stays unreconciled → flagged.
+    expect(plan.flaggedExisting).toEqual([{ txnId: 1, reason: "no_statement_match" }]);
+  });
+
+  it("respects nearMatch config overrides (tighter similarity cutoff)", () => {
+    const plan = matchStatement({
+      parsedRows: [
+        parsedRow({
+          occurredAt: date,
+          amountCents: BigInt(10_00),
+          direction: "out",
+          descriptionRaw: "ONE TWO THREE FOUR",
+        }),
+      ],
+      existingTxns: [
+        existingTxn({
+          id: 1,
+          occurredAt: date,
+          amountCents: BigInt(-9_50),
+          descriptionRaw: "ONE TWO FIVE SIX", // 2/6 = 0.33 jaccard
+        }),
+      ],
+      // default threshold 0.5 would reject this — tightening to 0.2 accepts.
+      config: { nearMatch: { descriptionSimilarityMin: 0.2 } },
+    });
+    expect(plan.decisions[0].action).toBe("near_match");
   });
 });

--- a/src/lib/reconciliation/engine/match.ts
+++ b/src/lib/reconciliation/engine/match.ts
@@ -5,6 +5,21 @@ const DEFAULT_DATE_TOLERANCE_DAYS = 3;
 const DEFAULT_MERCHANT_FUZZ_THRESHOLD = 0.5;
 const MS_PER_DAY = 86_400_000;
 
+// Near-match defaults. Tightened vs exact match: amount differs, so we need
+// stronger date + description signal to confidently propose a merge.
+const NEAR_MATCH_DEFAULTS = {
+  dateToleranceDays: 2,
+  descriptionSimilarityMin: 0.5,
+  // $500 COP — smaller than this is noise; also the Bancolombia statement
+  // FX-rounding amounts we've seen in real data (1–125 pesos) fit under it.
+  amountFloorCopCents: BigInt(500_00),
+  // $0.05 USD — same spirit as COP floor at a sensible scale.
+  amountFloorUsdCents: BigInt(5),
+  // 1% — scales the floor for larger transactions where absolute rounding
+  // noise is proportional.
+  amountPercentTolerance: 0.01,
+};
+
 export function matchStatement(input: MatchingInput): MatchingPlan {
   const dateToleranceDays = input.config?.dateToleranceDays ?? DEFAULT_DATE_TOLERANCE_DAYS;
   const merchantFuzzThreshold =
@@ -63,12 +78,85 @@ export function matchStatement(input: MatchingInput): MatchingPlan {
     }
   }
 
+  // Second pass: for each insert_new decision, look for a near-match among
+  // the remaining unmatched candidates. Near-match is a UI hint — the
+  // candidate is NOT consumed, so it still flows to flaggedExisting and the
+  // user merges post-Apply via the picker from #301.
+  const nearMatchCfg = { ...NEAR_MATCH_DEFAULTS, ...(input.config?.nearMatch ?? {}) };
+  const nearDateToleranceMs = nearMatchCfg.dateToleranceDays * MS_PER_DAY;
+
+  for (let i = 0; i < decisions.length; i++) {
+    const decision = decisions[i];
+    if (decision.action !== "insert_new") continue;
+
+    const parsed = input.parsedRows[decision.statementRowIndex];
+    const parsedSignedCents = parsed.direction === "in" ? parsed.amountCents : -parsed.amountCents;
+    const parsedTokens = tokenize(parsed.descriptionRaw);
+
+    let best: {
+      txnId: number;
+      score: number;
+      amountDiffCents: bigint;
+      dateDiffDays: number;
+      similarity: number;
+    } | null = null;
+
+    for (const candidate of eligibleExisting) {
+      if (consumed.has(candidate.id)) continue;
+      if (candidate.currency !== parsed.currency) continue;
+      // Same sign — a debit and a credit of similar magnitude is not a merge.
+      if (sameSign(candidate.amountCents, parsedSignedCents) === false) continue;
+
+      const amountDiff = absBigInt(candidate.amountCents - parsedSignedCents);
+      if (amountDiff === BigInt(0)) continue; // exact match would have caught this
+
+      const amountThreshold = nearMatchAmountThreshold(
+        absBigInt(candidate.amountCents),
+        candidate.currency,
+        nearMatchCfg,
+      );
+      if (amountDiff > amountThreshold) continue;
+
+      const deltaMs = Math.abs(candidate.occurredAt.getTime() - parsed.occurredAt.getTime());
+      if (deltaMs > nearDateToleranceMs) continue;
+
+      const candidateTokens = tokenize(`${candidate.descriptionRaw} ${candidate.merchant ?? ""}`);
+      const similarity = jaccard(parsedTokens, candidateTokens);
+      if (similarity < nearMatchCfg.descriptionSimilarityMin) continue;
+
+      const score = scoreMatch(deltaMs, similarity);
+      if (!best || score > best.score) {
+        best = {
+          txnId: candidate.id,
+          score,
+          amountDiffCents: amountDiff,
+          dateDiffDays: Math.round(deltaMs / MS_PER_DAY),
+          similarity,
+        };
+      }
+    }
+
+    if (best) {
+      decisions[i] = {
+        ...decision,
+        action: "near_match",
+        matchedTxnId: best.txnId,
+        matchScore: best.score,
+        matchReason: "near_match_fuzzy_amount",
+        amountDiffCents: best.amountDiffCents.toString(),
+        dateDiffDays: best.dateDiffDays,
+        descriptionSimilarity: best.similarity,
+      };
+    }
+  }
+
   const flaggedExisting = eligibleExisting
     .filter((e) => !consumed.has(e.id) && e.reconciliationStatus === "unreconciled")
     .map((e) => ({ txnId: e.id, reason: "no_statement_match" as const }));
 
   const matched = decisions.filter((d) => d.action === "match").length;
-  const newInserts = decisions.length - matched;
+  const nearMatches = decisions.filter((d) => d.action === "near_match").length;
+  const newInserts = decisions.length - matched - nearMatches;
 
   return {
     decisions,
@@ -76,9 +164,34 @@ export function matchStatement(input: MatchingInput): MatchingPlan {
     summary: {
       matched,
       newInserts,
+      nearMatches,
       flaggedExisting: flaggedExisting.length,
     },
   };
+}
+
+const ZERO = BigInt(0);
+
+function absBigInt(v: bigint): bigint {
+  return v < ZERO ? -v : v;
+}
+
+function sameSign(a: bigint, b: bigint): boolean {
+  if (a === ZERO || b === ZERO) return a === b;
+  return a < ZERO === b < ZERO;
+}
+
+function nearMatchAmountThreshold(
+  absAmountCents: bigint,
+  currency: "COP" | "USD",
+  cfg: typeof NEAR_MATCH_DEFAULTS,
+): bigint {
+  const floor = currency === "USD" ? cfg.amountFloorUsdCents : cfg.amountFloorCopCents;
+  // BigInt × fractional percent via integer arithmetic: multiply by basis points
+  // (percent × 10_000) then divide back, staying in bigint land.
+  const basisPoints = BigInt(Math.round(cfg.amountPercentTolerance * 10_000));
+  const percentBased = (absAmountCents * basisPoints) / BigInt(10_000);
+  return percentBased > floor ? percentBased : floor;
 }
 
 /**

--- a/src/lib/reconciliation/engine/types.ts
+++ b/src/lib/reconciliation/engine/types.ts
@@ -18,15 +18,34 @@ export interface ExistingTxnForMatch {
   reconciliationStatus: "unreconciled" | "matched" | "flagged" | "imported_from_statement";
 }
 
-export type MatchAction = "match" | "insert_new";
-export type MatchReason = "amount_date_exact" | "amount_date_fuzzy_merchant" | "no_match";
+export type MatchAction = "match" | "insert_new" | "near_match";
+export type MatchReason =
+  | "amount_date_exact"
+  | "amount_date_fuzzy_merchant"
+  | "near_match_fuzzy_amount"
+  | "no_match";
 
 export interface MatchDecision {
   statementRowIndex: number;
   action: MatchAction;
+  /**
+   * For action='match': the consumed existing txn id.
+   * For action='near_match': the candidate existing txn id (NOT consumed —
+   *   candidate still flows to flaggedExisting post-Apply; the user resolves
+   *   via the merge-into action from #301).
+   * For action='insert_new': null.
+   */
   matchedTxnId: number | null;
   matchScore: number;
   matchReason: MatchReason;
+  /**
+   * Populated only for near-match decisions so the preview UI can annotate
+   * the diff without re-deriving it from candidate + parsed row. Serialized
+   * as string since MatchingPlan crosses the RSC boundary intact.
+   */
+  amountDiffCents?: string;
+  dateDiffDays?: number;
+  descriptionSimilarity?: number;
 }
 
 export interface FlaggedExistingTxn {
@@ -40,6 +59,7 @@ export interface MatchingPlan {
   summary: {
     matched: number;
     newInserts: number;
+    nearMatches: number;
     flaggedExisting: number;
   };
 }
@@ -47,6 +67,18 @@ export interface MatchingPlan {
 export interface MatchingConfig {
   dateToleranceDays?: number;
   merchantFuzzThreshold?: number;
+  /**
+   * Tunable thresholds for the near-match fallback pass. The amount
+   * threshold is max(absoluteCopFloorCents | absoluteUsdFloorCents,
+   * amount × percentTolerance).
+   */
+  nearMatch?: {
+    dateToleranceDays?: number;
+    descriptionSimilarityMin?: number;
+    amountFloorCopCents?: bigint;
+    amountFloorUsdCents?: bigint;
+    amountPercentTolerance?: number;
+  };
 }
 
 export interface MatchingInput {


### PR DESCRIPTION
## Summary

Last of the 3 Epic R follow-ups (#301, #302→#304, #303) from today's smoke test. Adds a **second-pass near-match fallback** to the matching engine that catches FX-rounding duplicates the exact-match pass can't.

## Near-match criteria

When a statement row can't exact-match AND a candidate existing txn is:

- Within \`max(500 COP / 0.05 USD, 1% of amount)\` of the statement row
- Same sign (debit-vs-credit stays separate)
- Within ±2 days of statement's \`occurredAt\`
- Description jaccard similarity ≥ 0.5

… the engine emits \`action='near_match'\` with metadata (\`amountDiffCents\`, \`dateDiffDays\`, \`descriptionSimilarity\`). Thresholds live in \`MatchingConfig.nearMatch\` so they're tunable without code changes.

**Important**: the candidate is NOT consumed. It still flows to \`flaggedExisting\` so the user resolves via the merge-into picker from #301 post-Apply. Commit treats \`near_match\` identically to \`insert_new\` — the differentiation is UI-only (visual hint) + a new \`summary.nearMatches\` counter for telemetry.

## Preview UI

- Rows with \`near_match\` render an amber badge: \`near-match · $ 1 off · merge with #42 post-Apply\`
- New \`{n} near-match\` summary badge
- Apply button text updates: \`Apply (5 match + 20 new + 2 near + 3 flag)\`

## Test plan

- [x] 6 new engine tests: FX-rounding happy path, amount threshold enforcement, sign mismatch, description similarity gate, exact-match preferred over near-match, config override
- [x] \`absBigInt\` / \`sameSign\` / \`nearMatchAmountThreshold\` helpers covered via the scenarios above
- [x] Full suite: 518/518 pass; \`bun run typecheck\` clean; \`bun run lint\` clean
- [ ] Browser smoke skipped — local DB state post-#304/#301 has all statement rows already exact-matching, so near-match path isn't exercised without DB manipulation. Engine path is unit-tested end-to-end.

Closes #303