### PR TITLE
chore(observability): wire slo-alerts cron in-process every 30 min (#341)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -25,6 +25,7 @@ export async function register() {
   const cron = (await import("node-cron")).default;
   const { closePreviousMonthForAllUsers } = await import("@/lib/recurring/gap-detector");
   const { snapshotAllActiveUsers } = await import("@/lib/telemetry/user-health");
+  const { checkAndAlertSlos } = await import("@/lib/observability/slo-alerts");
   const { createLogger } = await import("@/lib/logger");
   const log = createLogger({ module: "instrumentation" });
 
@@ -90,8 +91,31 @@ export async function register() {
     { timezone: "America/Bogota" },
   );
 
+  // Every 30 min — evaluate each SLO over a rolling 48h window and fire /
+  // resolve Telegram alerts (#329 PR3, #341 wiring). Finer granularity is
+  // wasteful: the 48h window swallows sub-half-hour deltas. Dedup is built
+  // into `slo_alerts` (at most one unresolved row per sloKey).
+  cron.schedule(
+    "*/30 * * * *",
+    async () => {
+      try {
+        const decisions = await checkAndAlertSlos();
+        const fired = decisions.filter((d) => d.action === "fire").length;
+        const resolved = decisions.filter((d) => d.action === "resolve").length;
+        const noops = decisions.filter((d) => d.action === "noop").length;
+        log.info(
+          { total: decisions.length, fired, resolved, noops, event: "slo_alerts_checked" },
+          "slo-alerts tick",
+        );
+      } catch (err) {
+        log.error({ err, event: "slo_alerts_check_failed" }, "slo-alerts check failed");
+      }
+    },
+    { timezone: "America/Bogota" },
+  );
+
   log.info(
     { event: "crons_registered" },
-    "crons registered: recurring-gap (0 6 5 * *), user-health (0 3 * * *) America/Bogota",
+    "crons registered: recurring-gap (0 6 5 * *), user-health (0 3 * * *), slo-alerts (*/30 * * * *) America/Bogota",
   );
 }


### PR DESCRIPTION
## Summary

Closes #341. The HTTP endpoint from #337 needed an external trigger; in this project that is unnecessary plumbing. Same file already schedules recurring-gap (monthly) and user-health (daily) in-process — slo-alerts joins them at \`*/30 * * * *\`.

- Imports \`checkAndAlertSlos\` and registers a 30-min \`node-cron\` schedule in \`src/instrumentation.ts\`.
- Log line per tick: \`{total, fired, resolved, noops}\` so \`journalctl\` shows whether alerting is actually ticking.
- Failures are caught and logged; the worker never crashes on a bad tick.
- The HTTP route at \`/api/cron/slo-alerts\` stays — useful for manual triggering during debugging / staging smoke.
- \`FINDASH_DISABLE_CRON=1\` continues to disable every cron (existing guard at the top of register()).

Closes #341. Part of the #329 SLO dashboard initiative.

## Test plan

- [x] \`bun run typecheck\` — green
- [x] \`bun run lint\` — green
- [x] \`bun run format:check\` — green
- [ ] CI on this PR green
- [ ] After deploy: \`journalctl -u findash -f\` shows \`slo_alerts_checked\` every 30 min