### PR TITLE
feat(observability): log parse_outcome_success/skip to parser_events (#329)

### DIFF
--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -815,6 +815,8 @@ export type CanaryProjection = {
 // attempt. `regex_outcome` is the serialized ParseResult; `ai_outcome`
 // captures the AI response shape (+ error detail in the failure kinds).
 export const PARSER_EVENT_KINDS = [
+  "parse_outcome_success", // regex parser matched a known shape → ingest attempted
+  "parse_outcome_skip", // SMS intentionally skipped (failed/non-transactional); NOT a failure
   "parse_needs_review", // regex failed, AI fallback not invoked (kill-switch / disabled)
   "ai_fallback_success", // AI parsed, confidence ≥ threshold → ingested
   "ai_fallback_low_confidence", // AI parsed, below threshold → inbox

--- a/src/lib/ingestion/sms-ai-fallback.ts
+++ b/src/lib/ingestion/sms-ai-fallback.ts
@@ -256,3 +256,39 @@ export async function recordParserEvent(params: {
     log.error({ err, event: "parser_event_insert_failed" }, "parser_events insert failed");
   }
 }
+
+// Telemetry for the regex happy path. Non-blocking — telemetry failure
+// must never break ingestion. Emitted BEFORE ingest so the SLO denominator
+// counts "SMS we could understand" independent of DB-insert outcome.
+export async function recordParseSuccess(params: {
+  userId: number;
+  regexOutcome: Record<string, unknown>;
+}): Promise<void> {
+  try {
+    await db.insert(parserEvents).values({
+      userId: params.userId,
+      source: "sms",
+      eventKind: "parse_outcome_success",
+      regexOutcome: params.regexOutcome,
+      latencyMs: 0,
+    });
+  } catch (err) {
+    log.error({ err, event: "parser_event_insert_failed" }, "parser_events insert failed");
+  }
+}
+
+// Telemetry for the skip path (OTP, promo, failed-tx notifications).
+// Skips are excluded from the SLO denominator — not failures. Non-blocking.
+export async function recordParseSkip(params: { userId: number; reason: string }): Promise<void> {
+  try {
+    await db.insert(parserEvents).values({
+      userId: params.userId,
+      source: "sms",
+      eventKind: "parse_outcome_skip",
+      regexOutcome: { kind: "skip", reason: params.reason },
+      latencyMs: 0,
+    });
+  } catch (err) {
+    log.error({ err, event: "parser_event_insert_failed" }, "parser_events insert failed");
+  }
+}

--- a/src/lib/ingestion/sms-pipeline.test.ts
+++ b/src/lib/ingestion/sms-pipeline.test.ts
@@ -5,10 +5,12 @@ import { accounts, parserEvents, transactions, users } from "@/lib/db/schema";
 import { ingestParsed } from "./sms-pipeline";
 import type { ParseResult } from "./sms-bancolombia";
 
-// Covers the AI-fallback branch added in #257. The regex-pass path is
-// exercised indirectly through the existing SMS route + parser tests; this
-// file focuses on the new needs_review flow with the three terminal
-// outcomes: disabled, success, low_confidence.
+// Covers parser telemetry to parser_events:
+//   - #257 AI-fallback branch: parse_needs_review (disabled), ai_fallback_success,
+//     ai_fallback_low_confidence.
+//   - #329 PR1 parse-outcome logging: parse_outcome_success (regex happy path),
+//     parse_outcome_skip (non-transactional SMS). Pre-requisite for migrating
+//     SLO #1 to compute from parser_events.
 
 const TAG = "+pipeline-test@findash.local";
 
@@ -186,5 +188,104 @@ describe("ingestParsed — needs_review + AI fallback", () => {
     const [ev] = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
     expect(ev.eventKind).toBe("ai_fallback_low_confidence");
     expect(ev.aiConfidence).toBe("0.200");
+  });
+});
+
+describe("ingestParsed — parse outcome telemetry (#329 PR1)", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("records parse_outcome_skip for skip inputs and creates no tx", async () => {
+    const { userId } = await setupUserWithAccount(undefined);
+
+    const skipInput: ParseResult = {
+      kind: "skip",
+      reason: "non_transactional",
+      raw: "Bancolombia: Tu código de verificación es 123456",
+    };
+    const outcome = await ingestParsed(userId, skipInput);
+
+    expect(outcome.status).toBe("skipped");
+
+    const txs = await db.select().from(transactions).where(eq(transactions.userId, userId));
+    expect(txs).toHaveLength(0);
+
+    const events = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
+    expect(events).toHaveLength(1);
+    expect(events[0].eventKind).toBe("parse_outcome_skip");
+    expect(events[0].aiModel).toBeNull();
+    expect(events[0].aiConfidence).toBeNull();
+    const regex = events[0].regexOutcome as Record<string, unknown>;
+    expect(regex.kind).toBe("skip");
+    expect(regex.reason).toBe("non_transactional");
+  });
+
+  it("records parse_outcome_success for the regex happy path and inserts the tx", async () => {
+    const { userId, accountId } = await setupUserWithAccount(undefined);
+
+    const purchaseInput: ParseResult = {
+      kind: "purchase",
+      amountCents: BigInt(4500000),
+      currency: "COP",
+      merchant: "RAPPI",
+      cardLast4: "2575",
+      cardKind: "credit",
+      occurredOn: "2026-04-15",
+      occurredTime: "19:30",
+      externalId: "bcol-sms:regex-happy-path-test",
+      raw: "Bancolombia: Compraste $45.000,00 en RAPPI con tu T.Cred *2575, el 15/04/2026 19:30",
+    };
+
+    const outcome = await ingestParsed(userId, purchaseInput);
+
+    expect(outcome.status).toBe("inserted");
+    if (outcome.status !== "inserted") throw new Error("type guard");
+    // The AI-fallback path tags inserts with via=ai_fallback; regex path leaves it undefined.
+    expect(outcome.via).toBeUndefined();
+
+    const [tx] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.userId, userId))
+      .limit(1);
+    expect(tx.accountId).toBe(accountId);
+    expect(tx.amountCents).toBe(BigInt("-4500000"));
+
+    const events = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
+    expect(events).toHaveLength(1);
+    expect(events[0].eventKind).toBe("parse_outcome_success");
+    expect(events[0].aiModel).toBeNull();
+    expect(events[0].aiConfidence).toBeNull();
+    const regex = events[0].regexOutcome as Record<string, unknown>;
+    expect(regex.kind).toBe("purchase");
+    expect(regex.merchant).toBe("RAPPI");
+    // serializeParsed stringifies bigint for jsonb safety.
+    expect(regex.amountCents).toBe("4500000");
+  });
+
+  it("emits parse_outcome_success even if account routing fails (parse succeeded, ingest failed)", async () => {
+    const { userId } = await setupUserWithAccount(undefined);
+
+    // cardLast4=9999 has no matching account → ingestParsedSms returns error,
+    // but the regex parse itself succeeded and must still count in the SLO.
+    const purchaseInput: ParseResult = {
+      kind: "purchase",
+      amountCents: BigInt(1000000),
+      currency: "COP",
+      merchant: "AMAZON",
+      cardLast4: "9999",
+      cardKind: "credit",
+      occurredOn: "2026-04-15",
+      occurredTime: "10:00",
+      externalId: "bcol-sms:no-account-test",
+      raw: "Bancolombia: Compraste $10.000,00 en AMAZON con tu T.Cred *9999",
+    };
+
+    const outcome = await ingestParsed(userId, purchaseInput);
+
+    expect(outcome.status).toBe("error");
+    const events = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
+    expect(events).toHaveLength(1);
+    expect(events[0].eventKind).toBe("parse_outcome_success");
   });
 });

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -14,6 +14,8 @@ import {
 import {
   aiFallbackParseSms,
   isAiFallbackEnabled,
+  recordParseSkip,
+  recordParseSuccess,
   recordParserEvent,
   type AiFallbackOutcome,
 } from "@/lib/ingestion/sms-ai-fallback";
@@ -47,6 +49,7 @@ export async function ingestParsed(
   opts?: { forceAccountId?: number; aiFallbackFetchImpl?: typeof fetch },
 ): Promise<IngestOutcome> {
   if (parsed.kind === "skip") {
+    await recordParseSkip({ userId, reason: parsed.reason });
     return { status: "skipped", reason: `parser: ${parsed.reason}` };
   }
 
@@ -57,6 +60,10 @@ export async function ingestParsed(
     return ingestNeedsReviewWithAiFallback(userId, parsed.raw, opts?.aiFallbackFetchImpl);
   }
 
+  // Regex happy path (#329 PR1). Emit telemetry BEFORE delegating so the SLO
+  // denominator counts "SMS we could understand" independent of whether the
+  // DB insert ultimately succeeds, is duplicated, or fails on routing.
+  await recordParseSuccess({ userId, regexOutcome: serializeParsed(parsed) });
   return ingestParsedSms(userId, parsed, opts?.forceAccountId);
 }
 


### PR DESCRIPTION
## Summary

PR1 of 3 for #329 — instruments the SMS happy path and skip path so `parser_events` has a complete denominator. Required before PR2 (migrating SLO #1 to compute from `parser_events` instead of `ingestion_logs`).

- Added `parse_outcome_success` and `parse_outcome_skip` to `PARSER_EVENT_KINDS` in `src/lib/db/schema.ts`. No DB migration needed — the column is `varchar(40)` and the enum is a TS-only constraint.
- `recordParseSuccess` + `recordParseSkip` helpers in `src/lib/ingestion/sms-ai-fallback.ts`, mirroring the existing `recordParserEvent` pattern: try/catch + `log.error`, telemetry failure never breaks ingestion.
- Wired both helpers into `ingestParsed` in `src/lib/ingestion/sms-pipeline.ts`. Emission for `parse_outcome_success` happens BEFORE delegating to `ingestParsedSms` so the SLO denominator counts "SMS we could understand" independently of DB-insert outcome (routing failure, dedupe, FK error).
- Tests: 3 new `it` cases in `sms-pipeline.test.ts` — skip path, happy path, and happy path with failed account routing (asserts parse_outcome_success fires even when ingest errors).

Part of #329 (PR1 of 3 — does NOT close the issue). PR2 will migrate `sloParseSuccess` to `parser_events` and add a `/admin/slos/events` drill-down. PR3 will add 48h sustained-threshold alerting.

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — green
- [x] `bun run format:check` — green
- [x] `bun run test` — 625/625 passing (3 new + existing)
- [ ] CI on this PR green
- [ ] Manual: deploy to staging, send a real purchase SMS, verify one `parser_events` row with `event_kind='parse_outcome_success'` lands