### PR TITLE
feat(accounts): getAvailableCreditCOP helper + listAccountsDetailed join (#346)

### DIFF
--- a/src/lib/accounts/queries.test.ts
+++ b/src/lib/accounts/queries.test.ts
@@ -1,0 +1,234 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, physicalCards, users } from "@/lib/db/schema";
+import { getAvailableCreditCOP, listAccountsDetailed } from "./queries";
+
+const MARKER = "__test_accounts_queries";
+const OTHER_EMAIL = `${MARKER}-other@test.local`;
+
+let USER_A = 0;
+let USER_B = 0;
+
+async function cleanup() {
+  // Accounts reference physical_cards via FK (ON DELETE SET NULL), so it's safe
+  // to delete both in any order, but we clear accounts first to keep logs tidy.
+  await db.execute(sql`DELETE FROM accounts WHERE name LIKE ${MARKER + "%"}`);
+  await db.execute(
+    sql`DELETE FROM physical_cards WHERE metadata->>'coalescedFrom' IS NULL AND institution = 'Bancolombia' AND user_id IN (${USER_A}, ${USER_B})`,
+  );
+}
+
+beforeAll(async () => {
+  const [a] = await db
+    .insert(users)
+    .values({ email: `${MARKER}-a@test.local`, name: "A" })
+    .returning({ id: users.id });
+  const [b] = await db
+    .insert(users)
+    .values({ email: OTHER_EMAIL, name: "B" })
+    .returning({ id: users.id });
+  USER_A = a.id;
+  USER_B = b.id;
+});
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM users WHERE email LIKE ${MARKER + "%"}`);
+});
+
+describe("getAvailableCreditCOP", () => {
+  afterEach(cleanup);
+
+  async function seedPair(params: {
+    userId: number;
+    limitCents: number;
+    copBalanceCents: number;
+    usdBalanceCents: number;
+    name?: string;
+  }): Promise<string> {
+    const id = randomUUID();
+    await db.insert(physicalCards).values({
+      id,
+      userId: params.userId,
+      institution: "Bancolombia",
+      network: "mastercard",
+      last4: "7291",
+      creditLimitCents: BigInt(params.limitCents),
+    });
+    await db.insert(accounts).values([
+      {
+        userId: params.userId,
+        name: `${MARKER}${params.name ?? ""}-cop`,
+        institution: "Bancolombia",
+        type: "credit_card",
+        currency: "COP",
+        balanceCents: BigInt(params.copBalanceCents),
+        physicalCardId: id,
+      },
+      {
+        userId: params.userId,
+        name: `${MARKER}${params.name ?? ""}-usd`,
+        institution: "Bancolombia",
+        type: "credit_card",
+        currency: "USD",
+        balanceCents: BigInt(params.usdBalanceCents),
+        physicalCardId: id,
+      },
+    ]);
+    return id;
+  }
+
+  it("returns full limit when both balances are zero", async () => {
+    const id = await seedPair({
+      userId: USER_A,
+      limitCents: 20_000_000_00, // 20MM COP
+      copBalanceCents: 0,
+      usdBalanceCents: 0,
+    });
+    const available = await getAvailableCreditCOP(USER_A, id, 4100);
+    expect(available).toBe(BigInt(20_000_000_00));
+  });
+
+  it("subtracts COP debt directly (balances stored negative)", async () => {
+    // Limit 20MM, COP balance -500.000 (500k COP of debt)
+    const id = await seedPair({
+      userId: USER_A,
+      limitCents: 20_000_000_00,
+      copBalanceCents: -500_000_00,
+      usdBalanceCents: 0,
+    });
+    const available = await getAvailableCreditCOP(USER_A, id, 4100);
+    expect(available).toBe(BigInt(20_000_000_00 - 500_000_00));
+  });
+
+  it("converts USD debt to COP at the given rate", async () => {
+    // Limit 20MM, USD balance -100,00 ($100 USD of debt) @ TRM 4100 → -410.000 COP
+    const id = await seedPair({
+      userId: USER_A,
+      limitCents: 20_000_000_00,
+      copBalanceCents: 0,
+      usdBalanceCents: -100_00, // -$100,00 USD in cents
+    });
+    const available = await getAvailableCreditCOP(USER_A, id, 4100);
+    expect(available).toBe(BigInt(20_000_000_00 - 100_00 * 4100));
+  });
+
+  it("handles mixed COP + USD debts (AS-3 scenario)", async () => {
+    // Limit 20MM, COP -500k, USD -$100 @ 4100 → 19.090.000 COP available
+    const id = await seedPair({
+      userId: USER_A,
+      limitCents: 20_000_000_00,
+      copBalanceCents: -500_000_00,
+      usdBalanceCents: -100_00,
+      name: "-mixed",
+    });
+    const available = await getAvailableCreditCOP(USER_A, id, 4100);
+    expect(available).toBe(BigInt(20_000_000_00 - 500_000_00 - 100_00 * 4100));
+  });
+
+  it("returns null when physical_card_id belongs to a different user (tenancy guard)", async () => {
+    const id = await seedPair({
+      userId: USER_B,
+      limitCents: 10_000_000_00,
+      copBalanceCents: 0,
+      usdBalanceCents: 0,
+      name: "-tenant",
+    });
+    const result = await getAvailableCreditCOP(USER_A, id, 4100);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a non-existent physical_card_id", async () => {
+    const fakeId = randomUUID();
+    const result = await getAvailableCreditCOP(USER_A, fakeId, 4100);
+    expect(result).toBeNull();
+  });
+});
+
+describe("listAccountsDetailed: physical card join", () => {
+  afterEach(cleanup);
+
+  it("returns physicalCard fields when an account is linked", async () => {
+    const pcId = randomUUID();
+    await db.insert(physicalCards).values({
+      id: pcId,
+      userId: USER_A,
+      institution: "Bancolombia",
+      network: "mastercard",
+      last4: "7291",
+      creditLimitCents: BigInt(15_000_000_00),
+      statementCutoffDay: 15,
+    });
+    await db.insert(accounts).values({
+      userId: USER_A,
+      name: `${MARKER}-linked`,
+      institution: "Bancolombia",
+      type: "credit_card",
+      currency: "COP",
+      balanceCents: BigInt(0),
+      physicalCardId: pcId,
+    });
+
+    const rows = await listAccountsDetailed(USER_A);
+    const linked = rows.find((r) => r.name === `${MARKER}-linked`);
+    expect(linked).toBeDefined();
+    expect(linked!.physicalCardId).toBe(pcId);
+    expect(linked!.physicalCard).not.toBeNull();
+    expect(linked!.physicalCard!.creditLimitCents).toBe(BigInt(15_000_000_00));
+    expect(linked!.physicalCard!.statementCutoffDay).toBe(15);
+    expect(linked!.physicalCard!.network).toBe("mastercard");
+    expect(linked!.physicalCard!.last4).toBe("7291");
+  });
+
+  it("returns physicalCard: null for single-currency accounts", async () => {
+    await db.insert(accounts).values({
+      userId: USER_A,
+      name: `${MARKER}-single`,
+      institution: "Bancolombia",
+      type: "savings",
+      currency: "COP",
+      balanceCents: BigInt(1_000_000_00),
+    });
+    const rows = await listAccountsDetailed(USER_A);
+    const single = rows.find((r) => r.name === `${MARKER}-single`);
+    expect(single).toBeDefined();
+    expect(single!.physicalCardId).toBeNull();
+    expect(single!.physicalCard).toBeNull();
+  });
+
+  it("never joins a physical_card belonging to another user", async () => {
+    const pcId = randomUUID();
+    await db.insert(physicalCards).values({
+      id: pcId,
+      userId: USER_B,
+      institution: "Bancolombia",
+      creditLimitCents: BigInt(99_999),
+    });
+    // Artisanal dangling pointer: pretend something wrote user A's account
+    // pointing at user B's physical_card (this should never happen in prod,
+    // but the join must defend against it).
+    await db.insert(accounts).values({
+      userId: USER_A,
+      name: `${MARKER}-crosstenant`,
+      institution: "Bancolombia",
+      type: "credit_card",
+      currency: "COP",
+      balanceCents: BigInt(0),
+      physicalCardId: pcId,
+    });
+
+    const rowsA = await listAccountsDetailed(USER_A);
+    const crossed = rowsA.find((r) => r.name === `${MARKER}-crosstenant`);
+    // The row is returned (it's A's account), but physicalCard must be null
+    // because the join filtered out the cross-tenant parent.
+    expect(crossed).toBeDefined();
+    expect(crossed!.physicalCardId).toBe(pcId);
+    expect(crossed!.physicalCard).toBeNull();
+
+    // Cleanup this cross-tenant row explicitly — the MARKER deletes it, but the
+    // assertion above is the important part. Also nuke the PC.
+    await db.execute(sql`DELETE FROM accounts WHERE name = ${MARKER + "-crosstenant"}`);
+    await db.delete(physicalCards).where(eq(physicalCards.id, pcId));
+  });
+});

--- a/src/lib/accounts/queries.ts
+++ b/src/lib/accounts/queries.ts
@@ -1,8 +1,17 @@
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, type AccountMetadata } from "@/lib/db/schema";
+import { accounts, physicalCards, type AccountMetadata } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
+import { toCop } from "@/lib/money";
 import type { AccountType, Currency } from "@/lib/types";
+
+export type PhysicalCardSummary = {
+  id: string;
+  creditLimitCents: bigint;
+  statementCutoffDay: number | null;
+  network: string | null;
+  last4: string | null;
+};
 
 export type AccountDetail = {
   id: number;
@@ -13,10 +22,12 @@ export type AccountDetail = {
   balanceCents: bigint;
   active: boolean;
   metadata: AccountMetadata;
+  physicalCardId: string | null;
+  physicalCard: PhysicalCardSummary | null;
 };
 
 export async function listAccountsDetailed(userId: number): Promise<AccountDetail[]> {
-  return db
+  const rows = await db
     .select({
       id: accounts.id,
       name: accounts.name,
@@ -26,8 +37,90 @@ export async function listAccountsDetailed(userId: number): Promise<AccountDetai
       balanceCents: accounts.balanceCents,
       active: accounts.active,
       metadata: accounts.metadata,
+      physicalCardId: accounts.physicalCardId,
+      pcId: physicalCards.id,
+      pcCreditLimitCents: physicalCards.creditLimitCents,
+      pcStatementCutoffDay: physicalCards.statementCutoffDay,
+      pcNetwork: physicalCards.network,
+      pcLast4: physicalCards.last4,
     })
     .from(accounts)
+    .leftJoin(
+      physicalCards,
+      and(
+        eq(physicalCards.id, accounts.physicalCardId),
+        // Tenancy guard: never join across users even if a FK were ever corrupted
+        // (see engram `per-user-table-join-tenant-safety`).
+        eq(physicalCards.userId, accounts.userId),
+      ),
+    )
     .where(and(eq(accounts.userId, userId), notDeleted(accounts.deletedAt)))
     .orderBy(asc(accounts.type), asc(accounts.institution), asc(accounts.name));
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    institution: r.institution,
+    type: r.type,
+    currency: r.currency,
+    balanceCents: r.balanceCents,
+    active: r.active,
+    metadata: r.metadata,
+    physicalCardId: r.physicalCardId,
+    physicalCard: r.pcId
+      ? {
+          id: r.pcId,
+          creditLimitCents: r.pcCreditLimitCents!,
+          statementCutoffDay: r.pcStatementCutoffDay,
+          network: r.pcNetwork,
+          last4: r.pcLast4,
+        }
+      : null,
+  }));
+}
+
+/**
+ * Returns the available credit (in COP cents) for a physical card with a shared
+ * COP cupo spanning multiple sub-accounts (#346). USD balances are converted to
+ * COP at `copPerUsd`. Credit-card balances are stored as negative debt, so the
+ * formula is:
+ *
+ *   available = credit_limit_cents + sum(COP balances) + sum(USD balances) * rate
+ *
+ * Returns null when no physical card is found for `(userId, physicalCardId)` —
+ * tenancy guard is enforced via the WHERE clause.
+ */
+export async function getAvailableCreditCOP(
+  userId: number,
+  physicalCardId: string,
+  copPerUsd: number,
+): Promise<bigint | null> {
+  const [row] = await db
+    .select({
+      creditLimitCents: physicalCards.creditLimitCents,
+      copDebtCents: sql<string>`
+        COALESCE(SUM(CASE WHEN ${accounts.currency} = 'COP' THEN ${accounts.balanceCents} ELSE 0 END), 0)
+      `,
+      usdDebtCents: sql<string>`
+        COALESCE(SUM(CASE WHEN ${accounts.currency} = 'USD' THEN ${accounts.balanceCents} ELSE 0 END), 0)
+      `,
+    })
+    .from(physicalCards)
+    .leftJoin(
+      accounts,
+      and(
+        eq(accounts.physicalCardId, physicalCards.id),
+        // Tenancy guard on the join too.
+        eq(accounts.userId, physicalCards.userId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .where(and(eq(physicalCards.id, physicalCardId), eq(physicalCards.userId, userId)))
+    .groupBy(physicalCards.id, physicalCards.creditLimitCents);
+
+  if (!row) return null;
+
+  const copDebt = BigInt(row.copDebtCents);
+  const usdDebt = BigInt(row.usdDebtCents);
+  return row.creditLimitCents + copDebt + toCop(usdDebt, "USD", copPerUsd);
 }

--- a/src/lib/telegram/ocr-draft.test.ts
+++ b/src/lib/telegram/ocr-draft.test.ts
@@ -12,6 +12,8 @@ const ACCOUNT: AccountDetail = {
   balanceCents: BigInt(0),
   active: true,
   metadata: {},
+  physicalCardId: null,
+  physicalCard: null,
 };
 
 function row(overrides: Partial<OcrParsedRow> = {}): OcrParsedRow {

--- a/src/lib/telegram/sms-draft.test.ts
+++ b/src/lib/telegram/sms-draft.test.ts
@@ -13,6 +13,8 @@ const ACCOUNTS: AccountDetail[] = [
     balanceCents: BigInt(0),
     active: true,
     metadata: { last4s: ["1234"] },
+    physicalCardId: null,
+    physicalCard: null,
   },
   {
     id: 2,
@@ -23,6 +25,8 @@ const ACCOUNTS: AccountDetail[] = [
     balanceCents: BigInt(0),
     active: true,
     metadata: { last4s: ["2575"] },
+    physicalCardId: null,
+    physicalCard: null,
   },
   {
     id: 3,
@@ -33,6 +37,8 @@ const ACCOUNTS: AccountDetail[] = [
     balanceCents: BigInt(0),
     active: true,
     metadata: { last4s: ["2575"] },
+    physicalCardId: null,
+    physicalCard: null,
   },
   {
     id: 4,
@@ -43,6 +49,8 @@ const ACCOUNTS: AccountDetail[] = [
     balanceCents: BigInt(0),
     active: false,
     metadata: { last4s: ["9999"] },
+    physicalCardId: null,
+    physicalCard: null,
   },
 ];
 


### PR DESCRIPTION
## Summary

Task 3 of 9 for #346. Read-side only — no UI, no schema changes.

- Adds `getAvailableCreditCOP(userId, physicalCardId, copPerUsd): Promise<bigint | null>` in `src/lib/accounts/queries.ts`. Single SELECT with GROUP BY; folds COP and USD sub-account balances through the given TRM. Returns `null` when the physical card isn't found for the user (tenancy guard).
- Extends `AccountDetail` + `listAccountsDetailed` to LEFT JOIN `physical_cards` and return `physicalCardId` + `physicalCard: { id, creditLimitCents, statementCutoffDay, network, last4 } | null` per row. Tenancy guard on the JOIN too — `physical_cards.user_id = accounts.user_id`, per engram `per-user-table-join-tenant-safety`.
- Updates downstream test fixtures (`ocr-draft.test.ts`, `sms-draft.test.ts`) for the expanded type.
- New test file `src/lib/accounts/queries.test.ts` — 9 tests covering: zero balances, COP-only debt, USD-only debt, mixed debts (matches AS-3 scenario in the design), cross-tenant guard on both the helper and the join, non-existent id, single-currency accounts returning `physicalCard: null`.

## Formula

Credit-card balances are stored as negative debt, so:

```
available = credit_limit_cents + sum(COP balances) + sum(USD balances) × rate
```

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 658/658 passing (9 new)

## Next

Task 4 (group linked pairs on `/accounts` UI) is next, consumes these helpers.

Refs #346