### PR TITLE
feat(ui): rules table shows # + highlights :target row (#334)

### DIFF
--- a/src/app/(app)/settings/rules/rules-manager.tsx
+++ b/src/app/(app)/settings/rules/rules-manager.tsx
@@ -294,6 +294,7 @@ export function RulesManager({
                 <thead className="bg-muted/50 text-muted-foreground text-xs uppercase">
                   <tr>
                     <th className="w-8 p-2"></th>
+                    <th className="w-12 p-2 text-left">#</th>
                     <th className="p-2 text-left">Patrón</th>
                     <th className="p-2 text-left">Categoría</th>
                     <th className="p-2 text-right">Prioridad</th>
@@ -313,7 +314,16 @@ export function RulesManager({
                       <Fragment key={r.id}>
                         <tr
                           id={`rule-${r.id}`}
-                          className={cn("scroll-mt-20 border-t", !r.active && "opacity-50")}
+                          className={cn(
+                            "scroll-mt-20 border-t transition-colors",
+                            // #334: when the URL hash matches this row's id
+                            // (e.g. navigating from the "¿Por qué?" modal's
+                            // "Ver Regla #N" link), flash a visible highlight
+                            // so the user can tell which row is the one they
+                            // were sent to. Pure CSS — no JS, no state.
+                            "target:bg-amber-100 target:ring-2 target:ring-amber-400 target:ring-inset dark:target:bg-amber-900/40",
+                            !r.active && "opacity-50",
+                          )}
                           data-testid={`rule-row-${r.id}`}
                         >
                           <td className="p-2 text-center">
@@ -331,6 +341,9 @@ export function RulesManager({
                                 )}
                               </button>
                             ) : null}
+                          </td>
+                          <td className="text-muted-foreground p-2 font-mono text-xs tabular-nums">
+                            {r.id}
                           </td>
                           <td className="p-2 font-mono text-xs">{r.pattern}</td>
                           <td className="p-2">
@@ -422,7 +435,7 @@ export function RulesManager({
                         {isExpanded && canExpand ? (
                           <tr className="bg-muted/30">
                             <td></td>
-                            <td colSpan={8} className="text-muted-foreground p-2 text-xs">
+                            <td colSpan={9} className="text-muted-foreground p-2 text-xs">
                               <span className="font-medium">Generada por correcciones:</span>{" "}
                               {corrections.map((txId, i) => (
                                 <span key={txId}>


### PR DESCRIPTION
## Summary

The "Ver Regla #N" link from the "¿Por qué esta categoría?" modal already anchored to `/settings/rules#rule-N`, but two things made it feel broken:

1. The table had **no `#` column**, so the user couldn't cross-check the `N` they came from with what they were looking at.
2. Although `scroll-mt-20` put the row in view, nothing visually indicated which row was the target — indistinguishable from the rest.

Now:

- A narrow `#` column (rule id, font-mono, `text-muted-foreground`, tabular-nums) lives right after the expand chevron.
- The target row highlights with an amber background + inset ring via pure `:target` CSS — no JS, no state, no flicker on reload.

## Why the id "looks weird"

`classification_rules.id` is a Postgres `serial`. In my prod DB there are **41 rules with ids up to 292** — the gap comes from deleted rules and approved proposals advancing the sequence. Exposing the id as a column makes the gap self-explanatory, so users don't wonder "why #204 when there are only 41 rules?".

## Test plan

- [x] Browser smoke on localhost with real data (41 rules, ids up to 292):
  - Default view shows the `#` column, ids readable (screenshot)
  - Navigate to `/settings/rules#rule-204` — row #204 scrolls into view and lights up amber (light mode)
  - Toggle dark mode, re-navigate — highlight adapts (darker amber + ring)
- [x] `bun run test` → 58 files / 649 tests pass
- [x] `bun run lint` + `bunx tsc --noEmit` clean
- [x] Expanded-corrections row `colSpan` bumped 8 → 9 to account for the new column

## Out of scope

- Renaming/renumbering the `rule.id` (over-engineering — the serial is fine and tx-level audit logs reference it)
- Changing the "Ver Regla #N" link text in the modal (the # and the column map 1:1 now; no need)

Closes #334