### PR TITLE
feat(ui): fallback TRM warning icon + donut tooltip respects toggle (#251)

### DIFF
--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -59,8 +59,8 @@ export default async function AccountsPage() {
       <header>
         <h1 className="text-h1">Accounts</h1>
         <p className="text-body text-muted-foreground">
-          Saldos por cuenta agrupados por tipo. El patrimonio neto convierte USD a COP a{" "}
-          {RATE_FMT.format(fx.rate)} COP/USD
+          Saldos por cuenta agrupados por tipo. Las conversiones usan {RATE_FMT.format(fx.rate)}{" "}
+          COP/USD
           {fx.source === "fallback" ? " (fallback)" : ` (TRM ${fx.asOf})`}.
         </p>
       </header>

--- a/src/components/dashboard/category-donut.tsx
+++ b/src/components/dashboard/category-donut.tsx
@@ -3,7 +3,8 @@
 import { Cell, Pie, PieChart, Tooltip } from "recharts";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Money } from "@/components/display/money";
-import { formatCop } from "@/lib/money";
+import { useMoneyMode } from "@/components/display/money-mode-provider";
+import { convertCents, displayCurrencyFor, formatMoney } from "@/lib/money";
 
 const PALETTE = [
   "var(--chart-1)",
@@ -30,6 +31,13 @@ export function CategoryDonut({
   isFuture?: boolean;
 }) {
   const total = slices.reduce((acc, s) => acc + s.value, 0);
+  const { mode, fxRate } = useMoneyMode();
+  const target = displayCurrencyFor(mode, "COP");
+  const tooltipFormatter = (value: unknown) => {
+    const copCents = BigInt(Math.round(Number(value) || 0));
+    if (target === "COP" || fxRate === null) return formatMoney(copCents, "COP");
+    return formatMoney(convertCents(copCents, "COP", target, fxRate.rate), target);
+  };
 
   return (
     <Card className="lg:col-span-2">
@@ -65,7 +73,7 @@ export function CategoryDonut({
                     />
                   ))}
                 </Pie>
-                <Tooltip formatter={(value) => formatCop(BigInt(Math.round(Number(value) || 0)))} />
+                <Tooltip formatter={tooltipFormatter} />
               </PieChart>
             </div>
             <ul className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-x-3 gap-y-1.5 text-sm">

--- a/src/components/display/money.tsx
+++ b/src/components/display/money.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { TriangleAlertIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { convertCents, displayCurrencyFor, formatMoney } from "@/lib/money";
 import type { Currency } from "@/lib/types";
@@ -24,12 +25,23 @@ export function Money({
   }
 
   const converted = convertCents(cents, currency, target, fxRate.rate);
+  const stale = fxRate.source === "fallback";
   return (
     <span className={className}>
       {formatMoney(converted, target)}
       <span className={cn("text-muted-foreground ml-1 text-xs font-normal", footnoteClassName)}>
         ≈ {formatMoney(cents, currency)}
       </span>
+      {stale ? <StaleFxIcon /> : null}
     </span>
+  );
+}
+
+export function StaleFxIcon({ className }: { className?: string }) {
+  return (
+    <TriangleAlertIcon
+      aria-label="Conversion uses a fallback rate — live TRM unavailable"
+      className={cn("ml-1 inline size-3 align-[-1px] text-amber-600", className)}
+    />
   );
 }

--- a/src/components/ui/animated-money.tsx
+++ b/src/components/ui/animated-money.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import NumberFlow from "@number-flow/react";
+import { StaleFxIcon } from "@/components/display/money";
 import { useMoneyMode } from "@/components/display/money-mode-provider";
 import { convertCents, displayCurrencyFor, formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
@@ -46,12 +47,14 @@ export function AnimatedMoney({
 
   if (active.currency === currency) return number;
 
+  const stale = fxRate !== null && fxRate.source === "fallback";
   return (
     <span className="inline-flex items-baseline">
       {number}
       <span className={cn("text-muted-foreground ml-1 text-xs font-normal", footnoteClassName)}>
         ≈ {formatMoney(cents, currency)}
       </span>
+      {stale ? <StaleFxIcon /> : null}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Polish pass on the currency visual toggle (#251).

- **Fallback TRM warning icon**: when `fxRate.source === 'fallback'`, `<Money>` and `<AnimatedMoney>` append a small amber `TriangleAlert` icon with the aria-label `Conversion uses a fallback rate — live TRM unavailable`. Only shown on amounts that actually converted (same-currency renders and USD-native items stay clean).
- **Donut chart tooltip**: `CategoryDonut` now reads the money mode via `useMoneyMode()` and builds a tooltip formatter that converts COP→USD when the user is in `all-usd` mode. Closed the last `formatCop` gap on the dashboard.
- **Accounts page header copy**: removed the hard-coded "convierte USD a COP" direction, replaced with a mode-agnostic "Las conversiones usan X COP/USD" so the sentence no longer contradicts the active toggle.

PR 4 of 4 — closes out #251.

## Test plan

- [x] `bun run lint` / `bun run typecheck` / `bun run test` (536/536) — clean
- [x] Browser smoke via chrome-devtools MCP: dashboard in `all USD` (fx source = fallback) renders every converted amount with the amber icon exposed as `image "Conversion uses a fallback rate — live TRM unavailable"`. USD-native rows (CLAUDE.AI subscription, USD accounts) stay icon-free. Pie tooltip shows `$X` (USD) on hover in all-usd mode. Toggled back to `native` — icons disappear, footnotes disappear, amounts revert to native formatting.

Closes #251