### PR TITLE
feat(widget): TC Focus endpoint (#385)

### DIFF
--- a/src/app/api/widget/v1/[id]/registry.ts
+++ b/src/app/api/widget/v1/[id]/registry.ts
@@ -17,6 +17,13 @@ export type WidgetSize = "S" | "M" | "L";
 export type WidgetHandlerContext = {
   userId: number;
   size: WidgetSize;
+  /**
+   * Read-only view of the request URL's query string. The router already
+   * validates `size` before dispatch; per-widget params (e.g. `target` for
+   * `tc-focus`) are left to the handler to parse and validate with Zod.
+   * Shared as a `URLSearchParams` so handlers don't need to re-parse the URL.
+   */
+  searchParams: URLSearchParams;
 };
 
 export type WidgetHandlerResult = {

--- a/src/app/api/widget/v1/[id]/route.test.ts
+++ b/src/app/api/widget/v1/[id]/route.test.ts
@@ -169,9 +169,13 @@ describe("GET /api/widget/v1/[id]", () => {
   });
 
   it("dispatches to the registered handler with userId + size and returns 200", async () => {
-    const seen: Array<{ userId: number; size: string }> = [];
+    const seen: Array<{ userId: number; size: string; hasSearchParams: boolean }> = [];
     const stub: WidgetHandler = async (ctx) => {
-      seen.push({ userId: ctx.userId, size: ctx.size });
+      seen.push({
+        userId: ctx.userId,
+        size: ctx.size,
+        hasSearchParams: ctx.searchParams instanceof URLSearchParams,
+      });
       return { body: { greeting: "hola", user: ctx.userId, size: ctx.size } };
     };
     registerWidgetHandler(STUB_WIDGET_ID, stub);
@@ -180,7 +184,7 @@ describe("GET /api/widget/v1/[id]", () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as { greeting: string; user: number; size: string };
     expect(json).toEqual({ greeting: "hola", user: TEST_USER_A_ID, size: "M" });
-    expect(seen).toEqual([{ userId: TEST_USER_A_ID, size: "M" }]);
+    expect(seen).toEqual([{ userId: TEST_USER_A_ID, size: "M", hasSearchParams: true }]);
   });
 
   it("maps handler exceptions to a 500 internal_error without leaking internals", async () => {

--- a/src/app/api/widget/v1/[id]/route.ts
+++ b/src/app/api/widget/v1/[id]/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createLogger } from "@/lib/logger";
 import { resolveWebhookAuth } from "@/lib/webhook-tokens";
+// Importing the handlers index for its registerWidgetHandler side effects —
+// each handler module lives in src/lib/widgets/handlers/ and registers itself
+// on import. Keep this side-effect import even when nothing here references
+// the module directly, otherwise the registry would be empty at request time.
+import "@/lib/widgets/handlers";
 import { consumeRateLimit } from "./rate-limit";
 import { getWidgetHandler, type WidgetSize } from "./registry";
 
@@ -116,7 +121,11 @@ export async function GET(
   //    filter data. If a handler throws we log with Pino's err serializer
   //    (safe against log-injection) and return a generic 500.
   try {
-    const result = await handler({ userId: auth.userId, size });
+    const result = await handler({
+      userId: auth.userId,
+      size,
+      searchParams: url.searchParams,
+    });
     return NextResponse.json(result.body, { status: result.status ?? 200 });
   } catch (err) {
     log.error(

--- a/src/lib/widgets/handlers/index.ts
+++ b/src/lib/widgets/handlers/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Central registration point for all widget handlers.
+ *
+ * Each handler lives in its own file and is registered here — the widget
+ * route imports this module for its side effects so that by the time a
+ * request hits `GET /api/widget/v1/[id]`, every real handler is already in
+ * the registry. Tests continue to register stub handlers directly against
+ * the registry to simulate dispatch without running real SQL.
+ *
+ * Keep this file thin — logic belongs in the individual handler modules.
+ */
+
+import { registerWidgetHandler } from "@/app/api/widget/v1/[id]/registry";
+import { tcFocusHandler } from "./tc-focus";
+
+registerWidgetHandler("tc-focus", tcFocusHandler);

--- a/src/lib/widgets/handlers/tc-focus.test.ts
+++ b/src/lib/widgets/handlers/tc-focus.test.ts
@@ -1,0 +1,424 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, fxRates, physicalCards, transactions, users } from "@/lib/db/schema";
+import { tcFocusHandler, computeNextCutoff } from "./tc-focus";
+
+// Everything this file inserts is tagged with MARKER so the cleanup queries
+// only delete what this suite owns.
+const MARKER = "__widget_tc_focus_test";
+
+// `getCurrentFxRate()` orders by `as_of DESC`, so to guarantee our deterministic
+// rate wins over any residual row in `findash_test`, seed with a far-future
+// date. We scope by `source = MARKER` so cleanup only removes what we own.
+const TEST_FX_DATE = "9999-01-01";
+
+let USER_A = 0;
+let USER_B = 0;
+
+async function cleanup() {
+  // Txs (FK RESTRICT) → accounts → physical_cards → users (handled in afterAll).
+  await db.execute(
+    sql`DELETE FROM transactions WHERE account_id IN (SELECT id FROM accounts WHERE name LIKE ${MARKER + "%"})`,
+  );
+  await db.execute(sql`DELETE FROM accounts WHERE name LIKE ${MARKER + "%"}`);
+  await db.execute(
+    sql`DELETE FROM physical_cards WHERE name LIKE ${MARKER + "%"} OR institution = ${MARKER}`,
+  );
+}
+
+async function insertBalance(
+  userId: number,
+  accountId: number,
+  currency: "COP" | "USD",
+  amountCents: number,
+): Promise<void> {
+  if (amountCents === 0) return;
+  await db.insert(transactions).values({
+    userId,
+    accountId,
+    occurredAt: new Date(),
+    amountCents: BigInt(amountCents),
+    currency,
+    descriptionRaw: `${MARKER} opening`,
+    classificationMethod: "manual",
+    source: "balance_adjustment",
+    channel: "manual",
+    isAdjustment: true,
+  });
+}
+
+beforeAll(async () => {
+  const [a] = await db
+    .insert(users)
+    .values({ email: `${MARKER}-a@test.local`, name: "A" })
+    .returning({ id: users.id });
+  const [b] = await db
+    .insert(users)
+    .values({ email: `${MARKER}-b@test.local`, name: "B" })
+    .returning({ id: users.id });
+  USER_A = a.id;
+  USER_B = b.id;
+
+  // Seed a deterministic TRM of 4000 so tests can assert exact COP values.
+  // The handler reads getCurrentFxRate() which returns the most-recent row;
+  // using a past `as_of` keeps this seed stable across runs that may have
+  // newer production rates.
+  await db
+    .insert(fxRates)
+    .values({
+      base: "USD",
+      quote: "COP",
+      rateMicros: BigInt(4_000_000_000), // 4000 * 1_000_000
+      asOf: TEST_FX_DATE,
+      source: MARKER,
+    })
+    .onConflictDoUpdate({
+      target: [fxRates.base, fxRates.quote, fxRates.asOf],
+      set: { rateMicros: BigInt(4_000_000_000), source: MARKER },
+    });
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM fx_rates WHERE source = ${MARKER}`);
+  await db.execute(sql`DELETE FROM users WHERE email LIKE ${MARKER + "%"}`);
+  await db.$client.end({ timeout: 1 });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers — build the WidgetHandlerContext
+// ---------------------------------------------------------------------------
+
+function makeCtx(params: { userId: number; size?: "S" | "M" | "L"; target?: string | null }) {
+  const search = new URLSearchParams();
+  if (params.target !== null && params.target !== undefined) {
+    search.set("target", params.target);
+  }
+  return {
+    userId: params.userId,
+    size: (params.size ?? "S") as "S" | "M" | "L",
+    searchParams: search,
+  };
+}
+
+type SuccessBody = {
+  widget_id: "tc-focus";
+  size: "S";
+  data: {
+    card_name: string;
+    network: string | null;
+    last4: string | null;
+    credit_limit_cop: number;
+    used_cop: number;
+    available_cop: number;
+    utilization_pct: number;
+    next_statement_cutoff: string | null;
+    days_to_cutoff: number | null;
+  };
+  generated_at: string;
+};
+
+type ErrorBody = { error: { code: string; message: string } };
+
+// ---------------------------------------------------------------------------
+// Single-currency TC — target is accounts.id (integer)
+// ---------------------------------------------------------------------------
+
+describe("tcFocusHandler — single-currency TC", () => {
+  async function seedSingleCurrencyTc(params: {
+    userId: number;
+    creditLimitCents: number;
+    balanceCents: number;
+    cutoffDay?: number;
+    last4?: string;
+    network?: "visa" | "mastercard" | "amex";
+  }): Promise<number> {
+    const [row] = await db
+      .insert(accounts)
+      .values({
+        userId: params.userId,
+        name: `${MARKER}-single-currency-tc`,
+        institution: "Bancolombia",
+        type: "credit_card",
+        currency: "COP",
+        metadata: {
+          creditLimitCents: params.creditLimitCents,
+          cutoffDay: params.cutoffDay,
+          last4s: params.last4 ? [params.last4] : undefined,
+          network: params.network,
+        },
+      })
+      .returning({ id: accounts.id });
+    await insertBalance(params.userId, row.id, "COP", params.balanceCents);
+    return row.id;
+  }
+
+  it("returns cupo + utilization for a single-currency TC", async () => {
+    // Limit 5.000.000 COP, balance -3.200.000 COP → used 3.200.000, available 1.800.000.
+    // Utilization = 64 %.
+    const id = await seedSingleCurrencyTc({
+      userId: USER_A,
+      creditLimitCents: 5_000_000_00,
+      balanceCents: -3_200_000_00,
+      cutoffDay: 3,
+      last4: "1234",
+      network: "amex",
+    });
+
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, target: String(id) }));
+    expect(res.status).toBeUndefined(); // default 200
+    const body = res.body as SuccessBody;
+    expect(body.widget_id).toBe("tc-focus");
+    expect(body.size).toBe("S");
+    expect(body.data.network).toBe("amex");
+    expect(body.data.last4).toBe("1234");
+    expect(body.data.credit_limit_cop).toBe(5_000_000);
+    expect(body.data.used_cop).toBe(3_200_000);
+    expect(body.data.available_cop).toBe(1_800_000);
+    expect(body.data.utilization_pct).toBe(64);
+    // card_name uses formatAccountLabel — "<name> (<currency>)"
+    expect(body.data.card_name).toContain(MARKER);
+    expect(body.data.card_name).toContain("(COP)");
+    // Both fields populated for a cutoffDay=3 setup; exact day count depends
+    // on "today" which we assert below in the dedicated cutoff tests.
+    expect(body.data.next_statement_cutoff).toMatch(/^\d{4}-\d{2}-03$/);
+    expect(typeof body.data.days_to_cutoff).toBe("number");
+    expect(body.generated_at).toMatch(/-05:00$/);
+  });
+
+  it("returns 0 utilization and full available when balance is zero", async () => {
+    const id = await seedSingleCurrencyTc({
+      userId: USER_A,
+      creditLimitCents: 10_000_000_00,
+      balanceCents: 0,
+    });
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, target: String(id) }));
+    const body = res.body as SuccessBody;
+    expect(body.data.used_cop).toBe(0);
+    expect(body.data.available_cop).toBe(10_000_000);
+    expect(body.data.utilization_pct).toBe(0);
+  });
+
+  it("rounds utilization to the nearest integer percent", async () => {
+    // limit 3.000.000, used 1.000.000 → 33.333...% → round to 33
+    const id = await seedSingleCurrencyTc({
+      userId: USER_A,
+      creditLimitCents: 3_000_000_00,
+      balanceCents: -1_000_000_00,
+    });
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, target: String(id) }));
+    const body = res.body as SuccessBody;
+    expect(body.data.utilization_pct).toBe(33);
+    expect(Number.isInteger(body.data.utilization_pct)).toBe(true);
+  });
+
+  it("returns null cutoff fields when metadata.cutoffDay is missing", async () => {
+    const id = await seedSingleCurrencyTc({
+      userId: USER_A,
+      creditLimitCents: 1_000_000_00,
+      balanceCents: -100_000_00,
+    });
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, target: String(id) }));
+    const body = res.body as SuccessBody;
+    expect(body.data.next_statement_cutoff).toBeNull();
+    expect(body.data.days_to_cutoff).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-currency TC — target is physical_cards.id (uuid)
+// ---------------------------------------------------------------------------
+
+describe("tcFocusHandler — multi-currency TC", () => {
+  it("returns cupo + utilization for a physical_card with linked accounts", async () => {
+    const pcId = randomUUID();
+    await db.insert(physicalCards).values({
+      id: pcId,
+      userId: USER_A,
+      institution: "Bancolombia",
+      name: `${MARKER}-mc`,
+      network: "mastercard",
+      last4: "7291",
+      creditLimitCents: BigInt(20_000_000_00),
+      statementCutoffDay: 15,
+    });
+    // Sub-accounts: COP -500.000, USD -$100 @ TRM 4000 → used = 500k + 400k = 900k
+    const rows = await db
+      .insert(accounts)
+      .values([
+        {
+          userId: USER_A,
+          name: `${MARKER}-mc-cop`,
+          institution: "Bancolombia",
+          type: "credit_card",
+          currency: "COP",
+          physicalCardId: pcId,
+        },
+        {
+          userId: USER_A,
+          name: `${MARKER}-mc-usd`,
+          institution: "Bancolombia",
+          type: "credit_card",
+          currency: "USD",
+          physicalCardId: pcId,
+        },
+      ])
+      .returning({ id: accounts.id, currency: accounts.currency });
+    for (const r of rows) {
+      if (r.currency === "COP") await insertBalance(USER_A, r.id, "COP", -500_000_00);
+      else await insertBalance(USER_A, r.id, "USD", -100_00);
+    }
+
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, target: pcId }));
+    const body = res.body as SuccessBody;
+    expect(body.data.credit_limit_cop).toBe(20_000_000);
+    expect(body.data.network).toBe("mastercard");
+    expect(body.data.last4).toBe("7291");
+    // used = 500k COP + $100 * 4000 = 900.000 COP → available = 19.100.000
+    expect(body.data.used_cop).toBe(900_000);
+    expect(body.data.available_cop).toBe(19_100_000);
+    // 900k / 20MM = 4.5 % → rounds to 5
+    expect(body.data.utilization_pct).toBe(5);
+    // physicalCard.name used as card_name
+    expect(body.data.card_name).toContain(MARKER);
+    expect(body.data.next_statement_cutoff).toMatch(/^\d{4}-\d{2}-15$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error paths — target missing, bogus, cross-tenant, wrong type, size.
+// ---------------------------------------------------------------------------
+
+describe("tcFocusHandler — errors", () => {
+  it("returns 422 invalid_params when target is missing", async () => {
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, target: null }));
+    expect(res.status).toBe(422);
+    expect((res.body as ErrorBody).error.code).toBe("invalid_params");
+  });
+
+  it("returns 404 target_not_found for a random UUID that doesn't exist", async () => {
+    const fake = randomUUID();
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, target: fake }));
+    expect(res.status).toBe(404);
+    expect((res.body as ErrorBody).error.code).toBe("target_not_found");
+  });
+
+  it("returns 404 for a credit_card account that belongs to another user (tenancy)", async () => {
+    const [row] = await db
+      .insert(accounts)
+      .values({
+        userId: USER_B,
+        name: `${MARKER}-tenant-other`,
+        institution: "Bancolombia",
+        type: "credit_card",
+        currency: "COP",
+        metadata: { creditLimitCents: 1_000_000_00 },
+      })
+      .returning({ id: accounts.id });
+
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, target: String(row.id) }));
+    expect(res.status).toBe(404);
+    expect((res.body as ErrorBody).error.code).toBe("target_not_found");
+  });
+
+  it("returns 404 for a physical_card that belongs to another user (tenancy)", async () => {
+    const pcId = randomUUID();
+    await db.insert(physicalCards).values({
+      id: pcId,
+      userId: USER_B,
+      institution: "Bancolombia",
+      name: `${MARKER}-tenant-pc`,
+      creditLimitCents: BigInt(1_000_000_00),
+    });
+
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, target: pcId }));
+    expect(res.status).toBe(404);
+    expect((res.body as ErrorBody).error.code).toBe("target_not_found");
+  });
+
+  it("returns 404 when target is a non-credit_card account (e.g. savings)", async () => {
+    const [row] = await db
+      .insert(accounts)
+      .values({
+        userId: USER_A,
+        name: `${MARKER}-savings`,
+        institution: "Bancolombia",
+        type: "savings",
+        currency: "COP",
+      })
+      .returning({ id: accounts.id });
+
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, target: String(row.id) }));
+    expect(res.status).toBe(404);
+    expect((res.body as ErrorBody).error.code).toBe("target_not_found");
+  });
+
+  it("returns 422 invalid_params when size is M", async () => {
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, size: "M", target: "1" }));
+    expect(res.status).toBe(422);
+    expect((res.body as ErrorBody).error.code).toBe("invalid_params");
+  });
+
+  it("returns 422 invalid_params when size is L", async () => {
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, size: "L", target: "1" }));
+    expect(res.status).toBe(422);
+    expect((res.body as ErrorBody).error.code).toBe("invalid_params");
+  });
+
+  it("returns 404 for garbage target strings (non-uuid, non-integer)", async () => {
+    const res = await tcFocusHandler(makeCtx({ userId: USER_A, target: "not-a-thing" }));
+    expect(res.status).toBe(404);
+    expect((res.body as ErrorBody).error.code).toBe("target_not_found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeNextCutoff — pure unit tests. Exercises the two branches (this-month
+// vs next-month) and the clamp to short months.
+// ---------------------------------------------------------------------------
+
+describe("computeNextCutoff", () => {
+  it("picks the current month when cutoffDay is later than today", () => {
+    // Today is 2026-04-21 Bogota. cutoff=25 → next is 2026-04-25, 4 days away.
+    const res = computeNextCutoff(25, { year: 2026, month: 4, day: 21 });
+    expect(res.next).toBe("2026-04-25");
+    expect(res.daysTo).toBe(4);
+  });
+
+  it("picks next month when cutoffDay is today or earlier", () => {
+    const res = computeNextCutoff(15, { year: 2026, month: 4, day: 20 });
+    expect(res.next).toBe("2026-05-15");
+    expect(res.daysTo).toBe(25);
+  });
+
+  it("treats cutoff == today as next month (cutoff is in the future)", () => {
+    // When today.day === cutoffDay, the cutoff already fired, so next is
+    // the same day in the following month.
+    const res = computeNextCutoff(10, { year: 2026, month: 4, day: 10 });
+    expect(res.next).toBe("2026-05-10");
+    expect(res.daysTo).toBe(30);
+  });
+
+  it("wraps December → January with year +1", () => {
+    const res = computeNextCutoff(5, { year: 2026, month: 12, day: 20 });
+    expect(res.next).toBe("2027-01-05");
+    expect(res.daysTo).toBe(16);
+  });
+
+  it("clamps cutoffDay=31 to the last day of a 30-day target month", () => {
+    // Today 2026-03-31, cutoff=31 → fires again in April. April has 30 days,
+    // so the clamp lands on 2026-04-30 (30 days away).
+    const res = computeNextCutoff(31, { year: 2026, month: 3, day: 31 });
+    expect(res.next).toBe("2026-04-30");
+    expect(res.daysTo).toBe(30);
+  });
+
+  it("clamps cutoffDay=31 to Feb-28 in a non-leap year", () => {
+    const res = computeNextCutoff(31, { year: 2026, month: 1, day: 31 });
+    expect(res.next).toBe("2026-02-28");
+    expect(res.daysTo).toBe(28);
+  });
+});

--- a/src/lib/widgets/handlers/tc-focus.ts
+++ b/src/lib/widgets/handlers/tc-focus.ts
@@ -1,0 +1,348 @@
+/**
+ * Widget handler: `tc-focus` — cupo + utilization snapshot for ONE credit card.
+ *
+ * Supports both card shapes the codebase carries today (#346):
+ *
+ * - Single-currency TC  → `target` is an `accounts.id` (integer). Cupo lives on
+ *   `accounts.metadata.creditLimitCents` and the statement cutoff day on
+ *   `metadata.cutoffDay`. Balance is the derived SUM(transactions.amount_cents)
+ *   for that account — stored as negative debt, so `used = |balance|` and
+ *   `available = limit + balance`.
+ *
+ * - Multi-currency TC   → `target` is a `physical_cards.id` (uuid). The shared
+ *   COP cupo + statement cutoff live on the `physical_cards` row, and the
+ *   sub-accounts (COP + USD) hold the per-currency balances. We delegate the
+ *   available-credit math to `getAvailableCreditCOP`, which handles USD→COP
+ *   conversion at the current TRM.
+ *
+ * `target` is dispatched by UUID shape: anything that parses as a UUID is
+ * tried against `physical_cards` first; otherwise it is parsed as an integer
+ * account id. If neither resolves for the requesting user → 404 with code
+ * `target_not_found`. Cross-tenant `target`s fall through the same 404 — the
+ * handler NEVER reveals whether the id exists under a different user.
+ *
+ * Size: `tc-focus` is designed for a small home-screen tile; only `size=S` is
+ * supported. `M`/`L` requests return 422 `invalid_params` at the handler layer.
+ */
+
+import { z } from "zod";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, physicalCards, type AccountMetadata } from "@/lib/db/schema";
+import { derivedBalanceCentsSql, getAvailableCreditCOP } from "@/lib/accounts/queries";
+import { notDeleted } from "@/lib/db/helpers";
+import { getCurrentFxRate } from "@/lib/fx/repo";
+import { createLogger } from "@/lib/logger";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import type { WidgetHandler, WidgetHandlerResult } from "@/app/api/widget/v1/[id]/registry";
+
+const log = createLogger({ module: "widget-tc-focus" });
+
+// ---------------------------------------------------------------------------
+// Response shapes
+// ---------------------------------------------------------------------------
+
+type TcFocusData = {
+  card_name: string;
+  network: string | null;
+  last4: string | null;
+  credit_limit_cop: number;
+  used_cop: number;
+  available_cop: number;
+  utilization_pct: number;
+  next_statement_cutoff: string | null;
+  days_to_cutoff: number | null;
+};
+
+type TcFocusResponse = {
+  widget_id: "tc-focus";
+  size: "S";
+  data: TcFocusData;
+  generated_at: string;
+};
+
+type TcFocusErrorCode = "target_not_found" | "invalid_params";
+
+type TcFocusErrorBody = { error: { code: TcFocusErrorCode; message: string } };
+
+const STATUS_BY_CODE: Record<TcFocusErrorCode, number> = {
+  target_not_found: 404,
+  invalid_params: 422,
+};
+
+function errorResult(code: TcFocusErrorCode, message: string): WidgetHandlerResult {
+  const body: TcFocusErrorBody = { error: { code, message } };
+  return { body, status: STATUS_BY_CODE[code] };
+}
+
+// ---------------------------------------------------------------------------
+// Query param validation
+// ---------------------------------------------------------------------------
+
+const querySchema = z.object({
+  target: z.string().min(1, "target is required"),
+});
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ---------------------------------------------------------------------------
+// Bogota-aware date helpers — Colombia has no DST, so a fixed UTC-5 offset is
+// exact. We keep the math in milliseconds to avoid Date#getXxx() surprises at
+// month boundaries.
+// ---------------------------------------------------------------------------
+
+const BOGOTA_OFFSET_MS = 5 * 60 * 60 * 1000;
+
+type BogotaYmd = { year: number; month: number; day: number };
+
+function nowInBogota(now: Date): BogotaYmd {
+  const shifted = new Date(now.getTime() - BOGOTA_OFFSET_MS);
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1, // 1..12
+    day: shifted.getUTCDate(),
+  };
+}
+
+function daysInMonth(year: number, month: number): number {
+  // month is 1..12; Date(year, month, 0) gives the last day of `month`.
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function formatYmd(y: number, m: number, d: number): string {
+  return `${y}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+}
+
+/**
+ * Given a statement cutoff day-of-month (1..31), returns the ISO date of the
+ * NEXT cutoff and the number of days between today (Bogota) and that cutoff.
+ *
+ * Rules:
+ * - If `cutoffDay > today.day` → cutoff is this month.
+ * - Else → cutoff is next month.
+ * - If `cutoffDay` exceeds the target month's last day (e.g. cutoff=31 in
+ *   February), clamp to the last day of that month.
+ */
+export function computeNextCutoff(
+  cutoffDay: number,
+  today: BogotaYmd,
+): { next: string; daysTo: number } {
+  const inThisMonth = cutoffDay > today.day;
+  const year0 = today.year;
+  const month0 = today.month;
+  const targetYear = inThisMonth || month0 < 12 ? year0 : year0 + 1;
+  const targetMonth = inThisMonth ? month0 : month0 === 12 ? 1 : month0 + 1;
+  const clampedDay = Math.min(cutoffDay, daysInMonth(targetYear, targetMonth));
+  const next = formatYmd(targetYear, targetMonth, clampedDay);
+  // Day count via UTC midnight diff — both dates are "dates" in Bogota, so the
+  // offset cancels out; we just need whole-day subtraction.
+  const todayUtc = Date.UTC(today.year, today.month - 1, today.day);
+  const nextUtc = Date.UTC(targetYear, targetMonth - 1, clampedDay);
+  const daysTo = Math.round((nextUtc - todayUtc) / (24 * 60 * 60 * 1000));
+  return { next, daysTo };
+}
+
+// Bogota-offset ISO-8601 — e.g. `2026-04-21T17:23:00-05:00`. We format without
+// seconds of precision finer than whole-second and without milliseconds, which
+// matches the issue's sample response.
+function bogotaIsoNow(now: Date): string {
+  const shifted = new Date(now.getTime() - BOGOTA_OFFSET_MS);
+  const y = shifted.getUTCFullYear();
+  const m = String(shifted.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(shifted.getUTCDate()).padStart(2, "0");
+  const hh = String(shifted.getUTCHours()).padStart(2, "0");
+  const mm = String(shifted.getUTCMinutes()).padStart(2, "0");
+  const ss = String(shifted.getUTCSeconds()).padStart(2, "0");
+  return `${y}-${m}-${d}T${hh}:${mm}:${ss}-05:00`;
+}
+
+// ---------------------------------------------------------------------------
+// Money helpers — everything out of the DB is bigint cents. The widget
+// contract exposes COP as integer pesos (no cents shown in the tile).
+// ---------------------------------------------------------------------------
+
+const BI_ZERO = BigInt(0);
+const BI_HUNDRED = BigInt(100);
+const BI_TEN_THOUSAND = BigInt(10000);
+
+function centsToCop(cents: bigint): number {
+  // Integer division in bigint-space, then narrow to number. COP amounts we
+  // expect here (cupo, balances) comfortably fit in Number.MAX_SAFE_INTEGER
+  // after dividing by 100.
+  return Number(cents / BI_HUNDRED);
+}
+
+function roundUtilizationPct(used: bigint, limit: bigint): number {
+  if (limit <= BI_ZERO) return 0;
+  // (used * 10000) / limit yields "percent * 100"; round to integer percent.
+  const scaled = (used * BI_TEN_THOUSAND) / limit;
+  return Math.round(Number(scaled) / 100);
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export const tcFocusHandler: WidgetHandler = async (ctx) => {
+  // Size constraint — tile-only widget.
+  if (ctx.size !== "S") {
+    return errorResult("invalid_params", "tc-focus only supports size S");
+  }
+
+  // target param — Zod enforces required/string; shape dispatch happens next.
+  const parsed = querySchema.safeParse({ target: ctx.searchParams.get("target") });
+  if (!parsed.success) {
+    return errorResult("invalid_params", "target query param is required");
+  }
+  const target = parsed.data.target;
+
+  const now = new Date();
+  const today = nowInBogota(now);
+
+  // --- Multi-currency path: UUID targets look up physical_cards first. ----
+  if (UUID_RE.test(target)) {
+    const [pc] = await db
+      .select({
+        id: physicalCards.id,
+        name: physicalCards.name,
+        network: physicalCards.network,
+        last4: physicalCards.last4,
+        institution: physicalCards.institution,
+        creditLimitCents: physicalCards.creditLimitCents,
+        statementCutoffDay: physicalCards.statementCutoffDay,
+      })
+      .from(physicalCards)
+      .where(and(eq(physicalCards.id, target), eq(physicalCards.userId, ctx.userId)))
+      .limit(1);
+
+    if (pc) {
+      const fx = await getCurrentFxRate();
+      const availableCents = await getAvailableCreditCOP(ctx.userId, pc.id, fx.rate);
+      if (availableCents === null) {
+        // Belt-and-braces — the SELECT above proved the row exists, but the
+        // helper has its own tenancy guard and might disagree if a race
+        // deleted the card between calls. Surface as 404, not 500.
+        log.warn(
+          {
+            event: "tc_focus_available_mismatch",
+            userId: ctx.userId,
+            physicalCardId: pc.id,
+          },
+          "physical card exists but available-credit query returned null",
+        );
+        return errorResult("target_not_found", "Credit card not found");
+      }
+
+      const limitCents = pc.creditLimitCents;
+      // used = limit - available (in COP cents). Clamp at 0 to avoid negative
+      // utilization if the user is somehow above the cupo in the ledger.
+      const usedCents = limitCents - availableCents;
+      const usedClamped = usedCents < BI_ZERO ? BI_ZERO : usedCents;
+      const utilizationPct = roundUtilizationPct(usedClamped, limitCents);
+
+      const cutoff =
+        pc.statementCutoffDay !== null && pc.statementCutoffDay !== undefined
+          ? computeNextCutoff(pc.statementCutoffDay, today)
+          : null;
+
+      const cardName =
+        pc.name?.trim() ||
+        [pc.institution, pc.last4 ? `*${pc.last4}` : null].filter(Boolean).join(" ") ||
+        "Tarjeta de crédito";
+
+      const body: TcFocusResponse = {
+        widget_id: "tc-focus",
+        size: "S",
+        data: {
+          card_name: cardName,
+          network: pc.network,
+          last4: pc.last4,
+          credit_limit_cop: centsToCop(limitCents),
+          used_cop: centsToCop(usedClamped),
+          available_cop: centsToCop(availableCents < BI_ZERO ? BI_ZERO : availableCents),
+          utilization_pct: utilizationPct,
+          next_statement_cutoff: cutoff?.next ?? null,
+          days_to_cutoff: cutoff?.daysTo ?? null,
+        },
+        generated_at: bogotaIsoNow(now),
+      };
+      return { body };
+    }
+    // UUID but not one of this user's physical cards → 404. Do NOT fall
+    // through to accounts.id lookup (account ids are ints, never UUIDs).
+    return errorResult("target_not_found", "Credit card not found");
+  }
+
+  // --- Single-currency path: parse target as an accounts.id integer. -----
+  const asInt = Number(target);
+  if (!Number.isInteger(asInt) || asInt <= 0 || String(asInt) !== target) {
+    return errorResult("target_not_found", "Credit card not found");
+  }
+
+  const [acc] = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      institution: accounts.institution,
+      currency: accounts.currency,
+      type: accounts.type,
+      metadata: accounts.metadata,
+      balanceCents: derivedBalanceCentsSql,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.id, asInt),
+        eq(accounts.userId, ctx.userId),
+        eq(accounts.type, "credit_card"),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  if (!acc) {
+    return errorResult("target_not_found", "Credit card not found");
+  }
+
+  const metadata = (acc.metadata ?? {}) as AccountMetadata;
+  const limitCents = BigInt(metadata.creditLimitCents ?? 0);
+  const balanceCents = BigInt(acc.balanceCents);
+
+  // Credit card balances are stored as negative debt; absolute value = used.
+  const usedCents = balanceCents < BI_ZERO ? -balanceCents : BI_ZERO;
+  const availableCents = limitCents - usedCents < BI_ZERO ? BI_ZERO : limitCents - usedCents;
+  const utilizationPct = roundUtilizationPct(usedCents, limitCents);
+
+  const cutoffDay = metadata.cutoffDay ?? null;
+  const cutoff = cutoffDay !== null ? computeNextCutoff(cutoffDay, today) : null;
+
+  // For single-currency cards the ledger already embeds last4 in the account
+  // name (legacy) OR keeps it on metadata.last4s — prefer the latter.
+  const last4 = metadata.last4s?.[0] ?? null;
+  const network = metadata.network ?? null;
+
+  const cardName = formatAccountLabel({
+    name: acc.name,
+    currency: acc.currency,
+    institution: acc.institution,
+    metadata: { last4s: metadata.last4s ?? null },
+  });
+
+  const body: TcFocusResponse = {
+    widget_id: "tc-focus",
+    size: "S",
+    data: {
+      card_name: cardName,
+      network,
+      last4,
+      credit_limit_cop: centsToCop(limitCents),
+      used_cop: centsToCop(usedCents),
+      available_cop: centsToCop(availableCents),
+      utilization_pct: utilizationPct,
+      next_statement_cutoff: cutoff?.next ?? null,
+      days_to_cutoff: cutoff?.daysTo ?? null,
+    },
+    generated_at: bogotaIsoNow(now),
+  };
+  return { body };
+};


### PR DESCRIPTION
## Summary

Adds the `tc-focus` widget handler: cupo + utilization snapshot for a single credit card, dispatched by UUID (`physical_cards.id` for multi-currency cards) or integer (`accounts.id` for single-currency cards).

- `GET /api/widget/v1/tc-focus?size=S&target=<id>` with a `widget` bearer token.
- Single-currency: reads `accounts.metadata.creditLimitCents` + derived balance (`SUM(transactions.amount_cents)`, archived rows excluded).
- Multi-currency: delegates cupo math to `getAvailableCreditCOP` (USD debt converted at current TRM via `getCurrentFxRate`).
- Cutoff math: Bogota-aware (fixed UTC-5, Colombia has no DST). Next cutoff is this month when `cutoffDay > today.day`, otherwise next month; `cutoffDay=31` clamps to the target month's last day.
- `size` enforcement: only `S` is accepted — `M`/`L` return `422 invalid_params`.
- Error shape: `{ error: { code, message } }` — `target_not_found` (404), `invalid_params` (422). Cross-tenant `target`s fall through the same 404.

## Contract changes

- `WidgetHandlerContext` now carries a `searchParams: URLSearchParams`. The router passes `url.searchParams` straight through so handlers can parse their own params with Zod. Future handlers (mis-tcs, hoy, últimas-5, mes-actual) will use this too.
- `src/lib/widgets/handlers/index.ts` is the registration barrel — imported by `route.ts` for side effects so the registry is populated by request time. Tests still register stub handlers directly.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test src/lib/widgets src/app/api/widget` — 31 pass
- [x] Full pre-push test suite — pass

Covers:
- Happy path single-currency TC (64% utilization case from the spec)
- Happy path multi-currency TC (COP + USD sub-accounts, FX conversion)
- Utilization rounding (33.33% → 33)
- Missing target → 422 invalid_params
- Random UUID → 404
- Cross-tenant accounts.id → 404
- Cross-tenant physical_cards.id → 404
- Non-credit_card account (savings) → 404
- Garbage target string → 404
- size=M / size=L → 422
- computeNextCutoff unit: this-month, next-month, today==cutoff, Dec→Jan wrap, 31-clamp to 30/28 day months

Closes #385