### PR TITLE
feat(accounts): editar tarjeta física modal + updatePhysicalCard action (#346)

### DIFF
--- a/src/app/(app)/settings/accounts/accounts-manager.tsx
+++ b/src/app/(app)/settings/accounts/accounts-manager.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import {
   ArrowLeftRightIcon,
+  CreditCardIcon,
   LinkIcon,
   PencilIcon,
   PlusIcon,
@@ -31,11 +32,22 @@ import {
   adjustAccountBalance,
   archiveAccount,
   toggleAccountActive,
+  updatePhysicalCard,
   upsertAccount,
 } from "./actions";
 import { BalanceAdjustDialog } from "./balance-adjust-dialog";
 
 type AccountType = "savings" | "credit_card" | "loan";
+
+export type AccountRowPhysicalCard = {
+  id: string;
+  // Stringified bigint; same convention as balanceCents to stay serialization-safe
+  // when this type crosses the RSC → client boundary.
+  creditLimitCents: string;
+  statementCutoffDay: number | null;
+  last4: string | null;
+  network: string | null;
+};
 
 export type AccountRow = {
   id: number;
@@ -47,6 +59,7 @@ export type AccountRow = {
   active: boolean;
   metadata: AccountMetadata;
   physicalCardId: string | null;
+  physicalCard: AccountRowPhysicalCard | null;
 };
 
 const TYPE_LABEL: Record<AccountType, string> = {
@@ -59,10 +72,12 @@ const TYPE_ORDER: AccountType[] = ["savings", "credit_card", "loan"];
 
 type EditorState = { open: boolean; editing: AccountRow | null };
 type AdjustState = { open: boolean; target: AccountRow | null };
+type PhysicalCardState = { open: boolean; target: AccountRow | null };
 
 export function AccountsManager({ items }: { items: AccountRow[] }) {
   const [editor, setEditor] = useState<EditorState>({ open: false, editing: null });
   const [adjust, setAdjust] = useState<AdjustState>({ open: false, target: null });
+  const [pcard, setPcard] = useState<PhysicalCardState>({ open: false, target: null });
   const [pending, startTransition] = useTransition();
 
   const grouped = useMemo(() => {
@@ -204,6 +219,18 @@ export function AccountsManager({ items }: { items: AccountRow[] }) {
                                       <ArrowLeftRightIcon className="size-4" />
                                     </Link>
                                   </Button>
+                                  {r.physicalCard ? (
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      onClick={() => setPcard({ open: true, target: r })}
+                                      disabled={pending}
+                                      aria-label="Editar tarjeta física"
+                                      title="Editar cupo compartido de la tarjeta física"
+                                    >
+                                      <CreditCardIcon className="size-4" />
+                                    </Button>
+                                  ) : null}
                                   <Button
                                     variant="ghost"
                                     size="sm"
@@ -252,6 +279,12 @@ export function AccountsManager({ items }: { items: AccountRow[] }) {
         open={editor.open}
         editing={editor.editing}
         onClose={close}
+      />
+      <PhysicalCardEditor
+        key={pcard.target?.physicalCard?.id ?? "pcard-closed"}
+        open={pcard.open}
+        target={pcard.target}
+        onClose={() => setPcard({ open: false, target: null })}
       />
       <BalanceAdjustDialog
         key={adjust.target?.id ?? "adjust-closed"}
@@ -763,6 +796,151 @@ function AccountEditor({
             </Button>
             <Button type="submit" disabled={pending}>
               {pending ? "Saving…" : isEdit ? "Save" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PhysicalCardEditor({
+  open,
+  target,
+  onClose,
+}: {
+  open: boolean;
+  target: AccountRow | null;
+  onClose: () => void;
+}) {
+  const [pending, startTransition] = useTransition();
+  const pc = target?.physicalCard ?? null;
+  const [creditLimit, setCreditLimit] = useState(
+    pc ? (Number(BigInt(pc.creditLimitCents)) / 100).toString() : "",
+  );
+  const [statementCutoffDay, setStatementCutoffDay] = useState(
+    pc?.statementCutoffDay?.toString() ?? "",
+  );
+  const [last4, setLast4] = useState(pc?.last4 ?? "");
+  const [network, setNetwork] = useState(pc?.network ?? "");
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!pc) return;
+    const limitNum = Number(creditLimit);
+    if (!Number.isFinite(limitNum) || limitNum < 0) {
+      toast.error("El cupo debe ser un número positivo (o 0).");
+      return;
+    }
+    const cutoffNum = statementCutoffDay === "" ? null : Number(statementCutoffDay);
+    if (cutoffNum !== null && (!Number.isInteger(cutoffNum) || cutoffNum < 1 || cutoffNum > 31)) {
+      toast.error("Cutoff day debe ser 1-31.");
+      return;
+    }
+    const last4Clean = last4.trim();
+    if (last4Clean && !/^\d{4}$/.test(last4Clean)) {
+      toast.error("Last4 deben ser exactamente 4 dígitos.");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await updatePhysicalCard({
+        id: pc.id,
+        creditLimitCents: Math.round(limitNum * 100),
+        statementCutoffDay: cutoffNum,
+        last4: last4Clean === "" ? null : last4Clean,
+        network: network === "" ? null : (network as "visa" | "mastercard" | "amex"),
+      });
+      if (result.ok) {
+        toast.success("Tarjeta física actualizada.");
+        onClose();
+      } else {
+        toast.error(result.message);
+      }
+    });
+  }
+
+  if (!target || !pc) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Editar tarjeta física</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={onSubmit} className="flex flex-col gap-3">
+          <p className="text-muted-foreground text-xs">
+            Estos valores afectan a <strong>todas las sub-cuentas</strong> que comparten este
+            plástico ({target.name}). El cupo se mide en COP — las compras en USD consumen este cupo
+            a la TRM del día.
+          </p>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="pc-limit">Cupo total (COP)</Label>
+            <Input
+              id="pc-limit"
+              type="number"
+              inputMode="decimal"
+              step="1"
+              value={creditLimit}
+              onChange={(e) => setCreditLimit(e.target.value)}
+              required
+              className="tabular-nums"
+              autoFocus
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="pc-cutoff">Cutoff day</Label>
+              <Input
+                id="pc-cutoff"
+                type="number"
+                inputMode="numeric"
+                min={1}
+                max={31}
+                value={statementCutoffDay}
+                onChange={(e) => setStatementCutoffDay(e.target.value)}
+                placeholder="1-31"
+                className="tabular-nums"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="pc-network">Network</Label>
+              <select
+                id="pc-network"
+                value={network ?? ""}
+                onChange={(e) => setNetwork(e.target.value)}
+                className="bg-background h-9 rounded-md border px-2 text-sm"
+              >
+                <option value="">—</option>
+                <option value="visa">Visa</option>
+                <option value="mastercard">Mastercard</option>
+                <option value="amex">Amex</option>
+              </select>
+            </div>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="pc-last4">Last 4 digits</Label>
+            <Input
+              id="pc-last4"
+              value={last4 ?? ""}
+              onChange={(e) => setLast4(e.target.value)}
+              placeholder="e.g. 7291"
+              inputMode="numeric"
+              maxLength={4}
+              className="tabular-nums"
+            />
+          </div>
+          <DialogFooter className="mt-2">
+            <Button type="button" variant="outline" onClick={onClose} disabled={pending}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving…" : "Save"}
             </Button>
           </DialogFooter>
         </form>

--- a/src/app/(app)/settings/accounts/actions.test.ts
+++ b/src/app/(app)/settings/accounts/actions.test.ts
@@ -16,8 +16,13 @@ vi.mock("@/lib/auth/session", () => ({
   getSessionUser: vi.fn().mockResolvedValue({ id: 1, email: "test@test.local", name: "Test" }),
 }));
 
-const { upsertAccount, archiveAccount, toggleAccountActive, adjustAccountBalance } =
-  await import("./actions");
+const {
+  upsertAccount,
+  archiveAccount,
+  toggleAccountActive,
+  adjustAccountBalance,
+  updatePhysicalCard,
+} = await import("./actions");
 
 const TEST_USER_ID = 1;
 const MARKER = "__test_accounts_ui";
@@ -175,6 +180,69 @@ describe("accounts actions: multi-currency credit card", () => {
     expect(rows[1].metadata.creditLimitCents).toBeUndefined();
     expect(rows[0].metadata.cutoffDay).toBeUndefined();
     expect(rows[1].metadata.cutoffDay).toBeUndefined();
+  });
+
+  it("updatePhysicalCard updates shared cupo and attributes", async () => {
+    await upsertAccount({
+      name: `${MARKER}-update`,
+      institution: "Bancolombia",
+      type: "credit_card",
+      primary: { currency: "COP", balance: 0 },
+      secondary: { currency: "USD", balance: 0 },
+      physicalCard: { creditLimitCents: 10_000_000_00, cutoffDay: 10, network: "mastercard" },
+    });
+    const rows = await db
+      .select()
+      .from(accounts)
+      .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${MARKER}-update`)));
+    const pcId = rows[0].physicalCardId!;
+
+    const result = await updatePhysicalCard({
+      id: pcId,
+      creditLimitCents: 25_000_000_00,
+      statementCutoffDay: 15,
+      last4: "7291",
+      network: "mastercard",
+    });
+    expect(result.ok).toBe(true);
+    const [pc] = await db.select().from(physicalCards).where(eq(physicalCards.id, pcId));
+    expect(pc.creditLimitCents).toBe(BigInt(25_000_000_00));
+    expect(pc.statementCutoffDay).toBe(15);
+    expect(pc.last4).toBe("7291");
+    // Sub-accounts are untouched.
+    const [refreshed] = await db.select().from(accounts).where(eq(accounts.id, rows[0].id));
+    expect(refreshed.balanceCents).toBe(BigInt(0));
+    expect(refreshed.metadata.creditLimitCents).toBeUndefined();
+  });
+
+  it("updatePhysicalCard rejects when the uuid belongs to another user (tenancy guard)", async () => {
+    // Create a physical card under OTHER_USER_ID directly via the DB (bypassing
+    // the upsert helper which uses the mocked session user).
+    const [otherUser] = await db
+      .insert(users)
+      .values({ email: `${MARKER}-cross-tenant@test.local`, name: "Other" })
+      .returning({ id: users.id });
+    const { randomUUID } = await import("node:crypto");
+    const pcId = randomUUID();
+    await db.insert(physicalCards).values({
+      id: pcId,
+      userId: otherUser.id,
+      institution: "Bancolombia",
+      creditLimitCents: BigInt(99_999),
+    });
+
+    const result = await updatePhysicalCard({
+      id: pcId,
+      creditLimitCents: 1_000_000_00,
+    });
+    expect(result.ok).toBe(false);
+    // Row is unchanged.
+    const [unchanged] = await db.select().from(physicalCards).where(eq(physicalCards.id, pcId));
+    expect(unchanged.creditLimitCents).toBe(BigInt(99_999));
+
+    // Cleanup.
+    await db.execute(sql`DELETE FROM physical_cards WHERE id = ${pcId}`);
+    await db.execute(sql`DELETE FROM users WHERE email = ${MARKER + "-cross-tenant@test.local"}`);
   });
 
   it("rejects physicalCard without secondary (single-currency CCs use metadata)", async () => {

--- a/src/app/(app)/settings/accounts/actions.ts
+++ b/src/app/(app)/settings/accounts/actions.ts
@@ -187,6 +187,56 @@ export async function archiveAccount(id: number) {
   revalidate();
 }
 
+const updatePhysicalCardSchema = z
+  .object({
+    id: z.string().uuid(),
+    creditLimitCents: z.coerce.number().int().nonnegative(),
+    statementCutoffDay: z.coerce.number().int().min(1).max(31).nullable().optional(),
+    last4: z
+      .string()
+      .regex(/^\d{4}$/)
+      .nullable()
+      .optional(),
+    network: z.enum(["visa", "mastercard", "amex"]).nullable().optional(),
+  })
+  .strict();
+
+export type UpdatePhysicalCardInput = z.input<typeof updatePhysicalCardSchema>;
+
+/**
+ * Updates a multi-currency credit card's shared attributes (#346). Scoped by
+ * `user_id = session.id` so one user can never mutate another's card even if
+ * they obtain the uuid. Returns `{ ok: true }` on success, `{ ok: false }`
+ * when the card isn't found for the session user.
+ */
+export async function updatePhysicalCard(
+  input: UpdatePhysicalCardInput,
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  const session = await getSessionUser();
+  const parsed = updatePhysicalCardSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, message: parsed.error.issues[0]?.message ?? "Input inválido." };
+  }
+
+  const result = await db
+    .update(physicalCards)
+    .set({
+      creditLimitCents: BigInt(parsed.data.creditLimitCents),
+      statementCutoffDay: parsed.data.statementCutoffDay ?? null,
+      last4: parsed.data.last4 ?? null,
+      network: parsed.data.network ?? null,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(physicalCards.id, parsed.data.id), eq(physicalCards.userId, session.id)))
+    .returning({ id: physicalCards.id });
+
+  if (result.length === 0) {
+    return { ok: false, message: "Tarjeta física no encontrada." };
+  }
+  revalidate();
+  return { ok: true };
+}
+
 export async function toggleAccountActive(id: number, active: boolean) {
   const session = await getSessionUser();
   const parsedId = z.coerce.number().int().positive().parse(id);

--- a/src/app/(app)/settings/accounts/page.tsx
+++ b/src/app/(app)/settings/accounts/page.tsx
@@ -1,7 +1,6 @@
-import { asc } from "drizzle-orm";
-import { and, eq } from "drizzle-orm";
+import { asc, and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts } from "@/lib/db/schema";
+import { accounts, physicalCards } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { getSessionUser } from "@/lib/auth/session";
 import { AccountsManager, type AccountRow } from "./accounts-manager";
@@ -21,14 +20,43 @@ export default async function SettingsAccountsPage() {
       active: accounts.active,
       metadata: accounts.metadata,
       physicalCardId: accounts.physicalCardId,
+      pcCreditLimitCents: physicalCards.creditLimitCents,
+      pcStatementCutoffDay: physicalCards.statementCutoffDay,
+      pcLast4: physicalCards.last4,
+      pcNetwork: physicalCards.network,
     })
     .from(accounts)
+    .leftJoin(
+      physicalCards,
+      and(
+        eq(physicalCards.id, accounts.physicalCardId),
+        // Tenancy guard on the join — never surface another user's physical card
+        // even if a FK were ever corrupted (see per-user-table-join-tenant-safety).
+        eq(physicalCards.userId, accounts.userId),
+      ),
+    )
     .where(and(eq(accounts.userId, session.id), notDeleted(accounts.deletedAt)))
     .orderBy(asc(accounts.type), asc(accounts.name));
 
   const items: AccountRow[] = rows.map((r) => ({
-    ...r,
+    id: r.id,
+    name: r.name,
+    institution: r.institution,
+    type: r.type,
+    currency: r.currency,
     balanceCents: r.balanceCents.toString(),
+    active: r.active,
+    metadata: r.metadata,
+    physicalCardId: r.physicalCardId,
+    physicalCard: r.physicalCardId
+      ? {
+          id: r.physicalCardId,
+          creditLimitCents: r.pcCreditLimitCents!.toString(),
+          statementCutoffDay: r.pcStatementCutoffDay,
+          last4: r.pcLast4,
+          network: r.pcNetwork,
+        }
+      : null,
   }));
 
   return (


### PR DESCRIPTION
## Summary

Task 6 of 9 for #346. Unlocks **post-creation** edits of the shared cupo — previously the only way to set it was at pair creation.

- New server action `updatePhysicalCard({ id, creditLimitCents, statementCutoffDay?, last4?, network? })` in `src/app/(app)/settings/accounts/actions.ts`. Scoped by `user_id = session.id`; returns `{ ok: false, message }` when the card isn't found for the session user (tenancy guard).
- `/settings/accounts` LEFT JOINs `physical_cards` so the manager receives per-row `physicalCard` summary (id, creditLimitCents, statementCutoffDay, last4, network).
- `AccountRow` gains a new `physicalCard: AccountRowPhysicalCard | null` field — `bigint` stringified as per the existing `balanceCents` convention to stay RSC-serializable.
- New CreditCard icon button in the action column, only visible on rows with `physicalCard`. Opens a new `PhysicalCardEditor` modal prefilled with current values. Network dropdown (visa/mastercard/amex), last4 (`^\d{4}$`), cutoffDay (1-31), cupo in COP.

## Manual verification

Confirmed via chrome-devtools MCP on localhost:
- Icon appears only on the two *7291 rows, NOT on single-currency Visa *2575.
- Modal opens with the *7291 physical card prefilled (cupo=0, network=Mastercard, last4=7291).
- Save invokes the server action → revalidate refreshes the page.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 662/662 passing (2 new: `updatePhysicalCard updates shared cupo and attributes`, `updatePhysicalCard rejects cross-tenant edits`)
- [x] Visual verification via chrome-devtools MCP on localhost — icon + modal work end-to-end

## Next

Task 7 — rewire `balance-adjust-dialog` to ask for "cupo disponible (COP)" when the target has a `physicalCardId`, derive sub-account balance from user entry + sibling + TRM.

Refs #346