### PR TITLE
fix(fx): wire in-process TRM refresh cron + boot backfill (#347)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -8,6 +8,8 @@ declare global {
  * Next.js 16 instrumentation hook — runs once per worker on boot. Registers:
  * - recurring-gap detector cron (monthly)
  * - per-user health snapshot cron (daily 03:00 America/Bogota)
+ * - slo-alerts cron (every 30 min)
+ * - fx-refresh cron (twice daily, 06:15 and 18:15 America/Bogota)
  *
  * Telegram used to run a long-poll worker here; #185 moved it to per-user
  * webhooks (`src/app/api/telegram/webhook/[botId]/route.ts`) so there is no
@@ -26,8 +28,29 @@ export async function register() {
   const { closePreviousMonthForAllUsers } = await import("@/lib/recurring/gap-detector");
   const { snapshotAllActiveUsers } = await import("@/lib/telemetry/user-health");
   const { checkAndAlertSlos } = await import("@/lib/observability/slo-alerts");
+  const { fetchTrm } = await import("@/lib/fx/trm");
+  const { getCurrentFxRate, upsertFxRate } = await import("@/lib/fx/repo");
   const { createLogger } = await import("@/lib/logger");
   const log = createLogger({ module: "instrumentation" });
+
+  async function refreshFxOnce(trigger: "cron" | "boot") {
+    try {
+      const trm = await fetchTrm();
+      await upsertFxRate({
+        base: "USD",
+        quote: "COP",
+        rate: trm.rate,
+        asOf: trm.asOf,
+        source: trm.source,
+      });
+      log.info(
+        { rate: trm.rate, asOf: trm.asOf, trigger, event: "fx_refresh_ok" },
+        "fx-refresh tick",
+      );
+    } catch (err) {
+      log.error({ err, trigger, event: "fx_refresh_failed" }, "fx-refresh tick failed");
+    }
+  }
 
   // Day 5 of each month at 06:00 America/Bogota — gives a 4-day grace window
   // for late-posting SMS/Apple Pay events before we finalize gaps.
@@ -114,8 +137,28 @@ export async function register() {
     { timezone: "America/Bogota" },
   );
 
+  // TRM is published daily by SuperFinanciera via datos.gov.co. Two ticks per
+  // day (06:15 and 18:15 COT) balance freshness against API load: morning tick
+  // catches the day's official rate, evening tick retries if morning failed.
+  // POST /api/fx/refresh remains available for manual/emergency refresh.
+  cron.schedule("15 6,18 * * *", () => void refreshFxOnce("cron"), {
+    timezone: "America/Bogota",
+  });
+
   log.info(
     { event: "crons_registered" },
-    "crons registered: recurring-gap (0 6 5 * *), user-health (0 3 * * *), slo-alerts (*/30 * * * *) America/Bogota",
+    "crons registered: recurring-gap (0 6 5 * *), user-health (0 3 * * *), slo-alerts (*/30 * * * *), fx-refresh (15 6,18 * * *) America/Bogota",
   );
+
+  // Backfill on boot when the repo is empty or last known rate came from the
+  // hardcoded fallback. Without this, a fresh deploy shows `· fallback` in the
+  // Net worth card for up to ~12h until the first cron tick lands (#347).
+  try {
+    const current = await getCurrentFxRate();
+    if (current.source === "fallback") {
+      await refreshFxOnce("boot");
+    }
+  } catch (err) {
+    log.error({ err, event: "fx_refresh_boot_check_failed" }, "fx boot backfill check failed");
+  }
 }


### PR DESCRIPTION
## Summary

- Adds a 4th in-process cron in `src/instrumentation.ts` — `15 6,18 * * *` America/Bogota — that calls `fetchTrm()` + `upsertFxRate()` directly, no HTTP hop.
- Adds a boot-time backfill: if `getCurrentFxRate().source === "fallback"`, fire a one-shot refresh so a fresh deploy doesn't show `· fallback` in the Net worth card for up to ~12h until the first cron tick lands.
- Updates the `crons_registered` log line to list the new tick.

## Why

`POST /api/fx/refresh` has existed since #65 but nothing was invoking it on a schedule, so the `fx_rates` table stayed empty and `getCurrentFxRate()` kept returning the hardcoded fallback of 4000 COP/USD. The Net worth card surfaced this as `@ 4.000,00 COP/USD · fallback`, silently underestimating USD balances. Matching the pattern of the existing three crons (recurring-gap, user-health, slo-alerts) keeps operations consistent and avoids a new external cron dependency. `POST /api/fx/refresh` remains available for manual/emergency refresh.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 649/649 passing
- [ ] After deploy, verify Net worth card in `/` shows `· TRM <fecha>` (not `· fallback`)
- [ ] Verify log line `crons_registered` lists `fx-refresh (15 6,18 * * *)`
- [ ] Verify `FINDASH_DISABLE_CRON=1` still disables all crons including this one

Closes #347