### PR TITLE
feat(ui): credit-card balance adjust asks for cupo disponible (#328)

### DIFF
--- a/src/app/(app)/settings/accounts/accounts-manager.tsx
+++ b/src/app/(app)/settings/accounts/accounts-manager.tsx
@@ -258,11 +258,11 @@ export function AccountsManager({ items }: { items: AccountRow[] }) {
         open={adjust.open}
         target={adjust.target}
         onClose={() => setAdjust({ open: false, target: null })}
-        onConfirm={async (declaredBalanceCents, reason) => {
+        onConfirm={async (declared, reason) => {
           if (!adjust.target) return;
           const result = await adjustAccountBalance({
             accountId: adjust.target.id,
-            declaredBalanceCents,
+            declared,
             reason,
           });
           if (result.status === "ok") {

--- a/src/app/(app)/settings/accounts/actions.test.ts
+++ b/src/app/(app)/settings/accounts/actions.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { and, eq, isNotNull, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, categories, transactions, users } from "@/lib/db/schema";
+import { accounts, categories, transactions, users, type AccountMetadata } from "@/lib/db/schema";
 import { notAdjustment, notDeleted } from "@/lib/db/helpers";
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
@@ -275,7 +275,7 @@ describe("adjustAccountBalance", () => {
     const accountId = await seedAccount(100_000); // balance 10_000_000 cents
     const result = await adjustAccountBalance({
       accountId,
-      declaredBalanceCents: 12_000_000,
+      declared: { kind: "balance", balanceCents: 12_000_000 },
       reason: "Transferencia que no llegó por SMS",
     });
 
@@ -297,7 +297,10 @@ describe("adjustAccountBalance", () => {
 
   it("negative diff: creates adjustment tx for the shortfall", async () => {
     const accountId = await seedAccount(100_000);
-    const result = await adjustAccountBalance({ accountId, declaredBalanceCents: 8_000_000 });
+    const result = await adjustAccountBalance({
+      accountId,
+      declared: { kind: "balance", balanceCents: 8_000_000 },
+    });
     expect(result.status).toBe("ok");
     if (result.status === "ok") {
       expect(result.diffCents).toBe("-2000000");
@@ -306,7 +309,10 @@ describe("adjustAccountBalance", () => {
 
   it("no-op when declared matches current", async () => {
     const accountId = await seedAccount(100_000);
-    const result = await adjustAccountBalance({ accountId, declaredBalanceCents: 10_000_000 });
+    const result = await adjustAccountBalance({
+      accountId,
+      declared: { kind: "balance", balanceCents: 10_000_000 },
+    });
     expect(result.status).toBe("noop");
 
     const txs = await db.select().from(transactions).where(eq(transactions.accountId, accountId));
@@ -320,7 +326,10 @@ describe("adjustAccountBalance", () => {
       .set({ deletedAt: new Date() })
       .where(and(eq(categories.userId, TEST_USER_ID), eq(categories.slug, "adjustments")));
 
-    const result = await adjustAccountBalance({ accountId, declaredBalanceCents: 11_000_000 });
+    const result = await adjustAccountBalance({
+      accountId,
+      declared: { kind: "balance", balanceCents: 11_000_000 },
+    });
     expect(result.status).toBe("ok");
 
     const [cat] = await db
@@ -350,7 +359,7 @@ describe("adjustAccountBalance", () => {
 
     const result = await adjustAccountBalance({
       accountId: otherAccount.id,
-      declaredBalanceCents: 200_000_00,
+      declared: { kind: "balance", balanceCents: 200_000_00 },
     });
     expect(result.status).toBe("error");
 
@@ -360,7 +369,10 @@ describe("adjustAccountBalance", () => {
 
   it("notAdjustment helper filters adjustment rows from spend queries", async () => {
     const accountId = await seedAccount(100_000);
-    await adjustAccountBalance({ accountId, declaredBalanceCents: 11_500_000 });
+    await adjustAccountBalance({
+      accountId,
+      declared: { kind: "balance", balanceCents: 11_500_000 },
+    });
 
     // All user txns
     const all = await db.select().from(transactions).where(eq(transactions.userId, TEST_USER_ID));
@@ -374,5 +386,91 @@ describe("adjustAccountBalance", () => {
       .where(and(eq(transactions.userId, TEST_USER_ID), notAdjustment(transactions.isAdjustment)));
     const hasAdjustmentInSpend = spendOnly.some((t) => t.isAdjustment);
     expect(hasAdjustmentInSpend).toBe(false);
+  });
+
+  // #328: credit card balance tracks DEBT as a negative number. The bank
+  // app never shows debt directly — it shows the available limit ("cupo"),
+  // so the user declares that and the server derives the debt.
+  describe("credit_card adjustBalance via availableCredit", () => {
+    async function seedCreditCard(opts: {
+      creditLimit?: number;
+      balanceCents?: number;
+      availableCredit?: number;
+    }): Promise<number> {
+      const metadata: AccountMetadata = {};
+      if (opts.creditLimit !== undefined) metadata.creditLimitCents = opts.creditLimit;
+      if (opts.availableCredit !== undefined) metadata.availableCreditCents = opts.availableCredit;
+      const [row] = await db
+        .insert(accounts)
+        .values({
+          userId: TEST_USER_ID,
+          name: `${ADJ_MARKER}-cc`,
+          institution: "Bancolombia",
+          type: "credit_card",
+          currency: "COP",
+          balanceCents: BigInt(opts.balanceCents ?? 0),
+          metadata,
+        })
+        .returning({ id: accounts.id });
+      return row.id;
+    }
+
+    it("derives debt from cupo and stores balance as negative", async () => {
+      const accountId = await seedCreditCard({ creditLimit: 5_000_000, balanceCents: 0 });
+
+      const result = await adjustAccountBalance({
+        accountId,
+        declared: { kind: "availableCredit", availableCreditCents: 3_200_000 },
+        reason: "cupo según app del banco",
+      });
+
+      expect(result.status).toBe("ok");
+      if (result.status === "ok") {
+        // debt = limit - available = 1_800_000 → balance_cents = -1_800_000
+        // diff = -1_800_000 - 0 = -1_800_000
+        expect(result.diffCents).toBe("-1800000");
+      }
+
+      const [after] = await db.select().from(accounts).where(eq(accounts.id, accountId));
+      expect(after.balanceCents).toBe(BigInt(-1_800_000));
+      expect(after.metadata.availableCreditCents).toBe(3_200_000);
+      expect(after.metadata.creditLimitCents).toBe(5_000_000);
+    });
+
+    it("refuses when the account has no creditLimitCents in metadata", async () => {
+      const accountId = await seedCreditCard({ balanceCents: 0 });
+
+      const result = await adjustAccountBalance({
+        accountId,
+        declared: { kind: "availableCredit", availableCreditCents: 3_200_000 },
+      });
+
+      expect(result.status).toBe("error");
+      if (result.status === "error") {
+        expect(result.message).toMatch(/límite|creditLimit|cupo/i);
+      }
+    });
+
+    it("refuses availableCredit larger than the limit (sanity check)", async () => {
+      const accountId = await seedCreditCard({ creditLimit: 5_000_000, balanceCents: 0 });
+
+      const result = await adjustAccountBalance({
+        accountId,
+        declared: { kind: "availableCredit", availableCreditCents: 6_000_000 },
+      });
+
+      expect(result.status).toBe("error");
+    });
+
+    it("refuses kind=availableCredit on a non-credit_card account", async () => {
+      const accountId = await seedAccount(100_000); // savings
+
+      const result = await adjustAccountBalance({
+        accountId,
+        declared: { kind: "availableCredit", availableCreditCents: 1_000_000 },
+      });
+
+      expect(result.status).toBe("error");
+    });
   });
 });

--- a/src/app/(app)/settings/accounts/actions.ts
+++ b/src/app/(app)/settings/accounts/actions.ts
@@ -151,11 +151,24 @@ export async function toggleAccountActive(id: number, active: boolean) {
   revalidate();
 }
 
+const declaredSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("balance"),
+    balanceCents: z.coerce.number().int(),
+  }),
+  z.object({
+    kind: z.literal("availableCredit"),
+    availableCreditCents: z.coerce.number().int().nonnegative(),
+  }),
+]);
+
 const adjustSchema = z.object({
   accountId: z.coerce.number().int().positive(),
-  declaredBalanceCents: z.coerce.number().int(),
+  declared: declaredSchema,
   reason: z.string().max(500).optional(),
 });
+
+export type AdjustBalanceInput = z.input<typeof adjustSchema>;
 
 export type AdjustBalanceResult =
   | { status: "ok"; diffCents: string; txId: number }
@@ -164,15 +177,27 @@ export type AdjustBalanceResult =
 
 /**
  * Reconciliation balance adjustment (YNAB pattern). Inserts a transaction for
- * (declared - current) into the account with `is_adjustment=true`, then
- * updates `accounts.balance_cents` to the declared value. Both happen atomically.
+ * (target - current) into the account with `is_adjustment=true`, then updates
+ * `accounts.balance_cents` to the target value. Both happen atomically.
+ *
+ * Two input shapes via `declared`:
+ *
+ * - `kind: "balance"` — direct balance_cents target. Used for savings and loan,
+ *   where the bank app tells the user their balance literally.
+ *
+ * - `kind: "availableCredit"` — credit card cupo disponible. The bank app
+ *   never shows debt directly, only the available limit, so the server
+ *   reads `metadata.creditLimitCents` and derives
+ *   `balance_cents = availableCreditCents - creditLimitCents` (negative, per
+ *   the repo convention — see CreditMeter in /accounts). Also updates
+ *   `metadata.availableCreditCents` so the card display stays consistent.
  *
  * The adjustment tx is categorized as `adjustments` — spend/insights queries
  * filter these out via `is_adjustment = false`; balance/net-worth queries
  * include them.
  */
 export async function adjustAccountBalance(
-  input: z.input<typeof adjustSchema>,
+  input: AdjustBalanceInput,
 ): Promise<AdjustBalanceResult> {
   const session = await getSessionUser();
   const parsed = adjustSchema.safeParse(input);
@@ -184,8 +209,10 @@ export async function adjustAccountBalance(
     const [account] = await tx
       .select({
         id: accounts.id,
+        type: accounts.type,
         currency: accounts.currency,
         balanceCents: accounts.balanceCents,
+        metadata: accounts.metadata,
       })
       .from(accounts)
       .where(
@@ -200,10 +227,53 @@ export async function adjustAccountBalance(
       return { status: "error", message: "Cuenta no encontrada." };
     }
 
-    const declared = BigInt(parsed.data.declaredBalanceCents);
-    const diff = declared - account.balanceCents;
+    let targetBalanceCents: bigint;
+    let nextMetadata: AccountMetadata = account.metadata;
+
+    if (parsed.data.declared.kind === "balance") {
+      targetBalanceCents = BigInt(parsed.data.declared.balanceCents);
+    } else {
+      if (account.type !== "credit_card") {
+        return {
+          status: "error",
+          message: "El cupo disponible solo aplica a tarjetas de crédito.",
+        };
+      }
+      const limit = account.metadata.creditLimitCents;
+      if (limit === undefined || limit <= 0) {
+        return {
+          status: "error",
+          message: "La tarjeta no tiene límite de crédito configurado. Editala primero.",
+        };
+      }
+      const available = parsed.data.declared.availableCreditCents;
+      if (available > limit) {
+        return {
+          status: "error",
+          message: "El cupo disponible no puede superar al límite de la tarjeta.",
+        };
+      }
+      // debt is limit - available; balance_cents for credit_card is stored
+      // negative (debt reduces net worth — see CreditMeter).
+      targetBalanceCents = BigInt(available) - BigInt(limit);
+      nextMetadata = { ...account.metadata, availableCreditCents: available };
+    }
+
+    const diff = targetBalanceCents - account.balanceCents;
 
     if (diff === BigInt(0)) {
+      // Metadata might still need to be persisted even when the balance
+      // didn't move (e.g. first time availableCreditCents is stored).
+      const metadataDrifted =
+        parsed.data.declared.kind === "availableCredit" &&
+        account.metadata.availableCreditCents !== parsed.data.declared.availableCreditCents;
+      if (metadataDrifted) {
+        await tx
+          .update(accounts)
+          .set({ metadata: nextMetadata, updatedAt: new Date() })
+          .where(eq(accounts.id, account.id));
+        revalidate();
+      }
       return { status: "noop" };
     }
 
@@ -246,7 +316,8 @@ export async function adjustAccountBalance(
         isAdjustment: true,
         rawData: {
           reason: parsed.data.reason ?? null,
-          declaredBalanceCents: declared.toString(),
+          declared: parsed.data.declared,
+          declaredBalanceCents: targetBalanceCents.toString(),
           previousBalanceCents: account.balanceCents.toString(),
         },
       })
@@ -254,7 +325,7 @@ export async function adjustAccountBalance(
 
     await tx
       .update(accounts)
-      .set({ balanceCents: declared, updatedAt: today })
+      .set({ balanceCents: targetBalanceCents, metadata: nextMetadata, updatedAt: today })
       .where(eq(accounts.id, account.id));
 
     revalidate();

--- a/src/app/(app)/settings/accounts/balance-adjust-dialog.tsx
+++ b/src/app/(app)/settings/accounts/balance-adjust-dialog.tsx
@@ -16,6 +16,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { Money } from "@/components/display/money";
 import { formatAccountLabel } from "@/lib/accounts/format";
 import type { AccountRow } from "./accounts-manager";
+import type { AdjustBalanceInput } from "./actions";
+
+type DeclaredValue = AdjustBalanceInput["declared"];
 
 export function BalanceAdjustDialog({
   open,
@@ -26,16 +29,60 @@ export function BalanceAdjustDialog({
   open: boolean;
   target: AccountRow | null;
   onClose: () => void;
-  onConfirm: (declaredBalanceCents: number, reason?: string) => Promise<void>;
+  onConfirm: (declared: DeclaredValue, reason?: string) => Promise<void>;
+}) {
+  if (!target) {
+    return (
+      <Dialog open={open} onOpenChange={(o) => (o ? null : onClose())}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <WrenchIcon className="size-4" />
+              Ajustar saldo
+            </DialogTitle>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => (o ? null : onClose())}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <WrenchIcon className="size-4" />
+            Ajustar saldo · {formatAccountLabel(target)}
+          </DialogTitle>
+        </DialogHeader>
+        {target.type === "credit_card" ? (
+          <CreditCardForm target={target} onConfirm={onConfirm} onClose={onClose} />
+        ) : (
+          <BalanceForm target={target} onConfirm={onConfirm} onClose={onClose} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function BalanceForm({
+  target,
+  onConfirm,
+  onClose,
+}: {
+  target: AccountRow;
+  onConfirm: (declared: DeclaredValue, reason?: string) => Promise<void>;
+  onClose: () => void;
 }) {
   const [declared, setDeclared] = useState("");
   const [reason, setReason] = useState("");
   const [pending, startTransition] = useTransition();
 
-  const currentCents = target ? BigInt(target.balanceCents) : BigInt(0);
+  const currentCents = BigInt(target.balanceCents);
   const currentMajor = Number(currentCents) / 100;
 
   const declaredCents = useMemo(() => {
+    if (declared.trim() === "") return null;
     const n = Number(declared);
     if (!Number.isFinite(n)) return null;
     return Math.round(n * 100);
@@ -46,82 +93,260 @@ export function BalanceAdjustDialog({
 
   function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (declaredCents === null || !target) return;
+    if (declaredCents === null) return;
     startTransition(async () => {
-      await onConfirm(declaredCents, reason.trim() || undefined);
+      await onConfirm({ kind: "balance", balanceCents: declaredCents }, reason.trim() || undefined);
     });
   }
 
   return (
-    <Dialog open={open} onOpenChange={(o) => (o ? null : onClose())}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <WrenchIcon className="size-4" />
-            Ajustar saldo {target ? `· ${formatAccountLabel(target)}` : ""}
-          </DialogTitle>
-        </DialogHeader>
-        <form onSubmit={onSubmit} className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1.5">
-            <Label className="text-muted-foreground text-xs tracking-wide uppercase">
-              Saldo actual según Findash
-            </Label>
-            <div className="bg-muted/40 rounded-md border px-3 py-2 text-base font-semibold tabular-nums">
-              {target ? <Money cents={currentCents} currency={target.currency} /> : "—"}
-            </div>
-          </div>
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-muted-foreground text-xs tracking-wide uppercase">
+          Saldo actual según Findash
+        </Label>
+        <div className="bg-muted/40 rounded-md border px-3 py-2 text-base font-semibold tabular-nums">
+          <Money cents={currentCents} currency={target.currency} />
+        </div>
+      </div>
 
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="declared">Saldo real (según tu banco)</Label>
-            <Input
-              id="declared"
-              type="number"
-              inputMode="decimal"
-              step="0.01"
-              value={declared}
-              onChange={(e) => setDeclared(e.target.value)}
-              placeholder={currentMajor.toFixed(2)}
-              required
-              autoFocus
-            />
-            <p className="text-muted-foreground text-xs">
-              El monto que aparece en el extracto / app del banco ahora mismo.
-            </p>
-          </div>
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="declared">Saldo real (según tu banco)</Label>
+        <Input
+          id="declared"
+          type="number"
+          inputMode="decimal"
+          step="0.01"
+          value={declared}
+          onChange={(e) => setDeclared(e.target.value)}
+          placeholder={currentMajor.toFixed(2)}
+          required
+          autoFocus
+        />
+        <p className="text-muted-foreground text-xs">
+          El monto que aparece en el extracto / app del banco ahora mismo.
+        </p>
+      </div>
 
-          {hasDiff ? (
-            <div className="border-border/60 rounded-md border p-3 text-sm">
-              Se creará una transacción de{" "}
-              <span className="font-semibold tabular-nums">
-                {diffCents > BigInt(0) ? "+" : ""}
-                {target ? <Money cents={diffCents} currency={target.currency} /> : ""}
-              </span>{" "}
-              marcada como <strong>Ajuste</strong>. Queda fuera de spend / insights / budgets.
-            </div>
+      {hasDiff ? (
+        <div className="border-border/60 rounded-md border p-3 text-sm">
+          Se creará una transacción de{" "}
+          <span className="font-semibold tabular-nums">
+            {diffCents > BigInt(0) ? "+" : ""}
+            <Money cents={diffCents} currency={target.currency} />
+          </span>{" "}
+          marcada como <strong>Ajuste</strong>. Queda fuera de spend / insights / budgets.
+        </div>
+      ) : null}
+
+      <ReasonField reason={reason} setReason={setReason} />
+      <Actions pending={pending} canSubmit={hasDiff} onClose={onClose} />
+    </form>
+  );
+}
+
+function CreditCardForm({
+  target,
+  onConfirm,
+  onClose,
+}: {
+  target: AccountRow;
+  onConfirm: (declared: DeclaredValue, reason?: string) => Promise<void>;
+  onClose: () => void;
+}) {
+  const creditLimitCents = target.metadata.creditLimitCents;
+
+  if (creditLimitCents === undefined || creditLimitCents <= 0) {
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="border-border/60 bg-muted/40 rounded-md border p-3 text-sm">
+          Esta tarjeta todavía no tiene <strong>límite de crédito</strong> configurado. El ajuste
+          pide el cupo disponible y deriva la deuda restando del límite — sin límite no hay cómo
+          calcularlo.
+          <p className="text-muted-foreground mt-2 text-xs">
+            Cerrá este diálogo, tocá <strong>Editar</strong> en la tarjeta y cargá el límite
+            primero.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" type="button" onClick={onClose}>
+            Cerrar
+          </Button>
+        </DialogFooter>
+      </div>
+    );
+  }
+
+  return (
+    <CreditCardFormInner
+      target={target}
+      creditLimitCents={creditLimitCents}
+      onConfirm={onConfirm}
+      onClose={onClose}
+    />
+  );
+}
+
+function CreditCardFormInner({
+  target,
+  creditLimitCents,
+  onConfirm,
+  onClose,
+}: {
+  target: AccountRow;
+  creditLimitCents: number;
+  onConfirm: (declared: DeclaredValue, reason?: string) => Promise<void>;
+  onClose: () => void;
+}) {
+  const currentBalance = BigInt(target.balanceCents);
+  const currentDebt = currentBalance < BigInt(0) ? -currentBalance : BigInt(0);
+  const limitBig = BigInt(creditLimitCents);
+  const currentAvailableFromBalance = limitBig - currentDebt;
+  const priorAvailable = target.metadata.availableCreditCents;
+  const placeholderAvailable = Number(currentAvailableFromBalance) / 100;
+
+  const [declared, setDeclared] = useState("");
+  const [reason, setReason] = useState("");
+  const [pending, startTransition] = useTransition();
+
+  const declaredAvailableCents = useMemo(() => {
+    if (declared.trim() === "") return null;
+    const n = Number(declared);
+    if (!Number.isFinite(n) || n < 0) return null;
+    return Math.round(n * 100);
+  }, [declared]);
+
+  const exceedsLimit = declaredAvailableCents !== null && declaredAvailableCents > creditLimitCents;
+
+  const derivedDebt =
+    declaredAvailableCents !== null ? limitBig - BigInt(declaredAvailableCents) : null;
+  const derivedBalanceCents = derivedDebt !== null ? -derivedDebt : null;
+  const diffCents = derivedBalanceCents !== null ? derivedBalanceCents - currentBalance : BigInt(0);
+  const hasDiff = derivedBalanceCents !== null && diffCents !== BigInt(0);
+  const canSubmit = hasDiff && !exceedsLimit;
+
+  function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (declaredAvailableCents === null || exceedsLimit) return;
+    startTransition(async () => {
+      await onConfirm(
+        { kind: "availableCredit", availableCreditCents: declaredAvailableCents },
+        reason.trim() || undefined,
+      );
+    });
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-muted-foreground text-xs tracking-wide uppercase">
+            Límite de la tarjeta
+          </Label>
+          <div className="bg-muted/40 rounded-md border px-3 py-2 text-sm font-medium tabular-nums">
+            <Money cents={limitBig} currency={target.currency} />
+          </div>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-muted-foreground text-xs tracking-wide uppercase">
+            Deuda actual en Findash
+          </Label>
+          <div className="bg-muted/40 rounded-md border px-3 py-2 text-sm font-medium tabular-nums">
+            <Money cents={currentDebt} currency={target.currency} />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="declared-cupo">Cupo disponible (según tu banco)</Label>
+        <Input
+          id="declared-cupo"
+          type="number"
+          inputMode="decimal"
+          step="0.01"
+          min="0"
+          max={(creditLimitCents / 100).toFixed(2)}
+          value={declared}
+          onChange={(e) => setDeclared(e.target.value)}
+          placeholder={placeholderAvailable.toFixed(2)}
+          required
+          autoFocus
+        />
+        <p className="text-muted-foreground text-xs">
+          El monto disponible que te muestra la app del banco — no la deuda.{" "}
+          {priorAvailable !== undefined ? (
+            <>
+              Último registro: <Money cents={BigInt(priorAvailable)} currency={target.currency} />.
+            </>
           ) : null}
+        </p>
+        {exceedsLimit ? (
+          <p className="text-destructive text-xs">
+            El cupo disponible no puede superar al límite (
+            <Money cents={limitBig} currency={target.currency} />
+            ).
+          </p>
+        ) : null}
+      </div>
 
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="reason">Razón (opcional)</Label>
-            <Textarea
-              id="reason"
-              value={reason}
-              onChange={(e) => setReason(e.target.value)}
-              placeholder="Ej: transferencia que no llegó por SMS, error de parser, etc."
-              rows={3}
-              maxLength={500}
-            />
+      {hasDiff && derivedDebt !== null && !exceedsLimit ? (
+        <div className="border-border/60 rounded-md border p-3 text-sm">
+          <div>
+            Nueva deuda derivada:{" "}
+            <span className="font-semibold tabular-nums">
+              <Money cents={derivedDebt} currency={target.currency} />
+            </span>
           </div>
+          <div className="mt-1">
+            Se creará una transacción de{" "}
+            <span className="font-semibold tabular-nums">
+              {diffCents > BigInt(0) ? "+" : ""}
+              <Money cents={diffCents} currency={target.currency} />
+            </span>{" "}
+            marcada como <strong>Ajuste</strong>. Queda fuera de spend / insights / budgets.
+          </div>
+        </div>
+      ) : null}
 
-          <DialogFooter>
-            <Button variant="ghost" type="button" onClick={onClose} disabled={pending}>
-              Cancelar
-            </Button>
-            <Button type="submit" disabled={pending || !hasDiff}>
-              Confirmar ajuste
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+      <ReasonField reason={reason} setReason={setReason} />
+      <Actions pending={pending} canSubmit={canSubmit} onClose={onClose} />
+    </form>
+  );
+}
+
+function ReasonField({ reason, setReason }: { reason: string; setReason: (v: string) => void }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor="reason">Razón (opcional)</Label>
+      <Textarea
+        id="reason"
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        placeholder="Ej: transferencia que no llegó por SMS, error de parser, etc."
+        rows={3}
+        maxLength={500}
+      />
+    </div>
+  );
+}
+
+function Actions({
+  pending,
+  canSubmit,
+  onClose,
+}: {
+  pending: boolean;
+  canSubmit: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <DialogFooter>
+      <Button variant="ghost" type="button" onClick={onClose} disabled={pending}>
+        Cancelar
+      </Button>
+      <Button type="submit" disabled={pending || !canSubmit}>
+        Confirmar ajuste
+      </Button>
+    </DialogFooter>
   );
 }


### PR DESCRIPTION
## Summary

Bank apps never show credit card debt directly — they show the available limit ("cupo disponible"). The previous adjust-balance dialog asked users for their balance as if it were a savings account, which for a credit card means they had to do the mental math (`debt = limit − available`) before typing. Easy to get wrong, and unnatural.

The dialog now branches by `account.type`:

- **savings / loan**: unchanged — asks for the balance directly.
- **credit_card**: asks for **cupo disponible**, shows the credit limit + current debt as reference, derives `debt = limit − available` on the server, and persists the new `availableCreditCents` in account metadata so the card UI stays consistent. When `creditLimitCents` is missing from metadata, the dialog shows a short guidance to edit the account first (no silent default of `0` that would pretend the entire limit is the debt).

## Server contract

`adjustAccountBalance` now takes a discriminated union on `declared` so the action is explicit about what the user said, not what the client inferred:

```ts
declared:
  | { kind: "balance"; balanceCents: number }
  | { kind: "availableCredit"; availableCreditCents: number }
```

Validation: `availableCredit` is only accepted for `type = "credit_card"` with a configured `creditLimitCents`, and the declared value must not exceed the limit. The action is defensive — the dialog already enforces these, but the server enforces them too so replay and external-call paths are safe.

The audit trail stored under `transactions.raw_data.declared` preserves the raw input, so we can tell after the fact whether the user declared a balance or a cupo — useful when debugging reconciliations.

## Sign convention (confirmed, not changed)

credit_card `balance_cents` is stored **negative** (debt reduces net worth). This is the convention already used by `CreditMeter` at `src/app/(app)/accounts/page.tsx:229` (`used = limit - available` or `-balance`). The server now derives the negative balance from the user's positive cupo input.

## Before / after

| | Before | After |
|---|---|---|
| Dialog input (savings) | "Saldo real" | "Saldo real" (unchanged) |
| Dialog input (credit_card) | "Saldo real" — user had to compute debt | "Cupo disponible" + shows limit + preview derived debt |
| credit_card without limit | generic numeric input that silently set balance | guidance: "editá la tarjeta primero" |
| metadata.availableCreditCents | never updated on adjust | persisted with each adjust |

## Test plan

- [x] 6 existing `adjustAccountBalance` tests rewritten to the discriminated-union shape
- [x] 4 new tests cover: derive debt from cupo + persist metadata, reject when no limit, reject when cupo > limit, reject `availableCredit` on non-credit_card accounts
- [x] Browser smoke (localhost, dev-login bypass):
  - credit_card without limit → guidance screen, no numeric input shown
  - savings → unchanged UI
  - credit_card with $5M limit + `cupo = $3.2M` → preview shows debt = $1.8M, tx of −$1.8M
  - cupo > limit → error message, confirm disabled, preview hidden
  - confirm persists: `balance_cents = -180_000_000`, `metadata.availableCreditCents = 320_000_000`, adjustment tx with `raw_data.declared = { kind: "availableCredit", availableCreditCents: 320_000_000 }`
- [x] `bun run test` → 58 files / 649 tests pass
- [x] `bun run lint` + `bunx tsc --noEmit` clean

## Out of scope

Loans stay on `kind: "balance"` — the issue called out to revisit loans separately once the cuotas/intereses semantics are pinned down.

Closes #328