### PR TITLE
feat(ui): live filters on /transactions (no Apply button) (#377)

### DIFF
--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -94,18 +94,7 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
         <AiClassifyButton unclassified={unclassified} />
       </header>
 
-      <Filters
-        accounts={accounts}
-        categories={categories}
-        values={{
-          from: sp.from,
-          to: sp.to,
-          accountId: sp.accountId,
-          categorySlug: sp.categorySlug,
-          q: sp.q,
-          showAdjustments: sp.showAdjustments,
-        }}
-      />
+      <Filters accounts={accounts} categories={categories} />
 
       <TransactionTable
         rows={rows}

--- a/src/components/transactions/filters.tsx
+++ b/src/components/transactions/filters.tsx
@@ -1,40 +1,84 @@
-import Link from "next/link";
-import { ChevronDownIcon, SlidersHorizontalIcon } from "lucide-react";
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ChevronDownIcon, Loader2Icon, SlidersHorizontalIcon } from "lucide-react";
 import { formatAccountLabel } from "@/lib/accounts/format";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
+const SEARCH_DEBOUNCE_MS = 300;
+
 export type FiltersProps = {
   accounts: Array<{ id: number; name: string; currency: string }>;
   categories: Array<{ slug: string; name: string; parentSlug: string | null }>;
-  values: {
-    from?: string;
-    to?: string;
-    accountId?: string;
-    categorySlug?: string;
-    q?: string;
-    showAdjustments?: string;
-  };
 };
 
-export function Filters({ accounts, categories, values }: FiltersProps) {
+export function Filters({ accounts, categories }: FiltersProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const currentQ = searchParams.get("q") ?? "";
+  const currentFrom = searchParams.get("from") ?? "";
+  const currentTo = searchParams.get("to") ?? "";
+  const currentAccountId = searchParams.get("accountId") ?? "";
+  const currentCategorySlug = searchParams.get("categorySlug") ?? "";
+  const showAdjustmentsActive = Boolean(searchParams.get("showAdjustments"));
+
+  // Local mirror for the text search so every keystroke stays snappy; we push
+  // the URL (and therefore the DB query) only after SEARCH_DEBOUNCE_MS of idle.
+  const [q, setQ] = useState(currentQ);
+
+  // Keep the local mirror in sync when the URL changes externally — Reset,
+  // back/forward, or a link from another page.
+  useEffect(() => {
+    setQ(currentQ);
+  }, [currentQ]);
+
+  useEffect(() => {
+    if (q === currentQ) return;
+    const handle = setTimeout(() => {
+      applyChange("q", q);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [q, currentQ]);
+
+  function applyChange(key: string, value: string) {
+    const next = new URLSearchParams(searchParams.toString());
+    if (value) next.set(key, value);
+    else next.delete(key);
+    // Any filter change invalidates the cursor — its anchor row might no longer
+    // match the new predicate, so we always reset to page 1.
+    next.delete("cursor");
+    const qs = next.toString();
+    startTransition(() => {
+      router.replace(qs ? `/transactions?${qs}` : "/transactions", { scroll: false });
+    });
+  }
+
+  function reset() {
+    setQ("");
+    startTransition(() => {
+      router.replace("/transactions", { scroll: false });
+    });
+  }
+
   const stringActive = [
-    values.from,
-    values.to,
-    values.accountId,
-    values.categorySlug,
-    values.q,
-  ].filter((v) => Boolean(v && v.length > 0)).length;
-  // Default behavior hides adjustments — so "showAdjustments set" is itself a deviation
-  // from the default and counts as an active filter.
-  const showAdjustments = Boolean(values.showAdjustments);
-  const activeCount = stringActive + (showAdjustments ? 1 : 0);
+    currentFrom,
+    currentTo,
+    currentAccountId,
+    currentCategorySlug,
+    currentQ,
+  ].filter((v) => v.length > 0).length;
+  const activeCount = stringActive + (showAdjustmentsActive ? 1 : 0);
   const hasAny = activeCount > 0;
 
   return (
-    <details open={hasAny} className="group bg-card rounded-md border">
+    <details open={hasAny} aria-busy={isPending} className="group bg-card rounded-md border">
       <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 [&::-webkit-details-marker]:hidden">
         <div className="flex items-center gap-2">
           <SlidersHorizontalIcon className="text-muted-foreground size-4" />
@@ -44,42 +88,54 @@ export function Filters({ accounts, categories, values }: FiltersProps) {
               {activeCount} active
             </Badge>
           ) : null}
+          {isPending ? (
+            <Loader2Icon
+              className="text-muted-foreground size-4 animate-spin"
+              aria-label="Updating"
+            />
+          ) : null}
         </div>
         <ChevronDownIcon className="text-muted-foreground size-4 transition-transform group-open:rotate-180" />
       </summary>
 
-      <form
-        method="GET"
-        action="/transactions"
-        className="grid grid-cols-1 gap-3 border-t p-4 sm:grid-cols-2 lg:grid-cols-6"
-      >
+      <div className="grid grid-cols-1 gap-3 border-t p-4 sm:grid-cols-2 lg:grid-cols-6">
         <div className="flex flex-col gap-1">
           <Label htmlFor="q">Search</Label>
           <Input
             id="q"
-            name="q"
             type="search"
             placeholder="merchant, description…"
-            defaultValue={values.q ?? ""}
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
           />
         </div>
 
         <div className="flex flex-col gap-1">
           <Label htmlFor="from">From</Label>
-          <Input id="from" name="from" type="date" defaultValue={values.from ?? ""} />
+          <Input
+            id="from"
+            type="date"
+            value={currentFrom}
+            onChange={(e) => applyChange("from", e.target.value)}
+          />
         </div>
 
         <div className="flex flex-col gap-1">
           <Label htmlFor="to">To</Label>
-          <Input id="to" name="to" type="date" defaultValue={values.to ?? ""} />
+          <Input
+            id="to"
+            type="date"
+            value={currentTo}
+            onChange={(e) => applyChange("to", e.target.value)}
+          />
         </div>
 
         <div className="flex flex-col gap-1">
           <Label htmlFor="accountId">Account</Label>
           <select
             id="accountId"
-            name="accountId"
-            defaultValue={values.accountId ?? ""}
+            value={currentAccountId}
+            onChange={(e) => applyChange("accountId", e.target.value)}
             className="bg-background chevron-select h-9 rounded-md border text-sm"
           >
             <option value="">All</option>
@@ -95,8 +151,8 @@ export function Filters({ accounts, categories, values }: FiltersProps) {
           <Label htmlFor="categorySlug">Category</Label>
           <select
             id="categorySlug"
-            name="categorySlug"
-            defaultValue={values.categorySlug ?? ""}
+            value={currentCategorySlug}
+            onChange={(e) => applyChange("categorySlug", e.target.value)}
             className="bg-background chevron-select h-9 rounded-md border text-sm"
           >
             <option value="">All</option>
@@ -108,13 +164,10 @@ export function Filters({ accounts, categories, values }: FiltersProps) {
           </select>
         </div>
 
-        <div className="flex items-end gap-2">
-          <Button type="submit" className="flex-1">
-            Apply
-          </Button>
+        <div className="flex items-end">
           {hasAny ? (
-            <Button asChild type="button" variant="outline">
-              <Link href="/transactions">Reset</Link>
+            <Button type="button" variant="outline" onClick={reset} className="flex-1">
+              Clear filters
             </Button>
           ) : null}
         </div>
@@ -125,9 +178,9 @@ export function Filters({ accounts, categories, values }: FiltersProps) {
         >
           <input
             id="showAdjustments"
-            name="showAdjustments"
             type="checkbox"
-            defaultChecked={showAdjustments}
+            checked={showAdjustmentsActive}
+            onChange={(e) => applyChange("showAdjustments", e.target.checked ? "on" : "")}
             className="border-input size-4 rounded border"
           />
           <span>Show balance adjustments</span>
@@ -135,7 +188,7 @@ export function Filters({ accounts, categories, values }: FiltersProps) {
             (hidden by default — reconciliation entries, not spend)
           </span>
         </label>
-      </form>
+      </div>
     </details>
   );
 }


### PR DESCRIPTION
## Summary

Converts the filter panel on \`/transactions\` to a **client component** with **URL as the single source of truth**. No more Apply button, no more full-page reload — every field change updates the URL and refetches the server data automatically.

Motivated by the review of #374: the "Show balance adjustments" checkbox was perceived as broken because the form needed Apply to commit. The whole panel had the same problem.

## How it works

- \`filters.tsx\` → \`"use client"\` + \`useRouter\` + \`useSearchParams\` + \`useTransition\`.
- Search input (\`q\`) is debounced 300ms. Dates, account, category, checkbox fire immediately on change.
- \`router.replace\` (not \`push\`) to avoid filling browser history with every keystroke.
- Cursor is dropped on any filter change — prevents dangling pagination after the predicate moves.
- \`Loader2\` spinner in the filter header while the router transition is pending. \`aria-busy\` on the \`<details>\` element for screen readers.
- Apply button removed. Reset becomes "Clear filters" and is only visible when at least one filter is active.

## Verified end-to-end via chrome-devtools MCP

- ✅ Checkbox click → URL flips to \`?showAdjustments=on\` instantly, header drops "balance adjustments hidden" copy.
- ✅ Category dropdown change → URL updates immediately.
- ✅ Typing in search → URL updates exactly once after 300ms of idle (checked at t=0/100/400ms).
- ✅ Starting with \`?cursor=…\` then changing a filter → cursor is removed from URL.
- ✅ Reset → \`/transactions\` with all params cleared, local search state cleared too.

Screenshots (local): \`/tmp/findash-377/active-filters.png\`, \`/tmp/findash-377/default-collapsed.png\`.

## Out of scope

- Replicate the pattern on \`/budgets\`, \`/insights\` — ticket aparte si nos gusta.
- Persist filter preferences per user (today lives in URL only).
- Replace native \`<select>\` / \`<input type="date">\` with shadcn components — ortogonal.

## Test plan

- [x] \`bun run lint\` — clean
- [x] \`bun run typecheck\` — clean
- [x] \`bun run test\` — 683 passed (no new tests; the existing query tests from #374 still cover the backend behavior)
- [x] Manual: checkbox / select / date / search-with-debounce / cursor-reset / reset-button — all behave as specified
- [ ] Human eyeball on the live UX (debounce feel, pending indicator, back/forward)

Closes #377