### PR TITLE
fix(infra): isolate Node-only instrumentation from Edge bundle trace (#380)

### DIFF
--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -1,0 +1,164 @@
+// globalThis singleton guards against Turbopack/HMR re-entering registerNode()
+// and spawning duplicate cron schedules.
+declare global {
+  var __findashBgRegistered: boolean | undefined;
+}
+
+/**
+ * Node-runtime instrumentation body — runs once per worker on boot. Registers:
+ * - recurring-gap detector cron (monthly)
+ * - per-user health snapshot cron (daily 03:00 America/Bogota)
+ * - slo-alerts cron (every 30 min)
+ * - fx-refresh cron (twice daily, 06:15 and 18:15 America/Bogota)
+ *
+ * Telegram used to run a long-poll worker here; #185 moved it to per-user
+ * webhooks (`src/app/api/telegram/webhook/[botId]/route.ts`) so there is no
+ * background worker to wire up anymore.
+ *
+ * Loaded via `require()` from `instrumentation.ts` behind a `NEXT_RUNTIME`
+ * guard so Turbopack's Edge pass never traces this file (#380). Disable all
+ * crons with `FINDASH_DISABLE_CRON=1`.
+ */
+export async function registerNode() {
+  if (process.env.FINDASH_DISABLE_CRON === "1") return;
+  if (globalThis.__findashBgRegistered) return;
+  globalThis.__findashBgRegistered = true;
+
+  const cron = (await import("node-cron")).default;
+  const { closePreviousMonthForAllUsers } = await import("@/lib/recurring/gap-detector");
+  const { snapshotAllActiveUsers } = await import("@/lib/telemetry/user-health");
+  const { checkAndAlertSlos } = await import("@/lib/observability/slo-alerts");
+  const { fetchTrm } = await import("@/lib/fx/trm");
+  const { getCurrentFxRate, upsertFxRate } = await import("@/lib/fx/repo");
+  const { createLogger } = await import("@/lib/logger");
+  const log = createLogger({ module: "instrumentation" });
+
+  async function refreshFxOnce(trigger: "cron" | "boot") {
+    try {
+      const trm = await fetchTrm();
+      await upsertFxRate({
+        base: "USD",
+        quote: "COP",
+        rate: trm.rate,
+        asOf: trm.asOf,
+        source: trm.source,
+      });
+      log.info(
+        { rate: trm.rate, asOf: trm.asOf, trigger, event: "fx_refresh_ok" },
+        "fx-refresh tick",
+      );
+    } catch (err) {
+      log.error({ err, trigger, event: "fx_refresh_failed" }, "fx-refresh tick failed");
+    }
+  }
+
+  // Day 5 of each month at 06:00 America/Bogota — gives a 4-day grace window
+  // for late-posting SMS/Apple Pay events before we finalize gaps.
+  cron.schedule(
+    "0 6 5 * *",
+    async () => {
+      try {
+        const results = await closePreviousMonthForAllUsers();
+        for (const entry of results) {
+          if (entry.ok) {
+            log.info(
+              { userId: entry.userId, result: entry.result, event: "recurring_gap_closed" },
+              `recurring-gap detector closed ${entry.result.yearMonth}`,
+            );
+          } else {
+            log.error(
+              { err: entry.error, userId: entry.userId, event: "recurring_gap_failed" },
+              "recurring-gap detector failed",
+            );
+          }
+        }
+      } catch (err) {
+        log.error(
+          { err, event: "recurring_gap_fanout_failed" },
+          "recurring-gap detector fan-out failed",
+        );
+      }
+    },
+    { timezone: "America/Bogota" },
+  );
+
+  // 03:00 COT daily — early enough to be ready before the operator checks
+  // /admin/health in the morning, late enough that yesterday's last SMS had
+  // time to land.
+  cron.schedule(
+    "0 3 * * *",
+    async () => {
+      try {
+        const results = await snapshotAllActiveUsers();
+        const churned = results.filter((r) => r.ok && r.data.churnSignalFlag).length;
+        const failed = results.filter((r) => !r.ok).length;
+        log.info(
+          { total: results.length, churned, failed, event: "user_health_snapshots_done" },
+          "user-health snapshots",
+        );
+        for (const entry of results) {
+          if (!entry.ok) {
+            log.error(
+              { err: entry.error, userId: entry.userId, event: "user_health_snapshot_failed" },
+              "user-health snapshot failed",
+            );
+          }
+        }
+      } catch (err) {
+        log.error(
+          { err, event: "user_health_fanout_failed" },
+          "user-health snapshot fan-out failed",
+        );
+      }
+    },
+    { timezone: "America/Bogota" },
+  );
+
+  // Every 30 min — evaluate each SLO over a rolling 48h window and fire /
+  // resolve Telegram alerts (#329 PR3, #341 wiring). Finer granularity is
+  // wasteful: the 48h window swallows sub-half-hour deltas. Dedup is built
+  // into `slo_alerts` (at most one unresolved row per sloKey).
+  cron.schedule(
+    "*/30 * * * *",
+    async () => {
+      try {
+        const decisions = await checkAndAlertSlos();
+        const fired = decisions.filter((d) => d.action === "fire").length;
+        const resolved = decisions.filter((d) => d.action === "resolve").length;
+        const noops = decisions.filter((d) => d.action === "noop").length;
+        log.info(
+          { total: decisions.length, fired, resolved, noops, event: "slo_alerts_checked" },
+          "slo-alerts tick",
+        );
+      } catch (err) {
+        log.error({ err, event: "slo_alerts_check_failed" }, "slo-alerts check failed");
+      }
+    },
+    { timezone: "America/Bogota" },
+  );
+
+  // TRM is published daily by SuperFinanciera via datos.gov.co. Two ticks per
+  // day (06:15 and 18:15 COT) balance freshness against API load: morning tick
+  // catches the day's official rate, evening tick retries if morning failed.
+  // POST /api/fx/refresh remains available for manual/emergency refresh.
+  cron.schedule("15 6,18 * * *", () => void refreshFxOnce("cron"), {
+    timezone: "America/Bogota",
+  });
+
+  log.info(
+    { event: "crons_registered" },
+    "crons registered: recurring-gap (0 6 5 * *), user-health (0 3 * * *), slo-alerts (*/30 * * * *), fx-refresh (15 6,18 * * *) America/Bogota",
+  );
+
+  // Backfill on boot when the repo is empty or last known rate came from the
+  // hardcoded fallback. Without this, a fresh deploy shows `· fallback` in the
+  // Net worth card for up to ~12h until the first cron tick lands (#347).
+  try {
+    const current = await getCurrentFxRate();
+    if (current.source === "fallback") {
+      await refreshFxOnce("boot");
+    }
+  } catch (err) {
+    log.error({ err, event: "fx_refresh_boot_check_failed" }, "fx boot backfill check failed");
+  }
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,164 +1,22 @@
-// globalThis singleton guards against Turbopack/HMR re-entering register() and
-// spawning duplicate cron schedules.
-declare global {
-  var __findashBgRegistered: boolean | undefined;
-}
-
 /**
- * Next.js 16 instrumentation hook — runs once per worker on boot. Registers:
- * - recurring-gap detector cron (monthly)
- * - per-user health snapshot cron (daily 03:00 America/Bogota)
- * - slo-alerts cron (every 30 min)
- * - fx-refresh cron (twice daily, 06:15 and 18:15 America/Bogota)
+ * Next.js 16 instrumentation hook — routes to the Node-only implementation.
  *
- * Telegram used to run a long-poll worker here; #185 moved it to per-user
- * webhooks (`src/app/api/telegram/webhook/[botId]/route.ts`) so there is no
- * background worker to wire up anymore.
- *
- * Runs only in the Node.js runtime (skipped on Edge). Disable all crons with
- * `FINDASH_DISABLE_CRON=1`.
+ * The Node body lives in `instrumentation.node.ts` and is loaded via a
+ * synchronous `require()` gated by `NEXT_RUNTIME`. This is the pattern the
+ * Next 16 docs prescribe (see `instrumentation.md` → "Specifying the
+ * runtime"): a runtime-gated `require()` lets Turbopack tree-shake the Node
+ * imports out of the Edge bundle trace. A single-file `instrumentation.ts`
+ * with `await import(...)` inside `register()` still gets traced
+ * statically on the Edge pass, producing noisy Node-API warnings on every
+ * compile — even though `register()` returns early at runtime. See #380.
  */
 export async function register() {
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
-  if (process.env.FINDASH_DISABLE_CRON === "1") return;
-  if (globalThis.__findashBgRegistered) return;
-  globalThis.__findashBgRegistered = true;
-
-  const cron = (await import("node-cron")).default;
-  const { closePreviousMonthForAllUsers } = await import("@/lib/recurring/gap-detector");
-  const { snapshotAllActiveUsers } = await import("@/lib/telemetry/user-health");
-  const { checkAndAlertSlos } = await import("@/lib/observability/slo-alerts");
-  const { fetchTrm } = await import("@/lib/fx/trm");
-  const { getCurrentFxRate, upsertFxRate } = await import("@/lib/fx/repo");
-  const { createLogger } = await import("@/lib/logger");
-  const log = createLogger({ module: "instrumentation" });
-
-  async function refreshFxOnce(trigger: "cron" | "boot") {
-    try {
-      const trm = await fetchTrm();
-      await upsertFxRate({
-        base: "USD",
-        quote: "COP",
-        rate: trm.rate,
-        asOf: trm.asOf,
-        source: trm.source,
-      });
-      log.info(
-        { rate: trm.rate, asOf: trm.asOf, trigger, event: "fx_refresh_ok" },
-        "fx-refresh tick",
-      );
-    } catch (err) {
-      log.error({ err, trigger, event: "fx_refresh_failed" }, "fx-refresh tick failed");
-    }
-  }
-
-  // Day 5 of each month at 06:00 America/Bogota — gives a 4-day grace window
-  // for late-posting SMS/Apple Pay events before we finalize gaps.
-  cron.schedule(
-    "0 6 5 * *",
-    async () => {
-      try {
-        const results = await closePreviousMonthForAllUsers();
-        for (const entry of results) {
-          if (entry.ok) {
-            log.info(
-              { userId: entry.userId, result: entry.result, event: "recurring_gap_closed" },
-              `recurring-gap detector closed ${entry.result.yearMonth}`,
-            );
-          } else {
-            log.error(
-              { err: entry.error, userId: entry.userId, event: "recurring_gap_failed" },
-              "recurring-gap detector failed",
-            );
-          }
-        }
-      } catch (err) {
-        log.error(
-          { err, event: "recurring_gap_fanout_failed" },
-          "recurring-gap detector fan-out failed",
-        );
-      }
-    },
-    { timezone: "America/Bogota" },
-  );
-
-  // 03:00 COT daily — early enough to be ready before the operator checks
-  // /admin/health in the morning, late enough that yesterday's last SMS had
-  // time to land.
-  cron.schedule(
-    "0 3 * * *",
-    async () => {
-      try {
-        const results = await snapshotAllActiveUsers();
-        const churned = results.filter((r) => r.ok && r.data.churnSignalFlag).length;
-        const failed = results.filter((r) => !r.ok).length;
-        log.info(
-          { total: results.length, churned, failed, event: "user_health_snapshots_done" },
-          "user-health snapshots",
-        );
-        for (const entry of results) {
-          if (!entry.ok) {
-            log.error(
-              { err: entry.error, userId: entry.userId, event: "user_health_snapshot_failed" },
-              "user-health snapshot failed",
-            );
-          }
-        }
-      } catch (err) {
-        log.error(
-          { err, event: "user_health_fanout_failed" },
-          "user-health snapshot fan-out failed",
-        );
-      }
-    },
-    { timezone: "America/Bogota" },
-  );
-
-  // Every 30 min — evaluate each SLO over a rolling 48h window and fire /
-  // resolve Telegram alerts (#329 PR3, #341 wiring). Finer granularity is
-  // wasteful: the 48h window swallows sub-half-hour deltas. Dedup is built
-  // into `slo_alerts` (at most one unresolved row per sloKey).
-  cron.schedule(
-    "*/30 * * * *",
-    async () => {
-      try {
-        const decisions = await checkAndAlertSlos();
-        const fired = decisions.filter((d) => d.action === "fire").length;
-        const resolved = decisions.filter((d) => d.action === "resolve").length;
-        const noops = decisions.filter((d) => d.action === "noop").length;
-        log.info(
-          { total: decisions.length, fired, resolved, noops, event: "slo_alerts_checked" },
-          "slo-alerts tick",
-        );
-      } catch (err) {
-        log.error({ err, event: "slo_alerts_check_failed" }, "slo-alerts check failed");
-      }
-    },
-    { timezone: "America/Bogota" },
-  );
-
-  // TRM is published daily by SuperFinanciera via datos.gov.co. Two ticks per
-  // day (06:15 and 18:15 COT) balance freshness against API load: morning tick
-  // catches the day's official rate, evening tick retries if morning failed.
-  // POST /api/fx/refresh remains available for manual/emergency refresh.
-  cron.schedule("15 6,18 * * *", () => void refreshFxOnce("cron"), {
-    timezone: "America/Bogota",
-  });
-
-  log.info(
-    { event: "crons_registered" },
-    "crons registered: recurring-gap (0 6 5 * *), user-health (0 3 * * *), slo-alerts (*/30 * * * *), fx-refresh (15 6,18 * * *) America/Bogota",
-  );
-
-  // Backfill on boot when the repo is empty or last known rate came from the
-  // hardcoded fallback. Without this, a fresh deploy shows `· fallback` in the
-  // Net worth card for up to ~12h until the first cron tick lands (#347).
-  try {
-    const current = await getCurrentFxRate();
-    if (current.source === "fallback") {
-      await refreshFxOnce("boot");
-    }
-  } catch (err) {
-    log.error({ err, event: "fx_refresh_boot_check_failed" }, "fx boot backfill check failed");
-  }
+  // Synchronous require() is required here (not `await import`) so Turbopack
+  // can tree-shake instrumentation.node out of the Edge pass trace. This is
+  // the pattern the Next 16 docs prescribe for runtime-specific instrumentation.
+  const { registerNode } =
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("./instrumentation.node") as typeof import("./instrumentation.node");
+  await registerNode();
 }


### PR DESCRIPTION
## Summary

- Split `src/instrumentation.ts` into a thin wrapper (22 lines) + `src/instrumentation.node.ts` (164 lines, the Node body unchanged).
- Main file gates via `NEXT_RUNTIME !== "nodejs"` and loads the Node body through a synchronous `require()` — the pattern prescribed by Next 16 docs (`node_modules/next/dist/docs/01-app/03-api-reference/03-file-conventions/instrumentation.md:115`).
- With the split, Turbopack tree-shakes the Node imports out of the Edge pass trace. The runtime guard alone (already present since `fac4d13`) did not silence the warnings because Turbopack traces `await import(...)` statically regardless of runtime checks inside the function body.

## Why the issue's original fix wasn't enough

The issue proposed adding the `NEXT_RUNTIME` guard at the top of `register()`. That guard was already on line 22 since the file was introduced. I verified today with `bun run dev`: the 3 Node-API warnings still appear on boot + every request that triggers recompilation, even with the guard. The guard is a runtime check; Turbopack's static trace walks through `await import("@/lib/logger")`, `await import("@/lib/observability/slo-alerts")`, etc. regardless.

The "overkill" alternative the issue proposed (split by runtime) turned out to be the only fix that works and is actually the canonical Next 16 pattern.

## Verification

- [x] `bun run dev` boot + 2 requests: `0` matches for `Node.js API | node:crypto | node:https | Edge Instrumentation` in the log (vs. 9+ matches before).
- [x] Crons still register: `{"event":"crons_registered", ...}` fires once in boot log.
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (single `eslint-disable-next-line @typescript-eslint/no-require-imports` on the require line, with comment explaining why sync require is needed)
- [x] `bun run format:check` — clean
- [x] `bun run test` — 687/687 pass

## Scope

- No behavior change for Node runtime: same crons, same guards, same log output.
- Thin wrapper is the only `require()` in the repo; narrow ESLint exception localized to that line.

Closes #380