### PR TITLE
feat(ui): Money component + MoneyModeProvider + formatMoney JSX refactor (#251)

### DIFF
--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -8,6 +8,7 @@ import { getNetWorth } from "@/lib/dashboard/queries";
 import { listAccountsDetailed, type AccountDetail } from "@/lib/accounts/queries";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { toCop, formatCop, formatMoney } from "@/lib/money";
+import { Money } from "@/components/display/money";
 import type { Currency } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -188,7 +189,7 @@ function AccountCard({ account, muted }: { account: AccountDetail; muted?: boole
             negative ? "text-rose-600" : "text-foreground",
           )}
         >
-          {formatMoney(account.balanceCents, account.currency)}
+          <Money cents={account.balanceCents} currency={account.currency} />
         </div>
         {account.type === "credit_card" && creditLimit ? (
           <CreditMeter
@@ -200,7 +201,7 @@ function AccountCard({ account, muted }: { account: AccountDetail; muted?: boole
         ) : null}
         {account.type === "loan" && loanRemaining ? (
           <div className="text-muted-foreground text-xs">
-            Remaining: {formatMoney(BigInt(loanRemaining), account.currency)}
+            Remaining: <Money cents={BigInt(loanRemaining)} currency={account.currency} />
             {nextPayment ? ` · next ${nextPayment}` : ""}
           </div>
         ) : null}
@@ -239,8 +240,12 @@ function CreditMeter({
         />
       </div>
       <div className="text-muted-foreground flex items-center justify-between text-xs tabular-nums">
-        <span>{formatMoney(used, currency)} used</span>
-        <span>{formatMoney(limitCents, currency)} limit</span>
+        <span>
+          <Money cents={used} currency={currency} /> used
+        </span>
+        <span>
+          <Money cents={limitCents} currency={currency} /> limit
+        </span>
       </div>
     </div>
   );

--- a/src/app/(app)/budgets/budgets-manager.tsx
+++ b/src/app/(app)/budgets/budgets-manager.tsx
@@ -24,6 +24,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CategoryCombobox } from "@/components/transactions/category-combobox";
+import { Money } from "@/components/display/money";
 import { formatMoney } from "@/lib/money";
 import type { Currency } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -125,9 +126,12 @@ export function BudgetsManager({
             <span className="text-muted-foreground">Total</span>
             <span className="tabular-nums">
               <span className={cn(totalSpent > totalBudget && "font-medium text-rose-600")}>
-                {formatMoney(totalSpent, "COP")}
+                <Money cents={totalSpent} currency="COP" />
               </span>
-              <span className="text-muted-foreground"> / {formatMoney(totalBudget, "COP")}</span>
+              <span className="text-muted-foreground">
+                {" "}
+                / <Money cents={totalBudget} currency="COP" />
+              </span>
             </span>
           </CardContent>
         </Card>
@@ -229,7 +233,8 @@ function BudgetCard({
         </div>
         <div className="flex items-center justify-between text-xs tabular-nums">
           <span className={cn(over ? "font-medium text-rose-600" : "text-muted-foreground")}>
-            {formatMoney(spent, row.currency)} / {formatMoney(amount, row.currency)}
+            <Money cents={spent} currency={row.currency} /> /{" "}
+            <Money cents={amount} currency={row.currency} />
           </span>
           <span className={cn("text-muted-foreground", over && "font-medium text-rose-600")}>
             {over

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,8 +1,10 @@
 import { Header } from "@/components/layout/header";
 import { Breadcrumbs } from "@/components/layout/breadcrumbs";
+import { MoneyModeProvider } from "@/components/display/money-mode-provider";
 import { QuickExpenseFab } from "@/components/transactions/quick-expense-fab";
 import { LiveRefresh } from "@/components/live-refresh";
 import { getSessionUserOrNull } from "@/lib/auth/session";
+import { DEFAULT_DISPLAY_CURRENCY_MODE } from "@/lib/db/schema";
 import { auth } from "@/auth";
 
 export default async function AppLayout({
@@ -20,13 +22,16 @@ export default async function AppLayout({
       }
     : null;
 
+  // Currency display toggle: mode + fxRate will be wired in a follow-up; for
+  // now the provider runs in `native` mode with no rate → conversion is a
+  // no-op and every Money render matches the pre-toggle behavior.
   return (
-    <>
+    <MoneyModeProvider mode={DEFAULT_DISPLAY_CURRENCY_MODE} fxRate={null}>
       <Header user={headerUser} />
       <Breadcrumbs />
       <div className="flex flex-1 flex-col">{children}</div>
       <QuickExpenseFab />
       <LiveRefresh />
-    </>
+    </MoneyModeProvider>
   );
 }

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/flagged-review.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/flagged-review.tsx
@@ -12,6 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Money } from "@/components/display/money";
 import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import type { Currency } from "@/lib/types";
@@ -137,7 +138,7 @@ export function FlaggedReview({
                         cents < BigInt(0) ? "text-rose-600" : "text-emerald-600",
                       )}
                     >
-                      {formatMoney(cents, currency)}
+                      <Money cents={cents} currency={currency} />
                     </td>
                     <td className="p-2 text-right">
                       <div className="flex justify-end gap-1">
@@ -253,7 +254,7 @@ function MergePickerDialog({
                         cents < BigInt(0) ? "text-rose-600" : "text-emerald-600",
                       )}
                     >
-                      {formatMoney(cents, currency)}
+                      <Money cents={cents} currency={currency} />
                     </td>
                     <td className="p-2 text-right">
                       <Button

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/reconcile-form.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/reconcile-form.tsx
@@ -8,7 +8,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { formatMoney, parseTolerantMoney } from "@/lib/money";
+import { Money } from "@/components/display/money";
+import { parseTolerantMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { applyReconcile, previewReconcile, type ReconcilePreview } from "./actions";
 
@@ -187,7 +188,7 @@ export function ReconcileForm({
                             signed < BigInt(0) ? "text-rose-600" : "text-emerald-600",
                           )}
                         >
-                          {formatMoney(signed, row.currency)}
+                          <Money cents={signed} currency={row.currency} />
                         </td>
                         <td className="p-2 text-xs">
                           {decision?.action === "match" ? (
@@ -203,9 +204,14 @@ export function ReconcileForm({
                               title={`score ${decision.matchScore} (${decision.matchReason})`}
                             >
                               near-match ·{" "}
-                              {decision.amountDiffCents !== undefined
-                                ? formatMoney(BigInt(decision.amountDiffCents), row.currency)
-                                : "?"}{" "}
+                              {decision.amountDiffCents !== undefined ? (
+                                <Money
+                                  cents={BigInt(decision.amountDiffCents)}
+                                  currency={row.currency}
+                                />
+                              ) : (
+                                "?"
+                              )}{" "}
                               off · merge with #{decision.matchedTxnId} post-Apply
                             </span>
                           ) : (
@@ -247,7 +253,7 @@ export function ReconcileForm({
                 Copialo del app del banco. Si lo ingresás, habilitamos la métrica de divergencia en{" "}
                 <code>/admin/health</code>. Findash actual:{" "}
                 <span className="tabular-nums">
-                  {formatMoney(currentFindashBalance, accountCurrency)}
+                  <Money cents={currentFindashBalance} currency={accountCurrency} />
                 </span>
                 .
               </p>

--- a/src/app/(app)/settings/accounts/accounts-manager.tsx
+++ b/src/app/(app)/settings/accounts/accounts-manager.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { formatMoney } from "@/lib/money";
+import { Money } from "@/components/display/money";
 import type { Currency } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import type { AccountMetadata } from "@/lib/db/schema";
@@ -172,7 +172,7 @@ export function AccountsManager({ items }: { items: AccountRow[] }) {
                               <td className="text-muted-foreground p-2 text-xs">{r.institution}</td>
                               <td className="text-muted-foreground p-2 text-xs">{r.currency}</td>
                               <td className="p-2 text-right font-medium tabular-nums">
-                                {formatMoney(cents, r.currency)}
+                                <Money cents={cents} currency={r.currency} />
                               </td>
                               <td className="p-2 text-xs">
                                 <button

--- a/src/app/(app)/settings/accounts/balance-adjust-dialog.tsx
+++ b/src/app/(app)/settings/accounts/balance-adjust-dialog.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { formatMoney } from "@/lib/money";
+import { Money } from "@/components/display/money";
 import type { AccountRow } from "./accounts-manager";
 
 export function BalanceAdjustDialog({
@@ -66,7 +66,7 @@ export function BalanceAdjustDialog({
               Saldo actual según Findash
             </Label>
             <div className="bg-muted/40 rounded-md border px-3 py-2 text-base font-semibold tabular-nums">
-              {target ? formatMoney(currentCents, target.currency) : "—"}
+              {target ? <Money cents={currentCents} currency={target.currency} /> : "—"}
             </div>
           </div>
 
@@ -93,7 +93,7 @@ export function BalanceAdjustDialog({
               Se creará una transacción de{" "}
               <span className="font-semibold tabular-nums">
                 {diffCents > BigInt(0) ? "+" : ""}
-                {target ? formatMoney(diffCents, target.currency) : ""}
+                {target ? <Money cents={diffCents} currency={target.currency} /> : ""}
               </span>{" "}
               marcada como <strong>Ajuste</strong>. Queda fuera de spend / insights / budgets.
             </div>

--- a/src/app/(app)/settings/recurring/recurring-manager.tsx
+++ b/src/app/(app)/settings/recurring/recurring-manager.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { formatMoney } from "@/lib/money";
+import { Money } from "@/components/display/money";
 import type { Currency } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { archiveRecurring, toggleRecurringActive, upsertRecurring } from "./actions";
@@ -151,7 +151,7 @@ export function RecurringManager({
                             cents < BigInt(0) ? "text-rose-600" : "text-emerald-600",
                           )}
                         >
-                          {formatMoney(cents, r.currency)}
+                          <Money cents={cents} currency={r.currency} />
                         </td>
                         <td className="p-2 text-xs">
                           <button

--- a/src/components/dashboard/accounts-grid.tsx
+++ b/src/components/dashboard/accounts-grid.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-import { formatMoney } from "@/lib/money";
+import { Money } from "@/components/display/money";
 import type { AccountStatus } from "@/lib/dashboard/queries";
 
 const TYPE_LABEL: Record<AccountStatus["type"], string> = {
@@ -37,7 +37,7 @@ export function AccountsGrid({ accounts }: { accounts: AccountStatus[] }) {
                   negative ? "text-rose-600" : "text-foreground",
                 )}
               >
-                {formatMoney(a.balanceCents, a.currency)}
+                <Money cents={a.balanceCents} currency={a.currency} />
               </div>
             </CardContent>
           </Card>

--- a/src/components/dashboard/recurring-gap-link-dialog.tsx
+++ b/src/components/dashboard/recurring-gap-link-dialog.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
-import { formatMoney } from "@/lib/money";
+import { Money } from "@/components/display/money";
 import { cn } from "@/lib/utils";
 import { linkTxToRecurring } from "@/app/(app)/settings/recurring/actions";
 import type { LinkCandidate } from "@/lib/recurring/gap-queries";
@@ -73,7 +73,7 @@ export function RecurringGapLinkDialog({
         <DialogHeader>
           <DialogTitle>Asociar transacción — {label}</DialogTitle>
           <DialogDescription>
-            Mes {yearMonth} · esperado {formatMoney(expectedAmountCents, currency)}
+            Mes {yearMonth} · esperado <Money cents={expectedAmountCents} currency={currency} />
           </DialogDescription>
         </DialogHeader>
 
@@ -114,7 +114,7 @@ export function RecurringGapLinkDialog({
                       c.amountCents < BigInt(0) ? "text-rose-600" : "text-emerald-600",
                     )}
                   >
-                    {formatMoney(c.amountCents, currency)}
+                    <Money cents={c.amountCents} currency={currency} />
                   </div>
                 </button>
               );

--- a/src/components/dashboard/recurring-inbox-card.tsx
+++ b/src/components/dashboard/recurring-inbox-card.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { formatMoney } from "@/lib/money";
+import { Money } from "@/components/display/money";
 import { cn } from "@/lib/utils";
 import {
   dismissUpcoming,
@@ -156,7 +156,7 @@ export function RecurringInboxCard({ gaps }: { gaps: RecurringGapItem[] }) {
                         cents < BigInt(0) ? "text-rose-600" : "text-emerald-600",
                       )}
                     >
-                      {formatMoney(cents, item.currency)}
+                      <Money cents={cents} currency={item.currency} />
                     </div>
                   </div>
                   {isOpen ? (

--- a/src/components/dashboard/top-expenses-card.tsx
+++ b/src/components/dashboard/top-expenses-card.tsx
@@ -6,7 +6,7 @@ import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { useNewIds } from "@/lib/hooks/use-new-ids";
-import { formatMoney } from "@/lib/money";
+import { Money } from "@/components/display/money";
 import { hasSecondaryDescription, primaryDescription } from "@/lib/transactions/description";
 import type { TopExpense } from "@/lib/dashboard/queries";
 
@@ -88,10 +88,12 @@ export function TopExpensesCard({
                       </div>
                       <div className="shrink-0 text-right font-medium text-rose-600 tabular-nums">
                         −
-                        {formatMoney(
-                          r.amountCents < BigInt(0) ? r.amountCents * BigInt(-1) : r.amountCents,
-                          r.currency,
-                        )}
+                        <Money
+                          cents={
+                            r.amountCents < BigInt(0) ? r.amountCents * BigInt(-1) : r.amountCents
+                          }
+                          currency={r.currency}
+                        />
                       </div>
                     </Link>
                   </motion.li>

--- a/src/components/dashboard/upcoming-card.tsx
+++ b/src/components/dashboard/upcoming-card.tsx
@@ -7,7 +7,7 @@ import { CheckCircle2Icon, CircleXIcon, UndoIcon } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { formatMoney } from "@/lib/money";
+import { Money } from "@/components/display/money";
 import { cn } from "@/lib/utils";
 import {
   dismissUpcoming,
@@ -146,7 +146,7 @@ export function UpcomingCard({
                       cents < BigInt(0) ? "text-rose-600" : "text-emerald-600",
                     )}
                   >
-                    {formatMoney(cents, item.currency)}
+                    <Money cents={cents} currency={item.currency} />
                   </div>
                   <div className="flex items-center gap-1">
                     {item.status === "upcoming" || item.status === "overdue" ? (

--- a/src/components/display/money-mode-provider.tsx
+++ b/src/components/display/money-mode-provider.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+import { DEFAULT_DISPLAY_CURRENCY_MODE, type DisplayCurrencyMode } from "@/lib/db/schema";
+
+export type DisplayFxRate = {
+  rate: number;
+  source: string;
+};
+
+export type MoneyModeContextValue = {
+  mode: DisplayCurrencyMode;
+  fxRate: DisplayFxRate | null;
+};
+
+const MoneyModeContext = createContext<MoneyModeContextValue>({
+  mode: DEFAULT_DISPLAY_CURRENCY_MODE,
+  fxRate: null,
+});
+
+export function MoneyModeProvider({
+  mode,
+  fxRate,
+  children,
+}: {
+  mode: DisplayCurrencyMode;
+  fxRate: DisplayFxRate | null;
+  children: ReactNode;
+}) {
+  // No useMemo: the provider lives at (app) layout root, so its re-renders
+  // already propagate through the whole client tree — a stable reference
+  // wouldn't prevent consumer re-renders in practice.
+  const value: MoneyModeContextValue = { mode, fxRate };
+  return <MoneyModeContext.Provider value={value}>{children}</MoneyModeContext.Provider>;
+}
+
+export function useMoneyMode(): MoneyModeContextValue {
+  return useContext(MoneyModeContext);
+}

--- a/src/components/display/money.tsx
+++ b/src/components/display/money.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { convertCents, displayCurrencyFor, formatMoney } from "@/lib/money";
+import type { Currency } from "@/lib/types";
+import { useMoneyMode } from "./money-mode-provider";
+
+export function Money({
+  cents,
+  currency,
+  className,
+  footnoteClassName,
+}: {
+  cents: bigint;
+  currency: Currency;
+  className?: string;
+  footnoteClassName?: string;
+}) {
+  const { mode, fxRate } = useMoneyMode();
+  const target = displayCurrencyFor(mode, currency);
+
+  if (target === currency || fxRate === null) {
+    return <span className={className}>{formatMoney(cents, currency)}</span>;
+  }
+
+  const converted = convertCents(cents, currency, target, fxRate.rate);
+  return (
+    <span className={className}>
+      {formatMoney(converted, target)}
+      <span className={cn("text-muted-foreground ml-1 text-xs font-normal", footnoteClassName)}>
+        ≈ {formatMoney(cents, currency)}
+      </span>
+    </span>
+  );
+}

--- a/src/components/import/screenshot-upload.tsx
+++ b/src/components/import/screenshot-upload.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { formatMoney } from "@/lib/money";
+import { Money } from "@/components/display/money";
 import { cn } from "@/lib/utils";
 import {
   confirmOcrImport,
@@ -335,7 +335,7 @@ export function ScreenshotUpload({ accounts }: { accounts: AccountOption[] }) {
                             )}
                           />
                           <div className="text-muted-foreground text-xs tabular-nums">
-                            {formatMoney(r.amountCents, currency)}
+                            <Money cents={r.amountCents} currency={currency} />
                           </div>
                           <div className="text-muted-foreground text-[10px]">
                             {dateFmt.format(new Date(`${r.occurredOn}T12:00:00Z`))}

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { ReceiptTextIcon, UserIcon, BuildingIcon, WrenchIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Money } from "@/components/display/money";
 import { EmptyState } from "@/components/ui/empty-state";
 import {
   Table,
@@ -80,16 +81,6 @@ function CounterpartyTypeBadge({ type }: { type: NonNullable<TxRow["counterparty
     );
   }
   return null;
-}
-
-function formatAmount(cents: bigint, currency: TxRow["currency"]) {
-  const n = Number(cents) / 100;
-  const formatter = new Intl.NumberFormat(currency === "USD" ? "en-US" : "es-CO", {
-    style: "currency",
-    currency,
-    maximumFractionDigits: currency === "USD" ? 2 : 0,
-  });
-  return formatter.format(n);
 }
 
 function formatDate(d: Date) {
@@ -224,7 +215,7 @@ export function TransactionTable({
                       )}
                       suppressHydrationWarning
                     >
-                      {formatAmount(tx.amountCents, tx.currency)}
+                      <Money cents={tx.amountCents} currency={tx.currency} />
                     </TableCell>
                   </motion.tr>
                 );
@@ -280,7 +271,7 @@ export function TransactionTable({
                     }`}
                     suppressHydrationWarning
                   >
-                    {formatAmount(tx.amountCents, tx.currency)}
+                    <Money cents={tx.amountCents} currency={tx.currency} />
                   </span>
                 </div>
 

--- a/src/components/ui/animated-money.tsx
+++ b/src/components/ui/animated-money.tsx
@@ -1,34 +1,57 @@
 "use client";
 
 import NumberFlow from "@number-flow/react";
+import { useMoneyMode } from "@/components/display/money-mode-provider";
+import { convertCents, displayCurrencyFor, formatMoney } from "@/lib/money";
+import { cn } from "@/lib/utils";
 import type { Currency } from "@/lib/types";
 
 export function AnimatedMoney({
   cents,
   currency,
   className,
+  footnoteClassName,
   signDisplay = "auto",
 }: {
   cents: bigint;
   currency: Currency;
   className?: string;
+  footnoteClassName?: string;
   signDisplay?: Intl.NumberFormatOptions["signDisplay"];
 }) {
-  const locale = currency === "USD" ? "en-US" : "es-CO";
-  const maximumFractionDigits = currency === "USD" ? 2 : 0;
-  const value = Number(cents) / 100;
+  const { mode, fxRate } = useMoneyMode();
+  const target = displayCurrencyFor(mode, currency);
+  const active =
+    target === currency || fxRate === null
+      ? { cents, currency }
+      : { cents: convertCents(cents, currency, target, fxRate.rate), currency: target };
 
-  return (
+  const locale = active.currency === "USD" ? "en-US" : "es-CO";
+  const maximumFractionDigits = active.currency === "USD" ? 2 : 0;
+  const value = Number(active.cents) / 100;
+
+  const number = (
     <NumberFlow
       value={value}
       locales={locale}
       format={{
         style: "currency",
-        currency,
+        currency: active.currency,
         maximumFractionDigits,
         signDisplay,
       }}
       className={className}
     />
+  );
+
+  if (active.currency === currency) return number;
+
+  return (
+    <span className="inline-flex items-baseline">
+      {number}
+      <span className={cn("text-muted-foreground ml-1 text-xs font-normal", footnoteClassName)}>
+        ≈ {formatMoney(cents, currency)}
+      </span>
+    </span>
   );
 }

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { decimalStringToCents, parseTolerantMoney } from "./money";
+import {
+  convertCents,
+  decimalStringToCents,
+  displayCurrencyFor,
+  parseTolerantMoney,
+  toCop,
+} from "./money";
 
 describe("decimalStringToCents", () => {
   it("parses single-digit cent values", () => {
@@ -82,5 +88,46 @@ describe("parseTolerantMoney", () => {
     expect(() => parseTolerantMoney("abc")).toThrow(/Invalid money/);
     expect(() => parseTolerantMoney("")).toThrow(/Empty money/);
     expect(() => parseTolerantMoney("1e5")).toThrow(/Invalid money/);
+  });
+});
+
+describe("displayCurrencyFor", () => {
+  it("returns source currency in native mode", () => {
+    expect(displayCurrencyFor("native", "COP")).toBe("COP");
+    expect(displayCurrencyFor("native", "USD")).toBe("USD");
+  });
+
+  it("forces target currency in all-cop / all-usd modes", () => {
+    expect(displayCurrencyFor("all-cop", "COP")).toBe("COP");
+    expect(displayCurrencyFor("all-cop", "USD")).toBe("COP");
+    expect(displayCurrencyFor("all-usd", "COP")).toBe("USD");
+    expect(displayCurrencyFor("all-usd", "USD")).toBe("USD");
+  });
+});
+
+describe("convertCents", () => {
+  it("returns input unchanged when currencies match", () => {
+    expect(convertCents(BigInt(12345), "USD", "USD", 4000)).toBe(BigInt(12345));
+    expect(convertCents(BigInt(12345), "COP", "COP", 4000)).toBe(BigInt(12345));
+  });
+
+  it("USD -> COP matches toCop semantics (100 USD_cents @ 4000 = 400_000 COP_cents)", () => {
+    expect(convertCents(BigInt(100), "USD", "COP", 4000)).toBe(BigInt(400_000));
+    expect(convertCents(BigInt(100), "USD", "COP", 4000)).toBe(toCop(BigInt(100), "USD", 4000));
+  });
+
+  it("COP -> USD is the inverse of USD -> COP", () => {
+    expect(convertCents(BigInt(400_000), "COP", "USD", 4000)).toBe(BigInt(100));
+  });
+
+  it("roundtrips USD -> COP -> USD within integer rounding", () => {
+    const startUsdCents = BigInt(1234);
+    const cop = convertCents(startUsdCents, "USD", "COP", 3990);
+    const back = convertCents(cop, "COP", "USD", 3990);
+    expect(back).toBe(startUsdCents);
+  });
+
+  it("uses micros precision for non-round rates", () => {
+    expect(convertCents(BigInt(100), "USD", "COP", 3990.5)).toBe(BigInt(399_050));
   });
 });

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,3 +1,4 @@
+import type { DisplayCurrencyMode } from "@/lib/db/schema";
 import type { Currency } from "@/lib/types";
 
 export const FALLBACK_COP_PER_USD = 4000;
@@ -26,6 +27,38 @@ export function toCop(amountCents: bigint, currency: Currency, copPerUsd: number
   if (currency === "COP") return amountCents;
   const micros = BigInt(Math.round(copPerUsd * 1_000_000));
   return (amountCents * micros) / BigInt(1_000_000);
+}
+
+/**
+ * Resolves the effective display currency for a given native currency under a
+ * display mode. `native` returns the source unchanged; `all-cop` / `all-usd`
+ * force the target regardless of source.
+ */
+export function displayCurrencyFor(mode: DisplayCurrencyMode, source: Currency): Currency {
+  if (mode === "native") return source;
+  return mode === "all-cop" ? "COP" : "USD";
+}
+
+/**
+ * Converts `amountCents` from `from` to `to` using the USD↔COP rate. Returns
+ * the input unchanged when currencies match. Uses micros-scaled integer math
+ * to avoid float drift. FX is USD↔COP only today; any other pair throws.
+ */
+export function convertCents(
+  amountCents: bigint,
+  from: Currency,
+  to: Currency,
+  copPerUsd: number,
+): bigint {
+  if (from === to) return amountCents;
+  const micros = BigInt(Math.round(copPerUsd * 1_000_000));
+  if (from === "USD" && to === "COP") {
+    return (amountCents * micros) / BigInt(1_000_000);
+  }
+  if (from === "COP" && to === "USD") {
+    return (amountCents * BigInt(1_000_000)) / micros;
+  }
+  throw new Error(`Unsupported currency conversion: ${from} -> ${to}`);
 }
 
 export function formatCop(amountCents: bigint): string {


### PR DESCRIPTION
## Summary

- New `src/components/display/money.tsx` — `<Money cents currency />` wrapper. Reads `{ mode, fxRate }` from context; in `native` mode (or when `fxRate === null`) renders `formatMoney(cents, currency)` unchanged, so the whole PR is zero-regression today. In a conversion mode with a live rate it renders `<converted> ≈ <native>` with a muted footnote.
- New `MoneyModeProvider` at `src/components/display/money-mode-provider.tsx` — installed at `(app)/layout.tsx` with hard-coded defaults (`DEFAULT_DISPLAY_CURRENCY_MODE`, `fxRate: null`). PR 3 will wire the real user pref + TRM here.
- `AnimatedMoney` updated to the same context-aware pattern — keeps NumberFlow animation on the primary amount and appends the native footnote when conversion is active.
- New `convertCents(from, to, copPerUsd)` and `displayCurrencyFor(mode, source)` helpers in `src/lib/money.ts` — micros-precision integer math, USD↔COP symmetric. 5 new unit tests (match `toCop` semantics, roundtrip, non-round rate precision).
- Refactored every JSX usage of `formatMoney()` to `<Money>` across 13 files (dashboard cards, `/accounts`, `/budgets`, `/transactions`, settings accounts / reconcile / recurring, dialogs, screenshot upload). Removed the duplicated inline `formatAmount()` helper in `transaction-table.tsx`. String-context usages (`aria-label` interpolation, chart `formatter` callbacks, `<SummaryCard value={string}>`, template literals) intentionally keep `formatMoney`.

PR 2 of 4 for the currency visual toggle (#251). Next: (3) toggle dropdown in header + generalize aggregating queries to a bidirectional `displayCurrency` target; (4) fallback indicator + charts + polish.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 536/536 pass (+7: 5 new money-helper tests, 2 picked up after rename)
- [x] Manual smoke: dev server on :3100, dev-login bypass, fetched `/` + `/transactions` — 200 OK, no hydration warnings beyond existing `suppressHydrationWarning`, amounts render identically to pre-refactor.

Refs #251