### PR TITLE
feat(accounts): shared-cupo variant in balance-adjust (#346)

### DIFF
--- a/src/app/(app)/settings/accounts/accounts-manager.tsx
+++ b/src/app/(app)/settings/accounts/accounts-manager.tsx
@@ -74,7 +74,7 @@ type EditorState = { open: boolean; editing: AccountRow | null };
 type AdjustState = { open: boolean; target: AccountRow | null };
 type PhysicalCardState = { open: boolean; target: AccountRow | null };
 
-export function AccountsManager({ items }: { items: AccountRow[] }) {
+export function AccountsManager({ items, copPerUsd }: { items: AccountRow[]; copPerUsd: number }) {
   const [editor, setEditor] = useState<EditorState>({ open: false, editing: null });
   const [adjust, setAdjust] = useState<AdjustState>({ open: false, target: null });
   const [pcard, setPcard] = useState<PhysicalCardState>({ open: false, target: null });
@@ -290,6 +290,15 @@ export function AccountsManager({ items }: { items: AccountRow[] }) {
         key={adjust.target?.id ?? "adjust-closed"}
         open={adjust.open}
         target={adjust.target}
+        siblings={
+          adjust.target?.physicalCardId
+            ? items.filter(
+                (i) =>
+                  i.physicalCardId === adjust.target!.physicalCardId && i.id !== adjust.target!.id,
+              )
+            : []
+        }
+        copPerUsd={copPerUsd}
         onClose={() => setAdjust({ open: false, target: null })}
         onConfirm={async (declared, reason) => {
           if (!adjust.target) return;

--- a/src/app/(app)/settings/accounts/actions.test.ts
+++ b/src/app/(app)/settings/accounts/actions.test.ts
@@ -593,4 +593,147 @@ describe("adjustAccountBalance", () => {
       expect(result.status).toBe("error");
     });
   });
+
+  describe("kind: sharedAvailableCop (#346 multi-currency)", () => {
+    // Seed a *7291-like pair with a known limit + balances. Returns COP sub id
+    // and USD sub id for the assertions.
+    async function seedPair(params: {
+      limitCents: number;
+      copBalanceCents: number;
+      usdBalanceCents: number;
+    }): Promise<{ copId: number; usdId: number; pcId: string }> {
+      await upsertAccount({
+        name: `${ADJ_MARKER}-pair`,
+        institution: "Bancolombia",
+        type: "credit_card",
+        primary: { currency: "COP", balance: params.copBalanceCents / 100 },
+        secondary: { currency: "USD", balance: params.usdBalanceCents / 100 },
+        physicalCard: { creditLimitCents: params.limitCents, network: "mastercard" },
+      });
+      const rows = await db
+        .select()
+        .from(accounts)
+        .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${ADJ_MARKER}-pair`)));
+      const cop = rows.find((r) => r.currency === "COP")!;
+      const usd = rows.find((r) => r.currency === "USD")!;
+      return { copId: cop.id, usdId: usd.id, pcId: cop.physicalCardId! };
+    }
+
+    async function stubFxRate(rate: number) {
+      // Direct upsert into fx_rates for today so getCurrentFxRate returns the
+      // deterministic rate for the test (keeps the math predictable).
+      await db.execute(sql`
+        INSERT INTO fx_rates (base, quote, rate_micros, as_of, source)
+        VALUES ('USD', 'COP', ${BigInt(Math.round(rate * 1_000_000))}, CURRENT_DATE, 'test')
+        ON CONFLICT (base, quote, as_of) DO UPDATE SET
+          rate_micros = EXCLUDED.rate_micros,
+          source = EXCLUDED.source,
+          fetched_at = NOW()
+      `);
+    }
+
+    afterEach(async () => {
+      await db.execute(sql`DELETE FROM fx_rates WHERE source = 'test'`);
+    });
+
+    it("AS-4: adjusts only the COP sub when the target is COP", async () => {
+      // Limit 20MM COP, COP balance -500k, USD balance -100 USD, TRM 4100.
+      // User enters cupo disponible = 18.5MM COP.
+      // Expected: total_debt = 1.5MM, sibling (USD) debt = 100 × 4100 = 410k,
+      // target COP debt = 1.5MM - 410k = 1.090MM → new COP balance = -1.090MM.
+      await stubFxRate(4100);
+      const { copId, usdId } = await seedPair({
+        limitCents: 20_000_000_00,
+        copBalanceCents: -500_000_00,
+        usdBalanceCents: -100_00,
+      });
+
+      const result = await adjustAccountBalance({
+        accountId: copId,
+        declared: { kind: "sharedAvailableCop", availableCopCents: 18_500_000_00 },
+      });
+
+      expect(result.status).toBe("ok");
+      const [cop] = await db.select().from(accounts).where(eq(accounts.id, copId));
+      const [usd] = await db.select().from(accounts).where(eq(accounts.id, usdId));
+      expect(cop.balanceCents).toBe(BigInt(-1_090_000_00));
+      // USD sub is untouched.
+      expect(usd.balanceCents).toBe(BigInt(-100_00));
+    });
+
+    it("AS-5: adjusts only the USD sub when the target is USD (back-solve through TRM)", async () => {
+      // Limit 20MM, COP -500k, USD -100 USD, TRM 4100. User enters 19MM COP.
+      // Expected: total_debt = 1MM COP; sibling (COP) debt = 500k; remaining
+      // USD debt = 500k COP / 4100 = 121.95 USD → 12_195 USD cents → -12195.
+      await stubFxRate(4100);
+      const { copId, usdId } = await seedPair({
+        limitCents: 20_000_000_00,
+        copBalanceCents: -500_000_00,
+        usdBalanceCents: -100_00,
+      });
+
+      const result = await adjustAccountBalance({
+        accountId: usdId,
+        declared: { kind: "sharedAvailableCop", availableCopCents: 19_000_000_00 },
+      });
+
+      expect(result.status).toBe("ok");
+      const [usd] = await db.select().from(accounts).where(eq(accounts.id, usdId));
+      const [cop] = await db.select().from(accounts).where(eq(accounts.id, copId));
+      // 500_000_00 COP / 4100 = 12_195.12 → integer truncation = 12_195 cents USD.
+      expect(usd.balanceCents).toBe(BigInt(-12_195));
+      expect(cop.balanceCents).toBe(BigInt(-500_000_00));
+    });
+
+    it("rejects when the physical card has no limit configured", async () => {
+      await stubFxRate(4100);
+      const { copId } = await seedPair({
+        limitCents: 0,
+        copBalanceCents: 0,
+        usdBalanceCents: 0,
+      });
+
+      const result = await adjustAccountBalance({
+        accountId: copId,
+        declared: { kind: "sharedAvailableCop", availableCopCents: 100_000 },
+      });
+      expect(result.status).toBe("error");
+      if (result.status === "error") {
+        expect(result.message).toMatch(/cupo/i);
+      }
+    });
+
+    it("rejects when availableCopCents exceeds the shared cupo", async () => {
+      await stubFxRate(4100);
+      const { copId } = await seedPair({
+        limitCents: 10_000_000_00,
+        copBalanceCents: 0,
+        usdBalanceCents: 0,
+      });
+
+      const result = await adjustAccountBalance({
+        accountId: copId,
+        declared: { kind: "sharedAvailableCop", availableCopCents: 15_000_000_00 },
+      });
+      expect(result.status).toBe("error");
+    });
+
+    it("rejects kind=availableCredit on a paired sub-account (force shared path)", async () => {
+      await stubFxRate(4100);
+      const { copId } = await seedPair({
+        limitCents: 10_000_000_00,
+        copBalanceCents: 0,
+        usdBalanceCents: 0,
+      });
+
+      const result = await adjustAccountBalance({
+        accountId: copId,
+        declared: { kind: "availableCredit", availableCreditCents: 5_000_000_00 },
+      });
+      expect(result.status).toBe("error");
+      if (result.status === "error") {
+        expect(result.message).toMatch(/multi-moneda|cupo compartido/i);
+      }
+    });
+  });
 });

--- a/src/app/(app)/settings/accounts/actions.ts
+++ b/src/app/(app)/settings/accounts/actions.ts
@@ -14,6 +14,8 @@ import {
 } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { getSessionUser } from "@/lib/auth/session";
+import { getCurrentFxRate } from "@/lib/fx/repo";
+import { convertCents } from "@/lib/money";
 
 const ADJUSTMENT_CATEGORY_SLUG = "adjustments";
 
@@ -262,6 +264,12 @@ const declaredSchema = z.discriminatedUnion("kind", [
     kind: z.literal("availableCredit"),
     availableCreditCents: z.coerce.number().int().nonnegative(),
   }),
+  z.object({
+    kind: z.literal("sharedAvailableCop"),
+    // Cupo disponible COP del plástico según el banco. El server back-solves
+    // la deuda del target a partir del sibling + TRM (#346 AS-4/AS-5).
+    availableCopCents: z.coerce.number().int().nonnegative(),
+  }),
 ]);
 
 const adjustSchema = z.object({
@@ -315,6 +323,7 @@ export async function adjustAccountBalance(
         currency: accounts.currency,
         balanceCents: accounts.balanceCents,
         metadata: accounts.metadata,
+        physicalCardId: accounts.physicalCardId,
       })
       .from(accounts)
       .where(
@@ -334,11 +343,21 @@ export async function adjustAccountBalance(
 
     if (parsed.data.declared.kind === "balance") {
       targetBalanceCents = BigInt(parsed.data.declared.balanceCents);
-    } else {
+    } else if (parsed.data.declared.kind === "availableCredit") {
       if (account.type !== "credit_card") {
         return {
           status: "error",
           message: "El cupo disponible solo aplica a tarjetas de crédito.",
+        };
+      }
+      // Multi-currency cards (#346) use sharedAvailableCop — the per-currency
+      // availableCredit path would only mutate half the pair and leave the
+      // shared cupo inconsistent. Force clients onto the new path.
+      if (account.physicalCardId) {
+        return {
+          status: "error",
+          message:
+            "Esta tarjeta es multi-moneda. Usá el flujo de cupo compartido (COP) para ajustar.",
         };
       }
       const limit = account.metadata.creditLimitCents;
@@ -359,6 +378,79 @@ export async function adjustAccountBalance(
       // negative (debt reduces net worth — see CreditMeter).
       targetBalanceCents = BigInt(available) - BigInt(limit);
       nextMetadata = { ...account.metadata, availableCreditCents: available };
+    } else {
+      // kind: "sharedAvailableCop" (#346). Back-solve the target sub-account's
+      // balance from: the shared cupo, the declared-available-COP, the sibling
+      // sub-accounts' balances, and the current TRM.
+      if (account.type !== "credit_card" || !account.physicalCardId) {
+        return {
+          status: "error",
+          message: "El cupo compartido solo aplica a tarjetas multi-moneda.",
+        };
+      }
+      const [pc] = await tx
+        .select({
+          id: physicalCards.id,
+          creditLimitCents: physicalCards.creditLimitCents,
+        })
+        .from(physicalCards)
+        .where(
+          and(eq(physicalCards.id, account.physicalCardId), eq(physicalCards.userId, session.id)),
+        );
+      if (!pc || pc.creditLimitCents <= BigInt(0)) {
+        return {
+          status: "error",
+          message:
+            "El plástico no tiene cupo configurado. Editá la tarjeta física y cargá el cupo primero.",
+        };
+      }
+      const availableCopCents = BigInt(parsed.data.declared.availableCopCents);
+      if (availableCopCents > pc.creditLimitCents) {
+        return {
+          status: "error",
+          message: "El cupo disponible no puede superar al cupo total del plástico.",
+        };
+      }
+      const siblings = await tx
+        .select({
+          id: accounts.id,
+          currency: accounts.currency,
+          balanceCents: accounts.balanceCents,
+        })
+        .from(accounts)
+        .where(
+          and(
+            eq(accounts.userId, session.id),
+            eq(accounts.physicalCardId, account.physicalCardId),
+            sql`${accounts.id} != ${account.id}`,
+            notDeleted(accounts.deletedAt),
+          ),
+        );
+
+      const fx = await getCurrentFxRate();
+      // Total debt (COP) across the pair = limit - declared available.
+      const totalDebtCop = pc.creditLimitCents - availableCopCents;
+      // Sibling debt expressed in COP. Balances are negative, so we negate.
+      let siblingDebtCop = BigInt(0);
+      for (const sib of siblings) {
+        const sibDebtNative = sib.balanceCents < BigInt(0) ? -sib.balanceCents : BigInt(0);
+        siblingDebtCop += convertCents(sibDebtNative, sib.currency, "COP", fx.rate);
+      }
+      // Remainder is what the target sub-account must carry as debt.
+      const targetDebtCop = totalDebtCop - siblingDebtCop;
+      // Convert COP-denominated target debt to the target's native currency.
+      const targetDebtNative =
+        targetDebtCop <= BigInt(0)
+          ? BigInt(0)
+          : convertCents(targetDebtCop, "COP", account.currency, fx.rate);
+      targetBalanceCents = -targetDebtNative;
+      // Strip metadata.availableCreditCents if present — single source of truth
+      // lives in physical_cards.credit_limit_cents + sub-account balances.
+      if (account.metadata.availableCreditCents !== undefined) {
+        const { availableCreditCents: _drop, ...rest } = account.metadata;
+        void _drop;
+        nextMetadata = rest;
+      }
     }
 
     const diff = targetBalanceCents - account.balanceCents;

--- a/src/app/(app)/settings/accounts/balance-adjust-dialog.tsx
+++ b/src/app/(app)/settings/accounts/balance-adjust-dialog.tsx
@@ -15,7 +15,8 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Money } from "@/components/display/money";
 import { formatAccountLabel } from "@/lib/accounts/format";
-import type { AccountRow } from "./accounts-manager";
+import { convertCents } from "@/lib/money";
+import type { AccountRow, AccountRowPhysicalCard } from "./accounts-manager";
 import type { AdjustBalanceInput } from "./actions";
 
 type DeclaredValue = AdjustBalanceInput["declared"];
@@ -23,11 +24,19 @@ type DeclaredValue = AdjustBalanceInput["declared"];
 export function BalanceAdjustDialog({
   open,
   target,
+  siblings,
+  copPerUsd,
   onClose,
   onConfirm,
 }: {
   open: boolean;
   target: AccountRow | null;
+  // Other sub-accounts sharing `target.physicalCardId` — used by the shared-cupo
+  // form to preview the new target balance. Empty/ignored for single-currency.
+  siblings: AccountRow[];
+  // Current TRM from getCurrentFxRate() — passed down so the client preview
+  // matches what the server computes.
+  copPerUsd: number;
   onClose: () => void;
   onConfirm: (declared: DeclaredValue, reason?: string) => Promise<void>;
 }) {
@@ -55,7 +64,16 @@ export function BalanceAdjustDialog({
             Ajustar saldo · {formatAccountLabel(target)}
           </DialogTitle>
         </DialogHeader>
-        {target.type === "credit_card" ? (
+        {target.type === "credit_card" && target.physicalCard ? (
+          <SharedCupoForm
+            target={target}
+            siblings={siblings}
+            physicalCard={target.physicalCard}
+            copPerUsd={copPerUsd}
+            onConfirm={onConfirm}
+            onClose={onClose}
+          />
+        ) : target.type === "credit_card" ? (
           <CreditCardForm target={target} onConfirm={onConfirm} onClose={onClose} />
         ) : (
           <BalanceForm target={target} onConfirm={onConfirm} onClose={onClose} />
@@ -304,6 +322,167 @@ function CreditCardFormInner({
               <Money cents={diffCents} currency={target.currency} />
             </span>{" "}
             marcada como <strong>Ajuste</strong>. Queda fuera de spend / insights / budgets.
+          </div>
+        </div>
+      ) : null}
+
+      <ReasonField reason={reason} setReason={setReason} />
+      <Actions pending={pending} canSubmit={canSubmit} onClose={onClose} />
+    </form>
+  );
+}
+
+function SharedCupoForm({
+  target,
+  siblings,
+  physicalCard,
+  copPerUsd,
+  onConfirm,
+  onClose,
+}: {
+  target: AccountRow;
+  siblings: AccountRow[];
+  physicalCard: AccountRowPhysicalCard;
+  copPerUsd: number;
+  onConfirm: (declared: DeclaredValue, reason?: string) => Promise<void>;
+  onClose: () => void;
+}) {
+  const limitCop = BigInt(physicalCard.creditLimitCents);
+  const targetBalance = BigInt(target.balanceCents);
+
+  // Sibling debt in COP (sum of positive magnitudes). Used for preview only —
+  // the server recomputes authoritatively on submit.
+  const siblingDebtCop = siblings.reduce((acc, sib) => {
+    const bal = BigInt(sib.balanceCents);
+    const nativeDebt = bal < BigInt(0) ? -bal : BigInt(0);
+    return acc + convertCents(nativeDebt, sib.currency, "COP", copPerUsd);
+  }, BigInt(0));
+
+  // Current target debt expressed in COP for display.
+  const targetDebtCop =
+    targetBalance < BigInt(0)
+      ? convertCents(-targetBalance, target.currency, "COP", copPerUsd)
+      : BigInt(0);
+  const currentTotalDebtCop = siblingDebtCop + targetDebtCop;
+  const currentAvailableCop =
+    currentTotalDebtCop < limitCop ? limitCop - currentTotalDebtCop : BigInt(0);
+  const placeholderAvailable = Number(currentAvailableCop) / 100;
+
+  const [declared, setDeclared] = useState("");
+  const [reason, setReason] = useState("");
+  const [pending, startTransition] = useTransition();
+
+  const declaredAvailableCop = useMemo(() => {
+    if (declared.trim() === "") return null;
+    const n = Number(declared);
+    if (!Number.isFinite(n) || n < 0) return null;
+    return BigInt(Math.round(n * 100));
+  }, [declared]);
+
+  const exceedsLimit = declaredAvailableCop !== null && declaredAvailableCop > limitCop;
+
+  // Preview the new target balance using the same math as the server.
+  const previewTargetBalanceCents = useMemo(() => {
+    if (declaredAvailableCop === null || exceedsLimit) return null;
+    const totalDebtCop = limitCop - declaredAvailableCop;
+    const remainingDebtCop = totalDebtCop - siblingDebtCop;
+    if (remainingDebtCop <= BigInt(0)) return BigInt(0);
+    const nativeDebt = convertCents(remainingDebtCop, "COP", target.currency, copPerUsd);
+    return -nativeDebt;
+  }, [declaredAvailableCop, exceedsLimit, limitCop, siblingDebtCop, target.currency, copPerUsd]);
+
+  const diffCents =
+    previewTargetBalanceCents !== null ? previewTargetBalanceCents - targetBalance : BigInt(0);
+  const hasDiff = previewTargetBalanceCents !== null && diffCents !== BigInt(0);
+  const canSubmit = hasDiff && !exceedsLimit;
+
+  function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (declaredAvailableCop === null || exceedsLimit) return;
+    startTransition(async () => {
+      await onConfirm(
+        {
+          kind: "sharedAvailableCop",
+          availableCopCents: Number(declaredAvailableCop),
+        },
+        reason.trim() || undefined,
+      );
+    });
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <div className="border-border/60 bg-muted/30 rounded-md border p-3 text-xs">
+        <div className="text-muted-foreground">
+          Esta es una tarjeta multi-moneda — el cupo es uno solo en COP, compartido entre las
+          sub-cuentas COP y USD. Las compras en USD consumen el cupo a la TRM del día (
+          {Math.round(copPerUsd).toLocaleString("es-CO")} COP/USD).
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-muted-foreground text-xs tracking-wide uppercase">
+            Cupo total
+          </Label>
+          <div className="bg-muted/40 rounded-md border px-3 py-2 text-sm font-medium tabular-nums">
+            <Money cents={limitCop} currency="COP" />
+          </div>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-muted-foreground text-xs tracking-wide uppercase">
+            Disponible en Findash
+          </Label>
+          <div className="bg-muted/40 rounded-md border px-3 py-2 text-sm font-medium tabular-nums">
+            <Money cents={currentAvailableCop} currency="COP" />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="declared-shared-cupo">Cupo disponible (COP, según tu banco)</Label>
+        <Input
+          id="declared-shared-cupo"
+          type="number"
+          inputMode="decimal"
+          step="1"
+          min="0"
+          max={(Number(limitCop) / 100).toFixed(0)}
+          value={declared}
+          onChange={(e) => setDeclared(e.target.value)}
+          placeholder={placeholderAvailable.toFixed(0)}
+          required
+          autoFocus
+        />
+        <p className="text-muted-foreground text-xs">
+          El banco descuenta las compras USD al TRM, así que el disponible siempre se muestra en
+          COP. El server ajusta el saldo de <strong>{target.currency}</strong> y deja las otras
+          sub-cuentas intactas.
+        </p>
+        {exceedsLimit ? (
+          <p className="text-destructive text-xs">
+            El disponible no puede superar al cupo total (
+            <Money cents={limitCop} currency="COP" />
+            ).
+          </p>
+        ) : null}
+      </div>
+
+      {hasDiff && previewTargetBalanceCents !== null && !exceedsLimit ? (
+        <div className="border-border/60 rounded-md border p-3 text-sm">
+          <div>
+            Nuevo saldo <strong>{target.currency}</strong>:{" "}
+            <span className="font-semibold tabular-nums">
+              <Money cents={previewTargetBalanceCents} currency={target.currency} />
+            </span>
+          </div>
+          <div className="mt-1">
+            Ajuste a crear:{" "}
+            <span className="font-semibold tabular-nums">
+              {diffCents > BigInt(0) ? "+" : ""}
+              <Money cents={diffCents} currency={target.currency} />
+            </span>{" "}
+            (categorizado como <strong>Ajuste</strong>, fuera de spend/insights).
           </div>
         </div>
       ) : null}

--- a/src/app/(app)/settings/accounts/page.tsx
+++ b/src/app/(app)/settings/accounts/page.tsx
@@ -3,12 +3,14 @@ import { db } from "@/lib/db";
 import { accounts, physicalCards } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { getSessionUser } from "@/lib/auth/session";
+import { getCurrentFxRate } from "@/lib/fx/repo";
 import { AccountsManager, type AccountRow } from "./accounts-manager";
 
 export const dynamic = "force-dynamic";
 
 export default async function SettingsAccountsPage() {
   const session = await getSessionUser();
+  const fx = await getCurrentFxRate();
   const rows = await db
     .select({
       id: accounts.id,
@@ -68,7 +70,7 @@ export default async function SettingsAccountsPage() {
           that your transactions are associated with.
         </p>
       </header>
-      <AccountsManager items={items} />
+      <AccountsManager items={items} copPerUsd={fx.rate} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Task 7 of 9 for #346. Fixes the balance-adjust flow for multi-currency cards.

**Before**: hitting the Wrench on either *7291 sub opened the per-currency `CreditCardForm` which read `metadata.creditLimitCents` — now null/undefined since 0041 stripped it — so the dialog showed the "configure a credit limit first" empty state.

**After**:

- Server: new discriminated union variant `kind: "sharedAvailableCop"` in `adjustAccountBalance`. Loads the physical card + sibling sub-accounts + current TRM, back-solves the target sub-account's new balance from `limit - declaredAvailableCop - siblingDebtCop` converted to the target's native currency.
- Server: rejects `kind: "availableCredit"` when the target has `physicalCardId` set — forces stale clients onto the new path instead of mutating half the pair silently.
- Client: `BalanceAdjustDialog` branches on `target.physicalCard`. New `SharedCupoForm` asks for one number in COP ("Cupo disponible según tu banco"), shows: cupo total, current disponible, preview of new native-currency balance + adjustment diff.
- Page: passes `copPerUsd` (from `getCurrentFxRate`) into the manager, manager propagates to the dialog along with the filtered sibling list.

## Math (AS-4 / AS-5)

Let `L = limit (COP)`, `A = user-entered available (COP)`, `S = sum(|sibling balance|) in COP via TRM`, `T = target debt to reach`:

```
T = (L - A) - S     # in COP cents
if T < 0: T = 0     # target is in credit
new_balance = -convertCents(T, COP, target.currency, rate)
```

Rounding: integer truncation (`BigInt` division), same as `convertCents` in `money.ts`. Any residual < 1 cent of the target currency is absorbed into the adjustment diff.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 667/667 passing (5 new):
  - AS-4 (adjust COP sub, verify USD sub untouched)
  - AS-5 (adjust USD sub with back-solve through TRM, integer truncation at 12_195 USD cents)
  - Rejects when physical card has no limit configured
  - Rejects when availableCopCents > cupo total
  - Rejects kind=availableCredit on a paired sub-account

## Follow-up

Task 8 (seed creates a physical_cards row) + Task 9 (memory snapshot) close out the epic.

Refs #346