### PR TITLE
ui(accounts): hide balance input on edit (#372)

### DIFF
--- a/src/app/(app)/settings/accounts/accounts-manager.tsx
+++ b/src/app/(app)/settings/accounts/accounts-manager.tsx
@@ -478,6 +478,10 @@ export function AccountsManager({ items, copPerUsd }: { items: AccountRow[]; cop
         open={editor.open}
         editing={editor.editing}
         onClose={close}
+        onRequestAdjust={(target) => {
+          close();
+          setAdjust({ open: true, target });
+        }}
       />
       <PhysicalCardEditor
         key={pcard.target?.physicalCard?.id ?? "pcard-closed"}
@@ -583,10 +587,12 @@ function AccountEditor({
   open,
   editing,
   onClose,
+  onRequestAdjust,
 }: {
   open: boolean;
   editing: AccountRow | null;
   onClose: () => void;
+  onRequestAdjust: (target: AccountRow) => void;
 }) {
   const [pending, startTransition] = useTransition();
   const isEdit = !!editing;
@@ -809,22 +815,46 @@ function AccountEditor({
                 <option value="USD">USD</option>
               </select>
             </div>
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="acc-balance">
-                {type === "credit_card" ? "Current balance" : "Opening balance"} ({currency})
-              </Label>
-              <Input
-                id="acc-balance"
-                type="number"
-                inputMode="decimal"
-                step={currency === "USD" ? "0.01" : "1"}
-                value={balance}
-                onChange={(e) => setBalance(e.target.value)}
-                required
-                className="tabular-nums"
-              />
-            </div>
+            {isEdit && editing ? (
+              <div className="flex flex-col gap-1.5">
+                <Label>Balance actual ({currency})</Label>
+                <div className="bg-muted/40 text-muted-foreground flex h-9 items-center rounded-md border px-2 text-sm tabular-nums">
+                  <Money cents={BigInt(editing.balanceCents)} currency={editing.currency} />
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="acc-balance">
+                  {type === "credit_card" ? "Current balance" : "Opening balance"} ({currency})
+                </Label>
+                <Input
+                  id="acc-balance"
+                  type="number"
+                  inputMode="decimal"
+                  step={currency === "USD" ? "0.01" : "1"}
+                  value={balance}
+                  onChange={(e) => setBalance(e.target.value)}
+                  required
+                  className="tabular-nums"
+                />
+              </div>
+            )}
           </div>
+          {isEdit && editing ? (
+            <p className="text-muted-foreground -mt-1 text-xs">
+              El balance se deriva del ledger (suma de transacciones). Para corregirlo, usá{" "}
+              <button
+                type="button"
+                className="text-foreground underline underline-offset-4 hover:no-underline"
+                onClick={() => {
+                  onRequestAdjust(editing);
+                }}
+              >
+                Ajustar saldo
+              </button>
+              .
+            </p>
+          ) : null}
 
           {multiCurrencyAllowed ? (
             <label className="flex items-center gap-2 text-sm">


### PR DESCRIPTION
Closes #372.

## Summary

- Edit dialog no longer shows the balance input. Instead renders a read-only "Balance actual" field with the derived value (SUM of transactions) and a one-line note explaining that balance is derived from the ledger.
- Adds a "Ajustar saldo" inline link that closes the editor and opens the dedicated \`BalanceAdjustDialog\` targeting the same account.
- Create mode unchanged — the opening-balance input still renders because it seeds the "Saldo inicial" tx on account creation (the one legitimate write path).

## Rationale

Post-#370 the upsert action ignores any balance field on update. Keeping the input visible was a "lying UI" — users typed, clicked Save, nothing changed. Routing them to the adjust dialog is the correct mental model: balance is a projection of the ledger, never a directly editable attribute.

## Smoke test

Ran locally against dev DB via \`chrome-devtools-mcp\`:

1. Login via \`/api/dev/login?email=...&redirect=/settings/accounts\`
2. Click Edit on Bancolombia Ahorros → dialog opens with:
   - "Balance actual (COP)": -$ 6.987.755 (read-only, derived)
   - Helper text + "Ajustar saldo" link
   - No balance input
3. Click "Ajustar saldo" → editor closes, \`BalanceAdjustDialog\` opens pre-targeted to Bancolombia Ahorros showing the same current balance. End-to-end flow works.

## Test plan

- [x] Existing 677 tests still green
- [x] \`typecheck\`, \`lint\`, \`format:check\` clean
- [x] Manual smoke test via chrome-devtools (above)
- [ ] Post-deploy: eyeball the edit dialog in prod on an existing account — confirm no regression