### PR TITLE
feat(accounts): single shared-cupo input + top-level physicalCard on upsert (#346)

### DIFF
--- a/src/app/(app)/settings/accounts/accounts-manager.tsx
+++ b/src/app/(app)/settings/accounts/accounts-manager.tsx
@@ -390,7 +390,6 @@ function AccountEditor({
     currency === "COP" ? "USD" : "COP",
   );
   const [secondaryBalance, setSecondaryBalance] = useState("0");
-  const [secondaryCreditLimit, setSecondaryCreditLimit] = useState("");
 
   const multiCurrencyAllowed = !isEdit && type === "credit_card";
 
@@ -414,6 +413,7 @@ function AccountEditor({
     });
 
     let secondary: Parameters<typeof upsertAccount>[0]["secondary"];
+    let physicalCard: Parameters<typeof upsertAccount>[0]["physicalCard"];
     if (multiCurrencyAllowed && multiCurrency) {
       if (secondaryCurrency === currency) {
         toast.error("Secondary currency must differ from primary");
@@ -424,14 +424,29 @@ function AccountEditor({
         toast.error("Secondary balance must be a number");
         return;
       }
+      // Multi-currency credit cards: the primary `creditLimit` input is the
+      // shared COP cupo; no per-side limit. Submit via top-level `physicalCard`
+      // so it lands in `physical_cards` — NOT in either sub-account's metadata.
+      const sharedLimitCents = creditLimit !== "" ? Math.round(Number(creditLimit) * 100) : 0;
+      physicalCard = {
+        creditLimitCents: Number.isFinite(sharedLimitCents) ? sharedLimitCents : 0,
+        cutoffDay: cutoffDay !== "" ? Number(cutoffDay) : undefined,
+        last4: last4.split(/\s+/)[0]?.match(/^\d{4}$/)?.[0],
+        network: network ? (network as "visa" | "mastercard" | "amex") : undefined,
+      };
+      // Strip the shared-cupo keys from both sub-account metadata payloads —
+      // they belong to physical_cards now, not accounts.
+      const { creditLimitCents: _pLimit, cutoffDay: _pCutoff, ...primaryMdNoLimit } = primaryMd;
+      void _pLimit;
+      void _pCutoff;
       secondary = {
         currency: secondaryCurrency,
         balance: secBal,
         metadata: metadataFromForm({
           network,
           last4,
-          creditLimit: secondaryCreditLimit,
-          cutoffDay,
+          creditLimit: "", // lives in physical_cards now
+          cutoffDay: "", // lives in physical_cards now
           paymentDueDay,
           interestRateMonthly: "",
           termMonths: "",
@@ -439,6 +454,10 @@ function AccountEditor({
           monthlyPayment: "",
         }),
       };
+      // Apply the strip to primary metadata too (avoid duplicating the cupo).
+      Object.assign(primaryMd, primaryMdNoLimit);
+      delete primaryMd.creditLimitCents;
+      delete primaryMd.cutoffDay;
     }
 
     startTransition(async () => {
@@ -450,6 +469,7 @@ function AccountEditor({
           type,
           primary: { currency, balance: balNum, metadata: primaryMd },
           secondary,
+          physicalCard,
         });
         toast.success(isEdit ? "Updated" : "Created");
         onClose();
@@ -561,6 +581,10 @@ function AccountEditor({
           {multiCurrencyAllowed && multiCurrency ? (
             <div className="bg-muted/30 flex flex-col gap-3 rounded-md border p-3">
               <p className="text-xs font-medium">Secondary currency side</p>
+              <p className="text-muted-foreground text-xs">
+                El cupo es compartido en COP — usá &quot;Credit limit&quot; en Advanced abajo para
+                el cupo total. Esta sección sólo pide el saldo actual de la otra moneda.
+              </p>
               <div className="grid grid-cols-2 gap-3">
                 <div className="flex flex-col gap-1.5">
                   <Label htmlFor="acc-currency-2">Currency</Label>
@@ -587,19 +611,6 @@ function AccountEditor({
                   />
                 </div>
               </div>
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="acc-limit-2">Credit limit ({secondaryCurrency})</Label>
-                <Input
-                  id="acc-limit-2"
-                  type="number"
-                  inputMode="decimal"
-                  step={secondaryCurrency === "USD" ? "0.01" : "1"}
-                  value={secondaryCreditLimit}
-                  onChange={(e) => setSecondaryCreditLimit(e.target.value)}
-                  placeholder="Optional"
-                  className="tabular-nums"
-                />
-              </div>
             </div>
           ) : null}
 
@@ -623,15 +634,17 @@ function AccountEditor({
                     </select>
                   </div>
                   <div className="flex flex-col gap-1.5">
-                    <Label htmlFor="acc-limit">Credit limit ({currency})</Label>
+                    <Label htmlFor="acc-limit">
+                      {multiCurrency ? "Shared cupo (COP)" : `Credit limit (${currency})`}
+                    </Label>
                     <Input
                       id="acc-limit"
                       type="number"
                       inputMode="decimal"
-                      step={currency === "USD" ? "0.01" : "1"}
+                      step={multiCurrency || currency === "COP" ? "1" : "0.01"}
                       value={creditLimit}
                       onChange={(e) => setCreditLimit(e.target.value)}
-                      placeholder="Optional"
+                      placeholder={multiCurrency ? "e.g. 20000000" : "Optional"}
                       className="tabular-nums"
                     />
                   </div>

--- a/src/app/(app)/settings/accounts/actions.test.ts
+++ b/src/app/(app)/settings/accounts/actions.test.ts
@@ -1,7 +1,14 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { and, eq, isNotNull, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, categories, transactions, users, type AccountMetadata } from "@/lib/db/schema";
+import {
+  accounts,
+  categories,
+  physicalCards,
+  transactions,
+  users,
+  type AccountMetadata,
+} from "@/lib/db/schema";
 import { notAdjustment, notDeleted } from "@/lib/db/helpers";
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
@@ -135,6 +142,51 @@ describe("accounts actions: multi-currency credit card", () => {
     expect(rows[0].physicalCardId).toBe(rows[1].physicalCardId);
     const currencies = rows.map((r) => r.currency).sort();
     expect(currencies).toEqual(["COP", "USD"]);
+  });
+
+  it("creates a physical_cards row with the shared cupo when physicalCard is passed", async () => {
+    await upsertAccount({
+      name: `${MARKER}-shared`,
+      institution: "Bancolombia",
+      type: "credit_card",
+      primary: { currency: "COP", balance: 0 },
+      secondary: { currency: "USD", balance: 0 },
+      physicalCard: {
+        creditLimitCents: 20_000_000_00,
+        cutoffDay: 15,
+        last4: "7291",
+        network: "mastercard",
+      },
+    });
+    const rows = await db
+      .select()
+      .from(accounts)
+      .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${MARKER}-shared`)));
+    expect(rows).toHaveLength(2);
+    const pcId = rows[0].physicalCardId!;
+    const [pc] = await db.select().from(physicalCards).where(eq(physicalCards.id, pcId));
+    expect(pc).toBeDefined();
+    expect(pc.creditLimitCents).toBe(BigInt(20_000_000_00));
+    expect(pc.statementCutoffDay).toBe(15);
+    expect(pc.last4).toBe("7291");
+    expect(pc.network).toBe("mastercard");
+    // Sub-accounts MUST NOT carry the shared-cupo keys — single source of truth.
+    expect(rows[0].metadata.creditLimitCents).toBeUndefined();
+    expect(rows[1].metadata.creditLimitCents).toBeUndefined();
+    expect(rows[0].metadata.cutoffDay).toBeUndefined();
+    expect(rows[1].metadata.cutoffDay).toBeUndefined();
+  });
+
+  it("rejects physicalCard without secondary (single-currency CCs use metadata)", async () => {
+    await expect(
+      upsertAccount({
+        name: `${MARKER}-bad`,
+        institution: "Bancolombia",
+        type: "credit_card",
+        primary: { currency: "COP", balance: 0 },
+        physicalCard: { creditLimitCents: 100_000 },
+      }),
+    ).rejects.toThrow();
   });
 
   it("archives each linked row independently (no cascade)", async () => {

--- a/src/app/(app)/settings/accounts/actions.ts
+++ b/src/app/(app)/settings/accounts/actions.ts
@@ -42,6 +42,23 @@ const sideSchema = z.object({
   metadata: metadataSchema.optional(),
 });
 
+// When creating a multi-currency credit card, the top-level `physicalCard`
+// carries the shared-cupo attributes (#346). Replaces the old per-side
+// `metadata.creditLimitCents` duplication. Optional — if omitted, the server
+// falls back to `MAX(primary.metadata.creditLimitCents, secondary.metadata.creditLimitCents)`
+// for backwards compat with the pre-Task-5 form payload.
+const physicalCardInputSchema = z
+  .object({
+    creditLimitCents: z.number().int().nonnegative().optional(),
+    cutoffDay: z.number().int().min(1).max(31).optional(),
+    last4: z
+      .string()
+      .regex(/^\d{4}$/)
+      .optional(),
+    network: z.enum(["visa", "mastercard", "amex"]).optional(),
+  })
+  .strict();
+
 const upsertSchema = z
   .object({
     id: z.coerce.number().int().positive().optional(),
@@ -51,6 +68,7 @@ const upsertSchema = z
     active: z.coerce.boolean().default(true),
     primary: sideSchema,
     secondary: sideSchema.optional(),
+    physicalCard: physicalCardInputSchema.optional(),
   })
   .refine((v) => !v.secondary || v.type === "credit_card", {
     message: "Multi-currency only supported for credit_card",
@@ -63,6 +81,10 @@ const upsertSchema = z
   .refine((v) => !v.secondary || !v.id, {
     message: "Multi-currency can only be set on create",
     path: ["secondary"],
+  })
+  .refine((v) => !v.physicalCard || v.secondary, {
+    message: "physicalCard requires a secondary side (multi-currency only)",
+    path: ["physicalCard"],
   });
 
 export type AccountUpsertInput = z.input<typeof upsertSchema>;
@@ -113,25 +135,29 @@ export async function upsertAccount(input: AccountUpsertInput) {
   if (parsed.secondary) {
     // Multi-currency credit cards have a shared COP cupo owned by `physical_cards`
     // (#346). Insert the parent row first so the FK on accounts.physical_card_id
-    // resolves within the same transaction. Cupo initializes to 0 — Task 5
-    // (issue #346) will add a top-level creditLimit input to the create form;
-    // for now the user edits it via the future "Editar tarjeta física" modal.
+    // resolves within the same transaction.
     const physicalCardId = randomUUID();
     const primaryMeta = parsed.primary.metadata ?? {};
     const secondaryMeta = parsed.secondary.metadata ?? {};
-    const coalescedLimit = Math.max(
-      primaryMeta.creditLimitCents ?? 0,
-      secondaryMeta.creditLimitCents ?? 0,
-    );
+    // Prefer the explicit top-level physicalCard payload (Task 5 form). Fall
+    // back to MAX of per-side metadata for pre-Task-5 callers and tests.
+    const creditLimitCents =
+      parsed.physicalCard?.creditLimitCents ??
+      Math.max(primaryMeta.creditLimitCents ?? 0, secondaryMeta.creditLimitCents ?? 0);
+    const cutoffDay =
+      parsed.physicalCard?.cutoffDay ?? primaryMeta.cutoffDay ?? secondaryMeta.cutoffDay;
+    const network = parsed.physicalCard?.network ?? primaryMeta.network ?? secondaryMeta.network;
+    const last4 =
+      parsed.physicalCard?.last4 ?? primaryMeta.last4s?.[0] ?? secondaryMeta.last4s?.[0];
     await db.transaction(async (trx) => {
       await trx.insert(physicalCards).values({
         id: physicalCardId,
         userId: session.id,
         institution: parsed.institution,
-        network: primaryMeta.network ?? secondaryMeta.network,
-        last4: primaryMeta.last4s?.[0] ?? secondaryMeta.last4s?.[0],
-        creditLimitCents: BigInt(coalescedLimit),
-        statementCutoffDay: primaryMeta.cutoffDay ?? secondaryMeta.cutoffDay,
+        network,
+        last4,
+        creditLimitCents: BigInt(creditLimitCents),
+        statementCutoffDay: cutoffDay,
       });
       await trx.insert(accounts).values([
         { ...base, ...sideToValues(parsed.primary), physicalCardId },


### PR DESCRIPTION
## Summary

Task 5 of 9 for #346. Form rewire on `/settings/accounts` so multi-currency creation doesn't duplicate the cupo.

- Drops the per-side "Credit limit (secondary currency)" input from the multi-currency section of the account editor.
- When the multi-currency toggle is on, the primary "Credit limit" input renames to **"Shared cupo (COP)"** with a placeholder (`e.g. 20000000`).
- Server: `upsertSchema` gains a top-level `physicalCard: { creditLimitCents?, cutoffDay?, last4?, network? }` block. Refined to require a `secondary` side when present.
- `upsertAccount` prefers `parsed.physicalCard.creditLimitCents` over the old `MAX(primary.meta, secondary.meta)` fallback. The fallback stays for pre-Task-5 callers and the existing "creates two linked rows sharing physical_card_id" test, which passes `creditLimitCents` in metadata.
- Form now submits `physicalCard: {...}` when multi-currency is active and strips `creditLimitCents` / `cutoffDay` from both sub-account metadata payloads — single source of truth lives in `physical_cards`.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 660/660 passing (2 new: `creates a physical_cards row with the shared cupo when physicalCard is passed`, `rejects physicalCard without secondary`)

## Follow-up

Task 6 (edit modal + updatePhysicalCard action) unlocks post-creation cupo edits. Until that ships, the user sets the cupo exactly once at creation time.

Refs #346