### PR TITLE
refactor(ai): migrate insights + nlu to centralized callClaude (#331)

### DIFF
--- a/src/lib/ai/anthropic-client.test.ts
+++ b/src/lib/ai/anthropic-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import Anthropic from "@anthropic-ai/sdk";
-import { callClaude } from "./anthropic-client";
+import { callClaude, callClaudeText } from "./anthropic-client";
 
 type CapturedRequest = {
   url: string;
@@ -143,5 +143,79 @@ describe("callClaude", () => {
     } finally {
       if (original !== undefined) process.env.ANTHROPIC_API_KEY = original;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// callClaudeText — prose path (no schema, returns raw text)
+// ---------------------------------------------------------------------------
+
+function fakeTextResponse(text: string): Record<string, unknown> {
+  return {
+    id: "msg_test",
+    type: "message",
+    role: "assistant",
+    model: "claude-sonnet-4-6",
+    content: [{ type: "text", text }],
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: 800,
+      output_tokens: 250,
+      cache_read_input_tokens: 640,
+      cache_creation_input_tokens: 0,
+    },
+  };
+}
+
+describe("callClaudeText", () => {
+  it("returns the concatenated text + cache usage", async () => {
+    const result = await callClaudeText({
+      system: [{ text: "You are a financial advisor.", cacheControl: true }],
+      userPrompt: "summarize this",
+      apiKey: "sk-test",
+      fetchImpl: mockFetch(fakeTextResponse("## Report\n\nAll good."), []),
+    });
+
+    expect(result.text).toBe("## Report\n\nAll good.");
+    expect(result.model).toBe("claude-sonnet-4-6");
+    expect(result.usage.inputTokens).toBe(800);
+    expect(result.usage.cacheReadTokens).toBe(640);
+  });
+
+  it("sends cache_control on the marked system block", async () => {
+    const captured: CapturedRequest[] = [];
+    await callClaudeText({
+      system: [{ text: "stable rules", cacheControl: true }, { text: "volatile context" }],
+      userPrompt: "ok",
+      apiKey: "sk-test",
+      fetchImpl: mockFetch(fakeTextResponse("reply"), captured),
+    });
+    const system = captured[0].body.system as Array<Record<string, unknown>>;
+    expect(system[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[1].cache_control).toBeUndefined();
+  });
+
+  it("throws when the response has no text blocks", async () => {
+    await expect(
+      callClaudeText({
+        userPrompt: "x",
+        apiKey: "sk-test",
+        fetchImpl: mockFetch(fakeTextResponse(""), []),
+      }),
+    ).rejects.toThrow(/empty text/i);
+  });
+
+  it("rethrows typed Anthropic.APIError on non-2xx", async () => {
+    await expect(
+      callClaudeText({
+        userPrompt: "x",
+        apiKey: "sk-test",
+        fetchImpl: mockFetch({}, [], {
+          status: 500,
+          errorBody: { type: "error", error: { type: "api_error", message: "boom" } },
+        }),
+      }),
+    ).rejects.toBeInstanceOf(Anthropic.APIError);
   });
 });

--- a/src/lib/ai/anthropic-client.ts
+++ b/src/lib/ai/anthropic-client.ts
@@ -22,20 +22,21 @@ export type SystemPromptBlock = {
   // When true, adds cache_control: { type: "ephemeral" } to this block. Use
   // for stable content (category list, few-shots, task instructions). Cache
   // only takes effect once the prefix exceeds the model minimum (Haiku 4.5:
-  // 4096 tokens); shorter prefixes silently won't cache but the marker is
-  // harmless. See shared/prompt-caching.md.
+  // 4096 tokens, Sonnet 4.6: 2048 tokens); shorter prefixes silently won't
+  // cache but the marker is harmless. See shared/prompt-caching.md.
   cacheControl?: boolean;
 };
 
-export type CallClaudeOpts<T> = {
-  // Stable, cacheable content — instructions, categories, few-shots.
-  // String for simple cases; array of blocks when you want selective caching.
+export type ClaudeUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+};
+
+type BaseCallOpts = {
   system?: string | SystemPromptBlock[];
-  // Volatile per-request content — the transaction list, the SMS body.
   userPrompt: string;
-  // Zod schema for the model's JSON response. Enforced server-side via
-  // output_config.format — rejects hallucinations before they reach us.
-  schema: ZodType<T>;
   model?: string;
   maxTokens?: number;
   apiKey?: string;
@@ -46,36 +47,38 @@ export type CallClaudeOpts<T> = {
   fetchImpl?: typeof fetch;
 };
 
+export type CallClaudeOpts<T> = BaseCallOpts & {
+  // Zod schema for the model's JSON response. Enforced server-side via
+  // output_config.format — rejects hallucinations before they reach us.
+  schema: ZodType<T>;
+};
+
 export type CallClaudeResult<T> = {
   data: T;
   model: string;
-  usage: {
-    inputTokens: number;
-    outputTokens: number;
-    cacheReadTokens: number;
-    cacheCreationTokens: number;
-  };
+  usage: ClaudeUsage;
 };
 
+export type CallClaudeTextResult = {
+  text: string;
+  model: string;
+  usage: ClaudeUsage;
+};
+
+/**
+ * Structured call — use for any response that should be validated against a
+ * Zod schema. Uses messages.parse() + output_config.format so the server
+ * rejects hallucinated shapes before we touch the payload.
+ */
 export async function callClaude<T>(opts: CallClaudeOpts<T>): Promise<CallClaudeResult<T>> {
-  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
-
+  const client = buildClient(opts);
   const model = opts.model ?? DEFAULT_MODEL;
-  const maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
 
-  const clientOpts: { apiKey: string; fetch?: typeof fetch; timeout?: number } = { apiKey };
-  if (opts.fetchImpl) clientOpts.fetch = opts.fetchImpl;
-  if (opts.timeoutMs !== undefined) clientOpts.timeout = opts.timeoutMs;
-  const client = new Anthropic(clientOpts);
-
-  const systemBlocks = buildSystemBlocks(opts.system);
-
-  try {
+  return runWithErrorHandling(model, async () => {
     const response = await client.messages.parse({
       model,
-      max_tokens: maxTokens,
-      ...(systemBlocks && { system: systemBlocks }),
+      max_tokens: opts.maxTokens ?? DEFAULT_MAX_TOKENS,
+      ...systemField(opts.system),
       messages: [{ role: "user", content: opts.userPrompt }],
       output_config: { format: zodOutputFormat(opts.schema) },
     });
@@ -89,26 +92,68 @@ export async function callClaude<T>(opts: CallClaudeOpts<T>): Promise<CallClaude
     return {
       data: response.parsed_output,
       model: response.model,
-      usage: {
-        inputTokens: response.usage.input_tokens,
-        outputTokens: response.usage.output_tokens,
-        cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
-        cacheCreationTokens: response.usage.cache_creation_input_tokens ?? 0,
-      },
+      usage: extractUsage(response.usage),
     };
-  } catch (err) {
-    if (err instanceof Anthropic.RateLimitError) {
-      log.warn({ err, model, event: "ai_rate_limited" }, "anthropic rate limited");
-    } else if (err instanceof Anthropic.APIError) {
-      log.error({ err, model, status: err.status, event: "ai_api_error" }, "anthropic api error");
-    }
-    throw err;
-  }
+  });
 }
 
-function buildSystemBlocks(
-  system: CallClaudeOpts<unknown>["system"],
-): Anthropic.TextBlockParam[] | undefined {
+/**
+ * Prose call — use when the response is free-form text (markdown, long
+ * analysis). No schema means no server-side format constraint; the caller
+ * is responsible for any downstream validation.
+ */
+export async function callClaudeText(opts: BaseCallOpts): Promise<CallClaudeTextResult> {
+  const client = buildClient(opts);
+  const model = opts.model ?? DEFAULT_MODEL;
+
+  return runWithErrorHandling(model, async () => {
+    const response = await client.messages.create({
+      model,
+      max_tokens: opts.maxTokens ?? DEFAULT_MAX_TOKENS,
+      ...systemField(opts.system),
+      messages: [{ role: "user", content: opts.userPrompt }],
+    });
+
+    const text = response.content
+      .flatMap((block) => (block.type === "text" ? [block.text] : []))
+      .join("")
+      .trim();
+    if (!text) {
+      throw new Error(
+        `Claude returned empty text (stop_reason=${response.stop_reason}, blocks=${response.content.length})`,
+      );
+    }
+
+    return {
+      text,
+      model: response.model,
+      usage: extractUsage(response.usage),
+    };
+  });
+}
+
+function buildClient(opts: {
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Anthropic {
+  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
+
+  const clientOpts: { apiKey: string; fetch?: typeof fetch; timeout?: number } = { apiKey };
+  if (opts.fetchImpl) clientOpts.fetch = opts.fetchImpl;
+  if (opts.timeoutMs !== undefined) clientOpts.timeout = opts.timeoutMs;
+  return new Anthropic(clientOpts);
+}
+
+function systemField(
+  system: BaseCallOpts["system"],
+): { system: Anthropic.TextBlockParam[] } | Record<string, never> {
+  const blocks = buildSystemBlocks(system);
+  return blocks ? { system: blocks } : {};
+}
+
+function buildSystemBlocks(system: BaseCallOpts["system"]): Anthropic.TextBlockParam[] | undefined {
   if (!system) return undefined;
   if (typeof system === "string") {
     return [{ type: "text", text: system }];
@@ -118,4 +163,26 @@ function buildSystemBlocks(
       ? { type: "text", text: block.text, cache_control: { type: "ephemeral" } }
       : { type: "text", text: block.text },
   );
+}
+
+function extractUsage(usage: Anthropic.Usage): ClaudeUsage {
+  return {
+    inputTokens: usage.input_tokens,
+    outputTokens: usage.output_tokens,
+    cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+    cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+  };
+}
+
+async function runWithErrorHandling<T>(model: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof Anthropic.RateLimitError) {
+      log.warn({ err, model, event: "ai_rate_limited" }, "anthropic rate limited");
+    } else if (err instanceof Anthropic.APIError) {
+      log.error({ err, model, status: err.status, event: "ai_api_error" }, "anthropic api error");
+    }
+    throw err;
+  }
 }

--- a/src/lib/ai/insights.ts
+++ b/src/lib/ai/insights.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/db/schema";
 import { notAdjustment, notDeleted } from "@/lib/db/helpers";
 import type { Currency } from "@/lib/types";
+import { callClaudeText } from "@/lib/ai/anthropic-client";
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 export const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -346,12 +347,11 @@ export function hashSummary(summary: InsightsSummary): string {
   return createHash("sha256").update(JSON.stringify(summary)).digest("hex");
 }
 
-function buildPrompt(summary: InsightsSummary): string {
-  return `Sos un asesor financiero personal para un usuario colombiano. Analizás sus finanzas mensuales y das recomendaciones PRÁCTICAS y LOCALES.
-
-Datos del mes ${summary.yearMonth} (montos en COP, valor absoluto):
-
-${JSON.stringify(summary, null, 2)}
+// Stable across all users and months — task framing, output structure, and
+// the formatting rules. Gets cache_control so Sonnet 4.6 can amortize it
+// across requests (cache threshold is 2048 tokens; this + the stable
+// investment advisory block combine to comfortably exceed that).
+const INSIGHTS_SYSTEM_PROMPT = `Sos un asesor financiero personal para un usuario colombiano. Analizás sus finanzas mensuales y das recomendaciones PRÁCTICAS y LOCALES.
 
 Generá un reporte en MARKDOWN con estas secciones (usá headings H2):
 
@@ -390,6 +390,11 @@ Reglas:
 - Si no hay datos para una sección, decilo brevemente y seguí.
 
 Devolvé SOLO el markdown del reporte, sin prefacio.`;
+
+function buildUserPrompt(summary: InsightsSummary): string {
+  return `Datos del mes ${summary.yearMonth} (montos en COP, valor absoluto):
+
+${JSON.stringify(summary, null, 2)}`;
 }
 
 export async function generateInsightsReport(opts: {
@@ -402,47 +407,19 @@ export async function generateInsightsReport(opts: {
   model: string;
   usage: { inputTokens: number; outputTokens: number };
 }> {
-  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
-
-  const model = opts.model ?? DEFAULT_MODEL;
-  const doFetch = opts.fetchImpl ?? fetch;
-  const prompt = buildPrompt(opts.summary);
-
-  const res = await doFetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-    },
-    body: JSON.stringify({
-      model,
-      max_tokens: 3000,
-      messages: [{ role: "user", content: prompt }],
-    }),
+  const result = await callClaudeText({
+    system: [{ text: INSIGHTS_SYSTEM_PROMPT, cacheControl: true }],
+    userPrompt: buildUserPrompt(opts.summary),
+    model: opts.model ?? DEFAULT_MODEL,
+    maxTokens: 3000,
+    apiKey: opts.apiKey,
+    fetchImpl: opts.fetchImpl,
   });
 
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`Anthropic API error ${res.status}: ${body.slice(0, 300)}`);
-  }
-
-  const payload = (await res.json()) as {
-    content: Array<{ type: string; text?: string }>;
-    usage?: { input_tokens: number; output_tokens: number };
-  };
-
-  const markdown = (payload.content?.find((c) => c.type === "text")?.text ?? "").trim();
-  if (!markdown) throw new Error("Model returned empty response");
-
   return {
-    markdown,
-    model,
-    usage: {
-      inputTokens: payload.usage?.input_tokens ?? 0,
-      outputTokens: payload.usage?.output_tokens ?? 0,
-    },
+    markdown: result.text,
+    model: result.model,
+    usage: { inputTokens: result.usage.inputTokens, outputTokens: result.usage.outputTokens },
   };
 }
 

--- a/src/lib/ai/transaction-nlu.test.ts
+++ b/src/lib/ai/transaction-nlu.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import Anthropic from "@anthropic-ai/sdk";
 import {
   parseTransactionMessage,
   type NluAccountOption,
@@ -277,12 +278,26 @@ describe("parseTransactionMessage", () => {
     expect(result.draft.confidence).toBe(10);
   });
 
-  it("throws on invalid JSON from model", async () => {
+  it("throws on invalid JSON from model (SDK structured-output parse error)", async () => {
+    // The centralized client uses messages.parse() with output_config.format,
+    // so the SDK's own parser rejects non-JSON before we see it. The error
+    // message comes from the SDK, not our code.
     const fetchImpl: typeof fetch = async () =>
       new Response(
         JSON.stringify({
+          id: "msg_test",
+          type: "message",
+          role: "assistant",
+          model: "claude-haiku-4-5",
           content: [{ type: "text", text: "not-json-at-all" }],
-          usage: { input_tokens: 10, output_tokens: 0 },
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
         }),
         { status: 200, headers: { "content-type": "application/json" } },
       );
@@ -294,11 +309,18 @@ describe("parseTransactionMessage", () => {
         apiKey: "test-key",
         fetchImpl,
       }),
-    ).rejects.toThrow("invalid JSON");
+    ).rejects.toThrow(/parse|JSON/i);
   });
 
-  it("throws on API error", async () => {
-    const fetchImpl: typeof fetch = async () => new Response("rate limit", { status: 429 });
+  it("rethrows typed Anthropic.RateLimitError on 429", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({
+          type: "error",
+          error: { type: "rate_limit_error", message: "rate limit" },
+        }),
+        { status: 429, headers: { "content-type": "application/json" } },
+      );
 
     await expect(
       parseTransactionMessage({
@@ -307,6 +329,6 @@ describe("parseTransactionMessage", () => {
         apiKey: "test-key",
         fetchImpl,
       }),
-    ).rejects.toThrow("Anthropic API error 429");
+    ).rejects.toBeInstanceOf(Anthropic.RateLimitError);
   });
 });

--- a/src/lib/ai/transaction-nlu.ts
+++ b/src/lib/ai/transaction-nlu.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { callClaude, type SystemPromptBlock } from "@/lib/ai/anthropic-client";
 
 export type NluAccountOption = {
   id: number;
@@ -39,7 +40,7 @@ export type NluResult = {
   usage: { inputTokens: number; outputTokens: number };
 };
 
-const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+const DEFAULT_MODEL = "claude-haiku-4-5";
 
 // All optional fields use `.nullish()` (accepts null OR undefined) because
 // Claude routinely returns explicit `"field": null` for absent values instead
@@ -70,40 +71,16 @@ function formatBogotaDate(now: Date): string {
   return `${y}-${m}-${day}`;
 }
 
-function buildPrompt(text: string, ctx: NluContext): string {
-  const today = formatBogotaDate(ctx.now);
-  const accList = ctx.accounts
-    .map((a) => {
-      const last4Part = a.last4s?.length ? ` — termina en ${a.last4s.join(", ")}` : "";
-      return `- id=${a.id}: ${a.name} (${a.institution}, ${a.currency})${last4Part}`;
-    })
-    .join("\n");
-
-  const catList = ctx.categories
-    .map((c) => (c.parentSlug ? `- ${c.slug} (sub de ${c.parentSlug})` : `- ${c.slug}`))
-    .join("\n");
-
-  return `Sos un parser de transacciones financieras personales para un usuario colombiano. Extraés datos estructurados de mensajes en español informal.
-
-Hoy es ${today} (America/Bogota, UTC-5). Moneda default: COP.
-
-Cuentas disponibles:
-${accList}
-
-Categorías disponibles (usá el slug EXACTO):
-${catList}
-
-Mensaje del usuario:
-"""
-${text}
-"""
+// Stable across every user, every request — the parsing rules and output
+// format. First system block so it sits at the front of the cache prefix.
+const NLU_RULES = `Sos un parser de transacciones financieras personales para un usuario colombiano. Extraés datos estructurados de mensajes en español informal.
 
 Reglas de parsing:
 - "45k", "45 mil", "45K" = 45000. "2 millones", "2M" = 2000000. "450 lucas" = 450000.
 - Separador decimal colombiano = coma (45,50 = 45.50). Puntos son separadores de miles: "45.000" = 45000, "1.234.567" = 1234567.
 - amountCents: multiplicá el valor monetario por 100 y devolvelo como STRING de dígitos (ej: 45000 pesos → "4500000"; 1.50 USD → "150").
 - direction: "expense" por default. "income" sólo si dice "me pagaron", "ingresó", "me llegó", "sueldo", "me transfirieron", "recibí", "cobré".
-- occurredOn (YYYY-MM-DD): resolvé "hoy"/"ayer"/"anteayer"/"el viernes"/"hace 3 días" relativo a ${today}. Si no hay señal temporal → null.
+- occurredOn (YYYY-MM-DD): resolvé "hoy"/"ayer"/"anteayer"/"el viernes"/"hace 3 días" relativo al día actual provisto por el usuario. Si no hay señal temporal → null.
 - accountId: devolvé un id SOLO si el mensaje identifica la cuenta de forma inequívoca (por nombre, institución o últimos 4 dígitos). Si dice "la visa" y hay 2 visas → null. Si dice "*2575" → buscar por last4.
 - categorySlug: devolvé un slug SOLO con señal fuerte (ej: "pagué en el restaurante" → "restaurantes"; "uber" → "transporte_uber_didi" si existe, si no "transporte"). Ante duda → null (el pipeline usará rules+AI después).
 - currency: COP por default. USD sólo si dice explícitamente "dólares", "USD", "$USD", o la cuenta elegida es USD.
@@ -112,26 +89,27 @@ Reglas de parsing:
 - confidence: 0-100. Bajá si falta monto, si la dirección es ambigua, si hay múltiples interpretaciones.
 - notes: opcional, ≤200 chars. Usalo si hay algo raro o ambiguo que el usuario debería confirmar.
 
-Devolvé SOLO JSON válido (sin markdown, sin prosa, sin fences):
-{
-  "amountCents": "<digits-or-null>",
-  "currency": "COP" | "USD" | null,
-  "direction": "expense" | "income" | null,
-  "merchant": "<string-or-null>",
-  "description": "<string-or-null>",
-  "occurredOn": "YYYY-MM-DD" | null,
-  "accountId": <number-or-null>,
-  "categorySlug": "<slug-or-null>",
-  "confidence": <0-100>,
-  "notes": "<optional-string>"
-}`;
-}
+Devolvé un objeto con estos campos: amountCents (string-or-null), currency ("COP"|"USD"|null), direction ("expense"|"income"|null), merchant (string-or-null), description (string-or-null), occurredOn (YYYY-MM-DD-or-null), accountId (number-or-null), categorySlug (string-or-null), confidence (0-100), notes (optional string).`;
 
-function extractJson(text: string): unknown {
-  const trimmed = text.trim();
-  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  const candidate = fenced ? fenced[1] : trimmed;
-  return JSON.parse(candidate);
+function buildUserContextBlock(ctx: NluContext): string {
+  const today = formatBogotaDate(ctx.now);
+  const accList = ctx.accounts
+    .map((a) => {
+      const last4Part = a.last4s?.length ? ` — termina en ${a.last4s.join(", ")}` : "";
+      return `- id=${a.id}: ${a.name} (${a.institution}, ${a.currency})${last4Part}`;
+    })
+    .join("\n");
+  const catList = ctx.categories
+    .map((c) => (c.parentSlug ? `- ${c.slug} (sub de ${c.parentSlug})` : `- ${c.slug}`))
+    .join("\n");
+
+  return `Hoy es ${today} (America/Bogota, UTC-5). Moneda default: COP.
+
+Cuentas disponibles:
+${accList}
+
+Categorías disponibles (usá el slug EXACTO):
+${catList}`;
 }
 
 export async function parseTransactionMessage(opts: {
@@ -141,47 +119,26 @@ export async function parseTransactionMessage(opts: {
   apiKey?: string;
   fetchImpl?: typeof fetch;
 }): Promise<NluResult> {
-  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
+  // Two system blocks: the global rules (identical across every call —
+  // biggest cache win) and the user-specific context (accounts + categories
+  // + today's date — stable per user per day). Both marked cacheControl so
+  // the SDK places a cache_control breakpoint on each.
+  const system: SystemPromptBlock[] = [
+    { text: NLU_RULES, cacheControl: true },
+    { text: buildUserContextBlock(opts.context), cacheControl: true },
+  ];
 
-  const model = opts.model ?? DEFAULT_MODEL;
-  const doFetch = opts.fetchImpl ?? fetch;
-  const prompt = buildPrompt(opts.text, opts.context);
-
-  const res = await doFetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-    },
-    body: JSON.stringify({
-      model,
-      max_tokens: 512,
-      messages: [{ role: "user", content: prompt }],
-    }),
+  const result = await callClaude({
+    system,
+    userPrompt: opts.text,
+    schema: nluResponseSchema,
+    model: opts.model ?? DEFAULT_MODEL,
+    maxTokens: 512,
+    apiKey: opts.apiKey,
+    fetchImpl: opts.fetchImpl,
   });
 
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`Anthropic API error ${res.status}: ${body.slice(0, 300)}`);
-  }
-
-  const payload = (await res.json()) as {
-    content: Array<{ type: string; text?: string }>;
-    usage?: { input_tokens: number; output_tokens: number };
-  };
-
-  const textBlock = payload.content?.find((c) => c.type === "text")?.text ?? "";
-  let parsedJson: unknown;
-  try {
-    parsedJson = extractJson(textBlock);
-  } catch {
-    throw new Error("NLU model returned invalid JSON");
-  }
-
-  const parsed = nluResponseSchema.parse(parsedJson);
-
+  const parsed = result.data;
   const validAccountIds = new Set(opts.context.accounts.map((a) => a.id));
   const validCategorySlugs = new Set(opts.context.categories.map((c) => c.slug));
   // Normalize `undefined` to `null` so downstream consumers only handle one
@@ -204,10 +161,7 @@ export async function parseTransactionMessage(opts: {
 
   return {
     draft,
-    model,
-    usage: {
-      inputTokens: payload.usage?.input_tokens ?? 0,
-      outputTokens: payload.usage?.output_tokens ?? 0,
-    },
+    model: result.model,
+    usage: { inputTokens: result.usage.inputTokens, outputTokens: result.usage.outputTokens },
   };
 }


### PR DESCRIPTION
Closes #331. Follow-up to #257's centralized Anthropic client.

## Summary

Three commits, one cohesive cleanup:

1. **\`callClaudeText\` sibling** — new prose-path helper on \`src/lib/ai/anthropic-client.ts\`. \`callClaude\` needs a Zod schema (uses \`messages.parse()\` + \`output_config.format\`); \`callClaudeText\` uses \`messages.create()\` and returns concatenated text blocks. Shares the same cache_control support, typed errors, and \`fetchImpl\` seam via extracted helpers (\`buildClient\`, \`systemField\`, \`extractUsage\`, \`runWithErrorHandling\`).
2. **Migrate \`generateInsightsReport\`** — splits the single inlined prompt into a cached system block (task framing + output rules) and a volatile user block (the month's JSON summary). Sonnet 4.6 stays; 3000 max_tokens stays.
3. **Migrate \`parseTransactionMessage\`** — three-block structure: stable rules (cache_control), per-user accounts+categories (cache_control), and the user's raw message (uncached). Drops hand-rolled \`extractJson\` + manual \`parse\`. Haiku 4.5 stays.

All four fetch-based Claude callsites in the repo (classify + shadow canary shipped in #257, insights + NLU in this PR) now go through the single \`src/lib/ai/anthropic-client.ts\` entry.

## Why it matters

- **Prompt caching enabled where it pays off.** NLU especially: users sending multiple bot messages in the same day hit the cached rules + accounts/categories prefix on every call after the first. Per AI Strategy memory, this is the single biggest cost lever.
- **Typed errors.** Callers can branch on \`Anthropic.RateLimitError\` vs \`APIError\` instead of string-matching our own hand-rolled messages — matches what's already live in the SMS AI fallback path.
- **Consistency.** No more divergent header construction, JSON extraction, or error-format drift between modules. Future AI features have exactly one client to adopt.

## Test coverage

- 4 new tests for \`callClaudeText\` (cache_control, typed errors, empty-response rejection, text + usage extraction).
- 2 existing NLU tests updated for the SDK's new error surfaces (structured-output parse error, typed \`Anthropic.RateLimitError\`).
- Insights tests: no changes needed — the \`fetchImpl\` seam flows through unchanged.
- **622/622 tests pass. Typecheck clean. Lint clean.**

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bun run lint\`
- [x] \`bun run test\`
- [ ] CI passes (GitHub Actions)
- [ ] Post-merge spot check: monitor \`cache_read_input_tokens\` in Anthropic dashboard for insights + NLU — should see cache reads appear on 2nd+ call for the same user.