### PR TITLE
feat(ui): hide balance adjustments filter on /transactions (#374)

### DIFF
--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -24,6 +24,7 @@ type SearchParams = Promise<{
   q?: string;
   cursor?: string;
   highlight?: string;
+  showAdjustments?: string;
 }>;
 
 function buildHref(base: Record<string, string | undefined>, cursor: string | null) {
@@ -43,6 +44,7 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
   const accountId = sp.accountId ? Number(sp.accountId) : undefined;
   const highlightRaw = sp.highlight ? Number(sp.highlight) : undefined;
   const highlightId = Number.isFinite(highlightRaw) ? highlightRaw : undefined;
+  const hideAdjustments = !sp.showAdjustments;
   const filters = {
     from: sp.from,
     to: sp.to,
@@ -50,6 +52,7 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
     categorySlug: sp.categorySlug,
     q: sp.q,
     cursor: sp.cursor,
+    hideAdjustments,
   };
 
   const [{ rows, nextCursor }, accounts, categories, total, unclassified, allCounterparties] =
@@ -74,6 +77,7 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
     accountId: sp.accountId,
     categorySlug: sp.categorySlug,
     q: sp.q,
+    showAdjustments: sp.showAdjustments,
   };
 
   return (
@@ -82,8 +86,9 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
         <div>
           <h1 className="text-h1">Transactions</h1>
           <p className="text-body text-muted-foreground">
-            {total.toLocaleString()} total · {unclassified.toLocaleString()} unclassified · showing
-            up to {PAGE_SIZE} per page
+            {total.toLocaleString()} total · {unclassified.toLocaleString()} unclassified
+            {hideAdjustments ? " · balance adjustments hidden" : null} · showing up to {PAGE_SIZE}{" "}
+            per page
           </p>
         </div>
         <AiClassifyButton unclassified={unclassified} />
@@ -98,6 +103,7 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
           accountId: sp.accountId,
           categorySlug: sp.categorySlug,
           q: sp.q,
+          showAdjustments: sp.showAdjustments,
         }}
       />
 

--- a/src/components/transactions/filters.tsx
+++ b/src/components/transactions/filters.tsx
@@ -15,17 +15,22 @@ export type FiltersProps = {
     accountId?: string;
     categorySlug?: string;
     q?: string;
+    showAdjustments?: string;
   };
 };
 
 export function Filters({ accounts, categories, values }: FiltersProps) {
-  const activeCount = [
+  const stringActive = [
     values.from,
     values.to,
     values.accountId,
     values.categorySlug,
     values.q,
   ].filter((v) => Boolean(v && v.length > 0)).length;
+  // Default behavior hides adjustments — so "showAdjustments set" is itself a deviation
+  // from the default and counts as an active filter.
+  const showAdjustments = Boolean(values.showAdjustments);
+  const activeCount = stringActive + (showAdjustments ? 1 : 0);
   const hasAny = activeCount > 0;
 
   return (
@@ -113,6 +118,23 @@ export function Filters({ accounts, categories, values }: FiltersProps) {
             </Button>
           ) : null}
         </div>
+
+        <label
+          htmlFor="showAdjustments"
+          className="flex cursor-pointer items-center gap-2 text-sm sm:col-span-2 lg:col-span-6"
+        >
+          <input
+            id="showAdjustments"
+            name="showAdjustments"
+            type="checkbox"
+            defaultChecked={showAdjustments}
+            className="border-input size-4 rounded border"
+          />
+          <span>Show balance adjustments</span>
+          <span className="text-muted-foreground text-xs">
+            (hidden by default — reconciliation entries, not spend)
+          </span>
+        </label>
       </form>
     </details>
   );

--- a/src/lib/transactions/queries.test.ts
+++ b/src/lib/transactions/queries.test.ts
@@ -1,0 +1,150 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, categories, transactions, users } from "@/lib/db/schema";
+import { countTotal, listTransactions } from "./queries";
+
+const MARKER = "__test_tx_queries";
+let USER_ID = 0;
+let ACCOUNT_ID = 0;
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE ${MARKER + "%"}`);
+}
+
+beforeAll(async () => {
+  const [u] = await db
+    .insert(users)
+    .values({ email: `${MARKER}@test.local`, name: "Tx Queries" })
+    .returning({ id: users.id });
+  USER_ID = u.id;
+
+  await db.insert(categories).values({
+    userId: USER_ID,
+    slug: "adjustments",
+    name: "Ajustes de saldo",
+    icon: "wrench",
+    color: "#475569",
+    sortOrder: 1000,
+  });
+  await db.insert(categories).values({
+    userId: USER_ID,
+    slug: "food",
+    name: "Alimentación",
+    icon: "utensils",
+    color: "#ef4444",
+    sortOrder: 1,
+  });
+
+  const [a] = await db
+    .insert(accounts)
+    .values({
+      userId: USER_ID,
+      name: `${MARKER}-acct`,
+      institution: "Test",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  ACCOUNT_ID = a.id;
+});
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM transactions WHERE account_id = ${ACCOUNT_ID}`);
+  await db.execute(sql`DELETE FROM accounts WHERE id = ${ACCOUNT_ID}`);
+  await db.execute(sql`DELETE FROM categories WHERE user_id = ${USER_ID}`);
+  await db.execute(sql`DELETE FROM users WHERE id = ${USER_ID}`);
+});
+
+async function seedRows() {
+  await db.insert(transactions).values([
+    {
+      userId: USER_ID,
+      accountId: ACCOUNT_ID,
+      occurredAt: new Date("2026-04-10T12:00:00Z"),
+      amountCents: BigInt(-5000),
+      currency: "COP",
+      descriptionRaw: `${MARKER}-food-1`,
+      categorySlug: "food",
+      classificationMethod: "manual",
+      source: "manual",
+    },
+    {
+      userId: USER_ID,
+      accountId: ACCOUNT_ID,
+      occurredAt: new Date("2026-04-11T12:00:00Z"),
+      amountCents: BigInt(-7500),
+      currency: "COP",
+      descriptionRaw: `${MARKER}-food-2`,
+      categorySlug: "food",
+      classificationMethod: "manual",
+      source: "manual",
+    },
+    {
+      userId: USER_ID,
+      accountId: ACCOUNT_ID,
+      occurredAt: new Date("2026-04-12T12:00:00Z"),
+      amountCents: BigInt(10000),
+      currency: "COP",
+      descriptionRaw: `${MARKER}-adj`,
+      categorySlug: "adjustments",
+      classificationMethod: "manual",
+      source: "balance_adjustment",
+      channel: "manual",
+      isAdjustment: true,
+    },
+  ]);
+}
+
+describe("listTransactions hideAdjustments", () => {
+  afterEach(cleanup);
+
+  it("includes adjustments when filter is omitted", async () => {
+    await seedRows();
+    const { rows } = await listTransactions(USER_ID, {});
+    const mine = rows.filter((r) => r.descriptionRaw.startsWith(MARKER));
+    expect(mine).toHaveLength(3);
+    expect(mine.some((r) => r.isAdjustment)).toBe(true);
+  });
+
+  it("includes adjustments when hideAdjustments=false", async () => {
+    await seedRows();
+    const { rows } = await listTransactions(USER_ID, { hideAdjustments: false });
+    const mine = rows.filter((r) => r.descriptionRaw.startsWith(MARKER));
+    expect(mine).toHaveLength(3);
+  });
+
+  it("excludes adjustments when hideAdjustments=true", async () => {
+    await seedRows();
+    const { rows } = await listTransactions(USER_ID, { hideAdjustments: true });
+    const mine = rows.filter((r) => r.descriptionRaw.startsWith(MARKER));
+    expect(mine).toHaveLength(2);
+    expect(mine.every((r) => !r.isAdjustment)).toBe(true);
+  });
+
+  it("composes with other filters (category + hideAdjustments)", async () => {
+    await seedRows();
+    const { rows } = await listTransactions(USER_ID, {
+      categorySlug: "adjustments",
+      hideAdjustments: true,
+    });
+    const mine = rows.filter((r) => r.descriptionRaw.startsWith(MARKER));
+    expect(mine).toHaveLength(0);
+  });
+});
+
+describe("countTotal hideAdjustments", () => {
+  afterEach(cleanup);
+
+  it("counts all rows when filter is omitted", async () => {
+    await seedRows();
+    const n = await countTotal(USER_ID, {});
+    expect(n).toBe(3);
+  });
+
+  it("excludes adjustments when hideAdjustments=true", async () => {
+    await seedRows();
+    const n = await countTotal(USER_ID, { hideAdjustments: true });
+    expect(n).toBe(2);
+  });
+});

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -21,6 +21,7 @@ export type TxFilters = {
   categorySlug?: string;
   q?: string;
   cursor?: string;
+  hideAdjustments?: boolean;
 };
 
 export type TxListResult = {
@@ -66,6 +67,7 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
       )!,
     );
   }
+  if (filters.hideAdjustments) conditions.push(eq(transactions.isAdjustment, false));
   if (filters.cursor) {
     const c = decodeCursor(filters.cursor);
     if (c) {
@@ -236,6 +238,7 @@ export async function countTotal(
       )!,
     );
   }
+  if (filters.hideAdjustments) conditions.push(eq(transactions.isAdjustment, false));
   const [row] = await db
     .select({ n: sql<number>`count(*)::int` })
     .from(transactions)


### PR DESCRIPTION
## Summary

- Adds a **"Show balance adjustments"** checkbox to the `/transactions` Filters panel. Default behavior **hides** adjustments since they're reconciliation / higiene entries, not spend.
- Header counter surfaces the filter state: when adjustments are hidden the line reads *"N total · M unclassified · **balance adjustments hidden** · showing up to 50 per page"*.
- Query layer extends `listTransactions` and `countTotal` with `hideAdjustments`. URL param `showAdjustments=on` to show, absent = hidden. Pagination links preserve the toggle state.
- Having `showAdjustments` set counts as an active filter (deviation from default) — surfaces in the "N active" badge and auto-expands the Filters panel.

## Behavior (dev-db walkthrough)

| State | URL | Header | Filters badge |
|---|---|---|---|
| Default | `/transactions` | `327 total · 134 unclassified · balance adjustments hidden · …` | none (collapsed) |
| Show toggled | `/transactions?showAdjustments=on` | `327 total · 134 unclassified · showing up to 50 per page` | `Filters · 1 active` (expanded, checkbox checked) |

Verified end-to-end via chrome-devtools MCP on localhost:3100 with dev-login bypass for \`ing.amartinez94@gmail.com\`. Screenshots captured locally at \`/tmp/findash-374/after-hidden.png\` and \`/tmp/findash-374/after-showing.png\` — please eyeball on your side before merging.

## Out of scope

- Persist the preference per user (follow-up; today it's URL-only).
- Archive/delete transactions — tracked separately in #375.
- Additional kind/channel/source filters — propio ticket si hace falta.

## Test plan

- [x] \`bun run lint\` — clean
- [x] \`bun run typecheck\` — clean
- [x] \`bun run test\` — 683 passed (6 new in \`src/lib/transactions/queries.test.ts\`)
- [x] Manual: default page hides adjustments, toggle shows them, header copy reflects state, pagination cursor preserves the param
- [ ] Human eyeball on \`/transactions\` + \`/transactions?showAdjustments=on\`

Closes #374