### PR TITLE
fix(reconciliation): near-match uses overlap coefficient for asymmetric descriptions (#308)

### DIFF
--- a/src/lib/reconciliation/engine/match.test.ts
+++ b/src/lib/reconciliation/engine/match.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { jaccard, matchStatement, tokenize } from "./match";
+import { jaccard, matchStatement, overlapCoefficient, tokenize } from "./match";
 import type { ExistingTxnForMatch } from "./types";
 import type { ParsedStatementRow } from "../parsers/types";
 
@@ -55,6 +55,32 @@ describe("jaccard", () => {
   });
   it("returns 0 for two empty sets", () => {
     expect(jaccard(new Set(), new Set())).toBe(0);
+  });
+});
+
+describe("overlapCoefficient", () => {
+  it("is 1 when the smaller set is fully contained in the larger", () => {
+    // The key property: asymmetric size does NOT penalize.
+    expect(
+      overlapCoefficient(
+        new Set(["polar", "tonnoz"]),
+        new Set(["compra", "polar", "tonnoz", "ser"]),
+      ),
+    ).toBe(1);
+  });
+  it("handles the real POLAR smoke-test case above the 0.5 threshold", () => {
+    const bank = new Set(["compra", "intl", "polar", "tonnoz", "ser"]);
+    const sms = new Set(["polar", "tonnoz", "servic"]);
+    // 2 / min(5,3) = 0.67, where jaccard would give 2/6 = 0.33 (below 0.5).
+    expect(overlapCoefficient(bank, sms)).toBeCloseTo(2 / 3);
+  });
+  it("is 0 when either side is empty", () => {
+    expect(overlapCoefficient(new Set(), new Set(["a"]))).toBe(0);
+    expect(overlapCoefficient(new Set(["a"]), new Set())).toBe(0);
+    expect(overlapCoefficient(new Set(), new Set())).toBe(0);
+  });
+  it("is 0 for disjoint sets", () => {
+    expect(overlapCoefficient(new Set(["a", "b"]), new Set(["c", "d"]))).toBe(0);
   });
 });
 
@@ -288,25 +314,27 @@ describe("matchStatement — invariants", () => {
 describe("matchStatement — near-match fallback", () => {
   const date = new Date("2026-04-14T05:00:00Z");
 
-  it("emits near_match when amount is 1 peso off but date + description align (FX rounding case)", () => {
-    // Real shape from smoke-test today: bank statement has "COMPRA INTL POLAR
-    // TONNOZ SER" and the SMS-captured findash row has "POLAR TONNOZ SERVIC"
-    // — decent token overlap + 1-peso amount drift from FX rounding.
+  it("emits near_match for the real POLAR smoke-test case (asymmetric descriptions)", () => {
+    // Actual descriptions captured on 2026-04-19: bank-feed is longer and
+    // has prefix noise ("COMPRA INTL") — jaccard would score 2/6 = 0.33 and
+    // reject. Overlap coefficient scores 2/3 = 0.67 and accepts, which is
+    // the correct behavior for this real FX-rounding duplicate.
     const plan = matchStatement({
       parsedRows: [
         parsedRow({
           occurredAt: date,
-          amountCents: BigInt(1_320_565_00),
+          amountCents: BigInt(25_573_00),
           direction: "out",
-          descriptionRaw: "COMPRA INTL POLAR TONNOZ SERVIC",
+          descriptionRaw: "COMPRA INTL POLAR TONNOZ SER",
         }),
       ],
       existingTxns: [
         existingTxn({
           id: 42,
           occurredAt: date,
-          amountCents: BigInt(-1_320_564_00), // ← 1 peso off
-          descriptionRaw: "POLAR TONNOZ SERVIC",
+          amountCents: BigInt(-25_448_00), // ← 125 pesos off
+          descriptionRaw: "POLAR* TONNOZ-SERVIC",
+          merchant: "POLAR* TONNOZ-SERVIC",
         }),
       ],
     });
@@ -314,7 +342,7 @@ describe("matchStatement — near-match fallback", () => {
     expect(plan.decisions[0].action).toBe("near_match");
     expect(plan.decisions[0].matchedTxnId).toBe(42);
     expect(plan.decisions[0].matchReason).toBe("near_match_fuzzy_amount");
-    expect(plan.decisions[0].amountDiffCents).toBe("100");
+    expect(plan.decisions[0].amountDiffCents).toBe("12500");
     expect(plan.decisions[0].dateDiffDays).toBe(0);
     expect(plan.summary.nearMatches).toBe(1);
     expect(plan.summary.newInserts).toBe(0);
@@ -390,6 +418,30 @@ describe("matchStatement — near-match fallback", () => {
     expect(plan.decisions[0].action).toBe("insert_new");
   });
 
+  it("does NOT emit near_match when the smaller side has fewer than 2 tokens (noise guard)", () => {
+    // A 1-token SMS like `{pago}` would score overlap 1.0 against any
+    // description containing "pago" — the guard rejects before that.
+    const plan = matchStatement({
+      parsedRows: [
+        parsedRow({
+          occurredAt: date,
+          amountCents: BigInt(100_00),
+          direction: "out",
+          descriptionRaw: "PAGO QR SOLUCIONES RESTAURANTE ARGENTINO",
+        }),
+      ],
+      existingTxns: [
+        existingTxn({
+          id: 1,
+          occurredAt: date,
+          amountCents: BigInt(-99_00),
+          descriptionRaw: "PAGO", // 1 meaningful token — below guard
+        }),
+      ],
+    });
+    expect(plan.decisions[0].action).toBe("insert_new");
+  });
+
   it("prefers exact match over near-match when both candidates are available", () => {
     const plan = matchStatement({
       parsedRows: [
@@ -423,14 +475,14 @@ describe("matchStatement — near-match fallback", () => {
     expect(plan.flaggedExisting).toEqual([{ txnId: 1, reason: "no_statement_match" }]);
   });
 
-  it("respects nearMatch config overrides (tighter similarity cutoff)", () => {
+  it("respects nearMatch.descriptionSimilarityMin override (looser cutoff)", () => {
     const plan = matchStatement({
       parsedRows: [
         parsedRow({
           occurredAt: date,
           amountCents: BigInt(10_00),
           direction: "out",
-          descriptionRaw: "ONE TWO THREE FOUR",
+          descriptionRaw: "ALPHA BETA GAMMA DELTA EPSILON",
         }),
       ],
       existingTxns: [
@@ -438,11 +490,35 @@ describe("matchStatement — near-match fallback", () => {
           id: 1,
           occurredAt: date,
           amountCents: BigInt(-9_50),
-          descriptionRaw: "ONE TWO FIVE SIX", // 2/6 = 0.33 jaccard
+          descriptionRaw: "ALPHA ZULU OMEGA SIGMA LAMBDA", // 1/5 overlap = 0.2
         }),
       ],
-      // default threshold 0.5 would reject this — tightening to 0.2 accepts.
-      config: { nearMatch: { descriptionSimilarityMin: 0.2 } },
+      // default threshold 0.5 would reject — loosening to 0.15 accepts.
+      config: { nearMatch: { descriptionSimilarityMin: 0.15 } },
+    });
+    expect(plan.decisions[0].action).toBe("near_match");
+  });
+
+  it("respects nearMatch.minTokensInSmallerSet override (loosening the noise guard)", () => {
+    const plan = matchStatement({
+      parsedRows: [
+        parsedRow({
+          occurredAt: date,
+          amountCents: BigInt(100_00),
+          direction: "out",
+          descriptionRaw: "PAGO QR SOLUCIONES RESTAURANTE",
+        }),
+      ],
+      existingTxns: [
+        existingTxn({
+          id: 1,
+          occurredAt: date,
+          amountCents: BigInt(-99_00),
+          descriptionRaw: "PAGO", // 1-token SMS, default guard rejects
+        }),
+      ],
+      // Loosen the guard to 1 token — now the 1.0 overlap is accepted.
+      config: { nearMatch: { minTokensInSmallerSet: 1 } },
     });
     expect(plan.decisions[0].action).toBe("near_match");
   });

--- a/src/lib/reconciliation/engine/match.ts
+++ b/src/lib/reconciliation/engine/match.ts
@@ -9,7 +9,14 @@ const MS_PER_DAY = 86_400_000;
 // stronger date + description signal to confidently propose a merge.
 const NEAR_MATCH_DEFAULTS = {
   dateToleranceDays: 2,
+  // Overlap-coefficient threshold. 0.5 means at least half of the smaller
+  // set must be in the larger — strict enough that pairs need real shared
+  // content, lenient enough to ignore bank prefix noise.
   descriptionSimilarityMin: 0.5,
+  // Minimum tokens in the SMALLER description after tokenize(). Below this
+  // the similarity signal is too noisy (a 1-token SMS scores 1.0 against
+  // anything containing that token).
+  minTokensInSmallerSet: 2,
   // $500 COP — smaller than this is noise; also the Bancolombia statement
   // FX-rounding amounts we've seen in real data (1–125 pesos) fit under it.
   amountFloorCopCents: BigInt(500_00),
@@ -121,7 +128,14 @@ export function matchStatement(input: MatchingInput): MatchingPlan {
       if (deltaMs > nearDateToleranceMs) continue;
 
       const candidateTokens = tokenize(`${candidate.descriptionRaw} ${candidate.merchant ?? ""}`);
-      const similarity = jaccard(parsedTokens, candidateTokens);
+      // Overlap coefficient (not jaccard) to ignore the asymmetry between
+      // bank-feed descriptions (long, with prefixes like "COMPRA INTL")
+      // vs SMS-captured descriptions (short, merchant-focused). Guard
+      // against tiny sets: a 1-token SMS like `{pago}` would score 1.0
+      // against any description containing "pago".
+      const smallerSetSize = Math.min(parsedTokens.size, candidateTokens.size);
+      if (smallerSetSize < nearMatchCfg.minTokensInSmallerSet) continue;
+      const similarity = overlapCoefficient(parsedTokens, candidateTokens);
       if (similarity < nearMatchCfg.descriptionSimilarityMin) continue;
 
       const score = scoreMatch(deltaMs, similarity);
@@ -225,6 +239,26 @@ export function jaccard(a: Set<string>, b: Set<string>): number {
   for (const t of a) if (b.has(t)) intersectionSize++;
   const unionSize = a.size + b.size - intersectionSize;
   return unionSize === 0 ? 0 : intersectionSize / unionSize;
+}
+
+/**
+ * Overlap (Szymkiewicz–Simpson) coefficient: |A ∩ B| / min(|A|, |B|).
+ *
+ * Unlike jaccard, this ignores size asymmetry — ideal for comparing a short
+ * SMS description against a longer bank-feed description where the bank
+ * systematically prefixes extra tokens ("COMPRA INTL", "PAGO SUC VIRT").
+ * Near-match uses this instead of jaccard so bank prefix noise doesn't
+ * suppress legitimate merges.
+ *
+ * Callers can combine with a minimum-tokens guard on the smaller set to
+ * avoid 1-token SMS like `{pago}` scoring 1.0 against everything.
+ */
+export function overlapCoefficient(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersectionSize = 0;
+  for (const t of a) if (b.has(t)) intersectionSize++;
+  const smaller = Math.min(a.size, b.size);
+  return intersectionSize / smaller;
 }
 
 export type { ParsedStatementRow, ExistingTxnForMatch };

--- a/src/lib/reconciliation/engine/types.ts
+++ b/src/lib/reconciliation/engine/types.ts
@@ -70,11 +70,15 @@ export interface MatchingConfig {
   /**
    * Tunable thresholds for the near-match fallback pass. The amount
    * threshold is max(absoluteCopFloorCents | absoluteUsdFloorCents,
-   * amount × percentTolerance).
+   * amount × percentTolerance). `descriptionSimilarityMin` applies to the
+   * overlap coefficient (|A ∩ B| / min(|A|, |B|)) rather than jaccard —
+   * chosen so asymmetric bank-vs-SMS descriptions are not penalized for
+   * the bank's longer prefix.
    */
   nearMatch?: {
     dateToleranceDays?: number;
     descriptionSimilarityMin?: number;
+    minTokensInSmallerSet?: number;
     amountFloorCopCents?: bigint;
     amountFloorUsdCents?: bigint;
     amountPercentTolerance?: number;


### PR DESCRIPTION
## Summary

Hotfix on top of #303 / PR #307. Browser smoke test on real Bancolombia data revealed the shipped near-match feature did NOT catch the case that motivated it — because **jaccard penalizes set-size asymmetry** and bank descriptions are systematically longer than SMS.

Real case:
- Bank: \`COMPRA INTL POLAR TONNOZ SER\` → 5 tokens
- SMS: \`POLAR* TONNOZ-SERVIC\` → 3 tokens
- Intersection: \`{polar, tonnoz}\` = 2
- jaccard = 2/6 = **0.33** → rejected at 0.5 threshold ❌
- overlap = 2/min(5,3) = **0.67** → accepted at 0.5 threshold ✅

## What changed

- New \`overlapCoefficient(a, b)\` = \`|A ∩ B| / min(|A|, |B|)\` in \`match.ts\`
- Near-match similarity computation switched from jaccard to overlap
- Added \`minTokensInSmallerSet\` guard (default 2) so 1-token SMS like \`{pago}\` doesn't false-positive with score 1.0
- Default threshold stays 0.5 — overlap with this threshold catches real cases without blanket loosening
- Exact-match path keeps jaccard (there it's only labeling \`amount_date_fuzzy_merchant\` vs \`amount_date_exact\`, not a gate)

## Test plan

- [x] 4 new unit tests for \`overlapCoefficient\` (asymmetric fill, POLAR case, empty, disjoint)
- [x] Replaced the synthetic FX-rounding test with the REAL POLAR smoke-test case
- [x] New test for the min-tokens noise guard (1-token SMS rejected despite 1.0 overlap)
- [x] Config override tests updated for overlap semantics
- [x] Full suite: 524/524 pass; \`bun run typecheck\` clean; \`bun run lint\` clean
- [x] **Browser smoke test end-to-end** with real Bancolombia statement against fresh DB state — engine emits 2 near-matches exactly as expected:
  - \`\"PAGO SUC VIRT TC MASTER DOLAR\" -\$1.320.565\` → \`near-match · \$ 1 off · merge with #974 post-Apply\`
  - \`\"COMPRA INTL POLAR TONNOZ SER\" -\$25.573\` → \`near-match · \$ 125 off · merge with #955 post-Apply\`

Closes #308