### PR TITLE
feat(classification): AI fallback for SMS needs_review path (#257)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ PGUSER=
 # Conseguí una key en https://console.anthropic.com/
 ANTHROPIC_API_KEY=sk-ant-your-key-here
 
+# AI fallback para SMS needs_review (#257). "true" habilita Haiku como red
+# de seguridad cuando el regex parser falla (~5% de SMS). Default "false"
+# (safe) — prendelo explícitamente en prod cuando quieras el fallback.
+# Per-user override disponible en users.feature_flags.aiFallbackEnabled.
+AI_FALLBACK_ENABLED=false
+
 # Groq API — requerido para transcripción de notas de voz (Whisper)
 # Conseguí una key en https://console.groq.com/keys
 # Sin esta key, el bot de Telegram responde con error al recibir voice notes.

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "personal-financial-dashboard",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -68,6 +69,8 @@
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.90.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg=="],
+
     "@auth/core": ["@auth/core@0.41.2", "", { "dependencies": { "@panva/hkdf": "^1.2.1", "jose": "^6.0.6", "oauth4webapi": "^3.3.0", "preact": "10.24.3", "preact-render-to-string": "6.5.11" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^7.0.7" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -119,6 +122,8 @@
     "@babel/plugin-transform-typescript": ["@babel/plugin-transform-typescript@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-create-class-features-plugin": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw=="],
 
     "@babel/preset-typescript": ["@babel/preset-typescript@7.28.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.28.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
@@ -1320,6 +1325,8 @@
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
@@ -1867,6 +1874,8 @@
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -106,6 +106,8 @@ Ordered steps matching what was actually done:
    #   AUTH_TRUST_HOST=true
    #   ANTHROPIC_API_KEY, GROQ_API_KEY, TELEGRAM_TOKEN_ENCRYPTION_KEY
    #   FX_REFRESH_TOKEN, BOOTSTRAP_USER_EMAIL, BOOTSTRAP_USER_NAME
+   # Optional:
+   #   AI_FALLBACK_ENABLED=true  (SMS AI fallback kill-switch; default off, #257)
    ```
 
 7. **Add deploy SSH key** to the `deploy` user:

--- a/drizzle/0037_quiet_ultimatum.sql
+++ b/drizzle/0037_quiet_ultimatum.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "parser_events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer,
+	"source" varchar(20) NOT NULL,
+	"event_kind" varchar(40) NOT NULL,
+	"regex_outcome" jsonb,
+	"ai_outcome" jsonb,
+	"ai_confidence" numeric(4, 3),
+	"ai_model" varchar(50),
+	"ai_input_tokens" integer,
+	"ai_output_tokens" integer,
+	"latency_ms" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "parser_events" ADD CONSTRAINT "parser_events_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "parser_events_created_idx" ON "parser_events" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "parser_events_kind_idx" ON "parser_events" USING btree ("event_kind","created_at");--> statement-breakpoint
+CREATE INDEX "parser_events_ai_fallback_idx" ON "parser_events" USING btree ("created_at") WHERE "parser_events"."event_kind" LIKE 'ai_fallback_%';

--- a/drizzle/0038_chilly_madame_web.sql
+++ b/drizzle/0038_chilly_madame_web.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "feature_flags" jsonb DEFAULT '{}'::jsonb NOT NULL;

--- a/drizzle/meta/0037_snapshot.json
+++ b/drizzle/meta/0037_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "1ba4b53a-2fcd-48da-9401-83fad353d34a",
-  "prevId": "91925ff4-2b7e-427e-9869-0e02d7a81005",
+  "id": "f4710e64-5c12-4af9-abf8-a587a24bacf1",
+  "prevId": "1ba4b53a-2fcd-48da-9401-83fad353d34a",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1915,6 +1915,159 @@
         "parser_canary_events_user_id_users_id_fk": {
           "name": "parser_canary_events_user_id_users_id_fk",
           "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
           "tableTo": "users",
           "columnsFrom": [
             "user_id"

--- a/drizzle/meta/0038_snapshot.json
+++ b/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,3971 @@
+{
+  "id": "c08d2759-2e0d-4edd-83c8-aff90a8a3df3",
+  "prevId": "f4710e64-5c12-4af9-abf8-a587a24bacf1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_corrections": {
+      "name": "classification_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_category_slug": {
+          "name": "new_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_corrections_learning_idx": {
+          "name": "classification_corrections_learning_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "new_category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_corrections_user_id_users_id_fk": {
+          "name": "classification_corrections_user_id_users_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_corrections_transaction_id_transactions_id_fk": {
+          "name": "classification_corrections_transaction_id_transactions_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_from_corrections": {
+          "name": "generated_from_corrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_proposals": {
+      "name": "rule_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_txn_ids": {
+          "name": "correction_txn_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rule_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rule_proposals_user_merchant_category_pending_unique": {
+          "name": "rule_proposals_user_merchant_category_pending_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rule_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rule_proposals_user_status_idx": {
+          "name": "rule_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_proposals_user_id_users_id_fk": {
+          "name": "rule_proposals_user_id_users_id_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_proposals_user_category_fk": {
+          "name": "rule_proposals_user_category_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retroactive_rule_id": {
+          "name": "retroactive_rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_retroactive_rule_id_classification_rules_id_fk": {
+          "name": "transactions_retroactive_rule_id_classification_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "classification_rules",
+          "columnsFrom": [
+            "retroactive_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ui_preferences": {
+          "name": "ui_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "classification_context": {
+          "name": "classification_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "rule_retroactive",
+        "ai",
+        "manual",
+        "manual_confirmed",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.rule_proposal_status": {
+      "name": "rule_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1776660720954,
       "tag": "0037_quiet_ultimatum",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1776660801407,
+      "tag": "0038_chilly_madame_web",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1776658496155,
       "tag": "0036_strip_account_currency_suffix",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1776660720954,
+      "tag": "0037_quiet_ultimatum",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     ]
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/scripts/analyze-sms-dump.ts
+++ b/scripts/analyze-sms-dump.ts
@@ -183,13 +183,17 @@ async function main() {
     if (result.kind === "skip") {
       const k = `skip:${result.reason}`;
       byKind.set(k, (byKind.get(k) ?? 0) + 1);
-      if (result.reason === "unknown") {
-        const n = normalize(body);
-        const b = unknownPatterns.get(n) ?? { count: 0, samples: [] };
-        b.count++;
-        if (b.samples.length < 2) b.samples.push(body);
-        unknownPatterns.set(n, b);
-      }
+      continue;
+    }
+
+    if (result.kind === "needs_review") {
+      const k = `needs_review:${result.reason}`;
+      byKind.set(k, (byKind.get(k) ?? 0) + 1);
+      const n = normalize(body);
+      const b = unknownPatterns.get(n) ?? { count: 0, samples: [] };
+      b.count++;
+      if (b.samples.length < 2) b.samples.push(body);
+      unknownPatterns.set(n, b);
       continue;
     }
 

--- a/scripts/backfill-counterparties.ts
+++ b/scripts/backfill-counterparties.ts
@@ -38,10 +38,15 @@ async function main() {
       continue;
     }
     const parsed = parseSmsBancolombia(rawSms);
-    if (parsed.kind === "skip") {
+    if (parsed.kind === "skip" || parsed.kind === "needs_review") {
       log.warn(
-        { txId: row.id, reason: parsed.reason, event: "backfill_counterparties_skip_parsed" },
-        "parser returned skip — skipped",
+        {
+          txId: row.id,
+          kind: parsed.kind,
+          reason: parsed.reason,
+          event: "backfill_counterparties_skip_parsed",
+        },
+        "parser returned non-ingest result — skipped",
       );
       continue;
     }

--- a/scripts/replay-sms-dump.ts
+++ b/scripts/replay-sms-dump.ts
@@ -52,7 +52,10 @@ async function main() {
 
   for (const body of bodies) {
     const parsed = parseSmsBancolombia(body);
-    const kind = parsed.kind === "skip" ? `skip:${parsed.reason}` : parsed.kind;
+    const kind =
+      parsed.kind === "skip" || parsed.kind === "needs_review"
+        ? `${parsed.kind}:${parsed.reason}`
+        : parsed.kind;
     byKind[kind] = (byKind[kind] ?? 0) + 1;
 
     // Replay script scopes to user 1 (bootstrap).

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -728,7 +728,7 @@ export async function splitCounterparty(
     if (!smsBody) continue;
 
     const parseResult = parseSmsBancolombia(smsBody);
-    if (parseResult.kind === "skip") continue;
+    if (parseResult.kind === "skip" || parseResult.kind === "needs_review") continue;
 
     const key = keyForParsed(parseResult);
     if (!key) continue;

--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -516,7 +516,11 @@ describe("POST /api/ingest/sms", () => {
     expect(json.reason).toContain("non_transactional");
   });
 
-  it("skips unknown SMS formats", async () => {
+  it("surfaces unknown SMS formats as needs_review errors (AI fallback off)", async () => {
+    // After #257 the parser returns `kind: "needs_review"` for formats it
+    // can't match. With AI fallback disabled (default in tests) this flows
+    // through the pipeline as an error so the SMS shows up in the inbox
+    // rather than being silently dropped as "skipped".
     const body = "Bancolombia: algo completamente desconocido que no matchea ningun patron";
     const res = await POST(
       makeRequest({
@@ -525,8 +529,8 @@ describe("POST /api/ingest/sms", () => {
       }),
     );
     const json = (await res.json()) as { status: string; reason?: string };
-    expect(json.status).toBe("skipped");
-    expect(json.reason).toContain("unknown");
+    expect(json.status).toBe("error");
+    expect(json.reason).toContain("unknown_pattern");
   });
 
   // ---------------------------------------------------------------------------

--- a/src/lib/ai/anthropic-client.test.ts
+++ b/src/lib/ai/anthropic-client.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import Anthropic from "@anthropic-ai/sdk";
+import { callClaude } from "./anthropic-client";
+
+type CapturedRequest = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+function mockFetch(
+  responseBody: unknown,
+  captured: CapturedRequest[],
+  init?: { status?: number; errorBody?: unknown },
+): typeof fetch {
+  return (async (input: Request | URL | string, reqInit?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = reqInit?.body ? JSON.parse(String(reqInit.body)) : {};
+    captured.push({ url, body });
+    const status = init?.status ?? 200;
+    const resBody = status === 200 ? responseBody : (init?.errorBody ?? { error: "oops" });
+    return new Response(JSON.stringify(resBody), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+function fakeMessageResponse(payload: unknown): Record<string, unknown> {
+  // Minimal shape of a v1/messages response — just enough for the SDK's
+  // parser to extract `parsed_output` when output_config.format is set.
+  return {
+    id: "msg_test",
+    type: "message",
+    role: "assistant",
+    model: "claude-haiku-4-5-20251001",
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: 50,
+      output_tokens: 10,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+  };
+}
+
+describe("callClaude", () => {
+  const Schema = z.object({
+    label: z.string(),
+    confidence: z.number(),
+  });
+
+  it("sends cache_control on system blocks that request it", async () => {
+    const captured: CapturedRequest[] = [];
+    await callClaude({
+      system: [
+        { text: "STABLE: category list", cacheControl: true },
+        { text: "VOLATILE: this-run context" },
+      ],
+      userPrompt: "classify this",
+      schema: Schema,
+      apiKey: "sk-test",
+      fetchImpl: mockFetch(fakeMessageResponse({ label: "food", confidence: 0.9 }), captured),
+    });
+
+    expect(captured).toHaveLength(1);
+    const system = captured[0].body.system as Array<Record<string, unknown>>;
+    expect(system).toHaveLength(2);
+    expect(system[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[1].cache_control).toBeUndefined();
+  });
+
+  it("accepts a bare string system prompt with no cache breakpoint", async () => {
+    const captured: CapturedRequest[] = [];
+    await callClaude({
+      system: "plain system",
+      userPrompt: "hi",
+      schema: Schema,
+      apiKey: "sk-test",
+      fetchImpl: mockFetch(fakeMessageResponse({ label: "x", confidence: 0 }), captured),
+    });
+
+    const system = captured[0].body.system as Array<Record<string, unknown>>;
+    expect(system[0]).toEqual({ type: "text", text: "plain system" });
+    expect(system[0].cache_control).toBeUndefined();
+  });
+
+  it("returns typed parsed_output and usage stats", async () => {
+    const payload = { label: "transporte", confidence: 0.85 };
+    const result = await callClaude({
+      userPrompt: "classify",
+      schema: Schema,
+      apiKey: "sk-test",
+      fetchImpl: mockFetch(fakeMessageResponse(payload), []),
+    });
+
+    expect(result.data).toEqual(payload);
+    expect(result.usage.inputTokens).toBe(50);
+    expect(result.usage.outputTokens).toBe(10);
+  });
+
+  it("rethrows typed Anthropic.APIError on non-2xx responses", async () => {
+    await expect(
+      callClaude({
+        userPrompt: "x",
+        schema: Schema,
+        apiKey: "sk-test",
+        fetchImpl: mockFetch({}, [], {
+          status: 500,
+          errorBody: { type: "error", error: { type: "api_error", message: "boom" } },
+        }),
+      }),
+    ).rejects.toBeInstanceOf(Anthropic.APIError);
+  });
+
+  it("rethrows typed RateLimitError on 429", async () => {
+    await expect(
+      callClaude({
+        userPrompt: "x",
+        schema: Schema,
+        apiKey: "sk-test",
+        fetchImpl: mockFetch({}, [], {
+          status: 429,
+          errorBody: { type: "error", error: { type: "rate_limit_error", message: "slow down" } },
+        }),
+      }),
+    ).rejects.toBeInstanceOf(Anthropic.RateLimitError);
+  });
+
+  it("throws when ANTHROPIC_API_KEY is not set and no apiKey is passed", async () => {
+    const original = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      await expect(
+        callClaude({
+          userPrompt: "x",
+          schema: Schema,
+          fetchImpl: mockFetch(fakeMessageResponse({ label: "x", confidence: 0 }), []),
+        }),
+      ).rejects.toThrow("ANTHROPIC_API_KEY is not set");
+    } finally {
+      if (original !== undefined) process.env.ANTHROPIC_API_KEY = original;
+    }
+  });
+});

--- a/src/lib/ai/anthropic-client.ts
+++ b/src/lib/ai/anthropic-client.ts
@@ -1,0 +1,121 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import type { ZodType } from "zod";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "ai/anthropic-client" });
+
+// Haiku 4.5 is the cost-effective default for Findash's two primary AI
+// workloads today: transaction classification and SMS parse fallback. Per
+// AI Strategy (see engram memory): Haiku for hot-path-ish and bulk work,
+// Sonnet reserved for conversational / multi-step reasoning.
+// Callsites needing a different model must pass `model` explicitly.
+export const DEFAULT_MODEL = "claude-haiku-4-5";
+
+// Parse/classify responses are tiny structured JSON blobs — not long prose.
+// Keep the default small to bound latency; callers override when they need
+// room (batch classification with many items).
+export const DEFAULT_MAX_TOKENS = 1024;
+
+export type SystemPromptBlock = {
+  text: string;
+  // When true, adds cache_control: { type: "ephemeral" } to this block. Use
+  // for stable content (category list, few-shots, task instructions). Cache
+  // only takes effect once the prefix exceeds the model minimum (Haiku 4.5:
+  // 4096 tokens); shorter prefixes silently won't cache but the marker is
+  // harmless. See shared/prompt-caching.md.
+  cacheControl?: boolean;
+};
+
+export type CallClaudeOpts<T> = {
+  // Stable, cacheable content — instructions, categories, few-shots.
+  // String for simple cases; array of blocks when you want selective caching.
+  system?: string | SystemPromptBlock[];
+  // Volatile per-request content — the transaction list, the SMS body.
+  userPrompt: string;
+  // Zod schema for the model's JSON response. Enforced server-side via
+  // output_config.format — rejects hallucinations before they reach us.
+  schema: ZodType<T>;
+  model?: string;
+  maxTokens?: number;
+  apiKey?: string;
+  // Per-request timeout. Pipelines with hard budgets (SMS AI fallback: 2s)
+  // must set this explicitly.
+  timeoutMs?: number;
+  // Test seam — the SDK passes this through as its HTTP transport.
+  fetchImpl?: typeof fetch;
+};
+
+export type CallClaudeResult<T> = {
+  data: T;
+  model: string;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+  };
+};
+
+export async function callClaude<T>(opts: CallClaudeOpts<T>): Promise<CallClaudeResult<T>> {
+  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
+
+  const model = opts.model ?? DEFAULT_MODEL;
+  const maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+
+  const clientOpts: { apiKey: string; fetch?: typeof fetch; timeout?: number } = { apiKey };
+  if (opts.fetchImpl) clientOpts.fetch = opts.fetchImpl;
+  if (opts.timeoutMs !== undefined) clientOpts.timeout = opts.timeoutMs;
+  const client = new Anthropic(clientOpts);
+
+  const systemBlocks = buildSystemBlocks(opts.system);
+
+  try {
+    const response = await client.messages.parse({
+      model,
+      max_tokens: maxTokens,
+      ...(systemBlocks && { system: systemBlocks }),
+      messages: [{ role: "user", content: opts.userPrompt }],
+      output_config: { format: zodOutputFormat(opts.schema) },
+    });
+
+    if (response.parsed_output == null) {
+      throw new Error(
+        `Claude response did not parse against schema (stop_reason=${response.stop_reason})`,
+      );
+    }
+
+    return {
+      data: response.parsed_output,
+      model: response.model,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+        cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
+        cacheCreationTokens: response.usage.cache_creation_input_tokens ?? 0,
+      },
+    };
+  } catch (err) {
+    if (err instanceof Anthropic.RateLimitError) {
+      log.warn({ err, model, event: "ai_rate_limited" }, "anthropic rate limited");
+    } else if (err instanceof Anthropic.APIError) {
+      log.error({ err, model, status: err.status, event: "ai_api_error" }, "anthropic api error");
+    }
+    throw err;
+  }
+}
+
+function buildSystemBlocks(
+  system: CallClaudeOpts<unknown>["system"],
+): Anthropic.TextBlockParam[] | undefined {
+  if (!system) return undefined;
+  if (typeof system === "string") {
+    return [{ type: "text", text: system }];
+  }
+  return system.map<Anthropic.TextBlockParam>((block) =>
+    block.cacheControl
+      ? { type: "text", text: block.text, cache_control: { type: "ephemeral" } }
+      : { type: "text", text: block.text },
+  );
+}

--- a/src/lib/classification/ai.ts
+++ b/src/lib/classification/ai.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { Currency } from "@/lib/types";
 import type { UserClassificationContextHint } from "@/lib/db/schema";
+import { callClaude, DEFAULT_MODEL } from "@/lib/ai/anthropic-client";
 
 export type AiClassifiable = {
   id: number;
@@ -29,8 +30,6 @@ export type AiClassifyResult = {
   model: string;
   usage: { inputTokens: number; outputTokens: number };
 };
-
-const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
 
 const responseSchema = z.object({
   classifications: z.array(
@@ -69,11 +68,7 @@ function formatUserHints(hints: AiUserHint[]): string {
   return lines.join("\n");
 }
 
-function buildPrompt(
-  txs: AiClassifiable[],
-  cats: AiCategoryOption[],
-  userHints: AiUserHint[],
-): string {
+function buildSystemPrompt(cats: AiCategoryOption[]): string {
   const categoryList = cats
     .map((c) =>
       c.parentSlug
@@ -82,6 +77,26 @@ function buildPrompt(
     )
     .join("\n");
 
+  return `You classify personal finance transactions for a Colombian user.
+
+Available categories (use the slug, exactly as written):
+${categoryList}
+
+For each transaction, pick the MOST specific category slug that fits. Prefer subcategories (e.g. "restaurantes" over "alimentacion"). If you genuinely cannot tell, return null.
+
+Confidence scale:
+- 90-100: obvious match (e.g. "NETFLIX" → "suscripciones")
+- 70-89: strong signal
+- 50-69: educated guess
+- 0-49: unsure — consider null
+
+Rules:
+- "categorySlug" MUST be one of the slugs above, or null if truly unclassifiable.
+- Include one entry per input transaction, same "id".
+- Keep "reason" under 80 chars.`;
+}
+
+function buildUserPrompt(txs: AiClassifiable[], userHints: AiUserHint[]): string {
   const txList = txs
     .map(
       (t) =>
@@ -93,42 +108,10 @@ function buildPrompt(
     ? `\n\nThis user has previously re-categorized these merchants. Treat as a STRONG preference signal for identical or similar merchant names, but categories above still constrain the final slug.\n${formatUserHints(userHints)}`
     : "";
 
-  return `You classify personal finance transactions for a Colombian user.
-
-Available categories (use the slug, exactly as written):
-${categoryList}
-
-Transactions to classify:
+  return `Transactions to classify:
 [
   ${txList}
-]
-
-For each transaction, pick the MOST specific category slug that fits. Prefer subcategories (e.g. "restaurantes" over "alimentacion"). If you genuinely cannot tell, return "otros".
-
-Confidence scale:
-- 90-100: obvious match (e.g. "NETFLIX" → "suscripciones")
-- 70-89: strong signal
-- 50-69: educated guess
-- 0-49: unsure — consider "otros"
-
-Return ONLY valid JSON (no prose, no markdown):
-{
-  "classifications": [
-    { "id": <number>, "categorySlug": "<slug-or-null>", "confidence": <0-100>, "reason": "<short phrase>" }
-  ]
-}
-
-Rules:
-- "categorySlug" MUST be one of the slugs above, or null if truly unclassifiable.
-- Include one entry per input transaction, same "id".
-- Keep "reason" under 80 chars.${hintsBlock}`;
-}
-
-function extractJson(text: string): unknown {
-  const trimmed = text.trim();
-  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  const candidate = fenced ? fenced[1] : trimmed;
-  return JSON.parse(candidate);
+]${hintsBlock}`;
 }
 
 export type AiSingleClassifyResult = {
@@ -173,58 +156,30 @@ export async function classifyBatchWithAi(opts: {
     };
   }
 
-  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
-
-  const model = opts.model ?? DEFAULT_MODEL;
-  const doFetch = opts.fetchImpl ?? fetch;
-  const prompt = buildPrompt(opts.transactions, opts.categories, opts.userHints ?? []);
-
-  const res = await doFetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-    },
-    body: JSON.stringify({
-      model,
-      max_tokens: 2048,
-      messages: [{ role: "user", content: prompt }],
-    }),
+  // cache_control on the system prompt — the categoryList + instructions are
+  // stable across every batch for this user. With output_config.format the
+  // model can't hallucinate a shape, so the slug-validation below only needs
+  // to reject slugs outside the user's current category set (edge case:
+  // categories deleted between requests).
+  const result = await callClaude({
+    system: [{ text: buildSystemPrompt(opts.categories), cacheControl: true }],
+    userPrompt: buildUserPrompt(opts.transactions, opts.userHints ?? []),
+    schema: responseSchema,
+    maxTokens: 2048,
+    model: opts.model,
+    apiKey: opts.apiKey,
+    fetchImpl: opts.fetchImpl,
   });
 
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`Anthropic API error ${res.status}: ${body.slice(0, 300)}`);
-  }
-
-  const payload = (await res.json()) as {
-    content: Array<{ type: string; text?: string }>;
-    usage?: { input_tokens: number; output_tokens: number };
-  };
-
-  const textBlock = payload.content?.find((c) => c.type === "text")?.text ?? "";
-  let parsedJson: unknown;
-  try {
-    parsedJson = extractJson(textBlock);
-  } catch {
-    throw new Error("Model returned invalid JSON");
-  }
-
-  const parsed = responseSchema.parse(parsedJson);
   const validSlugs = new Set(opts.categories.map((c) => c.slug));
-  const classifications = parsed.classifications.map((c) => ({
+  const classifications = result.data.classifications.map((c) => ({
     ...c,
     categorySlug: c.categorySlug && validSlugs.has(c.categorySlug) ? c.categorySlug : null,
   }));
 
   return {
     classifications,
-    model,
-    usage: {
-      inputTokens: payload.usage?.input_tokens ?? 0,
-      outputTokens: payload.usage?.output_tokens ?? 0,
-    },
+    model: result.model,
+    usage: { inputTokens: result.usage.inputTokens, outputTokens: result.usage.outputTokens },
   };
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -29,6 +29,16 @@ export type UiPreferences = {
   displayCurrencyMode?: DisplayCurrencyMode;
 };
 
+// Per-user feature toggles. Default for every flag is "inherit from process
+// env" — per-feature env vars act as the global default and each user can
+// override explicitly via the `/settings` UI (future work). Prefer adding
+// new fields here over new columns.
+export type UserFeatureFlags = {
+  // AI fallback for SMS needs_review path (#257). If unset, uses
+  // AI_FALLBACK_ENABLED env var. If set, user's preference wins.
+  aiFallbackEnabled?: boolean;
+};
+
 export type UserClassificationContextHint = {
   merchant: string;
   category: string;
@@ -50,6 +60,7 @@ export const users = pgTable(
     role: varchar("role", { length: 20 }).notNull().default("user"),
     active: boolean("active").notNull().default(true),
     uiPreferences: jsonb("ui_preferences").$type<UiPreferences>().notNull().default({}),
+    featureFlags: jsonb("feature_flags").$type<UserFeatureFlags>().notNull().default({}),
     classificationContext: jsonb("classification_context")
       .$type<UserClassificationContext>()
       .notNull()

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -793,6 +793,55 @@ export type CanaryProjection = {
   occurredOn: string | null;
 };
 
+// Per-SMS audit row for the AI fallback pipeline (#257) and the eventual
+// /admin/slos dashboard (#329 — continuation of closed #249). Append-only.
+// Today we only emit rows on the needs_review path (regex failed → maybe
+// AI fallback); the dashboard issue later extends this to log all parse
+// outcomes for SLO cards.
+//
+// `source` is the ingest channel (today just "sms"). `eventKind` is the
+// lifecycle terminal state for this SMS — exactly one row per ingest
+// attempt. `regex_outcome` is the serialized ParseResult; `ai_outcome`
+// captures the AI response shape (+ error detail in the failure kinds).
+export const PARSER_EVENT_KINDS = [
+  "parse_needs_review", // regex failed, AI fallback not invoked (kill-switch / disabled)
+  "ai_fallback_success", // AI parsed, confidence ≥ threshold → ingested
+  "ai_fallback_low_confidence", // AI parsed, below threshold → inbox
+  "ai_fallback_error", // AI timeout / API error / schema rejected
+] as const;
+export type ParserEventKind = (typeof PARSER_EVENT_KINDS)[number];
+
+export const PARSER_EVENT_SOURCES = ["sms", "apple_pay", "other"] as const;
+export type ParserEventSource = (typeof PARSER_EVENT_SOURCES)[number];
+
+export const parserEvents = pgTable(
+  "parser_events",
+  {
+    id: serial("id").primaryKey(),
+    userId: integer("user_id").references(() => users.id, { onDelete: "cascade" }),
+    source: varchar("source", { length: 20 }).$type<ParserEventSource>().notNull(),
+    eventKind: varchar("event_kind", { length: 40 }).$type<ParserEventKind>().notNull(),
+    regexOutcome: jsonb("regex_outcome").$type<Record<string, unknown>>(),
+    aiOutcome: jsonb("ai_outcome").$type<Record<string, unknown>>(),
+    aiConfidence: numeric("ai_confidence", { precision: 4, scale: 3 }),
+    aiModel: varchar("ai_model", { length: 50 }),
+    aiInputTokens: integer("ai_input_tokens"),
+    aiOutputTokens: integer("ai_output_tokens"),
+    latencyMs: integer("latency_ms"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("parser_events_created_idx").on(t.createdAt),
+    index("parser_events_kind_idx").on(t.eventKind, t.createdAt),
+    // Partial index for dashboard drill-down: "show me recent AI fallback
+    // outcomes" is the most common ad-hoc query and avoids scanning the
+    // table once parse-outcome logging is also added in #329.
+    index("parser_events_ai_fallback_idx")
+      .on(t.createdAt)
+      .where(sql`${t.eventKind} LIKE 'ai_fallback_%'`),
+  ],
+);
+
 export const parserCanaryEvents = pgTable(
   "parser_canary_events",
   {

--- a/src/lib/ingestion/sms-ai-fallback.test.ts
+++ b/src/lib/ingestion/sms-ai-fallback.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { parserEvents, users } from "@/lib/db/schema";
+import { aiFallbackParseSms, isAiFallbackEnabled, recordParserEvent } from "./sms-ai-fallback";
+
+// ---------------------------------------------------------------------------
+// Mock fetch helpers
+// ---------------------------------------------------------------------------
+
+function fakeMessageResponse(payload: unknown): Record<string, unknown> {
+  return {
+    id: "msg_test",
+    type: "message",
+    role: "assistant",
+    model: "claude-haiku-4-5-20251001",
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: 120,
+      output_tokens: 30,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+  };
+}
+
+function mockFetch(
+  responseBody: unknown,
+  init?: { status?: number; errorBody?: unknown },
+): typeof fetch {
+  return (async () => {
+    const status = init?.status ?? 200;
+    const body = status === 200 ? responseBody : (init?.errorBody ?? { error: "oops" });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+// ---------------------------------------------------------------------------
+// aiFallbackParseSms — pure behavior, mocked HTTP
+// ---------------------------------------------------------------------------
+
+describe("aiFallbackParseSms", () => {
+  const validHighConfidence = {
+    kind: "purchase",
+    amountCents: "4500000",
+    currency: "COP",
+    merchant: "RAPPI",
+    cardLast4: "2575",
+    cardKind: "credit",
+    occurredOn: "2026-04-15",
+    occurredTime: "19:30",
+    confidence: 0.95,
+  };
+
+  it("returns success with a ParsedSms when confidence ≥ 0.8", async () => {
+    const result = await aiFallbackParseSms(
+      "Bancolombia: weird format ... RAPPI 45.000 2575 15/04/2026 19:30",
+      {
+        apiKey: "sk-test",
+        fetchImpl: mockFetch(fakeMessageResponse(validHighConfidence)),
+      },
+    );
+
+    expect(result.status).toBe("success");
+    if (result.status !== "success") throw new Error("type guard");
+    expect(result.parsed.kind).toBe("purchase");
+    expect(result.parsed.amountCents).toBe(BigInt("4500000"));
+    expect(result.parsed.currency).toBe("COP");
+    // Purchases carry merchant, not sender; guard the union.
+    if (result.parsed.kind === "purchase") {
+      expect(result.parsed.merchant).toBe("RAPPI");
+      expect(result.parsed.cardLast4).toBe("2575");
+    }
+    expect(result.confidence).toBe(0.95);
+    expect(result.ai.model).toBe("claude-haiku-4-5-20251001");
+    expect(result.ai.tokensIn).toBe(120);
+  });
+
+  it("returns low_confidence (not success) when confidence < 0.8", async () => {
+    const result = await aiFallbackParseSms("Bancolombia: something ambiguous", {
+      apiKey: "sk-test",
+      fetchImpl: mockFetch(fakeMessageResponse({ ...validHighConfidence, confidence: 0.4 })),
+    });
+
+    expect(result.status).toBe("low_confidence");
+    if (result.status !== "low_confidence") throw new Error("type guard");
+    expect(result.confidence).toBe(0.4);
+    expect(result.rawAi.merchant).toBe("RAPPI");
+  });
+
+  it("returns error:api_error on non-2xx responses", async () => {
+    const result = await aiFallbackParseSms("Bancolombia: whatever", {
+      apiKey: "sk-test",
+      fetchImpl: mockFetch(
+        {},
+        {
+          status: 500,
+          errorBody: { type: "error", error: { type: "api_error", message: "boom" } },
+        },
+      ),
+    });
+
+    expect(result.status).toBe("error");
+    if (result.status !== "error") throw new Error("type guard");
+    expect(result.reason).toBe("api_error");
+    expect(result.detail).toContain("500");
+  });
+
+  it("returns error:api_error on 429 rate limit", async () => {
+    const result = await aiFallbackParseSms("Bancolombia: whatever", {
+      apiKey: "sk-test",
+      fetchImpl: mockFetch(
+        {},
+        {
+          status: 429,
+          errorBody: { type: "error", error: { type: "rate_limit_error", message: "slow" } },
+        },
+      ),
+    });
+
+    expect(result.status).toBe("error");
+    if (result.status !== "error") throw new Error("type guard");
+    expect(result.reason).toBe("api_error");
+    expect(result.detail).toContain("429");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAiFallbackEnabled — DB-backed, covers env + per-user override precedence
+// ---------------------------------------------------------------------------
+
+const TAG = "+ai-fallback-test@findash.local";
+
+async function createTestUser(flag: boolean | undefined): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({
+      email: `${crypto.randomUUID()}${TAG}`,
+      name: "AI fallback test",
+      role: "user",
+      active: true,
+      googleSub: `sub-${crypto.randomUUID()}`,
+      featureFlags: flag === undefined ? {} : { aiFallbackEnabled: flag },
+    })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+// Collect IDs by email suffix then cascade-delete — safer than raw SQL LIKE.
+async function cleanup() {
+  const rows = await db.select({ id: users.id, email: users.email }).from(users);
+  const ids = rows.filter((r) => r.email.endsWith(TAG)).map((r) => r.id);
+  if (ids.length === 0) return;
+  await db.delete(parserEvents).where(inArray(parserEvents.userId, ids));
+  await db.delete(users).where(inArray(users.id, ids));
+}
+
+describe("isAiFallbackEnabled", () => {
+  const originalEnv = process.env.AI_FALLBACK_ENABLED;
+
+  beforeEach(cleanup);
+  afterEach(async () => {
+    await cleanup();
+    if (originalEnv === undefined) delete process.env.AI_FALLBACK_ENABLED;
+    else process.env.AI_FALLBACK_ENABLED = originalEnv;
+  });
+
+  it("defers to env var when user has no flag set", async () => {
+    const id = await createTestUser(undefined);
+
+    process.env.AI_FALLBACK_ENABLED = "true";
+    expect(await isAiFallbackEnabled(id)).toBe(true);
+
+    process.env.AI_FALLBACK_ENABLED = "false";
+    expect(await isAiFallbackEnabled(id)).toBe(false);
+
+    delete process.env.AI_FALLBACK_ENABLED;
+    expect(await isAiFallbackEnabled(id)).toBe(false);
+  });
+
+  it("per-user flag=true overrides env var=false", async () => {
+    const id = await createTestUser(true);
+    process.env.AI_FALLBACK_ENABLED = "false";
+    expect(await isAiFallbackEnabled(id)).toBe(true);
+  });
+
+  it("per-user flag=false overrides env var=true", async () => {
+    const id = await createTestUser(false);
+    process.env.AI_FALLBACK_ENABLED = "true";
+    expect(await isAiFallbackEnabled(id)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recordParserEvent — persists correct event_kind per outcome
+// ---------------------------------------------------------------------------
+
+describe("recordParserEvent", () => {
+  let userId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    userId = await createTestUser(undefined);
+  });
+  afterEach(cleanup);
+
+  const regexOutcome = { kind: "needs_review", reason: "unknown_pattern" };
+
+  it("writes parse_needs_review when outcome is disabled", async () => {
+    await recordParserEvent({
+      userId,
+      outcome: { status: "disabled" },
+      regexOutcome,
+      latencyMs: 0,
+    });
+    const rows = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].eventKind).toBe("parse_needs_review");
+    expect(rows[0].aiModel).toBeNull();
+  });
+
+  it("writes ai_fallback_success with AI metadata", async () => {
+    await recordParserEvent({
+      userId,
+      outcome: {
+        status: "success",
+        parsed: {
+          kind: "purchase",
+          amountCents: BigInt(4500000),
+          currency: "COP",
+          merchant: "RAPPI",
+          cardLast4: "2575",
+          cardKind: "credit",
+          occurredOn: "2026-04-15",
+          occurredTime: "19:30",
+          externalId: "bcol-sms:abc123",
+          raw: "Bancolombia: ...",
+        },
+        confidence: 0.93,
+        ai: { model: "claude-haiku-4-5", tokensIn: 120, tokensOut: 30 },
+      },
+      regexOutcome,
+      latencyMs: 1800,
+    });
+    const [row] = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
+    expect(row.eventKind).toBe("ai_fallback_success");
+    expect(row.aiModel).toBe("claude-haiku-4-5");
+    expect(row.aiInputTokens).toBe(120);
+    expect(row.aiOutputTokens).toBe(30);
+    expect(row.latencyMs).toBe(1800);
+    // numeric(4,3) comes back as a string from Postgres; 0.93 → "0.930".
+    expect(row.aiConfidence).toBe("0.930");
+  });
+
+  it("writes ai_fallback_low_confidence with the rawAi output", async () => {
+    await recordParserEvent({
+      userId,
+      outcome: {
+        status: "low_confidence",
+        confidence: 0.42,
+        rawAi: {
+          kind: "purchase",
+          amountCents: "1000",
+          currency: "COP",
+          merchant: "?",
+          cardLast4: "0000",
+          cardKind: "credit",
+          occurredOn: "2026-04-15",
+          occurredTime: "00:00",
+          confidence: 0.42,
+        },
+        ai: { model: "claude-haiku-4-5", tokensIn: 120, tokensOut: 30 },
+      },
+      regexOutcome,
+      latencyMs: 1500,
+    });
+    const [row] = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
+    expect(row.eventKind).toBe("ai_fallback_low_confidence");
+    expect(row.aiConfidence).toBe("0.420");
+  });
+
+  it("writes ai_fallback_error with detail", async () => {
+    await recordParserEvent({
+      userId,
+      outcome: { status: "error", reason: "timeout" },
+      regexOutcome,
+      latencyMs: 2000,
+    });
+    const [row] = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
+    expect(row.eventKind).toBe("ai_fallback_error");
+    const ai = row.aiOutcome as Record<string, unknown>;
+    expect(ai.reason).toBe("timeout");
+  });
+
+  it("filters work: ai_fallback_* partial index covers the three fallback kinds", async () => {
+    // This is really a smoke test that the partial index predicate matches
+    // what we write — if event_kind values diverge the index silently loses
+    // coverage on the dashboard drill-down.
+    const outcomes = ["ai_fallback_success", "ai_fallback_low_confidence", "ai_fallback_error"];
+    for (const kind of outcomes) {
+      await db.insert(parserEvents).values({
+        userId,
+        source: "sms",
+        eventKind: kind as never,
+      });
+    }
+    const rows = await db
+      .select()
+      .from(parserEvents)
+      .where(
+        and(eq(parserEvents.userId, userId), inArray(parserEvents.eventKind, outcomes as never[])),
+      );
+    expect(rows).toHaveLength(3);
+  });
+});

--- a/src/lib/ingestion/sms-ai-fallback.ts
+++ b/src/lib/ingestion/sms-ai-fallback.ts
@@ -1,0 +1,252 @@
+import { createHash } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import Anthropic from "@anthropic-ai/sdk";
+import { callClaude } from "@/lib/ai/anthropic-client";
+import { db } from "@/lib/db";
+import { parserEvents, users } from "@/lib/db/schema";
+import type { ParsedSms } from "./sms-bancolombia";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "sms-ai-fallback" });
+
+// Hot-path budget: AI must return within 2s or the fallback is aborted and
+// the SMS drops to the inbox. Keeps the user-perceived latency bounded even
+// on the 5% needs_review path. Note this is wall-clock on the SDK call,
+// not CPU time — network + prompt caching + inference all fit inside.
+export const DEFAULT_TIMEOUT_MS = 2000;
+
+// Auto-ingest threshold. Below this, the extraction is persisted as a
+// low-confidence fallback and surfaces in /settings/inbox for user review
+// rather than creating a transaction automatically.
+export const MIN_CONFIDENCE = 0.8;
+
+/**
+ * Resolves whether AI fallback is enabled for this user.
+ *
+ * Priority:
+ *   1. users.featureFlags.aiFallbackEnabled (per-user override) — wins if set
+ *   2. process.env.AI_FALLBACK_ENABLED === "true" (global default)
+ *
+ * Defaults to OFF globally so enabling in prod is an explicit operator flip.
+ */
+export async function isAiFallbackEnabled(userId: number): Promise<boolean> {
+  const rows = await db
+    .select({ flags: users.featureFlags })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  const perUser = rows[0]?.flags?.aiFallbackEnabled;
+  if (perUser !== undefined) return perUser;
+  return process.env.AI_FALLBACK_ENABLED === "true";
+}
+
+// MVP scope: the AI fallback only attempts the "purchase" kind today —
+// format-drifted Bancolombia purchase SMS are the majority of needs_review
+// cases. Transfers/QR/ATM stay in the inbox until we have enough
+// observations to expand the schema. See #257 acceptance criteria.
+const aiPurchaseSchema = z.object({
+  kind: z.literal("purchase"),
+  amountCents: z.string().regex(/^\d+$/),
+  currency: z.enum(["COP", "USD"]),
+  merchant: z.string().min(1),
+  cardLast4: z.string().regex(/^\d{4}$/),
+  cardKind: z.enum(["credit", "debit"]),
+  occurredOn: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  occurredTime: z.string().regex(/^\d{2}:\d{2}$/),
+  confidence: z.number().min(0).max(1),
+});
+
+type AiPurchase = z.infer<typeof aiPurchaseSchema>;
+
+const AI_FALLBACK_SYSTEM = `You parse a Bancolombia SMS that the deterministic regex parser could not extract. Return a single JSON object with these fields, or set confidence below 0.8 if the SMS is not a purchase or you cannot extract all fields reliably.
+
+- kind: always "purchase" (other SMS kinds are not supported in fallback yet — set low confidence for those).
+- amountCents: integer as a string, amount × 100. "$50,000.00" → "5000000". "COP35.450,00" → "3545000". No decimals, no separators.
+- currency: "COP" or "USD". If no explicit currency marker but amount format is Colombian ($ / COP), use "COP".
+- merchant: the store / counterparty name. Trim whitespace. Preserve original case.
+- cardLast4: 4 digits — the card *NNNN suffix. If missing, you cannot parse reliably → set confidence low.
+- cardKind: "credit" for T.Cred, "debit" for T.Deb. Default "credit" if ambiguous.
+- occurredOn: YYYY-MM-DD. Convert DD/MM/YYYY inputs; assume current year if only DD/MM.
+- occurredTime: HH:MM (24h). Drop any seconds.
+- confidence: 0..1. Use the scale below.
+
+Confidence scale:
+- 0.95-1.00: every field matches the format guide with zero ambiguity.
+- 0.85-0.94: minor reformatting but every field is extractable.
+- 0.80-0.84: one field required a judgment call (date assumed current year, cardKind defaulted).
+- 0.60-0.79: the SMS is a purchase but a field is missing or suspicious. Will surface to the user's inbox.
+- 0.00-0.59: not a purchase, or unparseable — auto-surface to inbox.
+
+Few-shot examples:
+
+Input: "Bancolombia: Compraste $45.000,00 en RAPPI con tu T.Cred *2575, el 15/04/2026 a las 19:30"
+Output: {"kind":"purchase","amountCents":"4500000","currency":"COP","merchant":"RAPPI","cardLast4":"2575","cardKind":"credit","occurredOn":"2026-04-15","occurredTime":"19:30","confidence":0.97}
+
+Input: "Bancolombia: Pago de USD12,50 en NETFLIX.COM desde T.Deb *7073 el 2026/04/10 08:00"
+Output: {"kind":"purchase","amountCents":"1250","currency":"USD","merchant":"NETFLIX.COM","cardLast4":"7073","cardKind":"debit","occurredOn":"2026-04-10","occurredTime":"08:00","confidence":0.88}
+
+Input: "Bancolombia: Transferiste $50.000 a la cuenta *1234 el 14/04/2026"
+Output: {"kind":"purchase","amountCents":"0","currency":"COP","merchant":"","cardLast4":"0000","cardKind":"credit","occurredOn":"2026-04-14","occurredTime":"00:00","confidence":0.10}`;
+
+export type AiFallbackOutcome =
+  | {
+      status: "success";
+      parsed: ParsedSms;
+      confidence: number;
+      ai: { model: string; tokensIn: number; tokensOut: number };
+    }
+  | {
+      status: "low_confidence";
+      confidence: number;
+      rawAi: AiPurchase;
+      ai: { model: string; tokensIn: number; tokensOut: number };
+    }
+  | {
+      status: "error";
+      reason: "timeout" | "api_error" | "schema_rejected" | "disabled";
+      detail?: string;
+    };
+
+/**
+ * Calls Haiku to extract a purchase from an SMS the regex parser couldn't
+ * match. Returns a status union — callers persist both the transaction
+ * (success) and the telemetry row (all outcomes) so dashboards can measure
+ * fallback win rate and cost.
+ */
+export async function aiFallbackParseSms(
+  smsBody: string,
+  opts?: { apiKey?: string; timeoutMs?: number; fetchImpl?: typeof fetch },
+): Promise<AiFallbackOutcome> {
+  try {
+    const result = await callClaude({
+      system: [{ text: AI_FALLBACK_SYSTEM, cacheControl: true }],
+      userPrompt: smsBody,
+      schema: aiPurchaseSchema,
+      maxTokens: 512,
+      timeoutMs: opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      apiKey: opts?.apiKey,
+      fetchImpl: opts?.fetchImpl,
+    });
+
+    const ai = {
+      model: result.model,
+      tokensIn: result.usage.inputTokens,
+      tokensOut: result.usage.outputTokens,
+    };
+
+    if (result.data.confidence < MIN_CONFIDENCE) {
+      return {
+        status: "low_confidence",
+        confidence: result.data.confidence,
+        rawAi: result.data,
+        ai,
+      };
+    }
+
+    const parsed = synthesizeParsedSms(result.data, smsBody);
+    return { status: "success", parsed, confidence: result.data.confidence, ai };
+  } catch (err) {
+    if (err instanceof Anthropic.APIConnectionTimeoutError) {
+      return { status: "error", reason: "timeout" };
+    }
+    if (err instanceof Anthropic.APIError) {
+      return { status: "error", reason: "api_error", detail: `${err.status}: ${err.message}` };
+    }
+    if (err instanceof z.ZodError) {
+      return { status: "error", reason: "schema_rejected", detail: err.message };
+    }
+    log.error({ err, event: "ai_fallback_unexpected_error" }, "unexpected error in AI fallback");
+    return {
+      status: "error",
+      reason: "api_error",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// Reconstruct a ParsedSms "purchase" variant from the AI's extraction +
+// the original body. externalId derivation matches the regex parser so
+// a retried-then-newly-regex'd SMS dedupes against the AI-ingested row.
+function synthesizeParsedSms(ai: AiPurchase, rawBody: string): ParsedSms {
+  const cents = BigInt(ai.amountCents);
+  const payload = [
+    "purchase",
+    ai.cardLast4,
+    ai.currency,
+    ai.occurredOn,
+    ai.occurredTime,
+    cents.toString(),
+    ai.merchant,
+  ].join("|");
+  const externalId = "bcol-sms:" + createHash("sha256").update(payload).digest("hex").slice(0, 24);
+
+  return {
+    kind: "purchase",
+    amountCents: cents,
+    currency: ai.currency,
+    merchant: ai.merchant,
+    cardLast4: ai.cardLast4,
+    cardKind: ai.cardKind,
+    occurredOn: ai.occurredOn,
+    occurredTime: ai.occurredTime,
+    externalId,
+    raw: rawBody.trim(),
+  };
+}
+
+/**
+ * Persists a parser_events row describing the fallback outcome. Caller is
+ * responsible for measuring `latencyMs`. This is write-only and non-blocking
+ * from the caller's perspective — pipeline control flow uses the return of
+ * aiFallbackParseSms(), not the event log.
+ */
+export async function recordParserEvent(params: {
+  userId: number;
+  outcome: AiFallbackOutcome | { status: "disabled" };
+  regexOutcome: Record<string, unknown>;
+  latencyMs: number;
+}): Promise<void> {
+  try {
+    const { userId, outcome, regexOutcome, latencyMs } = params;
+    const base = { userId, source: "sms" as const, regexOutcome, latencyMs };
+
+    if (outcome.status === "disabled") {
+      await db.insert(parserEvents).values({ ...base, eventKind: "parse_needs_review" });
+      return;
+    }
+    if (outcome.status === "success") {
+      await db.insert(parserEvents).values({
+        ...base,
+        eventKind: "ai_fallback_success",
+        aiOutcome: outcome.parsed as unknown as Record<string, unknown>,
+        aiConfidence: outcome.confidence.toFixed(3),
+        aiModel: outcome.ai.model,
+        aiInputTokens: outcome.ai.tokensIn,
+        aiOutputTokens: outcome.ai.tokensOut,
+      });
+      return;
+    }
+    if (outcome.status === "low_confidence") {
+      await db.insert(parserEvents).values({
+        ...base,
+        eventKind: "ai_fallback_low_confidence",
+        aiOutcome: outcome.rawAi as unknown as Record<string, unknown>,
+        aiConfidence: outcome.confidence.toFixed(3),
+        aiModel: outcome.ai.model,
+        aiInputTokens: outcome.ai.tokensIn,
+        aiOutputTokens: outcome.ai.tokensOut,
+      });
+      return;
+    }
+    // error
+    await db.insert(parserEvents).values({
+      ...base,
+      eventKind: "ai_fallback_error",
+      aiOutcome: { reason: outcome.reason, detail: outcome.detail ?? null },
+    });
+  } catch (err) {
+    // A telemetry write failure must never break the ingestion path.
+    log.error({ err, event: "parser_event_insert_failed" }, "parser_events insert failed");
+  }
+}

--- a/src/lib/ingestion/sms-ai-fallback.ts
+++ b/src/lib/ingestion/sms-ai-fallback.ts
@@ -216,10 +216,16 @@ export async function recordParserEvent(params: {
       return;
     }
     if (outcome.status === "success") {
+      // jsonb serialization chokes on bigint — convert amountCents to string
+      // the same way sms-pipeline.ts:serializeParsed does.
+      const aiOutcome: Record<string, unknown> = {
+        ...outcome.parsed,
+        amountCents: outcome.parsed.amountCents.toString(),
+      };
       await db.insert(parserEvents).values({
         ...base,
         eventKind: "ai_fallback_success",
-        aiOutcome: outcome.parsed as unknown as Record<string, unknown>,
+        aiOutcome,
         aiConfidence: outcome.confidence.toFixed(3),
         aiModel: outcome.ai.model,
         aiInputTokens: outcome.ai.tokensIn,

--- a/src/lib/ingestion/sms-bancolombia.test.ts
+++ b/src/lib/ingestion/sms-bancolombia.test.ts
@@ -651,12 +651,16 @@ describe("parseSmsBancolombia — skip reasons", () => {
     }
   });
 
-  it("skips unknown formats as 'unknown'", () => {
+  it("flags unrecognized formats as needs_review, not skip", () => {
+    // A body that doesn't match any regex AND doesn't match any known skip
+    // pattern surfaces as needs_review — semantically distinct from an
+    // intentional skip (failed tx, non-transactional notification). This is
+    // the trigger for AI fallback (#257).
     const body = "Bancolombia: mensaje totalmente desconocido que no matchea nada";
     const r = parseSmsBancolombia(body);
-    expect(r.kind).toBe("skip");
-    if (r.kind !== "skip") throw new Error("type guard");
-    expect(r.reason).toBe("unknown");
+    expect(r.kind).toBe("needs_review");
+    if (r.kind !== "needs_review") throw new Error("type guard");
+    expect(r.reason).toBe("unknown_pattern");
   });
 });
 
@@ -707,7 +711,9 @@ describe("parseSmsBancolombia — idempotency", () => {
       "Bancolombia: Compraste COP35.450,00 en DLO*DiDi Food CO Pay con tu T.Cred *2575, el 15/04/2026 a las 20:34. Si tienes dudas, encuentranos aqui: 6045109095 o 018000931987. Estamos cerca.";
     const a = parseSmsBancolombia(body);
     const b = parseSmsBancolombia(body);
-    if (a.kind === "skip" || b.kind === "skip") throw new Error("unexpected skip");
+    if (a.kind !== "purchase" || b.kind !== "purchase") {
+      throw new Error(`expected purchase, got ${a.kind} / ${b.kind}`);
+    }
     expect(a.externalId).toBe(b.externalId);
   });
 
@@ -718,7 +724,9 @@ describe("parseSmsBancolombia — idempotency", () => {
       "Bancolombia: Compraste COP36.290,00 en DLO*DiDi Food CO Pay con tu T.Cred *2575, el 15/04/2026 a las 20:34. Si tienes dudas, encuentranos aqui: 6045109095 o 018000931987. Estamos cerca.";
     const a = parseSmsBancolombia(bodyA);
     const b = parseSmsBancolombia(bodyB);
-    if (a.kind === "skip" || b.kind === "skip") throw new Error("unexpected skip");
+    if (a.kind !== "purchase" || b.kind !== "purchase") {
+      throw new Error(`expected purchase, got ${a.kind} / ${b.kind}`);
+    }
     expect(a.externalId).not.toBe(b.externalId);
   });
 });

--- a/src/lib/ingestion/sms-bancolombia.ts
+++ b/src/lib/ingestion/sms-bancolombia.ts
@@ -65,13 +65,26 @@ export type ParsedSms =
       recipientName: string;
     });
 
+// Intentional skip: the SMS matched a known non-ingest pattern (failed tx,
+// non-transactional notification). These are NOT parse failures — the parser
+// recognized them and decided not to ingest.
 export type SkippedSms = {
   kind: "skip";
-  reason: "failed" | "non_transactional" | "unknown";
+  reason: "failed" | "non_transactional";
   raw: string;
 };
 
-export type ParseResult = ParsedSms | SkippedSms;
+// Parse failure: no regex variant matched. The body came through as SMS but
+// the parser could not extract structured fields. This is the trigger for AI
+// fallback (#257) — semantically distinct from SkippedSms, which is "I saw
+// this and chose to skip." NeedsReviewSms is "I don't know what this is."
+export type NeedsReviewSms = {
+  kind: "needs_review";
+  reason: "unknown_pattern";
+  raw: string;
+};
+
+export type ParseResult = ParsedSms | SkippedSms | NeedsReviewSms;
 
 // -----------------------------------------------------------------------------
 // Amount parsing
@@ -679,7 +692,7 @@ export function parseSmsBancolombia(body: string): ParseResult {
     }
   }
 
-  return { kind: "skip", reason: "unknown", raw };
+  return { kind: "needs_review", reason: "unknown_pattern", raw };
 }
 
 // -----------------------------------------------------------------------------

--- a/src/lib/ingestion/sms-pipeline.test.ts
+++ b/src/lib/ingestion/sms-pipeline.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { desc, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, parserEvents, transactions, users } from "@/lib/db/schema";
+import { ingestParsed } from "./sms-pipeline";
+import type { ParseResult } from "./sms-bancolombia";
+
+// Covers the AI-fallback branch added in #257. The regex-pass path is
+// exercised indirectly through the existing SMS route + parser tests; this
+// file focuses on the new needs_review flow with the three terminal
+// outcomes: disabled, success, low_confidence.
+
+const TAG = "+pipeline-test@findash.local";
+
+function fakeMessageResponse(payload: unknown): Record<string, unknown> {
+  return {
+    id: "msg_test",
+    type: "message",
+    role: "assistant",
+    model: "claude-haiku-4-5-20251001",
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: 200,
+      output_tokens: 40,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+  };
+}
+
+function mockFetch(responseBody: unknown): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+async function setupUserWithAccount(flag: boolean | undefined): Promise<{
+  userId: number;
+  accountId: number;
+}> {
+  const [u] = await db
+    .insert(users)
+    .values({
+      email: `${crypto.randomUUID()}${TAG}`,
+      name: "Pipeline test",
+      role: "user",
+      active: true,
+      googleSub: `sub-${crypto.randomUUID()}`,
+      featureFlags: flag === undefined ? {} : { aiFallbackEnabled: flag },
+    })
+    .returning({ id: users.id });
+  const [a] = await db
+    .insert(accounts)
+    .values({
+      userId: u.id,
+      institution: "Bancolombia",
+      name: "TC Visa *2575",
+      type: "credit_card",
+      currency: "COP",
+      active: true,
+      metadata: { last4s: ["2575"] },
+    })
+    .returning({ id: accounts.id });
+  return { userId: u.id, accountId: a.id };
+}
+
+async function cleanup() {
+  const rows = await db.select({ id: users.id, email: users.email }).from(users);
+  const ids = rows.filter((r) => r.email.endsWith(TAG)).map((r) => r.id);
+  if (ids.length === 0) return;
+  await db.delete(transactions).where(inArray(transactions.userId, ids));
+  await db.delete(parserEvents).where(inArray(parserEvents.userId, ids));
+  await db.delete(accounts).where(inArray(accounts.userId, ids));
+  await db.delete(users).where(inArray(users.id, ids));
+}
+
+const rawSms =
+  "Bancolombia: mensaje raro que el regex no entiende ... RAPPI 45000 COP *2575 15/04/2026 19:30";
+const needsReviewInput: ParseResult = {
+  kind: "needs_review",
+  reason: "unknown_pattern",
+  raw: rawSms,
+};
+
+describe("ingestParsed — needs_review + AI fallback", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("records parse_needs_review and errors when fallback is disabled", async () => {
+    const { userId } = await setupUserWithAccount(false);
+
+    const outcome = await ingestParsed(userId, needsReviewInput);
+
+    expect(outcome.status).toBe("error");
+    if (outcome.status !== "error") throw new Error("type guard");
+    expect(outcome.reason).toContain("ai fallback disabled");
+
+    // No tx should be created.
+    const txs = await db.select().from(transactions).where(eq(transactions.userId, userId));
+    expect(txs).toHaveLength(0);
+
+    // Exactly one parser_events row, kind = parse_needs_review.
+    const events = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
+    expect(events).toHaveLength(1);
+    expect(events[0].eventKind).toBe("parse_needs_review");
+    expect(events[0].aiModel).toBeNull();
+  });
+
+  it("creates tx + records ai_fallback_success on high-confidence AI output", async () => {
+    const { userId, accountId } = await setupUserWithAccount(true);
+
+    const outcome = await ingestParsed(userId, needsReviewInput, {
+      aiFallbackFetchImpl: mockFetch(
+        fakeMessageResponse({
+          kind: "purchase",
+          amountCents: "4500000",
+          currency: "COP",
+          merchant: "RAPPI",
+          cardLast4: "2575",
+          cardKind: "credit",
+          occurredOn: "2026-04-15",
+          occurredTime: "19:30",
+          confidence: 0.95,
+        }),
+      ),
+    });
+
+    expect(outcome.status).toBe("inserted");
+    if (outcome.status !== "inserted") throw new Error("type guard");
+    expect(outcome.via).toBe("ai_fallback");
+
+    // Tx should be on the 2575 account with parsedBy marker in raw_data.
+    const [tx] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.userId, userId))
+      .orderBy(desc(transactions.id))
+      .limit(1);
+    expect(tx.accountId).toBe(accountId);
+    // Purchase: negative amountCents.
+    expect(tx.amountCents).toBe(BigInt("-4500000"));
+    expect(tx.currency).toBe("COP");
+    expect(tx.merchant).toBe("RAPPI");
+    const raw = tx.rawData as Record<string, unknown>;
+    expect(raw.parsedBy).toBe("ai_fallback");
+    expect(raw.aiConfidence).toBe(0.95);
+
+    // parser_events has ai_fallback_success with token counts.
+    const [ev] = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
+    expect(ev.eventKind).toBe("ai_fallback_success");
+    expect(ev.aiInputTokens).toBe(200);
+    expect(ev.aiConfidence).toBe("0.950");
+    expect(ev.latencyMs).not.toBeNull();
+  });
+
+  it("records ai_fallback_low_confidence and returns error (no tx) when AI confidence < 0.8", async () => {
+    const { userId } = await setupUserWithAccount(true);
+
+    const outcome = await ingestParsed(userId, needsReviewInput, {
+      aiFallbackFetchImpl: mockFetch(
+        fakeMessageResponse({
+          kind: "purchase",
+          amountCents: "0",
+          currency: "COP",
+          merchant: "?",
+          cardLast4: "0000",
+          cardKind: "credit",
+          occurredOn: "2026-04-15",
+          occurredTime: "00:00",
+          confidence: 0.2,
+        }),
+      ),
+    });
+
+    expect(outcome.status).toBe("error");
+    if (outcome.status !== "error") throw new Error("type guard");
+    expect(outcome.reason).toContain("low_confidence");
+
+    const txs = await db.select().from(transactions).where(eq(transactions.userId, userId));
+    expect(txs).toHaveLength(0);
+
+    const [ev] = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
+    expect(ev.eventKind).toBe("ai_fallback_low_confidence");
+    expect(ev.aiConfidence).toBe("0.200");
+  });
+});

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -40,6 +40,13 @@ export async function ingestParsed(
     return { status: "skipped", reason: `parser: ${parsed.reason}` };
   }
 
+  // needs_review: parser could not match any known shape. AI fallback hooks
+  // here in #257. Until then, treat as an ingest error so it surfaces in
+  // /settings/inbox for manual triage.
+  if (parsed.kind === "needs_review") {
+    return { status: "error", reason: `parser: ${parsed.reason}` };
+  }
+
   const allAccounts = (await db
     .select({
       id: accounts.id,
@@ -324,7 +331,9 @@ function buildTxFields(parsed: ParsedSms): {
 }
 
 export function serializeParsed(parsed: ParseResult): Record<string, unknown> {
-  if (parsed.kind === "skip") return { kind: "skip", reason: parsed.reason };
+  if (parsed.kind === "skip" || parsed.kind === "needs_review") {
+    return { kind: parsed.kind, reason: parsed.reason };
+  }
   return {
     ...parsed,
     amountCents: parsed.amountCents.toString(),

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -11,6 +11,12 @@ import {
   type ParsedSms,
   type RoutableAccount,
 } from "@/lib/ingestion/sms-bancolombia";
+import {
+  aiFallbackParseSms,
+  isAiFallbackEnabled,
+  recordParserEvent,
+  type AiFallbackOutcome,
+} from "@/lib/ingestion/sms-ai-fallback";
 import { keyForParsed } from "@/lib/counterparties/alias-key";
 import type { ClassificationMethod } from "@/lib/types";
 
@@ -18,7 +24,7 @@ import type { ClassificationMethod } from "@/lib/types";
 const COP_TIMEZONE_OFFSET = "-05:00";
 
 export type IngestOutcome =
-  | { status: "inserted"; txId: number }
+  | { status: "inserted"; txId: number; via?: "regex" | "ai_fallback" }
   | { status: "duplicated" }
   | { status: "skipped"; reason: string }
   | { status: "error"; reason: string };
@@ -30,23 +36,78 @@ export type IngestOutcome =
  * `opts.forceAccountId` is used by the retry path (#261): bypass last4/currency
  * routing and use the account the user picked in the inbox. Currency is still
  * enforced so a wrong-currency account never gets a mismatched amount.
+ *
+ * `opts.aiFallbackFetchImpl` is a test seam — the SMS AI fallback path uses
+ * the Anthropic SDK, and tests inject a mock fetch. Production callers leave
+ * it undefined so the SDK uses its real transport.
  */
 export async function ingestParsed(
   userId: number,
   parsed: ParseResult,
-  opts?: { forceAccountId?: number },
+  opts?: { forceAccountId?: number; aiFallbackFetchImpl?: typeof fetch },
 ): Promise<IngestOutcome> {
   if (parsed.kind === "skip") {
     return { status: "skipped", reason: `parser: ${parsed.reason}` };
   }
 
-  // needs_review: parser could not match any known shape. AI fallback hooks
-  // here in #257. Until then, treat as an ingest error so it surfaces in
-  // /settings/inbox for manual triage.
+  // needs_review: the regex parser could not match any known shape. Either
+  // invoke the AI fallback (#257) or surface to the inbox. Either path emits
+  // exactly one parser_events row for the SLO dashboard (#329).
   if (parsed.kind === "needs_review") {
-    return { status: "error", reason: `parser: ${parsed.reason}` };
+    return ingestNeedsReviewWithAiFallback(userId, parsed.raw, opts?.aiFallbackFetchImpl);
   }
 
+  return ingestParsedSms(userId, parsed, opts?.forceAccountId);
+}
+
+async function ingestNeedsReviewWithAiFallback(
+  userId: number,
+  rawBody: string,
+  fetchImpl: typeof fetch | undefined,
+): Promise<IngestOutcome> {
+  const regexOutcome = { kind: "needs_review" as const, reason: "unknown_pattern" as const };
+  const enabled = await isAiFallbackEnabled(userId);
+
+  if (!enabled) {
+    await recordParserEvent({
+      userId,
+      outcome: { status: "disabled" },
+      regexOutcome,
+      latencyMs: 0,
+    });
+    return { status: "error", reason: "parser: unknown_pattern (ai fallback disabled)" };
+  }
+
+  const startedAt = Date.now();
+  const outcome: AiFallbackOutcome = await aiFallbackParseSms(rawBody, { fetchImpl });
+  const latencyMs = Date.now() - startedAt;
+
+  await recordParserEvent({ userId, outcome, regexOutcome, latencyMs });
+
+  if (outcome.status !== "success") {
+    const detail =
+      outcome.status === "low_confidence"
+        ? `confidence=${outcome.confidence.toFixed(2)}`
+        : outcome.reason;
+    return { status: "error", reason: `ai_fallback: ${outcome.status} (${detail})` };
+  }
+
+  const result = await ingestParsedSms(userId, outcome.parsed, undefined, {
+    parsedByAiFallback: true,
+    aiConfidence: outcome.confidence,
+  });
+  // Tag successful AI-fallback inserts so callers (and the SMS route log) can
+  // distinguish them from the regex path.
+  if (result.status === "inserted") return { ...result, via: "ai_fallback" };
+  return result;
+}
+
+async function ingestParsedSms(
+  userId: number,
+  parsed: ParsedSms,
+  forceAccountId: number | undefined,
+  aiFallbackMeta?: { parsedByAiFallback: boolean; aiConfidence: number },
+): Promise<IngestOutcome> {
   const allAccounts = (await db
     .select({
       id: accounts.id,
@@ -61,10 +122,10 @@ export async function ingestParsed(
   >;
 
   let account: RoutableAccount | null;
-  if (opts?.forceAccountId !== undefined) {
-    const forced = allAccounts.find((a) => a.id === opts.forceAccountId);
+  if (forceAccountId !== undefined) {
+    const forced = allAccounts.find((a) => a.id === forceAccountId);
     if (!forced) {
-      return { status: "error", reason: `account ${opts.forceAccountId} not found for user` };
+      return { status: "error", reason: `account ${forceAccountId} not found for user` };
     }
     if (forced.currency !== parsed.currency) {
       return {
@@ -131,6 +192,10 @@ export async function ingestParsed(
         rawData: {
           kind: parsed.kind,
           sms: parsed.raw,
+          ...(aiFallbackMeta && {
+            parsedBy: "ai_fallback",
+            aiConfidence: aiFallbackMeta.aiConfidence,
+          }),
         },
       })
       .onConflictDoNothing({

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -88,7 +88,7 @@ async function ingestNeedsReviewWithAiFallback(
     const detail =
       outcome.status === "low_confidence"
         ? `confidence=${outcome.confidence.toFixed(2)}`
-        : outcome.reason;
+        : `${outcome.reason}${outcome.detail ? `: ${outcome.detail}` : ""}`;
     return { status: "error", reason: `ai_fallback: ${outcome.status} (${detail})` };
   }
 

--- a/src/lib/observability/canary.test.ts
+++ b/src/lib/observability/canary.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  compareProjections,
-  hashSmsBody,
-  parseProjectionJson,
-  projectFromRegex,
-  sampleForCanary,
-} from "./canary";
+import { compareProjections, hashSmsBody, projectFromRegex, sampleForCanary } from "./canary";
 import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
 
 describe("sampleForCanary", () => {
@@ -107,30 +101,9 @@ describe("compareProjections", () => {
   });
 });
 
-describe("parseProjectionJson", () => {
-  it("extracts the JSON object even with prose wrapping", () => {
-    const text = `Sure, here's the extraction:
-{"amountCents": "5000000", "currency": "COP", "merchant": "EXITO", "occurredOn": "2026-04-15"}
-Hope that helps!`;
-    const p = parseProjectionJson(text);
-    expect(p.amountCents).toBe("5000000");
-    expect(p.currency).toBe("COP");
-    expect(p.merchant).toBe("EXITO");
-  });
-
-  it("coerces nulls + unknown currency to null", () => {
-    const p = parseProjectionJson(
-      `{"amountCents": null, "currency": "BRL", "merchant": "", "occurredOn": null}`,
-    );
-    expect(p).toEqual({
-      amountCents: null,
-      currency: null,
-      merchant: null,
-      occurredOn: null,
-    });
-  });
-
-  it("throws when there is no JSON object in the response", () => {
-    expect(() => parseProjectionJson("I cannot parse this SMS.")).toThrow();
-  });
-});
+// NOTE: the former parseProjectionJson + its tests were removed. Response
+// parsing is now handled by the SDK via output_config.format (structured
+// outputs), which constrains the model server-side — unknown currencies
+// and prose-wrapped JSON are impossible at the wire level. The Zod schema
+// in canary.ts still guards amount/merchant/date coercion client-side;
+// those paths are exercised via shadowParseSms integration tests.

--- a/src/lib/observability/canary.ts
+++ b/src/lib/observability/canary.ts
@@ -1,12 +1,13 @@
 import { createHash } from "node:crypto";
+import { z } from "zod";
 import { db } from "@/lib/db";
 import { parserCanaryEvents, type CanaryProjection } from "@/lib/db/schema";
 import { parseSmsBancolombia, type ParseResult } from "@/lib/ingestion/sms-bancolombia";
+import { callClaude } from "@/lib/ai/anthropic-client";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger({ module: "canary" });
 
-const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
 const SAMPLE_NUMERATOR = 1;
 const SAMPLE_DENOMINATOR = 100;
 const PROJECTION_FIELDS = ["amountCents", "currency", "merchant", "occurredOn"] as const;
@@ -83,17 +84,28 @@ function normalizeMerchant(s: string): string {
     .trim();
 }
 
-const AI_PROMPT_HEADER = `You are parsing a single Bancolombia SMS notification. Extract these fields as strict JSON.
+const AI_PROMPT_SYSTEM = `You are parsing a single Bancolombia SMS notification. Extract these fields as strict JSON.
 
 - amountCents: integer as string, amount × 100 (e.g. "$50,000 COP" → "5000000"). null if no amount.
 - currency: "COP" | "USD" | null
 - merchant: name of the other party — store name, person, provider. null if it's a transfer/withdrawal/ATM with no counterparty name.
 - occurredOn: date as YYYY-MM-DD from the SMS (assume current year if only month/day shown). null if not present.
 
-Return ONLY valid JSON with exactly these 4 keys. No prose.
+Return ONLY valid JSON with exactly these 4 keys. No prose.`;
 
-SMS:
-`;
+// Accept string or number for amountCents (model occasionally emits a raw int
+// instead of stringified), normalize to string-or-null. Strings get trimmed;
+// empty strings collapse to null.
+const canaryProjectionSchema = z.object({
+  amountCents: z
+    .union([z.string(), z.number(), z.null()])
+    .transform((v) => (v == null ? null : typeof v === "number" ? String(v) : v.trim() || null)),
+  currency: z.enum(["COP", "USD"]).nullable(),
+  merchant: z.union([z.string(), z.null()]).transform((v) => (v == null ? null : v.trim() || null)),
+  occurredOn: z
+    .union([z.string(), z.null()])
+    .transform((v) => (v == null ? null : v.trim() || null)),
+});
 
 export async function shadowParseSms(
   smsBody: string,
@@ -104,61 +116,22 @@ export async function shadowParseSms(
   inputTokens: number;
   outputTokens: number;
 }> {
-  const apiKey = opts?.apiKey ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
-  const model = opts?.model ?? DEFAULT_MODEL;
-  const doFetch = opts?.fetchImpl ?? fetch;
-
-  const res = await doFetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-    },
-    body: JSON.stringify({
-      model,
-      max_tokens: 256,
-      messages: [{ role: "user", content: AI_PROMPT_HEADER + smsBody }],
-    }),
+  const result = await callClaude({
+    system: [{ text: AI_PROMPT_SYSTEM, cacheControl: true }],
+    userPrompt: smsBody,
+    schema: canaryProjectionSchema,
+    maxTokens: 256,
+    model: opts?.model,
+    apiKey: opts?.apiKey,
+    fetchImpl: opts?.fetchImpl,
   });
 
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`Anthropic API error ${res.status}: ${body.slice(0, 300)}`);
-  }
-
-  const payload = (await res.json()) as {
-    content: Array<{ type: string; text?: string }>;
-    usage?: { input_tokens: number; output_tokens: number };
-  };
-  const text = payload.content?.find((c) => c.type === "text")?.text ?? "";
   return {
-    projection: parseProjectionJson(text),
-    model,
-    inputTokens: payload.usage?.input_tokens ?? 0,
-    outputTokens: payload.usage?.output_tokens ?? 0,
+    projection: result.data,
+    model: result.model,
+    inputTokens: result.usage.inputTokens,
+    outputTokens: result.usage.outputTokens,
   };
-}
-
-export function parseProjectionJson(text: string): CanaryProjection {
-  const match = text.match(/\{[\s\S]*\}/);
-  if (!match) throw new Error("shadowParseSms: no JSON object in response");
-  const raw = JSON.parse(match[0]) as Record<string, unknown>;
-  return {
-    amountCents: coerceStringOrNull(raw.amountCents),
-    currency:
-      raw.currency === "COP" || raw.currency === "USD" ? (raw.currency as "COP" | "USD") : null,
-    merchant: coerceStringOrNull(raw.merchant),
-    occurredOn: coerceStringOrNull(raw.occurredOn),
-  };
-}
-
-function coerceStringOrNull(v: unknown): string | null {
-  if (v === null || v === undefined) return null;
-  if (typeof v === "string") return v.trim() || null;
-  if (typeof v === "number" || typeof v === "bigint") return String(v);
-  return null;
 }
 
 // Entry point used by the SMS route's after() hook. Swallows errors — a

--- a/src/lib/observability/canary.ts
+++ b/src/lib/observability/canary.ts
@@ -25,7 +25,7 @@ export function sampleForCanary(smsBody: string): boolean {
 }
 
 export function projectFromRegex(parsed: ParseResult): CanaryProjection {
-  if (parsed.kind === "skip") {
+  if (parsed.kind === "skip" || parsed.kind === "needs_review") {
     return { amountCents: null, currency: null, merchant: null, occurredOn: null };
   }
   return {
@@ -36,7 +36,9 @@ export function projectFromRegex(parsed: ParseResult): CanaryProjection {
   };
 }
 
-function merchantFromParsed(parsed: Exclude<ParseResult, { kind: "skip" }>): string | null {
+function merchantFromParsed(
+  parsed: Exclude<ParseResult, { kind: "skip" | "needs_review" }>,
+): string | null {
   switch (parsed.kind) {
     case "purchase":
       return parsed.merchant;

--- a/src/lib/telegram/router.ts
+++ b/src/lib/telegram/router.ts
@@ -398,9 +398,10 @@ async function handleText(
 
   // Forwarded Bancolombia SMS branch: deterministic parser first, NLU fallback.
   // Calling the parser unconditionally is safe — its regexes are tight enough
-  // that normal freeform text returns skip:"unknown" and falls through.
+  // that normal freeform text returns needs_review:"unknown_pattern" and falls
+  // through to the NLU path below.
   const smsParsed = parseSmsBancolombia(text);
-  if (smsParsed.kind !== "skip") {
+  if (smsParsed.kind !== "skip" && smsParsed.kind !== "needs_review") {
     const { draft, externalId } = buildDraftFromParsedSms(smsParsed, accountsFull);
     const categories = await deps.listCategories();
     const state: TelegramSessionState = {

--- a/src/lib/telegram/sms-draft.test.ts
+++ b/src/lib/telegram/sms-draft.test.ts
@@ -48,7 +48,9 @@ const ACCOUNTS: AccountDetail[] = [
 
 function parseOrThrow(body: string): ParsedSms {
   const parsed = parseSmsBancolombia(body);
-  if (parsed.kind === "skip") throw new Error(`expected parse, got skip: ${parsed.reason}`);
+  if (parsed.kind === "skip" || parsed.kind === "needs_review") {
+    throw new Error(`expected parse, got ${parsed.kind}: ${parsed.reason}`);
+  }
   return parsed;
 }
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -30,3 +30,11 @@ if (process.env.PGDATABASE !== TEST_DB_NAME) {
 // 32 zero bytes, base64-encoded. Deterministic so tampering tests are stable;
 // trivially insecure — do NOT reuse anywhere outside the test runtime.
 process.env.TELEGRAM_TOKEN_ENCRYPTION_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+// Anthropic SDK requires ANTHROPIC_API_KEY at client-init time, even when
+// the caller injects a mock fetch. Vitest isolates env so .env.local is
+// NOT loaded here — set a dummy key so AI tests that rely on env-default
+// credential resolution don't blow up before reaching the mock.
+if (!process.env.ANTHROPIC_API_KEY) {
+  process.env.ANTHROPIC_API_KEY = "sk-ant-test-dummy-for-vitest-do-not-use";
+}


### PR DESCRIPTION
Closes #257.

## Summary

Five-commit delivery building the SMS AI-fallback path end-to-end, plus the infrastructure needed to do it right:

1. **Parser refactor** — `ParseResult` gains a third kind, `NeedsReviewSms`, separating intentional skips (failed tx / non-transactional) from genuine parse failures. The latter is the AI-fallback trigger. Migrated 14 callsites.
2. **Centralized Anthropic SDK client** — new `src/lib/ai/anthropic-client.ts` with `cache_control`, typed errors, `output_config.format` via `zodOutputFormat`, and a `fetchImpl` test seam. Migrated `classifyBatchWithAi` + `shadowParseSms`. Official `@anthropic-ai/sdk` 0.90.0.
3. **`parser_events` table** (migration 0037) — append-only audit row per needs_review SMS. Fulfils the original intent of #249, which closed with only the narrower `parser_canary_events`. Three indexes incl. a partial one for AI-fallback drill-down.
4. **AI fallback module + pipeline wiring** — `src/lib/ingestion/sms-ai-fallback.ts`: 2s hot-path budget, Haiku 4.5, 3 few-shots, confidence gating at 0.8. Hooks into `ingestParsed` so successful AI extractions flow through the normal ingest path with `raw_data.parsedBy='ai_fallback'`. MVP scope = purchase kind only; other kinds surface to the inbox.
5. **Kill-switches** — global `AI_FALLBACK_ENABLED` env var (default OFF) + per-user override via new `users.feature_flags` jsonb column (migration 0038). Per-user wins over global.

### Test coverage

- `anthropic-client.test.ts` — 6 tests: cache_control placement, Zod validation, typed error surfaces (500 / 429 / missing key).
- `sms-ai-fallback.test.ts` — 12 tests: aiFallbackParseSms with mocked fetch (success / low_conf / api_error / 429), `isAiFallbackEnabled` precedence matrix, `recordParserEvent` event_kind correctness per outcome.
- `sms-pipeline.test.ts` — 3 integration tests exercising the full `ingestParsed` + needs_review flow (disabled / high-conf success / low-conf to inbox) against `findash_test`.
- Existing `sms-bancolombia.test.ts` + 56 other suites updated/green. **618/618 tests pass. Typecheck clean. Lint clean.**

### Behavior change at ship (important)

Previously, unrecognized SMS formats logged as `status: \"skipped\"` and were silently dropped. After this PR they log as `status: \"error\"` and surface in `/settings/inbox` with `reason: parser: unknown_pattern (ai fallback disabled)`. With `AI_FALLBACK_ENABLED=true` most become successful tx inserts instead. Users will see a one-time spike in inbox entries after deploy for any backlog of needs_review SMS.

### Follow-ups

- **#329** (new) picks up the `/admin/slos` dashboard from the original #249 scope — now backed by `parser_events`.
- `src/lib/ai/insights.ts` and `src/lib/ai/transaction-nlu.ts` still use direct fetch; can be migrated to the centralized client in a follow-up PR (same pattern).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` — 618/618
- [x] `bun run db:migrate` + `bun run db:migrate:test` apply 0037 + 0038 cleanly
- [x] Drizzle `_journal.json` is monotonic (`jq '[.entries[] | .when] | . == (sort)'` → true)
- [ ] CI passes (GitHub Actions)
- [ ] Smoke test after merge: POST a known-unparseable SMS to `/api/ingest/sms` with `AI_FALLBACK_ENABLED=false` (default) and confirm it lands in `/settings/inbox`; flip to `true` and confirm the same SMS ingests as a transaction with `raw_data.parsedBy='ai_fallback'`.