### PR TITLE
feat(ui): unificar tile de credit_card + exponer nextPaymentDate single-currency (#358)

### DIFF
--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -34,6 +34,8 @@ function formatNextPayment(isoDate: string): string {
   return NEXT_PAYMENT_FMT.format(new Date(`${isoDate}T12:00:00Z`));
 }
 
+const currencyRank: Record<Currency, number> = { COP: 0, USD: 1 };
+
 export const dynamic = "force-dynamic";
 
 const TYPE_LABEL: Record<AccountDetail["type"], string> = {
@@ -117,16 +119,49 @@ export default async function AccountsPage() {
       ))}
 
       {inactive.length > 0 ? (
-        <section className="flex flex-col gap-3">
-          <h2 className="text-h2 text-muted-foreground">Inactive</h2>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {inactive.map((a) => (
-              <AccountCard key={a.id} account={a} muted />
-            ))}
-          </div>
-        </section>
+        <InactiveSection
+          items={inactive}
+          copPerUsd={fx.rate}
+          fxFallback={fx.source === "fallback"}
+        />
       ) : null}
     </main>
+  );
+}
+
+function InactiveSection({
+  items,
+  copPerUsd,
+  fxFallback,
+}: {
+  items: AccountDetail[];
+  copPerUsd: number;
+  fxFallback: boolean;
+}) {
+  // Keep credit_card rows grouped by physical_card so shared-cupo pairs still
+  // render as one CreditCardTile (muted). Others render as muted AccountCard.
+  const creditCards = items.filter((a) => a.type === "credit_card");
+  const others = items.filter((a) => a.type !== "credit_card");
+  const creditGroups = groupCreditCards(creditCards);
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-h2 text-muted-foreground">Inactive</h2>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {creditGroups.map((g) => (
+          <CreditCardTile
+            key={g[0].physicalCardId ?? `acct-${g[0].id}`}
+            subs={g}
+            copPerUsd={copPerUsd}
+            fxFallback={fxFallback}
+            muted
+          />
+        ))}
+        {others.map((a) => (
+          <AccountCard key={a.id} account={a} muted />
+        ))}
+      </div>
+    </section>
   );
 }
 
@@ -166,23 +201,12 @@ function AccountTypeSection({
     type === "credit_card" ? CreditCardIcon : type === "loan" ? LandmarkIcon : PiggyBankIcon;
   const subtotal = sumBalanceCopCents(items, copPerUsd);
 
-  // Multi-currency credit cards (sharing a physicalCardId) render as one grouped
-  // tile with the shared cupo; remaining single-currency cards render as before.
-  const pairs = new Map<string, AccountDetail[]>();
-  const singles: AccountDetail[] = [];
-  if (type === "credit_card") {
-    for (const a of items) {
-      if (a.physicalCardId && a.physicalCard) {
-        const arr = pairs.get(a.physicalCardId) ?? [];
-        arr.push(a);
-        pairs.set(a.physicalCardId, arr);
-      } else {
-        singles.push(a);
-      }
-    }
-  } else {
-    singles.push(...items);
-  }
+  // credit_card items get grouped by physical_card — shared-cupo pairs share one
+  // tile, single-currency cards end up as single-member groups. Grid layout is
+  // the same as savings/loan: no col-span overrides, so every tile has the same
+  // width for consistent UX across card types.
+  const creditCardGroups: AccountDetail[][] | null =
+    type === "credit_card" ? groupCreditCards(items) : null;
 
   return (
     <section className="flex flex-col gap-3">
@@ -196,60 +220,105 @@ function AccountTypeSection({
         </div>
       </div>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {Array.from(pairs.values()).map((subs) => (
-          <PhysicalCardGroup
-            key={subs[0].physicalCardId!}
-            subs={subs}
-            copPerUsd={copPerUsd}
-            fxFallback={fxFallback}
-          />
-        ))}
-        {singles.map((a) => (
-          <AccountCard key={a.id} account={a} />
-        ))}
+        {creditCardGroups
+          ? creditCardGroups.map((g) => (
+              <CreditCardTile
+                key={g[0].physicalCardId ?? `acct-${g[0].id}`}
+                subs={g}
+                copPerUsd={copPerUsd}
+                fxFallback={fxFallback}
+              />
+            ))
+          : items.map((a) => <AccountCard key={a.id} account={a} />)}
       </div>
     </section>
   );
 }
 
-function PhysicalCardGroup({
+function groupCreditCards(items: AccountDetail[]): AccountDetail[][] {
+  const groups: AccountDetail[][] = [];
+  const byPcId = new Map<string, AccountDetail[]>();
+  for (const a of items) {
+    if (a.physicalCardId && a.physicalCard) {
+      const existing = byPcId.get(a.physicalCardId);
+      if (existing) {
+        existing.push(a);
+      } else {
+        const arr = [a];
+        byPcId.set(a.physicalCardId, arr);
+        groups.push(arr);
+      }
+    } else {
+      groups.push([a]);
+    }
+  }
+  return groups;
+}
+
+function CreditCardTile({
   subs,
   copPerUsd,
   fxFallback,
+  muted,
 }: {
   subs: AccountDetail[];
   copPerUsd: number;
   fxFallback: boolean;
+  muted?: boolean;
 }) {
-  const pc = subs[0].physicalCard as PhysicalCardSummary;
-  // available = limit + COP debts + USD debts × rate (balances are negative).
-  let copDebt = BigInt(0);
-  let usdDebt = BigInt(0);
-  for (const s of subs) {
-    if (s.currency === "COP") copDebt += s.balanceCents;
-    else usdDebt += s.balanceCents;
-  }
-  const availableCop = pc.creditLimitCents + copDebt + toCop(usdDebt, "USD", copPerUsd);
+  const isShared = subs.length > 1 || Boolean(subs[0].physicalCard);
+  const pc: PhysicalCardSummary | null = isShared ? subs[0].physicalCard : null;
+  const primary = subs[0];
   const hasUsd = subs.some((s) => s.currency === "USD");
-  // Bancolombia shows COP first, USD below; mirror that regardless of insert order.
-  const currencyRank: Record<Currency, number> = { COP: 0, USD: 1 };
   const orderedSubs = [...subs].sort((a, b) => currencyRank[a.currency] - currencyRank[b.currency]);
-  const name = subs[0].name;
-  const institution = subs[0].institution;
-  const meta: string[] = [];
-  if (pc.network) meta.push(pc.network.toUpperCase());
-  if (pc.last4) meta.push(`*${pc.last4}`);
+
+  // Meter data: shared cards use physical_cards (limit always COP); single
+  // cards use metadata in their native currency.
+  let limitCents: bigint | null = null;
+  let availableCents: bigint | null = null;
+  let meterCurrency: Currency = "COP";
+  if (isShared && pc) {
+    limitCents = pc.creditLimitCents;
+    let copDebt = BigInt(0);
+    let usdDebt = BigInt(0);
+    for (const s of subs) {
+      if (s.currency === "COP") copDebt += s.balanceCents;
+      else usdDebt += s.balanceCents;
+    }
+    availableCents = limitCents + copDebt + toCop(usdDebt, "USD", copPerUsd);
+    meterCurrency = "COP";
+  } else {
+    const limit = primary.metadata.creditLimitCents;
+    if (limit !== undefined && limit > 0) {
+      limitCents = BigInt(limit);
+      availableCents =
+        primary.metadata.availableCreditCents !== undefined
+          ? BigInt(primary.metadata.availableCreditCents)
+          : limitCents + primary.balanceCents;
+    }
+    meterCurrency = primary.currency;
+  }
+
+  const nextPaymentDate =
+    isShared && pc ? pc.nextPaymentDate : (primary.metadata.nextPaymentDate ?? null);
+
+  const badge = isShared ? "Cupo compartido" : primary.currency;
+  const network = isShared && pc ? pc.network : (primary.metadata.network ?? null);
+  const last4 = isShared && pc ? pc.last4 : (primary.metadata.last4s?.[0] ?? null);
+  const metaParts: string[] = [];
+  if (network) metaParts.push(network.toUpperCase());
+  if (last4) metaParts.push(`*${last4}`);
 
   return (
-    <Card size="sm" className="sm:col-span-2 lg:col-span-3">
+    <Card size="sm" className={cn(muted && "opacity-60")}>
       <CardHeader>
         <CardDescription className="flex items-center justify-between gap-2">
-          <span className="truncate">{institution}</span>
-          <span className="shrink-0 text-[10px] tracking-wide uppercase">Cupo compartido</span>
+          <span className="truncate">{primary.institution}</span>
+          <span className="shrink-0 text-[10px] tracking-wide uppercase">{badge}</span>
         </CardDescription>
-        <CardTitle className="truncate text-base">{name}</CardTitle>
-        {meta.length > 0 ? (
-          <div className="text-muted-foreground text-xs">{meta.join(" · ")}</div>
+        <CardTitle className="truncate text-base">{primary.name}</CardTitle>
+        {metaParts.length > 0 ? (
+          <div className="text-muted-foreground text-xs">{metaParts.join(" · ")}</div>
         ) : null}
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
@@ -261,27 +330,18 @@ function PhysicalCardGroup({
             ))}
           </div>
         </div>
-        <SharedCupoMeter
-          limitCents={pc.creditLimitCents}
-          availableCents={availableCop}
-          fxFallback={fxFallback && hasUsd}
+        <CreditMeter
+          limitCents={limitCents}
+          availableCents={availableCents}
+          currency={meterCurrency}
+          fxFallback={isShared && fxFallback && hasUsd}
         />
-        {pc.nextPaymentDate || hasUsd ? (
-          <div className="text-muted-foreground flex flex-col gap-0.5 text-xs">
-            {pc.nextPaymentDate ? (
-              <div className="flex items-center justify-between">
-                <span>Próximo pago</span>
-                <span className="tabular-nums">{formatNextPayment(pc.nextPaymentDate)}</span>
-              </div>
-            ) : null}
-            {hasUsd ? (
-              <div className="flex items-center justify-between">
-                <span>TRM{fxFallback ? " (fallback)" : ""}</span>
-                <span className="tabular-nums">$ {RATE_FMT.format(copPerUsd)}</span>
-              </div>
-            ) : null}
-          </div>
-        ) : null}
+        <FooterMeta
+          nextPaymentDate={nextPaymentDate}
+          showTRM={isShared && hasUsd}
+          trmRate={copPerUsd}
+          fxFallback={fxFallback}
+        />
       </CardContent>
     </Card>
   );
@@ -306,20 +366,31 @@ function DebtRow({ account }: { account: AccountDetail }) {
   );
 }
 
-function SharedCupoMeter({
+function CreditMeter({
   limitCents,
   availableCents,
+  currency,
   fxFallback,
 }: {
-  limitCents: bigint;
-  availableCents: bigint;
+  limitCents: bigint | null;
+  availableCents: bigint | null;
+  currency: Currency;
   fxFallback: boolean;
 }) {
+  if (limitCents === null || availableCents === null || limitCents === BigInt(0)) {
+    return (
+      <div className="flex flex-col gap-1">
+        <div className="bg-muted h-1.5 overflow-hidden rounded-full" />
+        <div className="text-muted-foreground flex items-center justify-between text-xs tabular-nums">
+          <span>Cupo disponible: —</span>
+          <span>Total: —</span>
+        </div>
+      </div>
+    );
+  }
   const used = limitCents > availableCents ? limitCents - availableCents : BigInt(0);
-  const pct =
-    limitCents > BigInt(0) ? Math.min(100, Number((used * BigInt(10000)) / limitCents) / 100) : 0;
+  const pct = Math.min(100, Number((used * BigInt(10000)) / limitCents) / 100);
   const high = pct >= 80;
-
   return (
     <div className="flex flex-col gap-1">
       <div className="bg-muted h-1.5 overflow-hidden rounded-full">
@@ -330,13 +401,42 @@ function SharedCupoMeter({
       </div>
       <div className="text-muted-foreground flex items-center justify-between text-xs tabular-nums">
         <span>
-          Cupo disponible: <Money cents={availableCents} currency="COP" />
+          Cupo disponible: <Money cents={availableCents} currency={currency} />
           {fxFallback ? " (TRM fallback)" : ""}
         </span>
         <span>
-          Total: <Money cents={limitCents} currency="COP" />
+          Total: <Money cents={limitCents} currency={currency} />
         </span>
       </div>
+    </div>
+  );
+}
+
+function FooterMeta({
+  nextPaymentDate,
+  showTRM,
+  trmRate,
+  fxFallback,
+}: {
+  nextPaymentDate: string | null;
+  showTRM: boolean;
+  trmRate: number;
+  fxFallback: boolean;
+}) {
+  return (
+    <div className="text-muted-foreground flex flex-col gap-0.5 text-xs">
+      <div className="flex items-center justify-between">
+        <span>Próximo pago</span>
+        <span className="tabular-nums">
+          {nextPaymentDate ? formatNextPayment(nextPaymentDate) : "—"}
+        </span>
+      </div>
+      {showTRM ? (
+        <div className="flex items-center justify-between">
+          <span>TRM{fxFallback ? " (fallback)" : ""}</span>
+          <span className="tabular-nums">$ {RATE_FMT.format(trmRate)}</span>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -349,8 +449,6 @@ function AccountCard({ account, muted }: { account: AccountDetail; muted?: boole
   if (metadata.network) meta.push(metadata.network.toUpperCase());
   if (last4) meta.push(`*${last4}`);
 
-  const creditLimit = metadata.creditLimitCents;
-  const availableCredit = metadata.availableCreditCents;
   const loanRemaining = metadata.loanRemainingCents;
   const nextPayment = metadata.nextPaymentDate;
 
@@ -375,14 +473,6 @@ function AccountCard({ account, muted }: { account: AccountDetail; muted?: boole
         >
           <Money cents={account.balanceCents} currency={account.currency} />
         </div>
-        {account.type === "credit_card" && creditLimit ? (
-          <CreditMeter
-            currency={account.currency}
-            limitCents={BigInt(creditLimit)}
-            availableCents={availableCredit !== undefined ? BigInt(availableCredit) : null}
-            balanceCents={account.balanceCents}
-          />
-        ) : null}
         {account.type === "loan" && loanRemaining ? (
           <div className="text-muted-foreground text-xs">
             Remaining: <Money cents={BigInt(loanRemaining)} currency={account.currency} />
@@ -391,46 +481,5 @@ function AccountCard({ account, muted }: { account: AccountDetail; muted?: boole
         ) : null}
       </CardContent>
     </Card>
-  );
-}
-
-function CreditMeter({
-  currency,
-  limitCents,
-  availableCents,
-  balanceCents,
-}: {
-  currency: Currency;
-  limitCents: bigint;
-  availableCents: bigint | null;
-  balanceCents: bigint;
-}) {
-  const used =
-    availableCents !== null
-      ? limitCents - availableCents
-      : balanceCents < BigInt(0)
-        ? -balanceCents
-        : BigInt(0);
-  const pct =
-    limitCents > BigInt(0) ? Math.min(100, Number((used * BigInt(10000)) / limitCents) / 100) : 0;
-  const high = pct >= 80;
-
-  return (
-    <div className="flex flex-col gap-1">
-      <div className="bg-muted h-1.5 overflow-hidden rounded-full">
-        <div
-          className={cn("h-full transition-all", high ? "bg-rose-600" : "bg-emerald-600")}
-          style={{ width: `${pct}%` }}
-        />
-      </div>
-      <div className="text-muted-foreground flex items-center justify-between text-xs tabular-nums">
-        <span>
-          <Money cents={used} currency={currency} /> used
-        </span>
-        <span>
-          <Money cents={limitCents} currency={currency} /> limit
-        </span>
-      </div>
-    </div>
   );
 }

--- a/src/app/(app)/settings/accounts/accounts-manager.tsx
+++ b/src/app/(app)/settings/accounts/accounts-manager.tsx
@@ -330,6 +330,7 @@ type SideMetadataKeys = Pick<
   | "creditLimitCents"
   | "cutoffDay"
   | "paymentDueDay"
+  | "nextPaymentDate"
   | "interestRateMonthly"
   | "termMonths"
   | "loanOriginalCents"
@@ -342,6 +343,7 @@ function metadataFromForm(values: {
   creditLimit: string;
   cutoffDay: string;
   paymentDueDay: string;
+  nextPaymentDate: string;
   interestRateMonthly: string;
   termMonths: string;
   loanOriginal: string;
@@ -367,6 +369,10 @@ function metadataFromForm(values: {
   if (values.paymentDueDay) {
     const n = Number(values.paymentDueDay);
     if (Number.isInteger(n) && n >= 1 && n <= 31) md.paymentDueDay = n;
+  }
+  const nextPaymentClean = values.nextPaymentDate.trim();
+  if (nextPaymentClean && /^\d{4}-\d{2}-\d{2}$/.test(nextPaymentClean)) {
+    md.nextPaymentDate = nextPaymentClean;
   }
   if (values.interestRateMonthly) {
     const n = Number(values.interestRateMonthly);
@@ -415,6 +421,7 @@ function AccountEditor({
   );
   const [cutoffDay, setCutoffDay] = useState(initialMeta.cutoffDay?.toString() ?? "");
   const [paymentDueDay, setPaymentDueDay] = useState(initialMeta.paymentDueDay?.toString() ?? "");
+  const [nextPaymentDate, setNextPaymentDate] = useState<string>(initialMeta.nextPaymentDate ?? "");
   const [interestRateMonthly, setInterestRateMonthly] = useState(
     initialMeta.interestRateMonthly?.toString() ?? "",
   );
@@ -449,6 +456,7 @@ function AccountEditor({
       creditLimit,
       cutoffDay,
       paymentDueDay,
+      nextPaymentDate,
       interestRateMonthly,
       termMonths,
       loanOriginal,
@@ -479,9 +487,15 @@ function AccountEditor({
       };
       // Strip the shared-cupo keys from both sub-account metadata payloads —
       // they belong to physical_cards now, not accounts.
-      const { creditLimitCents: _pLimit, cutoffDay: _pCutoff, ...primaryMdNoLimit } = primaryMd;
+      const {
+        creditLimitCents: _pLimit,
+        cutoffDay: _pCutoff,
+        nextPaymentDate: _pNext,
+        ...primaryMdNoLimit
+      } = primaryMd;
       void _pLimit;
       void _pCutoff;
+      void _pNext;
       secondary = {
         currency: secondaryCurrency,
         balance: secBal,
@@ -491,6 +505,7 @@ function AccountEditor({
           creditLimit: "", // lives in physical_cards now
           cutoffDay: "", // lives in physical_cards now
           paymentDueDay,
+          nextPaymentDate: "", // lives in physical_cards now
           interestRateMonthly: "",
           termMonths: "",
           loanOriginal: "",
@@ -501,6 +516,7 @@ function AccountEditor({
       Object.assign(primaryMd, primaryMdNoLimit);
       delete primaryMd.creditLimitCents;
       delete primaryMd.cutoffDay;
+      delete primaryMd.nextPaymentDate;
     }
 
     startTransition(async () => {
@@ -708,34 +724,54 @@ function AccountEditor({
               )}
 
               {type === "credit_card" ? (
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="flex flex-col gap-1.5">
-                    <Label htmlFor="acc-cutoff">Cutoff day</Label>
-                    <Input
-                      id="acc-cutoff"
-                      type="number"
-                      min="1"
-                      max="31"
-                      value={cutoffDay}
-                      onChange={(e) => setCutoffDay(e.target.value)}
-                      placeholder="Optional"
-                      className="tabular-nums"
-                    />
+                <>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="flex flex-col gap-1.5">
+                      <Label htmlFor="acc-cutoff">Cutoff day</Label>
+                      <Input
+                        id="acc-cutoff"
+                        type="number"
+                        min="1"
+                        max="31"
+                        value={cutoffDay}
+                        onChange={(e) => setCutoffDay(e.target.value)}
+                        placeholder="Optional"
+                        className="tabular-nums"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1.5">
+                      <Label htmlFor="acc-due">Payment due day</Label>
+                      <Input
+                        id="acc-due"
+                        type="number"
+                        min="1"
+                        max="31"
+                        value={paymentDueDay}
+                        onChange={(e) => setPaymentDueDay(e.target.value)}
+                        placeholder="Optional"
+                        className="tabular-nums"
+                      />
+                    </div>
                   </div>
-                  <div className="flex flex-col gap-1.5">
-                    <Label htmlFor="acc-due">Payment due day</Label>
-                    <Input
-                      id="acc-due"
-                      type="number"
-                      min="1"
-                      max="31"
-                      value={paymentDueDay}
-                      onChange={(e) => setPaymentDueDay(e.target.value)}
-                      placeholder="Optional"
-                      className="tabular-nums"
-                    />
-                  </div>
-                </div>
+                  {editing?.physicalCardId ? null : (
+                    <div className="flex flex-col gap-1.5">
+                      <Label htmlFor="acc-next-payment">Próximo pago</Label>
+                      <Input
+                        id="acc-next-payment"
+                        type="date"
+                        value={nextPaymentDate}
+                        onChange={(e) => setNextPaymentDate(e.target.value)}
+                        className="tabular-nums"
+                      />
+                      <p className="text-muted-foreground text-xs">
+                        Fecha puntual del próximo pago (se muestra en el widget).
+                        {multiCurrencyAllowed && multiCurrency
+                          ? " Para tarjetas multi-moneda, edítalo después desde la tarjeta física."
+                          : ""}
+                      </p>
+                    </div>
+                  )}
+                </>
               ) : null}
 
               {type === "loan" ? (

--- a/src/app/(app)/settings/accounts/actions.test.ts
+++ b/src/app/(app)/settings/accounts/actions.test.ts
@@ -116,6 +116,27 @@ describe("accounts actions: single-currency", () => {
       }),
     ).rejects.toThrow();
   });
+
+  it("persists nextPaymentDate in metadata for single-currency credit_card (#358)", async () => {
+    await upsertAccount({
+      name: `${MARKER}-cc-next-pay`,
+      institution: "Bancolombia",
+      type: "credit_card",
+      primary: {
+        currency: "COP",
+        balance: -100_000,
+        metadata: { creditLimitCents: 5_000_000_00, nextPaymentDate: "2026-05-15" },
+      },
+    });
+    const [row] = await db
+      .select()
+      .from(accounts)
+      .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${MARKER}-cc-next-pay`)));
+    expect(row).toBeDefined();
+    expect(row.physicalCardId).toBeNull();
+    expect(row.metadata.nextPaymentDate).toBe("2026-05-15");
+    expect(row.metadata.creditLimitCents).toBe(5_000_000_00);
+  });
 });
 
 describe("accounts actions: multi-currency credit card", () => {

--- a/src/app/(app)/settings/accounts/actions.ts
+++ b/src/app/(app)/settings/accounts/actions.ts
@@ -30,6 +30,10 @@ const metadataSchema = z
     availableCreditCents: z.number().int().nonnegative().optional(),
     cutoffDay: z.number().int().min(1).max(31).optional(),
     paymentDueDay: z.number().int().min(1).max(31).optional(),
+    nextPaymentDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional(),
     interestRateMonthly: z.number().nonnegative().optional(),
     termMonths: z.number().int().positive().optional(),
     loanOriginalCents: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
## Summary

- **Un solo `CreditCardTile`** para todas las credit_card — shared-cupo y single-currency renderizan con la misma estructura (header, Deuda a la fecha, Cupo meter, Próximo pago, TRM si USD). Todas mismo ancho en el grid (sin `col-span` override).
- **Input `Próximo pago`** en el form principal de `/settings/accounts` para credit_cards NO linkeadas a physical_cards → se guarda en `accounts.metadata.nextPaymentDate`. Linkeadas siguen editándose desde el 🎫 `Editar tarjeta física` (canonical path).
- **Dashes (`—`)** cuando no hay datos en campos opcionales (Próximo pago, Cupo disponible/Total).

## Changes

- `src/app/(app)/accounts/page.tsx` — reemplazado `PhysicalCardGroup` + `AccountCard` (branch credit_card) + `SharedCupoMeter` por `CreditCardTile` unificado. Agregado `InactiveSection` para mantener consistencia en la sección inactivos (shared-cupo pairs siguen agrupados). `currencyRank` promovido a module-level.
- `src/app/(app)/settings/accounts/accounts-manager.tsx` — nuevo state + input `Próximo pago` (type=date) en el bloque credit_card. Solo visible si el row NO está linkeado a physical_card (los linkeados muestran hint que apunte al 🎫). `metadataFromForm` acepta + valida YYYY-MM-DD.
- `src/app/(app)/settings/accounts/actions.ts` — `metadataSchema` incluye `nextPaymentDate` con regex.
- `src/app/(app)/settings/accounts/actions.test.ts` — test de round-trip `nextPaymentDate` para single-currency credit_card.

## Test plan

- [x] `bun run typecheck` + `bun run lint`
- [x] `bun run test` → 670/670 pass (+1 nuevo test)
- [x] Manual smoke via chrome-devtools MCP: ambas cards (Mastercard shared + Visa single) renderizan uniformes, mismo ancho, misma estructura. Próximo pago se muestra en ambas.

## Non-goals

- Multi-currency creation flow NO persiste `nextPaymentDate` al `physical_cards` (se strippea del metadata primario al guardar). El usuario lo setea después desde el 🎫. Scope para otro issue si molesta.
- El widget label "Deuda a la fecha" se mantiene aunque nuestro número incluya compras pending (más real-time que el snapshot Bancolombia). Revisar relabel en otra PR.

Closes #358