### PR TITLE
feat(observability): migrate SLO parse-success to parser_events + events drill-down (#329)

### DIFF
--- a/src/app/(app)/admin/slos/events/page.tsx
+++ b/src/app/(app)/admin/slos/events/page.tsx
@@ -1,0 +1,265 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { db } from "@/lib/db";
+import { PARSER_EVENT_KINDS, type ParserEventKind, parserEvents } from "@/lib/db/schema";
+import { getSessionUser } from "@/lib/auth/session";
+
+export const dynamic = "force-dynamic";
+
+const PAGE_SIZE = 25;
+
+// Shortcut macros for common operator queries. These are the URL contracts
+// linked from the SLO cards: /admin/slos/events?kind=failures is the default
+// drill-down for a red parse-success SLO.
+const KIND_MACROS: Record<string, readonly ParserEventKind[]> = {
+  failures: ["parse_needs_review", "ai_fallback_error", "ai_fallback_low_confidence"],
+  "ai_fallback_*": ["ai_fallback_success", "ai_fallback_low_confidence", "ai_fallback_error"],
+};
+
+function resolveKinds(kind: string | undefined): ParserEventKind[] | null {
+  if (!kind) return null;
+  if (kind in KIND_MACROS) return [...KIND_MACROS[kind]];
+  if ((PARSER_EVENT_KINDS as readonly string[]).includes(kind)) {
+    return [kind as ParserEventKind];
+  }
+  return null;
+}
+
+export default async function ParserEventsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ kind?: string; page?: string }>;
+}) {
+  const session = await getSessionUser();
+  if (session.role !== "admin") notFound();
+
+  const params = await searchParams;
+  const kinds = resolveKinds(params.kind);
+  const pageRaw = Number.parseInt(params.page ?? "1", 10);
+  const page = Number.isFinite(pageRaw) && pageRaw > 0 ? pageRaw : 1;
+  const offset = (page - 1) * PAGE_SIZE;
+
+  const where = kinds
+    ? and(eq(parserEvents.source, "sms"), inArray(parserEvents.eventKind, kinds))
+    : eq(parserEvents.source, "sms");
+
+  const [rows, [countRow]] = await Promise.all([
+    db
+      .select()
+      .from(parserEvents)
+      .where(where)
+      .orderBy(desc(parserEvents.createdAt))
+      .limit(PAGE_SIZE)
+      .offset(offset),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(parserEvents)
+      .where(where),
+  ]);
+
+  const total = countRow.count;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 sm:p-6">
+      <header className="flex flex-col gap-1">
+        <Link href="/admin/slos" className="text-muted-foreground text-xs hover:underline">
+          ← Volver a SLOs
+        </Link>
+        <h1 className="text-h1">Parser events</h1>
+        <p className="text-body text-muted-foreground">
+          Audit log per-SMS del pipeline de ingesta. Una fila por intento de parsing con regex + AI
+          fallback + raw body para debuggear casos que fallan el SLO.
+        </p>
+      </header>
+
+      <KindFilter current={params.kind} />
+
+      <div className="text-muted-foreground text-xs">
+        {total} evento{total === 1 ? "" : "s"} · página {page} de {totalPages}
+      </div>
+
+      <section className="flex flex-col gap-3">
+        {rows.length === 0 ? (
+          <p className="text-muted-foreground text-sm italic">No hay eventos con este filtro.</p>
+        ) : (
+          rows.map((ev) => <EventCard key={ev.id} event={ev} />)
+        )}
+      </section>
+
+      <Pagination page={page} totalPages={totalPages} kind={params.kind} />
+    </main>
+  );
+}
+
+function KindFilter({ current }: { current: string | undefined }) {
+  const options: { key: string; label: string }[] = [
+    { key: "", label: "Todos" },
+    { key: "failures", label: "Fallos" },
+    { key: "ai_fallback_*", label: "AI fallback" },
+    { key: "parse_outcome_success", label: "Regex success" },
+    { key: "parse_outcome_skip", label: "Skips" },
+    { key: "parse_needs_review", label: "Needs review" },
+    { key: "ai_fallback_success", label: "AI success" },
+    { key: "ai_fallback_low_confidence", label: "AI low conf" },
+    { key: "ai_fallback_error", label: "AI error" },
+  ];
+  return (
+    <nav className="flex flex-wrap items-center gap-1 text-xs">
+      <span className="text-muted-foreground mr-1">Kind:</span>
+      {options.map((opt) => {
+        const active = (current ?? "") === opt.key;
+        const href = opt.key ? `?kind=${encodeURIComponent(opt.key)}` : "?";
+        return (
+          <Link
+            key={opt.key}
+            href={href}
+            className={
+              active
+                ? "bg-foreground text-background rounded px-2 py-1 font-medium"
+                : "text-muted-foreground hover:text-foreground rounded px-2 py-1"
+            }
+          >
+            {opt.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+function Pagination({
+  page,
+  totalPages,
+  kind,
+}: {
+  page: number;
+  totalPages: number;
+  kind: string | undefined;
+}) {
+  if (totalPages <= 1) return null;
+  const suffix = kind ? `&kind=${encodeURIComponent(kind)}` : "";
+  return (
+    <nav className="flex items-center justify-center gap-2 text-xs">
+      {page > 1 ? (
+        <Link
+          href={`?page=${page - 1}${suffix}`}
+          className="hover:bg-muted rounded border px-2 py-1"
+        >
+          ← Anterior
+        </Link>
+      ) : null}
+      <span className="text-muted-foreground">
+        página {page} / {totalPages}
+      </span>
+      {page < totalPages ? (
+        <Link
+          href={`?page=${page + 1}${suffix}`}
+          className="hover:bg-muted rounded border px-2 py-1"
+        >
+          Siguiente →
+        </Link>
+      ) : null}
+    </nav>
+  );
+}
+
+function EventCard({ event }: { event: typeof parserEvents.$inferSelect }) {
+  const regexOutcome = (event.regexOutcome ?? {}) as Record<string, unknown>;
+  const aiOutcome = (event.aiOutcome ?? {}) as Record<string, unknown>;
+  const raw = typeof regexOutcome.raw === "string" ? regexOutcome.raw : null;
+  const hasAi = Object.keys(aiOutcome).length > 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            <span className="tabular-nums">{event.createdAt.toISOString()}</span>
+            <KindBadge kind={event.eventKind} />
+          </CardTitle>
+          <span className="text-muted-foreground text-[10px] tabular-nums">
+            id {event.id} · user {event.userId ?? "—"} · {event.source}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {raw ? (
+          <div className="flex flex-col gap-1">
+            <span className="text-muted-foreground text-[10px] tracking-wide uppercase">
+              Raw SMS
+            </span>
+            <pre className="bg-muted/30 rounded p-2 text-xs break-words whitespace-pre-wrap">
+              {raw}
+            </pre>
+          </div>
+        ) : null}
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <div className="flex flex-col gap-1">
+            <span className="text-muted-foreground text-[10px] tracking-wide uppercase">
+              Regex outcome
+            </span>
+            <JsonBlock data={regexOutcome} />
+          </div>
+          {hasAi ? (
+            <div className="flex flex-col gap-1">
+              <span className="text-muted-foreground text-[10px] tracking-wide uppercase">
+                AI outcome
+              </span>
+              <JsonBlock data={aiOutcome} />
+            </div>
+          ) : null}
+        </div>
+
+        {event.aiModel ||
+        event.aiConfidence ||
+        event.aiInputTokens != null ||
+        event.latencyMs != null ? (
+          <div className="text-muted-foreground flex flex-wrap gap-3 text-[10px]">
+            {event.aiModel ? <span>model: {event.aiModel}</span> : null}
+            {event.aiConfidence ? <span>confidence: {event.aiConfidence}</span> : null}
+            {event.aiInputTokens != null ? (
+              <span>
+                tokens: {event.aiInputTokens}→{event.aiOutputTokens ?? 0}
+              </span>
+            ) : null}
+            {event.latencyMs != null ? <span>latency: {event.latencyMs}ms</span> : null}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+const KIND_STYLES: Record<ParserEventKind, string> = {
+  parse_outcome_success:
+    "bg-emerald-100 text-emerald-900 dark:bg-emerald-950/50 dark:text-emerald-200",
+  parse_outcome_skip: "bg-muted text-muted-foreground",
+  parse_needs_review: "bg-amber-100 text-amber-900 dark:bg-amber-950/50 dark:text-amber-200",
+  ai_fallback_success: "bg-blue-100 text-blue-900 dark:bg-blue-950/50 dark:text-blue-200",
+  ai_fallback_low_confidence:
+    "bg-amber-100 text-amber-900 dark:bg-amber-950/50 dark:text-amber-200",
+  ai_fallback_error: "bg-red-100 text-red-900 dark:bg-red-950/50 dark:text-red-200",
+};
+
+function KindBadge({ kind }: { kind: ParserEventKind }) {
+  const style = KIND_STYLES[kind];
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${style}`}
+    >
+      {kind}
+    </span>
+  );
+}
+
+function JsonBlock({ data }: { data: Record<string, unknown> }) {
+  return (
+    <pre className="bg-muted/30 overflow-x-auto rounded p-2 text-[11px] leading-tight">
+      {JSON.stringify(data, null, 2)}
+    </pre>
+  );
+}

--- a/src/lib/ingestion/sms-ai-fallback.ts
+++ b/src/lib/ingestion/sms-ai-fallback.ts
@@ -279,13 +279,17 @@ export async function recordParseSuccess(params: {
 
 // Telemetry for the skip path (OTP, promo, failed-tx notifications).
 // Skips are excluded from the SLO denominator — not failures. Non-blocking.
-export async function recordParseSkip(params: { userId: number; reason: string }): Promise<void> {
+export async function recordParseSkip(params: {
+  userId: number;
+  reason: string;
+  raw: string;
+}): Promise<void> {
   try {
     await db.insert(parserEvents).values({
       userId: params.userId,
       source: "sms",
       eventKind: "parse_outcome_skip",
-      regexOutcome: { kind: "skip", reason: params.reason },
+      regexOutcome: { kind: "skip", reason: params.reason, raw: params.raw },
       latencyMs: 0,
     });
   } catch (err) {

--- a/src/lib/ingestion/sms-pipeline.test.ts
+++ b/src/lib/ingestion/sms-pipeline.test.ts
@@ -110,6 +110,9 @@ describe("ingestParsed — needs_review + AI fallback", () => {
     expect(events).toHaveLength(1);
     expect(events[0].eventKind).toBe("parse_needs_review");
     expect(events[0].aiModel).toBeNull();
+    // Raw SMS is persisted for drill-down debugging (#329 PR2).
+    const regex = events[0].regexOutcome as Record<string, unknown>;
+    expect(regex.raw).toBe(rawSms);
   });
 
   it("creates tx + records ai_fallback_success on high-confidence AI output", async () => {
@@ -218,6 +221,8 @@ describe("ingestParsed — parse outcome telemetry (#329 PR1)", () => {
     const regex = events[0].regexOutcome as Record<string, unknown>;
     expect(regex.kind).toBe("skip");
     expect(regex.reason).toBe("non_transactional");
+    // Raw SMS is persisted for drill-down debugging (#329 PR2).
+    expect(regex.raw).toBe(skipInput.raw);
   });
 
   it("records parse_outcome_success for the regex happy path and inserts the tx", async () => {

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -49,7 +49,7 @@ export async function ingestParsed(
   opts?: { forceAccountId?: number; aiFallbackFetchImpl?: typeof fetch },
 ): Promise<IngestOutcome> {
   if (parsed.kind === "skip") {
-    await recordParseSkip({ userId, reason: parsed.reason });
+    await recordParseSkip({ userId, reason: parsed.reason, raw: parsed.raw });
     return { status: "skipped", reason: `parser: ${parsed.reason}` };
   }
 
@@ -72,7 +72,11 @@ async function ingestNeedsReviewWithAiFallback(
   rawBody: string,
   fetchImpl: typeof fetch | undefined,
 ): Promise<IngestOutcome> {
-  const regexOutcome = { kind: "needs_review" as const, reason: "unknown_pattern" as const };
+  const regexOutcome = {
+    kind: "needs_review" as const,
+    reason: "unknown_pattern" as const,
+    raw: rawBody,
+  };
   const enabled = await isAiFallbackEnabled(userId);
 
   if (!enabled) {
@@ -404,7 +408,7 @@ function buildTxFields(parsed: ParsedSms): {
 
 export function serializeParsed(parsed: ParseResult): Record<string, unknown> {
   if (parsed.kind === "skip" || parsed.kind === "needs_review") {
-    return { kind: parsed.kind, reason: parsed.reason };
+    return { kind: parsed.kind, reason: parsed.reason, raw: parsed.raw };
   }
   return {
     ...parsed,

--- a/src/lib/telemetry/slos.test.ts
+++ b/src/lib/telemetry/slos.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, ingestionLogs, transactions } from "@/lib/db/schema";
+import {
+  accounts,
+  ingestionLogs,
+  parserEvents,
+  type ParserEventKind,
+  transactions,
+} from "@/lib/db/schema";
 import {
   sloClassificationRate,
   sloDataLoss,
@@ -23,6 +29,7 @@ const ago = (days: number, hours = 0) =>
 async function cleanup() {
   await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE '__slos_test_tx__%'`);
   await db.execute(sql`DELETE FROM ingestion_logs WHERE user_id = ${TEST_USER_ID}`);
+  await db.execute(sql`DELETE FROM parser_events WHERE user_id = ${TEST_USER_ID}`);
   await db.execute(sql`DELETE FROM accounts WHERE name = ${TEST_ACCOUNT}`);
 }
 
@@ -60,6 +67,21 @@ async function seedTx(opts: {
   });
 }
 
+async function seedParserEvent(opts: {
+  eventKind: ParserEventKind;
+  createdAt: Date;
+  source?: "sms" | "apple_pay" | "other";
+}): Promise<void> {
+  await db.insert(parserEvents).values({
+    userId: TEST_USER_ID,
+    source: opts.source ?? "sms",
+    eventKind: opts.eventKind,
+    regexOutcome: { kind: "slo-test", raw: "slo-test-sms" },
+    latencyMs: 0,
+    createdAt: opts.createdAt,
+  });
+}
+
 async function seedLog(opts: {
   source: "sms" | "csv" | "apple_pay" | "manual" | "telegram";
   status: "inserted" | "duplicated" | "error" | "skipped";
@@ -83,40 +105,66 @@ async function seedLog(opts: {
   return row.id;
 }
 
-describe("sloParseSuccess", () => {
+describe("sloParseSuccess — from parser_events (#329 PR2)", () => {
   beforeEach(cleanup);
   afterEach(cleanup);
 
-  it("green when success rate ≥ 95%", async () => {
-    for (let i = 0; i < 19; i++)
-      await seedLog({ source: "sms", status: "inserted", startedAt: ago(1) });
-    await seedLog({ source: "sms", status: "error", startedAt: ago(1) });
+  it("green when (regex_success + ai_fallback_success) / total ≥ 95%", async () => {
+    for (let i = 0; i < 18; i++)
+      await seedParserEvent({ eventKind: "parse_outcome_success", createdAt: ago(1) });
+    await seedParserEvent({ eventKind: "ai_fallback_success", createdAt: ago(1) });
+    await seedParserEvent({ eventKind: "ai_fallback_error", createdAt: ago(1) });
 
     const r = await sloParseSuccess(30, NOW);
     expect(r.raw).toBeCloseTo(0.95, 5);
     expect(r.status).toBe("green");
-    expect(r.drilldown).toBe("/settings/inbox");
+    expect(r.drilldown).toBe("/admin/slos/events?kind=failures");
   });
 
-  it("red when success rate <95% by more than 5%", async () => {
+  it("red when more than 5% below target", async () => {
     for (let i = 0; i < 5; i++)
-      await seedLog({ source: "sms", status: "error", startedAt: ago(1) });
+      await seedParserEvent({ eventKind: "parse_needs_review", createdAt: ago(1) });
     for (let i = 0; i < 5; i++)
-      await seedLog({ source: "sms", status: "inserted", startedAt: ago(1) });
+      await seedParserEvent({ eventKind: "parse_outcome_success", createdAt: ago(1) });
 
     const r = await sloParseSuccess(30, NOW);
     expect(r.raw).toBeCloseTo(0.5, 5);
     expect(r.status).toBe("red");
   });
 
-  it("excludes ai-classify and debug-capture rows", async () => {
-    await seedLog({ source: "sms", status: "inserted", startedAt: ago(1) });
-    await seedLog({ source: "manual", status: "inserted", startedAt: ago(1), kind: "ai-classify" });
-    await seedLog({
+  it("excludes parse_outcome_skip from denominator — skips are not failures", async () => {
+    await seedParserEvent({ eventKind: "parse_outcome_success", createdAt: ago(1) });
+    for (let i = 0; i < 10; i++)
+      await seedParserEvent({ eventKind: "parse_outcome_skip", createdAt: ago(1) });
+
+    const r = await sloParseSuccess(30, NOW);
+    // 1/1, not 1/11 — the 10 skips never enter the denominator.
+    expect(r.raw).toBe(1);
+  });
+
+  it("AI fallback success counts as parse success", async () => {
+    await seedParserEvent({ eventKind: "ai_fallback_success", createdAt: ago(1) });
+    await seedParserEvent({ eventKind: "parse_needs_review", createdAt: ago(1) });
+
+    const r = await sloParseSuccess(30, NOW);
+    expect(r.raw).toBe(0.5);
+  });
+
+  it("AI fallback low-confidence and error count as failures", async () => {
+    await seedParserEvent({ eventKind: "parse_outcome_success", createdAt: ago(1) });
+    await seedParserEvent({ eventKind: "ai_fallback_low_confidence", createdAt: ago(1) });
+    await seedParserEvent({ eventKind: "ai_fallback_error", createdAt: ago(1) });
+
+    const r = await sloParseSuccess(30, NOW);
+    expect(r.raw).toBeCloseTo(1 / 3, 5);
+  });
+
+  it("filters by source=sms — apple_pay events do not pollute the SMS SLO", async () => {
+    await seedParserEvent({ eventKind: "parse_outcome_success", createdAt: ago(1) });
+    await seedParserEvent({
+      eventKind: "parse_needs_review",
+      createdAt: ago(1),
       source: "apple_pay",
-      status: "error",
-      startedAt: ago(1),
-      kind: "debug-capture",
     });
 
     const r = await sloParseSuccess(30, NOW);
@@ -131,9 +179,22 @@ describe("sloParseSuccess", () => {
   });
 
   it("trend has one point per day in the window", async () => {
-    await seedLog({ source: "sms", status: "inserted", startedAt: ago(1) });
+    await seedParserEvent({ eventKind: "parse_outcome_success", createdAt: ago(1) });
     const r = await sloParseSuccess(7, NOW);
     expect(r.trend).toHaveLength(7);
+  });
+
+  it("description surfaces the regex/AI/failure breakdown", async () => {
+    for (let i = 0; i < 8; i++)
+      await seedParserEvent({ eventKind: "parse_outcome_success", createdAt: ago(1) });
+    await seedParserEvent({ eventKind: "ai_fallback_success", createdAt: ago(1) });
+    await seedParserEvent({ eventKind: "parse_needs_review", createdAt: ago(1) });
+
+    const r = await sloParseSuccess(30, NOW);
+    expect(r.description).toMatch(/regex 8/);
+    expect(r.description).toMatch(/AI 1/);
+    expect(r.description).toMatch(/fallos 1/);
+    expect(r.description).toMatch(/10 intentos/);
   });
 });
 

--- a/src/lib/telemetry/slos.ts
+++ b/src/lib/telemetry/slos.ts
@@ -1,6 +1,6 @@
-import { and, eq, gte, isNull, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, isNull, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { ingestionLogs, transactions } from "@/lib/db/schema";
+import { ingestionLogs, parserEvents, transactions } from "@/lib/db/schema";
 
 // Bancolombia Parser SLOs (PLAN.md §"Bancolombia Parser SLOs"). System-wide
 // aggregates across all users — NOT per-user (that is /admin/health).
@@ -62,12 +62,21 @@ function statusFor(raw: number | null, target: number, higherIsBetter: boolean):
 
 // ---------------------------------------------------------------------------
 // SLO #1 — SMS parse success rate (target ≥ 95%)
+//
+// Computed from `parser_events` (#329 PR2). One row per SMS ingest attempt.
+// Numerator: regex-success + AI-fallback-success (we extracted a tx).
+// Denominator: all parse attempts excluding intentional skips (OTPs, promos,
+// failed-tx notifications are NOT parser failures).
 // ---------------------------------------------------------------------------
 
-/**
- * Aggregates across ALL users, filters out ai-classify + debug-capture rows
- * (same semantics as `computeUserHealthSnapshot`). success = inserted|duplicated.
- */
+const PARSE_SUCCESS_DENOMINATOR_KINDS = [
+  "parse_outcome_success",
+  "parse_needs_review",
+  "ai_fallback_success",
+  "ai_fallback_low_confidence",
+  "ai_fallback_error",
+] as const;
+
 export async function sloParseSuccess(
   windowDays: SloWindow,
   now: Date = new Date(),
@@ -76,30 +85,37 @@ export async function sloParseSuccess(
 
   const [row] = await db
     .select({
-      success: sql<number>`count(*) FILTER (WHERE ${ingestionLogs.status} IN ('inserted', 'duplicated'))::int`,
+      regexSuccess: sql<number>`count(*) FILTER (WHERE ${parserEvents.eventKind} = 'parse_outcome_success')::int`,
+      aiSuccess: sql<number>`count(*) FILTER (WHERE ${parserEvents.eventKind} = 'ai_fallback_success')::int`,
       total: sql<number>`count(*)::int`,
     })
-    .from(ingestionLogs)
+    .from(parserEvents)
     .where(
       and(
-        gte(ingestionLogs.startedAt, start),
-        sql`(${ingestionLogs.payload} ->> 'kind') NOT IN ('ai-classify', 'debug-capture') OR (${ingestionLogs.payload} ->> 'kind') IS NULL`,
+        gte(parserEvents.createdAt, start),
+        eq(parserEvents.source, "sms"),
+        inArray(parserEvents.eventKind, [...PARSE_SUCCESS_DENOMINATOR_KINDS]),
       ),
     );
 
-  const raw = row.total === 0 ? null : row.success / row.total;
+  const success = row.regexSuccess + row.aiSuccess;
+  const raw = row.total === 0 ? null : success / row.total;
   const trend = await dailyParseSuccessTrend(windowDays, now);
+
+  const description =
+    row.total === 0
+      ? "regex + AI fallback / intentos de parsing. Sin datos en la ventana."
+      : `regex ${row.regexSuccess} · AI ${row.aiSuccess} · fallos ${row.total - success} en ${row.total} intentos`;
 
   return {
     key: "parse_success",
     label: "SMS parse success",
-    description:
-      "Ingests terminados sin error (inserted o duplicated) / total. Excluye ai-classify y debug.",
+    description,
     target: "≥ 95%",
     display: raw === null ? "—" : percent(raw),
     raw,
     status: statusFor(raw, 0.95, true),
-    drilldown: "/settings/inbox",
+    drilldown: "/admin/slos/events?kind=failures",
     trend,
   };
 }
@@ -108,15 +124,16 @@ async function dailyParseSuccessTrend(windowDays: SloWindow, now: Date): Promise
   const start = windowStart(windowDays, now);
   const rows = await db
     .select({
-      day: sql<string>`to_char(date_trunc('day', ${ingestionLogs.startedAt} AT TIME ZONE 'America/Bogota'), 'YYYY-MM-DD')`,
-      success: sql<number>`count(*) FILTER (WHERE ${ingestionLogs.status} IN ('inserted', 'duplicated'))::int`,
+      day: sql<string>`to_char(date_trunc('day', ${parserEvents.createdAt} AT TIME ZONE 'America/Bogota'), 'YYYY-MM-DD')`,
+      success: sql<number>`count(*) FILTER (WHERE ${parserEvents.eventKind} IN ('parse_outcome_success', 'ai_fallback_success'))::int`,
       total: sql<number>`count(*)::int`,
     })
-    .from(ingestionLogs)
+    .from(parserEvents)
     .where(
       and(
-        gte(ingestionLogs.startedAt, start),
-        sql`(${ingestionLogs.payload} ->> 'kind') NOT IN ('ai-classify', 'debug-capture') OR (${ingestionLogs.payload} ->> 'kind') IS NULL`,
+        gte(parserEvents.createdAt, start),
+        eq(parserEvents.source, "sms"),
+        inArray(parserEvents.eventKind, [...PARSE_SUCCESS_DENOMINATOR_KINDS]),
       ),
     )
     .groupBy(sql`1`)


### PR DESCRIPTION
## Summary

PR2 of 3 for #329 — now that PR1 (#333) is logging every parse attempt to `parser_events`, migrate SLO #1 (SMS parse success rate) to compute from that table and ship the operator drill-down the SLO card links to.

- Rewrote `sloParseSuccess` and `dailyParseSuccessTrend` in `src/lib/telemetry/slos.ts` against `parser_events` (filtered by `source='sms'`). Numerator = `parse_outcome_success` + `ai_fallback_success`. Denominator = all kinds EXCEPT `parse_outcome_skip` — OTPs / promos / failed-tx notifications are intentional skips and must not pollute the rate.
- SLO #1 card description now surfaces the actual breakdown (`regex N · AI M · fallos X en T intentos`) so operators see the cost of each code path at a glance. Display stays as the clean percentage.
- Preserved raw SMS body in `regex_outcome` for every parser_events row (skip, needs_review, AI-fallback paths). Existing `parse_outcome_success` rows already carried `raw` via `serializeParsed`.
- New route `/admin/slos/events` (`src/app/(app)/admin/slos/events/page.tsx`) — admin-only, filterable by `kind` (single kind, `failures` macro, or `ai_fallback_*` macro), paginated 25 per page, orders by `created_at DESC`. Each card shows raw SMS + pretty-printed `regex_outcome` + `ai_outcome` (when present) + model/confidence/tokens/latency.
- SLO #1 card `drilldown` now points at `/admin/slos/events?kind=failures` — clicking a red card lands the operator on the exact rows that are dragging the rate.

Part of #329 (PR2 of 3). PR3 will add 48h sustained-threshold alerting via email + Telegram.

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — green
- [x] `bun run format:check` — green
- [x] `bun run test` — 629/629 passing (4 new SLO semantics tests + existing)
- [ ] CI on this PR green
- [ ] Manual on staging:
  - [ ] `/admin/slos` card #1 renders new description line with counts and new drill-down link
  - [ ] `/admin/slos/events` loads, all kind filters work, pagination works, raw SMS is visible
  - [ ] Non-admin user gets 404 on `/admin/slos/events`