### PR TITLE
feat(accounts): persistir nextPaymentDate al crear TC multi-moneda (#360)

### DIFF
--- a/src/app/(app)/settings/accounts/accounts-manager.tsx
+++ b/src/app/(app)/settings/accounts/accounts-manager.tsx
@@ -479,9 +479,14 @@ function AccountEditor({
       // shared COP cupo; no per-side limit. Submit via top-level `physicalCard`
       // so it lands in `physical_cards` — NOT in either sub-account's metadata.
       const sharedLimitCents = creditLimit !== "" ? Math.round(Number(creditLimit) * 100) : 0;
+      const nextPaymentClean = nextPaymentDate.trim();
       physicalCard = {
         creditLimitCents: Number.isFinite(sharedLimitCents) ? sharedLimitCents : 0,
         cutoffDay: cutoffDay !== "" ? Number(cutoffDay) : undefined,
+        nextPaymentDate:
+          nextPaymentClean && /^\d{4}-\d{2}-\d{2}$/.test(nextPaymentClean)
+            ? nextPaymentClean
+            : undefined,
         last4: last4.split(/\s+/)[0]?.match(/^\d{4}$/)?.[0],
         network: network ? (network as "visa" | "mastercard" | "amex") : undefined,
       };
@@ -765,9 +770,6 @@ function AccountEditor({
                       />
                       <p className="text-muted-foreground text-xs">
                         Fecha puntual del próximo pago (se muestra en el widget).
-                        {multiCurrencyAllowed && multiCurrency
-                          ? " Para tarjetas multi-moneda, edítalo después desde la tarjeta física."
-                          : ""}
                       </p>
                     </div>
                   )}

--- a/src/app/(app)/settings/accounts/actions.test.ts
+++ b/src/app/(app)/settings/accounts/actions.test.ts
@@ -170,6 +170,37 @@ describe("accounts actions: multi-currency credit card", () => {
     expect(currencies).toEqual(["COP", "USD"]);
   });
 
+  it("persists nextPaymentDate to physical_cards on multi-currency creation (#360)", async () => {
+    await upsertAccount({
+      name: `${MARKER}-mc-next-pay`,
+      institution: "Bancolombia",
+      type: "credit_card",
+      primary: { currency: "COP", balance: 0 },
+      secondary: { currency: "USD", balance: 0 },
+      physicalCard: {
+        creditLimitCents: 15_000_000_00,
+        cutoffDay: 10,
+        nextPaymentDate: "2026-05-20",
+        last4: "7291",
+        network: "mastercard",
+      },
+    });
+    const rows = await db
+      .select()
+      .from(accounts)
+      .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${MARKER}-mc-next-pay`)));
+    expect(rows).toHaveLength(2);
+    const [pc] = await db
+      .select()
+      .from(physicalCards)
+      .where(eq(physicalCards.id, rows[0].physicalCardId!));
+    expect(pc.nextPaymentDate).toBe("2026-05-20");
+    // Must NOT leak into sub-account metadata — physical_cards is the single
+    // source of truth for shared-cupo cards.
+    expect(rows[0].metadata.nextPaymentDate).toBeUndefined();
+    expect(rows[1].metadata.nextPaymentDate).toBeUndefined();
+  });
+
   it("creates a physical_cards row with the shared cupo when physicalCard is passed", async () => {
     await upsertAccount({
       name: `${MARKER}-shared`,

--- a/src/app/(app)/settings/accounts/actions.ts
+++ b/src/app/(app)/settings/accounts/actions.ts
@@ -57,6 +57,10 @@ const physicalCardInputSchema = z
   .object({
     creditLimitCents: z.number().int().nonnegative().optional(),
     cutoffDay: z.number().int().min(1).max(31).optional(),
+    nextPaymentDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional(),
     last4: z
       .string()
       .regex(/^\d{4}$/)
@@ -152,6 +156,11 @@ export async function upsertAccount(input: AccountUpsertInput) {
       Math.max(primaryMeta.creditLimitCents ?? 0, secondaryMeta.creditLimitCents ?? 0);
     const cutoffDay =
       parsed.physicalCard?.cutoffDay ?? primaryMeta.cutoffDay ?? secondaryMeta.cutoffDay;
+    const nextPaymentDate =
+      parsed.physicalCard?.nextPaymentDate ??
+      primaryMeta.nextPaymentDate ??
+      secondaryMeta.nextPaymentDate ??
+      null;
     const network = parsed.physicalCard?.network ?? primaryMeta.network ?? secondaryMeta.network;
     const last4 =
       parsed.physicalCard?.last4 ?? primaryMeta.last4s?.[0] ?? secondaryMeta.last4s?.[0];
@@ -164,6 +173,7 @@ export async function upsertAccount(input: AccountUpsertInput) {
         last4,
         creditLimitCents: BigInt(creditLimitCents),
         statementCutoffDay: cutoffDay,
+        nextPaymentDate,
       });
       await trx.insert(accounts).values([
         { ...base, ...sideToValues(parsed.primary), physicalCardId },


### PR DESCRIPTION
## Summary

- `physicalCardInputSchema` (Zod): nuevo campo `nextPaymentDate` (YYYY-MM-DD).
- `upsertAccount`: al insertar `physical_cards` en creación multi-moneda, toma `nextPaymentDate` desde `parsed.physicalCard` con fallback a metadata primary/secondary.
- `PhysicalCardEditor` form: el submit multi-moneda ahora pasa `nextPaymentDate` al payload `physicalCard`. El viejo hint "edítalo después desde la tarjeta física" quedó obsoleto — removido.
- Test: creación multi-moneda con `nextPaymentDate` persiste a `physical_cards.next_payment_date` y NO a `accounts.metadata`.

## Test plan

- [x] `bun run typecheck` + `bun run lint` + `bun run format:check`
- [x] `bun run test` → 671/671 pass (+1 new)

## Scope guard

Closes el gap post-#358: ya no hay que hacer crear → abrir 🎫 → cargar fecha. El form principal lo guarda de entrada.

Closes #360