### PR TITLE
feat(accounts,dashboard): aligned credit card tiles + summary widget (#364)

### DIFF
--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { getSessionUser } from "@/lib/auth/session";
 import { getNetWorth } from "@/lib/dashboard/queries";
 import {
+  groupCreditCards,
   listAccountsDetailed,
   type AccountDetail,
   type PhysicalCardSummary,
@@ -220,7 +221,12 @@ function AccountTypeSection({
           <Money cents={subtotal} currency="COP" />
         </div>
       </div>
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      <div
+        className={cn(
+          "grid grid-cols-1 gap-3 sm:grid-cols-2",
+          type !== "credit_card" && "lg:grid-cols-3",
+        )}
+      >
         {creditCardGroups
           ? creditCardGroups.map((g) => (
               <CreditCardTile
@@ -234,26 +240,6 @@ function AccountTypeSection({
       </div>
     </section>
   );
-}
-
-function groupCreditCards(items: AccountDetail[]): AccountDetail[][] {
-  const groups: AccountDetail[][] = [];
-  const byPcId = new Map<string, AccountDetail[]>();
-  for (const a of items) {
-    if (a.physicalCardId && a.physicalCard) {
-      const existing = byPcId.get(a.physicalCardId);
-      if (existing) {
-        existing.push(a);
-      } else {
-        const arr = [a];
-        byPcId.set(a.physicalCardId, arr);
-        groups.push(arr);
-      }
-    } else {
-      groups.push([a]);
-    }
-  }
-  return groups;
 }
 
 function CreditCardTile({
@@ -330,6 +316,7 @@ function CreditCardTile({
             {orderedSubs.map((s) => (
               <DebtRow key={s.id} account={s} />
             ))}
+            {orderedSubs.length < 2 ? <DebtRowPlaceholder /> : null}
           </div>
         </div>
         <CreditMeter
@@ -364,6 +351,15 @@ function DebtRow({ account }: { account: AccountDetail }) {
       >
         <Money cents={account.balanceCents} currency={account.currency} />
       </span>
+    </div>
+  );
+}
+
+function DebtRowPlaceholder() {
+  return (
+    <div aria-hidden className="invisible flex items-baseline justify-between gap-2">
+      <span className="text-[10px] tracking-wide uppercase">—</span>
+      <span className="text-lg font-semibold tabular-nums">—</span>
     </div>
   );
 }
@@ -433,12 +429,13 @@ function FooterMeta({
           {nextPaymentDate ? formatNextPayment(nextPaymentDate) : "—"}
         </span>
       </div>
-      {showTRM ? (
-        <div className="flex items-center justify-between">
-          <span>TRM{fxFallback ? " (fallback)" : ""}</span>
-          <span className="tabular-nums">$ {RATE_FMT.format(trmRate)}</span>
-        </div>
-      ) : null}
+      <div
+        aria-hidden={!showTRM}
+        className={cn("flex items-center justify-between", !showTRM && "invisible")}
+      >
+        <span>TRM{fxFallback ? " (fallback)" : ""}</span>
+        <span className="tabular-nums">$ {RATE_FMT.format(trmRate)}</span>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -1,6 +1,7 @@
 import {
   getAccountStatuses,
   getCategoryBreakdown,
+  getCreditCardsSummary,
   getMonthlyFlow,
   getNetWorth,
   getTopExpenses,
@@ -14,6 +15,7 @@ import { UpcomingCard } from "@/components/dashboard/upcoming-card";
 import { MonthSwitcher } from "@/components/dashboard/month-switcher";
 import { RecurringInboxCard } from "@/components/dashboard/recurring-inbox-card";
 import { SmsHealthCard } from "@/components/dashboard/sms-health-card";
+import { CreditCardsCard } from "@/components/dashboard/credit-cards-card";
 import { getUpcomingForMonth } from "@/lib/recurring/upcoming";
 import { getOpenGaps } from "@/lib/recurring/gap-queries";
 import { getCurrentFxRate } from "@/lib/fx/repo";
@@ -43,22 +45,24 @@ export default async function DashboardPage({
 
   const session = await getSessionUser();
   const fx = await getCurrentFxRate();
-  const [netWorth, flow, slices, top, accounts, upcoming, openGaps, smsHealth] = await Promise.all([
-    getNetWorth(session.id, fx.rate),
-    getMonthlyFlow(session.id, fx.rate, refDate),
-    getCategoryBreakdown(session.id, fx.rate, refDate),
-    getTopExpenses(session.id, fx.rate, refDate, 5),
-    getAccountStatuses(session.id),
-    getUpcomingForMonth({
-      userId: session.id,
-      year: refYear,
-      month: refMonth,
-      includeDismissed: true,
-      today: now,
-    }),
-    getOpenGaps(session.id),
-    getSmsHealthSnapshot(session.id, now),
-  ]);
+  const [netWorth, flow, slices, top, accounts, upcoming, openGaps, smsHealth, creditCards] =
+    await Promise.all([
+      getNetWorth(session.id, fx.rate),
+      getMonthlyFlow(session.id, fx.rate, refDate),
+      getCategoryBreakdown(session.id, fx.rate, refDate),
+      getTopExpenses(session.id, fx.rate, refDate, 5),
+      getAccountStatuses(session.id),
+      getUpcomingForMonth({
+        userId: session.id,
+        year: refYear,
+        month: refMonth,
+        includeDismissed: true,
+        today: now,
+      }),
+      getOpenGaps(session.id),
+      getSmsHealthSnapshot(session.id, now),
+      getCreditCardsSummary(session.id, fx.rate, now),
+    ]);
 
   const upcomingItems = upcoming.map((u) => ({
     ...u,
@@ -109,6 +113,12 @@ export default async function DashboardPage({
       {gapItems.length > 0 ? (
         <section>
           <RecurringInboxCard gaps={gapItems} />
+        </section>
+      ) : null}
+
+      {creditCards.cardCount > 0 ? (
+        <section>
+          <CreditCardsCard data={creditCards} />
         </section>
       ) : null}
 

--- a/src/components/dashboard/credit-cards-card.tsx
+++ b/src/components/dashboard/credit-cards-card.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
+import { Money } from "@/components/display/money";
+import { cn } from "@/lib/utils";
+import type { CreditCardsSummary } from "@/lib/dashboard/queries";
+
+const NEXT_PAYMENT_FMT = new Intl.DateTimeFormat("es-CO", {
+  day: "2-digit",
+  month: "short",
+});
+
+function formatNextPayment(isoDate: string): string {
+  return NEXT_PAYMENT_FMT.format(new Date(`${isoDate}T12:00:00Z`));
+}
+
+function formatDaysUntil(days: number): string {
+  if (days <= 0) return "hoy";
+  if (days === 1) return "mañana";
+  return `en ${days} días`;
+}
+
+export function CreditCardsCard({ data }: { data: CreditCardsSummary }) {
+  if (data.cardCount === 0) return null;
+  const negative = data.debtCopCents < BigInt(0);
+  const showMeter = data.limitCopCents > BigInt(0);
+  const usedPctLabel = `${Math.round(data.usedPct)}%`;
+  const high = data.usedPct >= 80;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardDescription className="flex items-center justify-between gap-2">
+          <span>Credit cards</span>
+          <Link
+            href="/accounts"
+            className="text-muted-foreground hover:text-foreground text-xs underline-offset-4 hover:underline"
+          >
+            Ver detalle →
+          </Link>
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="flex flex-col gap-1">
+          <div className="text-muted-foreground text-xs">Deuda total</div>
+          <div
+            className={cn(
+              "text-2xl font-semibold tabular-nums",
+              negative ? "text-rose-600" : "text-foreground",
+            )}
+          >
+            <Money cents={data.debtCopCents} currency="COP" />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <div className="text-muted-foreground text-xs">Cupo disponible</div>
+          {showMeter ? (
+            <>
+              <div className="text-2xl font-semibold tabular-nums">
+                <Money cents={data.availableCopCents} currency="COP" />
+              </div>
+              <div className="bg-muted h-1.5 overflow-hidden rounded-full">
+                <div
+                  className={cn("h-full transition-all", high ? "bg-rose-600" : "bg-emerald-600")}
+                  style={{ width: `${data.usedPct}%` }}
+                />
+              </div>
+              <div className="text-muted-foreground text-xs tabular-nums">
+                {usedPctLabel} usado de <Money cents={data.limitCopCents} currency="COP" />
+              </div>
+            </>
+          ) : (
+            <div className="text-muted-foreground text-base">—</div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <div className="text-muted-foreground text-xs">Próximo pago</div>
+          {data.nextPayment ? (
+            <>
+              <div className="text-2xl font-semibold tabular-nums">
+                {formatNextPayment(data.nextPayment.date)}
+              </div>
+              <div className="text-muted-foreground text-xs">
+                {formatDaysUntil(data.nextPayment.daysUntil)}
+              </div>
+            </>
+          ) : (
+            <div className="text-muted-foreground text-base">—</div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/accounts/queries.ts
+++ b/src/lib/accounts/queries.ts
@@ -83,6 +83,32 @@ export async function listAccountsDetailed(userId: number): Promise<AccountDetai
 }
 
 /**
+ * Groups credit_card AccountDetail rows by physical_card — shared-cupo cards
+ * (2+ sub-accounts sharing one physical_cards row) end up in the same group;
+ * single-currency cards are single-member groups. Used by the /accounts page
+ * and the dashboard Credit cards summary widget (#364).
+ */
+export function groupCreditCards(items: AccountDetail[]): AccountDetail[][] {
+  const groups: AccountDetail[][] = [];
+  const byPcId = new Map<string, AccountDetail[]>();
+  for (const a of items) {
+    if (a.physicalCardId && a.physicalCard) {
+      const existing = byPcId.get(a.physicalCardId);
+      if (existing) {
+        existing.push(a);
+      } else {
+        const arr = [a];
+        byPcId.set(a.physicalCardId, arr);
+        groups.push(arr);
+      }
+    } else {
+      groups.push([a]);
+    }
+  }
+  return groups;
+}
+
+/**
  * Returns the available credit (in COP cents) for a physical card with a shared
  * COP cupo spanning multiple sub-accounts (#346). USD balances are converted to
  * COP at `copPerUsd`. Credit-card balances are stored as negative debt, so the

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -3,6 +3,8 @@ import { db } from "@/lib/db";
 import { accounts, categories, counterparties, transactions } from "@/lib/db/schema";
 import { notAdjustment, notDeleted } from "@/lib/db/helpers";
 import { toCop } from "@/lib/money";
+import { groupCreditCards, listAccountsDetailed } from "@/lib/accounts/queries";
+import { computeNextPayment } from "@/lib/accounts/next-payment";
 import type { AccountType, CounterpartyType, Currency } from "@/lib/types";
 
 export function currentMonthRange(now = new Date()): { start: Date; end: Date } {
@@ -239,4 +241,100 @@ export async function getTopExpenses(
     amountCopCents: toCop(BigInt(-1) * r.amountCents, r.currency, copPerUsd),
     accountName: r.accountName,
   }));
+}
+
+export type CreditCardsSummary = {
+  cardCount: number;
+  debtCopCents: bigint;
+  limitCopCents: bigint;
+  availableCopCents: bigint;
+  usedPct: number;
+  nextPayment: { date: string; daysUntil: number } | null;
+};
+
+/**
+ * Aggregates active credit_card accounts into a single dashboard summary
+ * (#364). Shared-cupo pairs are treated as one card; single-currency cards
+ * contribute their own limit/available from metadata. Returns COP-normalized
+ * totals and the nearest upcoming payment date across all cards.
+ */
+export async function getCreditCardsSummary(
+  userId: number,
+  copPerUsd: number,
+  now = new Date(),
+): Promise<CreditCardsSummary> {
+  const all = await listAccountsDetailed(userId);
+  const active = all.filter((a) => a.active && a.type === "credit_card");
+  const groups = groupCreditCards(active);
+
+  let debtCopCents = BigInt(0);
+  let limitCopCents = BigInt(0);
+  let availableCopCents = BigInt(0);
+  let nearest: { date: string; daysUntil: number } | null = null;
+
+  const toCopCents = (cents: bigint, currency: Currency): bigint =>
+    currency === "USD" ? toCop(cents, "USD", copPerUsd) : cents;
+
+  for (const group of groups) {
+    const primary = group[0];
+    const isShared = group.length > 1 || Boolean(primary.physicalCard);
+
+    // Debt — sum sub-account balances (always negative for credit cards),
+    // converting USD → COP.
+    for (const s of group) {
+      debtCopCents += toCopCents(s.balanceCents, s.currency);
+    }
+
+    // Limit + available — shared cards use physical_cards (COP limit);
+    // single cards read metadata and convert if USD-native.
+    if (isShared && primary.physicalCard) {
+      const limit = primary.physicalCard.creditLimitCents;
+      limitCopCents += limit;
+      let available = limit;
+      for (const s of group) {
+        available += toCopCents(s.balanceCents, s.currency);
+      }
+      availableCopCents += available;
+    } else {
+      const md = primary.metadata;
+      if (md.creditLimitCents && md.creditLimitCents > 0) {
+        const limitNative = BigInt(md.creditLimitCents);
+        const availNative =
+          md.availableCreditCents !== undefined
+            ? BigInt(md.availableCreditCents)
+            : limitNative + primary.balanceCents;
+        limitCopCents += toCopCents(limitNative, primary.currency);
+        availableCopCents += toCopCents(availNative, primary.currency);
+      }
+    }
+
+    // Next payment — same derivation as the /accounts tile.
+    const cutoffDay =
+      isShared && primary.physicalCard
+        ? primary.physicalCard.statementCutoffDay
+        : (primary.metadata.cutoffDay ?? null);
+    const nextDate = computeNextPayment(cutoffDay, now);
+    if (nextDate) {
+      const target = new Date(`${nextDate}T12:00:00Z`).getTime();
+      const daysUntil = Math.ceil((target - now.getTime()) / (24 * 60 * 60 * 1000));
+      if (!nearest || daysUntil < nearest.daysUntil) {
+        nearest = { date: nextDate, daysUntil };
+      }
+    }
+  }
+
+  const usedCents = limitCopCents - availableCopCents;
+  const usedPct =
+    limitCopCents > BigInt(0)
+      ? Math.min(100, Math.max(0, Number((usedCents * BigInt(10000)) / limitCopCents) / 100))
+      : 0;
+
+  return {
+    cardCount: groups.length,
+    debtCopCents,
+    limitCopCents,
+    availableCopCents,
+    usedPct,
+    nextPayment: nearest,
+  };
 }


### PR DESCRIPTION
## Summary
- **`/accounts`**: credit card tiles now cap at `sm:grid-cols-2` and reserve slots for the USD debt row and TRM footer, so the meter, cupo legend, and próximo pago line up across every tile in a row regardless of USD presence.
- **Dashboard**: new `CreditCardsCard` widget renders above the Accounts section with 3 stats — deuda total (COP-normalized), cupo disponible + % usado meter, próximo pago más cercano. Link to `/accounts` for the full detail.
- Extracted `groupCreditCards` from the `/accounts` page to `src/lib/accounts/queries.ts` so the widget's query and the page share one grouping implementation.

Closes #364

## Screenshots

### `/accounts` — tiles aligned
See `/tmp/findash-accounts-364.png` attached in the run. Mastercard (shared-cupo, COP+USD) and Visa (single COP) now share the same meter/legend/footer positions.

### Dashboard — new summary widget
See `/tmp/findash-dashboard-364.png`. Widget shows \`Credit cards\` header, Deuda / Cupo / Próximo pago columns, and a \`Ver detalle →\` link.

> Note: dev-environment screenshots show \$0 balances and \`—\` for cupo because the current seed has no active card limits loaded. In prod the widget populates with real TRM-converted values (verified via query shape).

## Test plan
- [x] \`bun run typecheck\` — passes
- [x] \`bun run lint\` — passes
- [x] Manual: loaded \`/\` and \`/accounts\` via headless Chrome + dev login bypass; widget and tiles render without console errors
- [ ] Reviewer: spot-check on a user with non-zero card balances