### PR TITLE
feat(ui): /settings/widgets page — mint/revoke tokens + cheatsheet (#384)

### DIFF
--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -11,6 +11,7 @@ const pages = [
   { name: "settings-ingestion", path: "/settings/ingestion", hasDonut: false },
   { name: "settings-rules", path: "/settings/rules", hasDonut: false },
   { name: "settings-inbox", path: "/settings/inbox", hasDonut: false },
+  { name: "settings-widgets", path: "/settings/widgets", hasDonut: false },
   { name: "signup-missing", path: "/signup", hasDonut: false },
   { name: "signup-unknown", path: "/signup?code=__DOESNOTEXIST__", hasDonut: false },
 ];

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -51,6 +51,12 @@ const LINKS = [
       "Per-user bearer tokens for the SMS and debug ingest endpoints. Mint, copy once, revoke when needed.",
   },
   {
+    href: "/settings/widgets",
+    title: "Widgets",
+    description:
+      "Tokens y cheatsheet para los widgets de pantalla de inicio (Scriptable / Tasker). Generá, copiá una vez, revocá cuando quieras.",
+  },
+  {
     href: "/settings/telegram",
     title: "Telegram bot",
     description:

--- a/src/app/(app)/settings/widgets/actions.test.ts
+++ b/src/app/(app)/settings/widgets/actions.test.ts
@@ -1,0 +1,205 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { users, webhookTokens } from "@/lib/db/schema";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+// Session mock: the current user is controllable per test via setSessionUser.
+const sessionState: { user: { id: number; email: string; name: string } | null } = {
+  user: { id: 1, email: "test@findash.local", name: "Test" },
+};
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn(async () => {
+    if (!sessionState.user) throw new Error("UNAUTHENTICATED");
+    return { ...sessionState.user, role: "user" as const, active: true };
+  }),
+  getSessionUserOrNull: vi.fn(async () => {
+    if (!sessionState.user) return null;
+    return { ...sessionState.user, role: "user" as const, active: true };
+  }),
+}));
+
+function setSessionUser(user: { id: number; email: string; name: string } | null) {
+  sessionState.user = user;
+}
+
+// Imported AFTER the mocks so they resolve to the stubs above.
+const { mintWidgetTokenAction, revokeWidgetTokenAction } = await import("./actions");
+
+const TEST_USER_ID = 1;
+const LABEL_PREFIX = "vitest-widget-actions-";
+
+function formData(input: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(input)) fd.set(k, v);
+  return fd;
+}
+
+async function cleanup() {
+  // Only nuke the test user's rows — cross-tenant tests seed their own user
+  // in beforeAll and rely on that row surviving between tests.
+  await db.execute(sql`
+    DELETE FROM webhook_tokens
+    WHERE user_id = ${TEST_USER_ID}
+      AND purpose = 'widget'
+      AND (label LIKE ${LABEL_PREFIX + "%"} OR label IS NULL)
+  `);
+}
+
+describe("settings/widgets actions", () => {
+  beforeEach(async () => {
+    setSessionUser({ id: TEST_USER_ID, email: "test@findash.local", name: "Test" });
+    await cleanup();
+  });
+
+  afterEach(cleanup);
+  afterAll(async () => {
+    await db.$client.end({ timeout: 1 });
+  });
+
+  describe("mintWidgetTokenAction", () => {
+    it("mints a widget token for the authenticated user (happy path)", async () => {
+      const result = await mintWidgetTokenAction(
+        { status: "idle" },
+        formData({ label: `${LABEL_PREFIX}scriptable` }),
+      );
+
+      expect(result.status).toBe("success");
+      if (result.status !== "success") return;
+      expect(result.plaintext).toMatch(/^[0-9a-f]{64}$/);
+      expect(result.id).toBeGreaterThan(0);
+
+      const [row] = await db.select().from(webhookTokens).where(eq(webhookTokens.id, result.id));
+      expect(row.userId).toBe(TEST_USER_ID);
+      expect(row.purpose).toBe("widget");
+      expect(row.label).toBe(`${LABEL_PREFIX}scriptable`);
+      expect(row.revokedAt).toBeNull();
+    });
+
+    it("allows minting without a label (mirrors webhook-tokens behavior)", async () => {
+      const result = await mintWidgetTokenAction({ status: "idle" }, formData({ label: "" }));
+      expect(result.status).toBe("success");
+      if (result.status !== "success") return;
+
+      const [row] = await db.select().from(webhookTokens).where(eq(webhookTokens.id, result.id));
+      // Trim + empty → stored as null.
+      expect(row.label).toBeNull();
+      expect(row.purpose).toBe("widget");
+    });
+
+    it("returns an error when no session is present", async () => {
+      setSessionUser(null);
+      const result = await mintWidgetTokenAction(
+        { status: "idle" },
+        formData({ label: `${LABEL_PREFIX}no-session` }),
+      );
+      expect(result.status).toBe("error");
+      if (result.status !== "error") return;
+      expect(result.message).toMatch(/autenticado/i);
+
+      // Nothing was written.
+      const rows = await db
+        .select()
+        .from(webhookTokens)
+        .where(
+          and(
+            eq(webhookTokens.userId, TEST_USER_ID),
+            eq(webhookTokens.label, `${LABEL_PREFIX}no-session`),
+          ),
+        );
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe("revokeWidgetTokenAction", () => {
+    it("revokes an owned token (happy path)", async () => {
+      const mintRes = await mintWidgetTokenAction(
+        { status: "idle" },
+        formData({ label: `${LABEL_PREFIX}to-revoke` }),
+      );
+      if (mintRes.status !== "success") throw new Error("mint failed");
+
+      await expect(revokeWidgetTokenAction({ tokenId: mintRes.id })).resolves.toBeUndefined();
+
+      const [row] = await db.select().from(webhookTokens).where(eq(webhookTokens.id, mintRes.id));
+      expect(row.revokedAt).not.toBeNull();
+    });
+
+    it("throws on an already-revoked token (mirrors webhook-tokens)", async () => {
+      const mintRes = await mintWidgetTokenAction(
+        { status: "idle" },
+        formData({ label: `${LABEL_PREFIX}double-revoke` }),
+      );
+      if (mintRes.status !== "success") throw new Error("mint failed");
+
+      await revokeWidgetTokenAction({ tokenId: mintRes.id });
+      await expect(revokeWidgetTokenAction({ tokenId: mintRes.id })).rejects.toThrow();
+    });
+
+    it("throws when no session is present", async () => {
+      const mintRes = await mintWidgetTokenAction(
+        { status: "idle" },
+        formData({ label: `${LABEL_PREFIX}auth-guard` }),
+      );
+      if (mintRes.status !== "success") throw new Error("mint failed");
+
+      setSessionUser(null);
+      await expect(revokeWidgetTokenAction({ tokenId: mintRes.id })).rejects.toThrow(
+        /autenticado/i,
+      );
+
+      // Token was NOT revoked.
+      const [row] = await db.select().from(webhookTokens).where(eq(webhookTokens.id, mintRes.id));
+      expect(row.revokedAt).toBeNull();
+    });
+  });
+
+  describe("cross-tenant enforcement", () => {
+    const OTHER_USER_EMAIL = "__widgets_other@test.local";
+    let otherUserId = 0;
+    let otherTokenId = 0;
+
+    beforeAll(async () => {
+      const [u] = await db
+        .insert(users)
+        .values({ email: OTHER_USER_EMAIL, name: "Widgets Other" })
+        .returning({ id: users.id });
+      otherUserId = u.id;
+
+      const [tok] = await db
+        .insert(webhookTokens)
+        .values({
+          userId: otherUserId,
+          purpose: "widget",
+          tokenHash: "a".repeat(64),
+          label: `${LABEL_PREFIX}other-user`,
+        })
+        .returning({ id: webhookTokens.id });
+      otherTokenId = tok.id;
+    });
+
+    afterAll(async () => {
+      await db.execute(sql`DELETE FROM webhook_tokens WHERE user_id = ${otherUserId}`);
+      await db.execute(sql`DELETE FROM users WHERE email = ${OTHER_USER_EMAIL}`);
+    });
+
+    it("user A cannot revoke user B's widget token", async () => {
+      // Session is user A (TEST_USER_ID). Target token belongs to otherUserId.
+      setSessionUser({ id: TEST_USER_ID, email: "test@findash.local", name: "Test" });
+
+      await expect(revokeWidgetTokenAction({ tokenId: otherTokenId })).rejects.toThrow(
+        /no encontrado|no te pertenece/i,
+      );
+
+      // Other user's token is STILL active.
+      const [row] = await db.select().from(webhookTokens).where(eq(webhookTokens.id, otherTokenId));
+      expect(row.revokedAt).toBeNull();
+      expect(row.userId).toBe(otherUserId);
+    });
+  });
+});

--- a/src/app/(app)/settings/widgets/actions.ts
+++ b/src/app/(app)/settings/widgets/actions.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSessionUserOrNull } from "@/lib/auth/session";
+import { mintWebhookToken, revokeWebhookToken } from "@/lib/webhook-tokens";
+import { mintWidgetTokenSchema, revokeWidgetTokenSchema } from "./schemas";
+
+export type MintWidgetActionState =
+  | { status: "idle" }
+  | { status: "error"; message: string }
+  | { status: "success"; id: number; plaintext: string };
+
+export async function mintWidgetTokenAction(
+  _prev: MintWidgetActionState,
+  formData: FormData,
+): Promise<MintWidgetActionState> {
+  const session = await getSessionUserOrNull();
+  if (!session) {
+    return { status: "error", message: "No autenticado." };
+  }
+  const parsed = mintWidgetTokenSchema.safeParse({
+    label: formData.get("label") ?? undefined,
+  });
+  if (!parsed.success) {
+    return { status: "error", message: "Entrada inválida." };
+  }
+  const { id, plaintext } = await mintWebhookToken({
+    userId: session.id,
+    purpose: "widget",
+    label: parsed.data.label ?? null,
+  });
+  revalidatePath("/settings/widgets");
+  return { status: "success", id, plaintext };
+}
+
+export async function revokeWidgetTokenAction(input: { tokenId: number }): Promise<void> {
+  const session = await getSessionUserOrNull();
+  if (!session) {
+    throw new Error("No autenticado.");
+  }
+  const { tokenId } = revokeWidgetTokenSchema.parse(input);
+  const ok = await revokeWebhookToken({ userId: session.id, tokenId });
+  if (!ok) {
+    throw new Error("Token no encontrado, ya revocado, o no te pertenece.");
+  }
+  revalidatePath("/settings/widgets");
+}

--- a/src/app/(app)/settings/widgets/page.tsx
+++ b/src/app/(app)/settings/widgets/page.tsx
@@ -1,0 +1,36 @@
+import { getSessionUser } from "@/lib/auth/session";
+import { listWidgetTokensForUser } from "@/lib/webhook-tokens";
+import { WidgetCheatsheet } from "./widget-cheatsheet";
+import { WidgetTokensManager } from "./widget-tokens-manager";
+
+export const dynamic = "force-dynamic";
+
+export default async function WidgetsPage() {
+  const session = await getSessionUser();
+  const tokens = await listWidgetTokensForUser(session.id);
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-h1">Widgets</h1>
+        <p className="text-body text-muted-foreground">
+          Tokens per-usuario para alimentar los widgets de pantalla de inicio (Scriptable en iOS,
+          Tasker en Android). Cada token habilita el endpoint{" "}
+          <code className="font-mono">/api/widget/v1/&lt;id&gt;</code>. El plaintext se muestra{" "}
+          <strong>una sola vez</strong> al generarlo — guardalo antes de salir.
+        </p>
+        {/* TODO(#390): link a /docs/widgets cuando la guía de setup esté publicada. */}
+      </header>
+      <WidgetTokensManager
+        tokens={tokens.map((t) => ({
+          id: t.id,
+          label: t.label,
+          createdAt: t.createdAt.toISOString(),
+          lastUsedAt: t.lastUsedAt ? t.lastUsedAt.toISOString() : null,
+          revokedAt: t.revokedAt ? t.revokedAt.toISOString() : null,
+        }))}
+      />
+      <WidgetCheatsheet />
+    </main>
+  );
+}

--- a/src/app/(app)/settings/widgets/schemas.ts
+++ b/src/app/(app)/settings/widgets/schemas.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+// Schemas live in a sibling file because Next.js 16 "use server" modules can
+// only export async functions — exporting a Zod schema from actions.ts would
+// 500 every action.
+export const mintWidgetTokenSchema = z.object({
+  label: z.string().trim().max(120).optional(),
+});
+
+export const revokeWidgetTokenSchema = z.object({
+  tokenId: z.coerce.number().int().positive(),
+});

--- a/src/app/(app)/settings/widgets/widget-cheatsheet.tsx
+++ b/src/app/(app)/settings/widgets/widget-cheatsheet.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+type CheatsheetRow = {
+  widget: string;
+  id: string;
+  sizes: string;
+  example: string;
+};
+
+// TODO(#390): once the setup guide lands at /docs/widgets, link to it from
+// the header description here and from the main page.
+const ROWS: readonly CheatsheetRow[] = [
+  { widget: "TC Focus", id: "tc-focus", sizes: "S", example: "tc-focus.S|<card_id>" },
+  { widget: "Mis TCs", id: "mis-tcs", sizes: "M, L", example: "mis-tcs.M" },
+  { widget: "Hoy", id: "hoy", sizes: "S", example: "hoy.S" },
+  { widget: "Mes actual", id: "mes-actual", sizes: "M", example: "mes-actual.M" },
+  { widget: "Últimas 5", id: "recent-tx", sizes: "M, L", example: "recent-tx.L" },
+] as const;
+
+export function WidgetCheatsheet() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Widgets disponibles</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-muted-foreground mb-3 text-sm">
+          Pegá el parámetro en Scriptable (iOS) o Tasker (Android) para elegir qué widget mostrar.
+          El formato es{" "}
+          <code className="bg-muted rounded px-1 font-mono text-xs">&lt;id&gt;.&lt;size&gt;</code> y
+          algunos widgets aceptan un argumento extra tras <code className="font-mono">|</code>.
+        </p>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Widget</TableHead>
+              <TableHead>ID</TableHead>
+              <TableHead>Tamaños</TableHead>
+              <TableHead>Parámetro de ejemplo</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {ROWS.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell className="font-medium">{row.widget}</TableCell>
+                <TableCell>
+                  <code className="bg-muted rounded px-1 font-mono text-xs">{row.id}</code>
+                </TableCell>
+                <TableCell className="text-muted-foreground">{row.sizes}</TableCell>
+                <TableCell>
+                  <code className="bg-muted rounded px-1 font-mono text-xs">{row.example}</code>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(app)/settings/widgets/widget-tokens-manager.tsx
+++ b/src/app/(app)/settings/widgets/widget-tokens-manager.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useActionState, useTransition } from "react";
+import { ClipboardCopyIcon, Trash2Icon } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import {
+  mintWidgetTokenAction,
+  revokeWidgetTokenAction,
+  type MintWidgetActionState,
+} from "./actions";
+
+type TokenRow = {
+  id: number;
+  label: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+};
+
+const INITIAL_STATE: MintWidgetActionState = { status: "idle" };
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+export function WidgetTokensManager({ tokens }: { tokens: TokenRow[] }) {
+  const [state, formAction, pending] = useActionState(mintWidgetTokenAction, INITIAL_STATE);
+  const [revoking, startRevoke] = useTransition();
+
+  function onRevoke(row: TokenRow) {
+    if (
+      !confirm(`¿Seguro que querés revocar este widget token${row.label ? ` "${row.label}"` : ""}?`)
+    ) {
+      return;
+    }
+    startRevoke(async () => {
+      try {
+        await revokeWidgetTokenAction({ tokenId: row.id });
+        toast.success("Token revocado");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "No se pudo revocar");
+      }
+    });
+  }
+
+  async function copyPlaintext(plaintext: string) {
+    try {
+      await navigator.clipboard.writeText(plaintext);
+      toast.success("Copiado");
+    } catch {
+      toast.error("No se pudo copiar — seleccioná y copiá manualmente");
+    }
+  }
+
+  const activeTokens = tokens.filter((t) => !t.revokedAt);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Generar un nuevo widget token</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form action={formAction} className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="label">Etiqueta (opcional)</Label>
+              <Input
+                id="label"
+                name="label"
+                placeholder="iPhone Scriptable, Pixel Tasker, etc."
+                maxLength={120}
+              />
+              <p className="text-muted-foreground text-xs">
+                Te ayuda a distinguir el token si tenés varios dispositivos.
+              </p>
+            </div>
+            <div>
+              <Button type="submit" disabled={pending}>
+                {pending ? "Generando…" : "Generar token"}
+              </Button>
+            </div>
+          </form>
+          {state.status === "error" && (
+            <p className="text-destructive mt-3 text-sm">{state.message}</p>
+          )}
+          {state.status === "success" && (
+            <div className="bg-muted/50 mt-4 rounded-md border p-4">
+              <p className="text-body font-medium">
+                Token generado. Es la <strong>única vez</strong> que vas a ver el plaintext —
+                copialo ahora.
+              </p>
+              <div className="mt-3 flex items-center gap-2">
+                <code className="bg-background flex-1 truncate rounded border px-2 py-1 font-mono text-sm">
+                  {state.plaintext}
+                </code>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => copyPlaintext(state.plaintext)}
+                >
+                  <ClipboardCopyIcon className="size-4" />
+                  Copiar
+                </Button>
+              </div>
+              <p className="text-muted-foreground mt-2 text-xs">
+                Enviá como <code className="font-mono">Authorization: Bearer {"<token>"}</code>{" "}
+                desde Scriptable/Tasker.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Tus widget tokens</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {tokens.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              Aún no tenés widgets configurados. Creá un token para empezar.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Label</TableHead>
+                  <TableHead>Creado</TableHead>
+                  <TableHead>Último uso</TableHead>
+                  <TableHead className="text-right">Acciones</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tokens.map((t) => (
+                  <TableRow key={t.id} className={cn(t.revokedAt && "opacity-60")}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{t.label ?? "(sin etiqueta)"}</span>
+                        {t.revokedAt && <Badge variant="destructive">Revocado</Badge>}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-xs">
+                      {formatDate(t.createdAt)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-xs">
+                      {t.lastUsedAt ? formatDate(t.lastUsedAt) : "nunca"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {!t.revokedAt && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          disabled={revoking}
+                          onClick={() => onRevoke(t)}
+                        >
+                          <Trash2Icon className="size-4" />
+                          Revocar
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+          {tokens.length > 0 && (
+            <p className="text-muted-foreground mt-3 text-xs">
+              {activeTokens.length} activo{activeTokens.length === 1 ? "" : "s"} · {tokens.length}{" "}
+              total
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/webhook-tokens/index.ts
+++ b/src/lib/webhook-tokens/index.ts
@@ -69,6 +69,26 @@ export async function listWebhookTokensForUser(userId: number) {
     .orderBy(desc(webhookTokens.createdAt));
 }
 
+/**
+ * Widget-scoped variant of {@link listWebhookTokensForUser}. Same shape, but
+ * filtered to `purpose = 'widget'` at the DB so /settings/widgets doesn't have
+ * to post-filter. Keeps the generic list method untouched.
+ */
+export async function listWidgetTokensForUser(userId: number) {
+  return db
+    .select({
+      id: webhookTokens.id,
+      purpose: webhookTokens.purpose,
+      label: webhookTokens.label,
+      createdAt: webhookTokens.createdAt,
+      lastUsedAt: webhookTokens.lastUsedAt,
+      revokedAt: webhookTokens.revokedAt,
+    })
+    .from(webhookTokens)
+    .where(and(eq(webhookTokens.userId, userId), eq(webhookTokens.purpose, "widget")))
+    .orderBy(desc(webhookTokens.createdAt));
+}
+
 export type ResolvedWebhookAuth = {
   userId: number;
   tokenId: number;


### PR DESCRIPTION
Closes #384

## Summary

- New page at `/settings/widgets` that lets the user mint and revoke
  per-user `widget`-purpose webhook tokens (reusing the
  `webhook_tokens` table from #383). Plaintext is shown once at mint
  time, same pattern as `/settings/webhooks`.
- Static cheatsheet rendered via shadcn `Table` listing the 5 Fase A
  widgets (`tc-focus`, `mis-tcs`, `hoy`, `mes-actual`, `recent-tx`)
  with their supported sizes and an example Scriptable/Tasker
  parameter string.
- Settings index (`/settings`) gets a new "Widgets" card linking here,
  styled to match the existing Webhook tokens card.
- All strings are in Rioplatense Spanish, consistent with the other
  settings pages.

## Implementation notes

- `listWidgetTokensForUser(userId)` helper added to
  `src/lib/webhook-tokens/index.ts` — filters `purpose = 'widget'` at
  the DB level. The generic `listWebhookTokensForUser` is untouched.
- `src/app/(app)/settings/widgets/actions.ts` only exports async
  functions (`mintWidgetTokenAction`, `revokeWidgetTokenAction`) —
  Zod schemas live in a sibling `schemas.ts`, per the Next.js 16
  `"use server"` rule (async-only exports).
- Auth guard uses `getSessionUserOrNull()` so the "no session" case
  returns a clean error state to the form instead of throwing
  `UNAUTHENTICATED` out of the action.
- Revoke delegates to `revokeWebhookToken`, which scopes the UPDATE
  with `userId = :session.id` — so a user can never revoke another
  user's token. Test covers this.
- `/settings/widgets` was added to `e2e/screenshots.spec.ts` so the
  next Playwright capture picks it up. E2E was not executed in this
  PR (capture-only spec, screenshots are gitignored).
- `page.tsx` carries a `TODO(#390)` comment pointing to the pending
  `/docs/widgets` setup guide so #390 doesn't miss the link target.

## Tests

`bun run test "src/app/(app)/settings/widgets"` — 7/7 green.

- happy path: mint returns 64-hex plaintext + persists `purpose=widget`
- empty label mints successfully and is stored as NULL
- no session → action returns `{ status: "error" }`, nothing written
- happy path revoke flips `revoked_at`
- double revoke throws (idempotent-with-error, matches webhook-tokens)
- revoke without session throws, token not revoked
- **cross-tenant**: user A cannot revoke a widget token owned by user B —
  action throws and user B's token remains active

Full suite: `bun run test` — 706/706 green.
Lint + prettier + typecheck: clean.

## Test plan

- [ ] Navigate to `/settings`, confirm the new "Widgets" card is present
  next to "Webhook tokens".
- [ ] Open `/settings/widgets`, mint a token, verify the plaintext
  appears once inside the card and the copy button works.
- [ ] Reload the page, verify the token is listed with "Creado" +
  "Último uso: nunca" and no plaintext is reachable.
- [ ] Revoke the token, confirm the row shows a "Revocado" badge and
  the action button disappears.
- [ ] Hit `/api/widget/v1/hoy` with the freshly minted token's
  `Authorization: Bearer <plaintext>` header, expect 200 (or the
  endpoint's own validation if not yet shipped) — confirms the
  `widget` purpose route resolves.
- [ ] Cheatsheet table renders all 5 rows; IDs and example params are
  selectable/copyable.