### PR TITLE
fix(budgets): scope page queries to session user (#338)

### DIFF
--- a/src/app/(app)/budgets/page.tsx
+++ b/src/app/(app)/budgets/page.tsx
@@ -1,8 +1,5 @@
-import { aliasedTable, and, asc, eq, gte, lte, sql } from "drizzle-orm";
-import { db } from "@/lib/db";
-import { budgets, categories, transactions } from "@/lib/db/schema";
-import { notAdjustment, notDeleted } from "@/lib/db/helpers";
 import { getSessionUser } from "@/lib/auth/session";
+import { getBudgetsOverview } from "@/lib/budgets/queries";
 import { BudgetsManager } from "./budgets-manager";
 
 export const dynamic = "force-dynamic";
@@ -14,18 +11,6 @@ function currentYearMonth(): string {
   return `${y}-${m}`;
 }
 
-function monthRange(ym: string) {
-  const [y, m] = ym.split("-").map(Number);
-  const start = new Date(Date.UTC(y, m - 1, 1));
-  const end = new Date(Date.UTC(y, m, 0, 23, 59, 59));
-  return {
-    start,
-    end,
-    startIso: `${ym}-01`,
-    endIso: `${ym}-${String(new Date(Date.UTC(y, m, 0)).getUTCDate()).padStart(2, "0")}`,
-  };
-}
-
 export default async function BudgetsPage({
   searchParams,
 }: {
@@ -34,66 +19,8 @@ export default async function BudgetsPage({
   const session = await getSessionUser();
   const params = await searchParams;
   const ym = params.ym && /^\d{4}-\d{2}$/.test(params.ym) ? params.ym : currentYearMonth();
-  const { start, end, startIso } = monthRange(ym);
 
-  const [cats, rows, spentRows] = await Promise.all([
-    db
-      .select({
-        slug: categories.slug,
-        name: categories.name,
-        parentSlug: categories.parentSlug,
-      })
-      .from(categories)
-      .where(and(eq(categories.userId, session.id), notDeleted(categories.deletedAt)))
-      .orderBy(asc(categories.sortOrder), asc(categories.name)),
-    db
-      .select({
-        id: budgets.id,
-        categorySlug: budgets.categorySlug,
-        categoryName: categories.name,
-        amountCents: budgets.amountCents,
-        currency: budgets.currency,
-        periodStart: budgets.periodStart,
-        periodEnd: budgets.periodEnd,
-      })
-      .from(budgets)
-      .leftJoin(categories, eq(categories.slug, budgets.categorySlug))
-      .where(and(eq(budgets.periodStart, startIso), notDeleted(budgets.deletedAt)))
-      .orderBy(asc(categories.sortOrder), asc(categories.name)),
-    (() => {
-      const txCategory = aliasedTable(categories, "tx_category");
-      const rootSlug = sql<string | null>`COALESCE(${txCategory.parentSlug}, ${txCategory.slug})`;
-      return db
-        .select({
-          rootSlug,
-          spentCents: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
-        })
-        .from(transactions)
-        .leftJoin(txCategory, eq(txCategory.slug, transactions.categorySlug))
-        .where(
-          and(
-            gte(transactions.occurredAt, start),
-            lte(transactions.occurredAt, end),
-            notAdjustment(transactions.isAdjustment),
-          ),
-        )
-        .groupBy(rootSlug);
-    })(),
-  ]);
-
-  const spentMap = new Map<string, bigint>();
-  for (const s of spentRows) {
-    if (s.rootSlug) spentMap.set(s.rootSlug, BigInt(s.spentCents));
-  }
-
-  const items = rows.map((r) => ({
-    id: r.id,
-    categorySlug: r.categorySlug,
-    categoryName: r.categoryName ?? r.categorySlug,
-    amountCents: r.amountCents.toString(),
-    spentCents: (spentMap.get(r.categorySlug) ?? BigInt(0)).toString(),
-    currency: r.currency,
-  }));
+  const { categories: cats, items } = await getBudgetsOverview(session.id, ym);
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">

--- a/src/lib/budgets/queries.ts
+++ b/src/lib/budgets/queries.ts
@@ -1,0 +1,114 @@
+import { aliasedTable, and, asc, eq, gte, lte, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { budgets, categories, transactions } from "@/lib/db/schema";
+import { notAdjustment, notDeleted } from "@/lib/db/helpers";
+import type { Currency } from "@/lib/types";
+
+export type BudgetCategory = {
+  slug: string;
+  name: string;
+  parentSlug: string | null;
+};
+
+export type BudgetOverviewItem = {
+  id: number;
+  categorySlug: string;
+  categoryName: string;
+  amountCents: string;
+  spentCents: string;
+  currency: Currency;
+};
+
+export type BudgetsOverview = {
+  categories: BudgetCategory[];
+  items: BudgetOverviewItem[];
+};
+
+function monthRange(ym: string) {
+  const [y, m] = ym.split("-").map(Number);
+  const start = new Date(Date.UTC(y, m - 1, 1));
+  const end = new Date(Date.UTC(y, m, 0, 23, 59, 59));
+  return { start, end, startIso: `${ym}-01` };
+}
+
+export async function getBudgetsOverview(
+  userId: number,
+  yearMonth: string,
+): Promise<BudgetsOverview> {
+  const { start, end, startIso } = monthRange(yearMonth);
+
+  const [cats, rows, spentRows] = await Promise.all([
+    db
+      .select({
+        slug: categories.slug,
+        name: categories.name,
+        parentSlug: categories.parentSlug,
+      })
+      .from(categories)
+      .where(and(eq(categories.userId, userId), notDeleted(categories.deletedAt)))
+      .orderBy(asc(categories.sortOrder), asc(categories.name)),
+    db
+      .select({
+        id: budgets.id,
+        categorySlug: budgets.categorySlug,
+        categoryName: categories.name,
+        amountCents: budgets.amountCents,
+        currency: budgets.currency,
+      })
+      .from(budgets)
+      .leftJoin(
+        categories,
+        and(eq(categories.slug, budgets.categorySlug), eq(categories.userId, budgets.userId)),
+      )
+      .where(
+        and(
+          eq(budgets.userId, userId),
+          eq(budgets.periodStart, startIso),
+          notDeleted(budgets.deletedAt),
+        ),
+      )
+      .orderBy(asc(categories.sortOrder), asc(categories.name)),
+    (() => {
+      const txCategory = aliasedTable(categories, "tx_category");
+      const rootSlug = sql<string | null>`COALESCE(${txCategory.parentSlug}, ${txCategory.slug})`;
+      return db
+        .select({
+          rootSlug,
+          spentCents: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
+        })
+        .from(transactions)
+        .leftJoin(
+          txCategory,
+          and(
+            eq(txCategory.slug, transactions.categorySlug),
+            eq(txCategory.userId, transactions.userId),
+          ),
+        )
+        .where(
+          and(
+            eq(transactions.userId, userId),
+            gte(transactions.occurredAt, start),
+            lte(transactions.occurredAt, end),
+            notAdjustment(transactions.isAdjustment),
+          ),
+        )
+        .groupBy(rootSlug);
+    })(),
+  ]);
+
+  const spentMap = new Map<string, bigint>();
+  for (const s of spentRows) {
+    if (s.rootSlug) spentMap.set(s.rootSlug, BigInt(s.spentCents));
+  }
+
+  const items: BudgetOverviewItem[] = rows.map((r) => ({
+    id: r.id,
+    categorySlug: r.categorySlug,
+    categoryName: r.categoryName ?? r.categorySlug,
+    amountCents: r.amountCents.toString(),
+    spentCents: (spentMap.get(r.categorySlug) ?? BigInt(0)).toString(),
+    currency: r.currency,
+  }));
+
+  return { categories: cats, items };
+}

--- a/src/lib/tenant-isolation.test.ts
+++ b/src/lib/tenant-isolation.test.ts
@@ -26,6 +26,7 @@ import {
 import { listAccountsDetailed } from "@/lib/accounts/queries";
 import { getOpenGaps, getLinkCandidates } from "@/lib/recurring/gap-queries";
 import { getUpcomingForMonth } from "@/lib/recurring/upcoming";
+import { getBudgetsOverview } from "@/lib/budgets/queries";
 import { getSmsHealthHistory } from "@/lib/ingestion/sms-health";
 import {
   countTotal,
@@ -339,6 +340,29 @@ describe("#183 tenant isolation", () => {
     const gapBId = gapsB[0]!.gapId;
     const crossCandidates = await getLinkCandidates(userA, gapBId);
     expect(crossCandidates).toEqual([]);
+  });
+
+  // #338: /budgets page-level queries had no user_id filter on either the
+  // budgets lookup or the spent aggregation — any logged-in user saw every
+  // other user's budgeted amounts, with the "spent" totals summed across
+  // the entire tenant pool. The fixture creates identical fixtures (same
+  // slug, same period, same amount) for both users so only proper scoping
+  // can produce the correct per-user numbers.
+  it("getBudgetsOverview is scoped per user", async () => {
+    const overviewA = await getBudgetsOverview(userA, "2026-04");
+    const overviewB = await getBudgetsOverview(userB, "2026-04");
+
+    // Each user sees exactly their own single budget, not both.
+    const otrosA = overviewA.items.filter((i) => i.categorySlug === "otros");
+    const otrosB = overviewB.items.filter((i) => i.categorySlug === "otros");
+    expect(otrosA).toHaveLength(1);
+    expect(otrosB).toHaveLength(1);
+
+    // userA: -1000 + -2000 → spent 3000. userB: -3000 → spent 3000. If the
+    // spent query leaked across tenants we would see 6000 for each (or more
+    // once fanout from the slug-only JOINs compounds).
+    expect(otrosA[0].spentCents).toBe("3000");
+    expect(otrosB[0].spentCents).toBe("3000");
   });
 
   it("getUpcomingForMonth is scoped per user", async () => {


### PR DESCRIPTION
## Summary

The `/budgets` page had two inline queries in `src/app/(app)/budgets/page.tsx` that never filtered by `user_id`:

1. **Budgets lookup** — `.where(and(eq(budgets.periodStart, startIso), notDeleted(budgets.deletedAt)))` — any logged-in user saw every other user's budgeted amounts for that period.
2. **Spent aggregation** — `.where(and(gte(transactions.occurredAt, start), lte(...), notAdjustment(...)))` — the "spent" per category summed transactions across all tenants.

The two `leftJoin(categories, ...)` were also missing user_id scoping, which compounded the leak with the same slug-only fanout tracked in #336.

Latent, not exploited yet: `SELECT COUNT(*) FROM budgets GROUP BY user_id` on prod returns zero rows, so the empty state was tapping the fuga. The first budget any user creates would have activated both leaks.

## What changed

- New: `src/lib/budgets/queries.ts` — `getBudgetsOverview(userId, yearMonth)` with the same logic, now scoped by `user_id` on both WHEREs and on both category joins.
- `src/app/(app)/budgets/page.tsx` — drops the inline queries, delegates to the lib function.
- `src/lib/tenant-isolation.test.ts` — new test `getBudgetsOverview is scoped per user` that creates identical fixtures for two users and asserts each sees only their own budget and their own spent total. Fails hard against the buggy code (sees 6 items instead of 1).

## Why a separate hotfix from #336

#336 is an arithmetic/display bug (numbers inflated by JOIN fanout, display identical because of seed). This is an active tenant leak on `WHERE`s. Different severity, different blast radius — shipping this alone keeps the change small and reviewable, and unblocks #336 for a calmer audit.

## Test plan

- [x] Unit test: `bun run test src/lib/tenant-isolation.test.ts` → 14/14 pass
- [x] Full suite: `bun run test` → 58/58 files, 645/645 tests pass
- [x] Lint + typecheck clean
- [ ] Post-merge smoke: `/budgets` in prod renders empty state (current) without regression

Closes #338