### PR TITLE
fix(queries): scope categories joins by user_id to prevent fanout (#336)

### DIFF
--- a/src/lib/ai/insights.ts
+++ b/src/lib/ai/insights.ts
@@ -145,8 +145,11 @@ export async function buildInsightsSummary(
             txCount: sql<number>`COUNT(*)::int`,
           })
           .from(transactions)
-          .leftJoin(leaf, eq(leaf.slug, transactions.categorySlug))
-          .leftJoin(root, eq(root.slug, rootSlug))
+          .leftJoin(
+            leaf,
+            and(eq(leaf.slug, transactions.categorySlug), eq(leaf.userId, transactions.userId)),
+          )
+          .leftJoin(root, and(eq(root.slug, rootSlug), eq(root.userId, transactions.userId)))
           .where(
             and(
               eq(transactions.userId, userId),
@@ -167,7 +170,10 @@ export async function buildInsightsSummary(
             spent: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
           })
           .from(transactions)
-          .leftJoin(leaf, eq(leaf.slug, transactions.categorySlug))
+          .leftJoin(
+            leaf,
+            and(eq(leaf.slug, transactions.categorySlug), eq(leaf.userId, transactions.userId)),
+          )
           .where(
             and(
               eq(transactions.userId, userId),

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -124,8 +124,17 @@ export async function getCategoryBreakdown(
       sumCents: sql<string>`SUM(-${transactions.amountCents})`,
     })
     .from(transactions)
-    .leftJoin(categories, eq(categories.slug, transactions.categorySlug))
-    .leftJoin(rootCategories, eq(rootCategories.slug, rootSlug))
+    .leftJoin(
+      categories,
+      and(
+        eq(categories.slug, transactions.categorySlug),
+        eq(categories.userId, transactions.userId),
+      ),
+    )
+    .leftJoin(
+      rootCategories,
+      and(eq(rootCategories.slug, rootSlug), eq(rootCategories.userId, transactions.userId)),
+    )
     .where(
       and(
         eq(transactions.userId, userId),
@@ -195,7 +204,13 @@ export async function getTopExpenses(
     })
     .from(transactions)
     .innerJoin(accounts, eq(accounts.id, transactions.accountId))
-    .leftJoin(categories, eq(categories.slug, transactions.categorySlug))
+    .leftJoin(
+      categories,
+      and(
+        eq(categories.slug, transactions.categorySlug),
+        eq(categories.userId, transactions.userId),
+      ),
+    )
     .leftJoin(counterparties, eq(counterparties.id, transactions.counterpartyId))
     .where(
       and(

--- a/src/lib/recurring/gap-queries.ts
+++ b/src/lib/recurring/gap-queries.ts
@@ -112,7 +112,13 @@ export async function getOpenGaps(userId: number, database: DB = defaultDb): Pro
     .from(recurringGaps)
     .innerJoin(recurringTransactions, eq(recurringTransactions.id, recurringGaps.recurringId))
     .innerJoin(accounts, eq(accounts.id, recurringTransactions.accountId))
-    .leftJoin(categories, eq(categories.slug, recurringTransactions.categorySlug))
+    .leftJoin(
+      categories,
+      and(
+        eq(categories.slug, recurringTransactions.categorySlug),
+        eq(categories.userId, recurringTransactions.userId),
+      ),
+    )
     .where(eq(recurringGaps.userId, userId))
     .orderBy(asc(recurringGaps.yearMonth), asc(recurringTransactions.dayOfMonth));
 

--- a/src/lib/recurring/upcoming.ts
+++ b/src/lib/recurring/upcoming.ts
@@ -89,7 +89,13 @@ export async function getUpcomingForMonth(
     })
     .from(recurringTransactions)
     .innerJoin(accounts, eq(accounts.id, recurringTransactions.accountId))
-    .leftJoin(categories, eq(categories.slug, recurringTransactions.categorySlug))
+    .leftJoin(
+      categories,
+      and(
+        eq(categories.slug, recurringTransactions.categorySlug),
+        eq(categories.userId, recurringTransactions.userId),
+      ),
+    )
     .where(
       and(
         eq(recurringTransactions.userId, userId),

--- a/src/lib/tenant-isolation.test.ts
+++ b/src/lib/tenant-isolation.test.ts
@@ -312,9 +312,22 @@ describe("#183 tenant isolation", () => {
 
     const catA = await getCategoryBreakdown(userA, 4000, new Date("2026-04-15"));
     expect(catA.every((c) => c.amountCopCents >= BigInt(0))).toBe(true);
+    // #336: categories is per-user, but getCategoryBreakdown joined it only
+    // by slug — every user sharing the "otros" slug compounded the fanout
+    // (and rootCategories doubled it). Exact-sum assertion is what catches
+    // the bug; the correct value is userA's two expenses combined
+    // (-1000 + -2000 → 3000 positive), regardless of how many other users
+    // exist in the DB.
+    const otrosA = catA.find((c) => c.slug === "otros");
+    expect(otrosA?.amountCopCents).toBe(BigInt(3000));
+    const totalCatA = catA.reduce((s, c) => s + c.amountCopCents, BigInt(0));
+    expect(totalCatA).toBe(BigInt(3000));
 
     const topA = await getTopExpenses(userA, 4000, new Date("2026-04-15"), 10);
     expect(topA.every((t) => t.descriptionRaw.includes(`${TAG}-A`))).toBe(true);
+    // #336: the categories slug join fanout also duplicates rows in top
+    // expenses — userA has exactly 2 fixture transactions, not 4.
+    expect(topA).toHaveLength(2);
   });
 
   it("classifyByRule only sees the calling user's rules", async () => {


### PR DESCRIPTION
## Summary

`categories` is a per-user table — its unique constraint is on `(user_id, slug)`, not on `slug` alone. Several read queries joined it only by slug:

- `dashboard.getCategoryBreakdown` (joins `categories` + `rootCategories` → **N² fanout**)
- `dashboard.getTopExpenses`
- `ai.insights` (current + previous period — one double-join + one single-join)
- `recurring.gap-queries`
- `recurring.upcoming`

With three users in prod sharing the seeded slug `delivery`, every transaction matched three `categories` rows → the `getCategoryBreakdown` double-join fanned out to **9×**. That's how Alimentación showed `$501_300` when the real April total was `$55_700`.

All joins now pair the slug equality with `eq(x.userId, t.userId)`. The join is defensive: if a caller ever removes the outer `WHERE user_id` filter, the join itself still refuses cross-tenant rows.

## What changed

| File | Joins fixed |
|---|---|
| `src/lib/dashboard/queries.ts` | `categories` + `rootCategories` in `getCategoryBreakdown`; `categories` in `getTopExpenses` |
| `src/lib/ai/insights.ts` | `leaf` + `root` in current-period subquery; `leaf` in previous-period subquery |
| `src/lib/recurring/gap-queries.ts` | `categories` via `recurringTransactions.categorySlug` |
| `src/lib/recurring/upcoming.ts` | `categories` via `recurringTransactions.categorySlug` |
| `src/lib/tenant-isolation.test.ts` | Exact-sum assertion on `getCategoryBreakdown` + row-count check on `getTopExpenses` |

## Verified: 3 validation paths already safe

These three paths look up a category by slug but already filter by `user_id` in the `WHERE`:

- `src/app/(app)/transactions/actions.ts:255`
- `src/app/(app)/budgets/actions.ts:46`
- `src/app/(app)/settings/recurring/actions.ts:65`

No changes needed there.

## Related

The same class of bug in `src/app/(app)/budgets/page.tsx` went deeper — it was missing `user_id` on the `WHERE` of both inline queries, not only on the joins — so it shipped as a separate hotfix (#338, merged before this PR). This PR rebases cleanly on top.

## Before / after (prod data, user 1, abril 2026)

| | Before | After |
|---|---|---|
| `getCategoryBreakdown` → Alimentación | $501.300, 18 rows | **$55.700, 2 rows** |
| `getTopExpenses` for DiDi Food | 6 rows (LIMIT 5 cut to 3+2) | **2 rows** |

## Test plan

- [x] `bun run test src/lib/tenant-isolation.test.ts` → 14/14 pass
- [x] `bun run test` → 58 files / 645 tests pass
- [x] `bun run lint` + `bunx tsc --noEmit` clean
- [ ] Post-merge smoke: `/` dashboard and `/insights` in prod show the correct totals

Closes #336