### PR TITLE
feat(ui): currency toggle dropdown + layout pref wiring (#251)

### DIFF
--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -7,10 +7,11 @@ import { getSessionUser } from "@/lib/auth/session";
 import { getNetWorth } from "@/lib/dashboard/queries";
 import { listAccountsDetailed, type AccountDetail } from "@/lib/accounts/queries";
 import { getCurrentFxRate } from "@/lib/fx/repo";
-import { toCop, formatCop, formatMoney } from "@/lib/money";
+import { toCop } from "@/lib/money";
 import { Money } from "@/components/display/money";
 import type { Currency } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
 
 const RATE_FMT = new Intl.NumberFormat("es-CO", {
   minimumFractionDigits: 2,
@@ -65,9 +66,13 @@ export default async function AccountsPage() {
       </header>
 
       <section className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <SummaryCard label="Net worth" valueCop={netWorth.totalCopCents} emphasis />
-        <SummaryCard label="COP" value={formatMoney(netWorth.copCents, "COP")} />
-        <SummaryCard label="USD" value={formatMoney(netWorth.usdCents, "USD")} />
+        <SummaryCard
+          label="Net worth"
+          value={<Money cents={netWorth.totalCopCents} currency="COP" />}
+          emphasis
+        />
+        <SummaryCard label="COP" value={<Money cents={netWorth.copCents} currency="COP" />} />
+        <SummaryCard label="USD" value={<Money cents={netWorth.usdCents} currency="USD" />} />
       </section>
 
       {all.length === 0 ? (
@@ -106,12 +111,10 @@ export default async function AccountsPage() {
 function SummaryCard({
   label,
   value,
-  valueCop,
   emphasis,
 }: {
   label: string;
-  value?: string;
-  valueCop?: bigint;
+  value: ReactNode;
   emphasis?: boolean;
 }) {
   return (
@@ -119,7 +122,7 @@ function SummaryCard({
       <CardContent className="flex flex-col gap-1 py-4">
         <div className="text-muted-foreground text-xs">{label}</div>
         <div className={cn("font-semibold tabular-nums", emphasis ? "text-2xl" : "text-lg")}>
-          {valueCop !== undefined ? formatCop(valueCop) : value}
+          {value}
         </div>
       </CardContent>
     </Card>
@@ -146,7 +149,9 @@ function AccountTypeSection({
           <Icon className="text-muted-foreground size-5" />
           {TYPE_LABEL[type]}
         </h2>
-        <div className="text-muted-foreground text-sm tabular-nums">{formatCop(subtotal)}</div>
+        <div className="text-muted-foreground text-sm tabular-nums">
+          <Money cents={subtotal} currency="COP" />
+        </div>
       </div>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {items.map((a) => (

--- a/src/app/(app)/insights/insights-viewer.tsx
+++ b/src/app/(app)/insights/insights-viewer.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useTransition } from "react";
+import { useTransition, type ReactNode } from "react";
 import { ChevronLeftIcon, ChevronRightIcon, RefreshCwIcon, SparklesIcon } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
-import { formatCop } from "@/lib/money";
+import { Money } from "@/components/display/money";
 import { cn } from "@/lib/utils";
 import { generateInsight } from "./actions";
 
@@ -108,16 +108,25 @@ export function InsightsViewer({
       </div>
 
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-        <StatCard label="Ingresos" value={formatCop(BigInt(summary.incomeCop * 100))} />
-        <StatCard label="Gastos" value={formatCop(BigInt(summary.expenseCop * 100))} />
+        <StatCard
+          label="Ingresos"
+          value={<Money cents={BigInt(summary.incomeCop * 100)} currency="COP" />}
+        />
+        <StatCard
+          label="Gastos"
+          value={<Money cents={BigInt(summary.expenseCop * 100)} currency="COP" />}
+        />
         <StatCard
           label="Neto"
-          value={formatCop(BigInt(summary.netCop * 100))}
+          value={<Money cents={BigInt(summary.netCop * 100)} currency="COP" />}
           valueClass={summary.netCop >= 0 ? "text-emerald-600" : "text-rose-600"}
           sub={
-            netDelta === 0
-              ? undefined
-              : `${netDelta > 0 ? "+" : ""}${formatCop(BigInt(netDelta * 100))} vs mes anterior`
+            netDelta === 0 ? undefined : (
+              <>
+                {netDelta > 0 ? "+" : ""}
+                <Money cents={BigInt(netDelta * 100)} currency="COP" /> vs mes anterior
+              </>
+            )
           }
         />
         <StatCard
@@ -172,8 +181,8 @@ function StatCard({
   valueClass,
 }: {
   label: string;
-  value: string;
-  sub?: string;
+  value: ReactNode;
+  sub?: ReactNode;
   valueClass?: string;
 }) {
   return (

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -4,6 +4,8 @@ import { MoneyModeProvider } from "@/components/display/money-mode-provider";
 import { QuickExpenseFab } from "@/components/transactions/quick-expense-fab";
 import { LiveRefresh } from "@/components/live-refresh";
 import { getSessionUserOrNull } from "@/lib/auth/session";
+import { getCurrentFxRate } from "@/lib/fx/repo";
+import { getUiPreferences } from "@/lib/preferences/repo";
 import { DEFAULT_DISPLAY_CURRENCY_MODE } from "@/lib/db/schema";
 import { auth } from "@/auth";
 
@@ -22,11 +24,18 @@ export default async function AppLayout({
       }
     : null;
 
-  // Currency display toggle: mode + fxRate will be wired in a follow-up; for
-  // now the provider runs in `native` mode with no rate → conversion is a
-  // no-op and every Money render matches the pre-toggle behavior.
+  // MoneyModeProvider feeds every `<Money>` / `<AnimatedMoney>` in the tree.
+  // When the user is unauthenticated we fall back to native mode with no rate
+  // so the toggle renders a no-op until login.
+  const [prefs, fx] = sessionUser
+    ? await Promise.all([getUiPreferences(sessionUser.id), getCurrentFxRate()])
+    : [{ displayCurrencyMode: DEFAULT_DISPLAY_CURRENCY_MODE }, null];
+
   return (
-    <MoneyModeProvider mode={DEFAULT_DISPLAY_CURRENCY_MODE} fxRate={null}>
+    <MoneyModeProvider
+      mode={prefs.displayCurrencyMode}
+      fxRate={fx ? { rate: fx.rate, source: fx.source } : null}
+    >
       <Header user={headerUser} />
       <Breadcrumbs />
       <div className="flex flex-1 flex-col">{children}</div>

--- a/src/components/dashboard/category-donut.tsx
+++ b/src/components/dashboard/category-donut.tsx
@@ -2,6 +2,7 @@
 
 import { Cell, Pie, PieChart, Tooltip } from "recharts";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Money } from "@/components/display/money";
 import { formatCop } from "@/lib/money";
 
 const PALETTE = [
@@ -35,7 +36,7 @@ export function CategoryDonut({
       <CardHeader>
         <CardDescription>Expenses by category · {monthLabel}</CardDescription>
         <CardTitle className="text-2xl tabular-nums">
-          {formatCop(BigInt(Math.round(total)))}
+          <Money cents={BigInt(Math.round(total))} currency="COP" />
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -82,7 +83,7 @@ export function CategoryDonut({
                       {pct.toFixed(1)}%
                     </span>
                     <span className="text-right font-medium tabular-nums">
-                      {formatCop(BigInt(Math.round(s.value)))}
+                      <Money cents={BigInt(Math.round(s.value))} currency="COP" />
                     </span>
                   </li>
                 );

--- a/src/components/layout/currency-mode-toggle.tsx
+++ b/src/components/layout/currency-mode-toggle.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeftRightIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useMoneyMode } from "@/components/display/money-mode-provider";
+import { setDisplayCurrencyMode } from "@/lib/preferences/actions";
+import { DISPLAY_CURRENCY_MODES, type DisplayCurrencyMode } from "@/lib/db/schema";
+import { cn } from "@/lib/utils";
+
+const MODE_LABEL: Record<DisplayCurrencyMode, string> = {
+  native: "Native",
+  "all-cop": "All COP",
+  "all-usd": "All USD",
+};
+
+const MODE_DESCRIPTION: Record<DisplayCurrencyMode, string> = {
+  native: "Each account in its own currency",
+  "all-cop": "Convert everything to COP",
+  "all-usd": "Convert everything to USD",
+};
+
+export function CurrencyModeToggle() {
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+  const { mode } = useMoneyMode();
+
+  function handleSelect(next: DisplayCurrencyMode) {
+    setOpen(false);
+    if (next === mode) return;
+    startTransition(async () => {
+      await setDisplayCurrencyMode(next);
+      router.refresh();
+    });
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Currency display mode"
+          className="gap-1.5"
+          disabled={pending}
+        >
+          <ArrowLeftRightIcon className="size-4" />
+          <span className="text-xs font-medium">{MODE_LABEL[mode]}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56 p-1">
+        {DISPLAY_CURRENCY_MODES.map((m) => {
+          const active = m === mode;
+          return (
+            <Button
+              key={m}
+              variant="ghost"
+              size="sm"
+              className={cn("h-auto w-full flex-col items-start gap-0 py-2", active && "bg-accent")}
+              onClick={() => handleSelect(m)}
+            >
+              <span className="font-medium">{MODE_LABEL[m]}</span>
+              <span className="text-muted-foreground text-xs font-normal">
+                {MODE_DESCRIPTION[m]}
+              </span>
+            </Button>
+          );
+        })}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { MenuIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { CurrencyModeToggle } from "./currency-mode-toggle";
 import { Nav } from "./nav";
 import { ThemeToggle } from "./theme-toggle";
 import { UserMenu } from "./user-menu";
@@ -33,6 +34,7 @@ export function Header({ user }: HeaderProps) {
         </div>
 
         <div className="ml-auto flex items-center gap-1">
+          {user ? <CurrencyModeToggle /> : null}
           <ThemeToggle />
           {user ? <UserMenu user={user} /> : null}
           <div className="md:hidden">


### PR DESCRIPTION
## Summary

- New `CurrencyModeToggle` dropdown in the header — Popover with 3 buttons (Native / All COP / All USD), each with a short description. Server action `setDisplayCurrencyMode` persists the choice; `router.refresh()` re-renders with the new value, no full page reload.
- `(app)/layout.tsx` now reads the user's pref via `getUiPreferences()` + current TRM via `getCurrentFxRate()` and feeds `MoneyModeProvider`. Unauthenticated routes stay in `native` with no rate (toggle hidden).
- Fixed the last static-COP aggregate displays to go through `<Money>` so the toggle reaches them: `/accounts` SummaryCard (net-worth, COP total, USD total), per-type subtotal (Savings / Credit cards / Loans), `/insights` StatCards (Ingresos, Gastos, Neto + delta footnote), category donut title and legend rows. `SummaryCard` and `StatCard` now accept `ReactNode` for `value`/`sub`.

PR 3 of 4. The feature is live after this merge: user toggles → every `Money`/`AnimatedMoney` in the tree (dashboard cards, transactions, accounts, budgets, insights, dialogs) re-renders in the chosen mode.

Known polish deferred to PR 4 (#251):
- Fallback TRM warning icon next to converted amounts when `fxRate.source === 'fallback'` (the provider already carries `source`)
- Donut chart tooltip still uses `formatCop` (recharts formatter callback, not JSX)
- `/accounts` header copy still hard-codes the COP narrative

## Test plan

- [x] `bun run lint` / `bun run typecheck` / `bun run test` (536/536) — all clean
- [x] Browser smoke via chrome-devtools MCP + dev-login bypass: opened `/`, toggled to **All USD**, confirmed net worth, cash flow, expense categories, top expenses, and account balances all re-render as USD with COP footnotes. USD-native items (Claude.ai sub, Efectivo USD, Bancolombia Mastercard USD) correctly render without footnote. No console errors/warnings.
- [x] Reloaded `/accounts` under All USD — pref persisted, same render. Switched back to native before exiting.

Refs #251