### PR TITLE
feat(widget): Mis TCs endpoint (#386)

### DIFF
--- a/src/lib/widgets/handlers/_shared.ts
+++ b/src/lib/widgets/handlers/_shared.ts
@@ -1,0 +1,59 @@
+/**
+ * Helpers shared by widget handlers that speak the v1 Scriptable/Tasker
+ * contract. Keep this module tiny — anything with a clear home in
+ * `@/lib/accounts` or `@/lib/money` belongs there, not here. The only reason
+ * these live under `widgets/` is that every widget response negotiates the
+ * same three things:
+ *
+ * - `generated_at` as a Bogota-offset ISO string (Colombia has no DST so
+ *   UTC-5 is exact year-round),
+ * - COP cents → integer pesos conversion (widgets never show cents),
+ * - `utilization_pct` rounded to an integer percentage.
+ *
+ * Other handlers (tc-focus, mis-tcs, …) import from here to stay byte-for-byte
+ * consistent on these small primitives.
+ */
+
+const BOGOTA_OFFSET_MS = 5 * 60 * 60 * 1000;
+
+/**
+ * Formats `now` as an ISO-8601 string in Bogota local time with the `-05:00`
+ * offset suffix, seconds precision, no millis — matches the sample response
+ * in issue #386 and #385 exactly. We format the shifted UTC components by
+ * hand to avoid Date.toLocaleString's non-ISO output.
+ */
+export function bogotaIsoNow(now: Date): string {
+  const shifted = new Date(now.getTime() - BOGOTA_OFFSET_MS);
+  const y = shifted.getUTCFullYear();
+  const m = String(shifted.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(shifted.getUTCDate()).padStart(2, "0");
+  const hh = String(shifted.getUTCHours()).padStart(2, "0");
+  const mm = String(shifted.getUTCMinutes()).padStart(2, "0");
+  const ss = String(shifted.getUTCSeconds()).padStart(2, "0");
+  return `${y}-${m}-${d}T${hh}:${mm}:${ss}-05:00`;
+}
+
+const BI_ZERO = BigInt(0);
+const BI_HUNDRED = BigInt(100);
+const BI_TEN_THOUSAND = BigInt(10000);
+
+/**
+ * Integer-pesos narrowing: COP amounts we surface (cupo, balances) fit
+ * comfortably under Number.MAX_SAFE_INTEGER after dividing by 100, so it is
+ * safe to coerce. Drops anything below the peso — the widget UX has no room
+ * for cents.
+ */
+export function centsToCop(cents: bigint): number {
+  return Number(cents / BI_HUNDRED);
+}
+
+/**
+ * Rounds `(used / limit) * 100` to the nearest integer percent. Returns 0
+ * when `limit` is zero or negative — a cupo of 0 is not a divide-by-zero, it
+ * is an un-utilized card with no headroom to measure.
+ */
+export function roundUtilizationPct(used: bigint, limit: bigint): number {
+  if (limit <= BI_ZERO) return 0;
+  const scaled = (used * BI_TEN_THOUSAND) / limit;
+  return Math.round(Number(scaled) / 100);
+}

--- a/src/lib/widgets/handlers/index.ts
+++ b/src/lib/widgets/handlers/index.ts
@@ -11,6 +11,8 @@
  */
 
 import { registerWidgetHandler } from "@/app/api/widget/v1/[id]/registry";
+import { misTcsHandler } from "./mis-tcs";
 import { tcFocusHandler } from "./tc-focus";
 
+registerWidgetHandler("mis-tcs", misTcsHandler);
 registerWidgetHandler("tc-focus", tcFocusHandler);

--- a/src/lib/widgets/handlers/mis-tcs.test.ts
+++ b/src/lib/widgets/handlers/mis-tcs.test.ts
@@ -1,0 +1,511 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, fxRates, physicalCards, transactions, users } from "@/lib/db/schema";
+import { misTcsHandler } from "./mis-tcs";
+
+// Cleanup gate: everything this suite touches is tagged so the delete queries
+// only remove what we own. Matches the tc-focus.test.ts pattern.
+const MARKER = "__widget_mis_tcs_test";
+
+// Stable, far-future FX date so getCurrentFxRate() returns our seeded row
+// (it ORDERs BY as_of DESC) regardless of any other rates in findash_test.
+const TEST_FX_DATE = "9999-01-01";
+
+let USER_A = 0;
+let USER_B = 0;
+
+async function cleanup() {
+  // FK cascade order: transactions → accounts → physical_cards. Users stay
+  // for the whole file lifetime (afterAll drops them).
+  await db.execute(
+    sql`DELETE FROM transactions WHERE account_id IN (SELECT id FROM accounts WHERE name LIKE ${MARKER + "%"})`,
+  );
+  await db.execute(sql`DELETE FROM accounts WHERE name LIKE ${MARKER + "%"}`);
+  await db.execute(
+    sql`DELETE FROM physical_cards WHERE name LIKE ${MARKER + "%"} OR institution = ${MARKER}`,
+  );
+}
+
+async function insertBalance(
+  userId: number,
+  accountId: number,
+  currency: "COP" | "USD",
+  amountCents: number,
+): Promise<void> {
+  if (amountCents === 0) return;
+  await db.insert(transactions).values({
+    userId,
+    accountId,
+    occurredAt: new Date(),
+    amountCents: BigInt(amountCents),
+    currency,
+    descriptionRaw: `${MARKER} opening`,
+    classificationMethod: "manual",
+    source: "balance_adjustment",
+    channel: "manual",
+    isAdjustment: true,
+  });
+}
+
+beforeAll(async () => {
+  const [a] = await db
+    .insert(users)
+    .values({ email: `${MARKER}-a@test.local`, name: "A" })
+    .returning({ id: users.id });
+  const [b] = await db
+    .insert(users)
+    .values({ email: `${MARKER}-b@test.local`, name: "B" })
+    .returning({ id: users.id });
+  USER_A = a.id;
+  USER_B = b.id;
+
+  // TRM = 4000 for deterministic COP math on multi-currency cards.
+  await db
+    .insert(fxRates)
+    .values({
+      base: "USD",
+      quote: "COP",
+      rateMicros: BigInt(4_000_000_000), // 4000 * 1_000_000
+      asOf: TEST_FX_DATE,
+      source: MARKER,
+    })
+    .onConflictDoUpdate({
+      target: [fxRates.base, fxRates.quote, fxRates.asOf],
+      set: { rateMicros: BigInt(4_000_000_000), source: MARKER },
+    });
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM fx_rates WHERE source = ${MARKER}`);
+  await db.execute(sql`DELETE FROM users WHERE email LIKE ${MARKER + "%"}`);
+  await db.$client.end({ timeout: 1 });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers — WidgetHandlerContext + seed helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(params: { userId: number; size?: "S" | "M" | "L" }) {
+  return {
+    userId: params.userId,
+    size: (params.size ?? "M") as "S" | "M" | "L",
+    searchParams: new URLSearchParams(),
+  };
+}
+
+type SuccessBody = {
+  widget_id: "mis-tcs";
+  size: "M" | "L";
+  data: {
+    cards: Array<{
+      id: string | number;
+      name: string;
+      network: string | null;
+      last4: string | null;
+      available_cop: number;
+      credit_limit_cop: number;
+      utilization_pct: number;
+    }>;
+    total_available_cop: number;
+    total_credit_cop: number;
+  };
+  generated_at: string;
+};
+
+type ErrorBody = { error: { code: string; message: string } };
+
+async function seedSingleCurrencyTc(params: {
+  userId: number;
+  slug: string;
+  creditLimitCents: number;
+  balanceCents: number;
+  currency?: "COP" | "USD";
+  last4?: string;
+  network?: "visa" | "mastercard" | "amex";
+}): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId: params.userId,
+      name: `${MARKER}-${params.slug}`,
+      institution: "Bancolombia",
+      type: "credit_card",
+      currency: params.currency ?? "COP",
+      metadata: {
+        creditLimitCents: params.creditLimitCents,
+        last4s: params.last4 ? [params.last4] : undefined,
+        network: params.network,
+      },
+    })
+    .returning({ id: accounts.id });
+  await insertBalance(params.userId, row.id, params.currency ?? "COP", params.balanceCents);
+  return row.id;
+}
+
+async function seedMultiCurrencyTc(params: {
+  userId: number;
+  slug: string;
+  creditLimitCents: number;
+  copBalanceCents: number;
+  usdBalanceCents: number;
+  network?: "visa" | "mastercard" | "amex";
+  last4?: string;
+}): Promise<string> {
+  const pcId = randomUUID();
+  await db.insert(physicalCards).values({
+    id: pcId,
+    userId: params.userId,
+    institution: "Bancolombia",
+    name: `${MARKER}-${params.slug}`,
+    network: params.network ?? "mastercard",
+    last4: params.last4 ?? "0000",
+    creditLimitCents: BigInt(params.creditLimitCents),
+  });
+  const rows = await db
+    .insert(accounts)
+    .values([
+      {
+        userId: params.userId,
+        name: `${MARKER}-${params.slug}-cop`,
+        institution: "Bancolombia",
+        type: "credit_card",
+        currency: "COP",
+        physicalCardId: pcId,
+      },
+      {
+        userId: params.userId,
+        name: `${MARKER}-${params.slug}-usd`,
+        institution: "Bancolombia",
+        type: "credit_card",
+        currency: "USD",
+        physicalCardId: pcId,
+      },
+    ])
+    .returning({ id: accounts.id, currency: accounts.currency });
+  for (const r of rows) {
+    if (r.currency === "COP")
+      await insertBalance(params.userId, r.id, "COP", params.copBalanceCents);
+    else await insertBalance(params.userId, r.id, "USD", params.usdBalanceCents);
+  }
+  return pcId;
+}
+
+// ---------------------------------------------------------------------------
+// Shape: mixed single + multi currency cards
+// ---------------------------------------------------------------------------
+
+describe("misTcsHandler — mixed roster", () => {
+  it("returns a single entry per physical_card PLUS one per single-currency account", async () => {
+    // Multi-currency: limit 20MM, COP debt 500k, USD debt $100 @ 4000 = 400k
+    // → used 900k, available 19.1MM, util 5 %.
+    const pcId = await seedMultiCurrencyTc({
+      userId: USER_A,
+      slug: "multi",
+      creditLimitCents: 20_000_000_00,
+      copBalanceCents: -500_000_00,
+      usdBalanceCents: -100_00,
+      network: "mastercard",
+      last4: "7291",
+    });
+    // Single-currency: limit 5MM, debt 3.2MM → util 64 %.
+    const singleId = await seedSingleCurrencyTc({
+      userId: USER_A,
+      slug: "single-high",
+      creditLimitCents: 5_000_000_00,
+      balanceCents: -3_200_000_00,
+      last4: "1234",
+      network: "amex",
+    });
+
+    const res = await misTcsHandler(makeCtx({ userId: USER_A, size: "L" }));
+    expect(res.status).toBeUndefined();
+    const body = res.body as SuccessBody;
+    expect(body.widget_id).toBe("mis-tcs");
+    expect(body.size).toBe("L");
+    expect(body.data.cards).toHaveLength(2);
+
+    // Ordering: util DESC → single (64 %) before multi (5 %).
+    expect(body.data.cards[0].id).toBe(singleId);
+    expect(body.data.cards[0].utilization_pct).toBe(64);
+    expect(body.data.cards[0].network).toBe("amex");
+    expect(body.data.cards[0].last4).toBe("1234");
+    expect(body.data.cards[0].credit_limit_cop).toBe(5_000_000);
+    expect(body.data.cards[0].available_cop).toBe(1_800_000);
+
+    expect(body.data.cards[1].id).toBe(pcId);
+    expect(body.data.cards[1].utilization_pct).toBe(5);
+    expect(body.data.cards[1].network).toBe("mastercard");
+    expect(body.data.cards[1].last4).toBe("7291");
+    expect(body.data.cards[1].credit_limit_cop).toBe(20_000_000);
+    expect(body.data.cards[1].available_cop).toBe(19_100_000);
+
+    // Totals over the full roster. 20MM + 5MM credit, 19.1MM + 1.8MM available.
+    expect(body.data.total_credit_cop).toBe(25_000_000);
+    expect(body.data.total_available_cop).toBe(20_900_000);
+
+    expect(body.generated_at).toMatch(/-05:00$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shape: only single-currency cards
+// ---------------------------------------------------------------------------
+
+describe("misTcsHandler — only single-currency", () => {
+  it("returns each account as its own row", async () => {
+    await seedSingleCurrencyTc({
+      userId: USER_A,
+      slug: "sc-a",
+      creditLimitCents: 2_000_000_00,
+      balanceCents: -500_000_00, // 25 %
+    });
+    await seedSingleCurrencyTc({
+      userId: USER_A,
+      slug: "sc-b",
+      creditLimitCents: 4_000_000_00,
+      balanceCents: -3_000_000_00, // 75 %
+    });
+
+    const res = await misTcsHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.cards).toHaveLength(2);
+    expect(body.data.cards[0].utilization_pct).toBe(75);
+    expect(body.data.cards[1].utilization_pct).toBe(25);
+    // All ids are numeric (accounts.id).
+    expect(typeof body.data.cards[0].id).toBe("number");
+    expect(typeof body.data.cards[1].id).toBe("number");
+    expect(body.data.total_credit_cop).toBe(6_000_000);
+    expect(body.data.total_available_cop).toBe(2_500_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shape: only multi-currency cards
+// ---------------------------------------------------------------------------
+
+describe("misTcsHandler — only multi-currency", () => {
+  it("returns each physical_card as a single row even with multiple sub-accounts", async () => {
+    const pc1 = await seedMultiCurrencyTc({
+      userId: USER_A,
+      slug: "mc-low",
+      creditLimitCents: 10_000_000_00,
+      copBalanceCents: -1_000_000_00,
+      usdBalanceCents: 0,
+    });
+    const pc2 = await seedMultiCurrencyTc({
+      userId: USER_A,
+      slug: "mc-high",
+      creditLimitCents: 8_000_000_00,
+      copBalanceCents: -3_000_000_00,
+      usdBalanceCents: -500_00, // $500 * 4000 = 2MM
+    });
+
+    const res = await misTcsHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.cards).toHaveLength(2);
+
+    // pc2: used 5MM / 8MM = 62.5 % → 63 %. pc1: 1MM / 10MM = 10 %.
+    expect(body.data.cards[0].id).toBe(pc2);
+    expect(body.data.cards[0].utilization_pct).toBe(63);
+    expect(body.data.cards[1].id).toBe(pc1);
+    expect(body.data.cards[1].utilization_pct).toBe(10);
+    // All ids are UUID strings.
+    expect(typeof body.data.cards[0].id).toBe("string");
+    expect(typeof body.data.cards[1].id).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty-state: user has no TCs
+// ---------------------------------------------------------------------------
+
+describe("misTcsHandler — empty roster", () => {
+  it("returns 200 with an empty cards array and zeroed totals", async () => {
+    const res = await misTcsHandler(makeCtx({ userId: USER_A, size: "M" }));
+    expect(res.status).toBeUndefined();
+    const body = res.body as SuccessBody;
+    expect(body.data.cards).toEqual([]);
+    expect(body.data.total_available_cop).toBe(0);
+    expect(body.data.total_credit_cop).toBe(0);
+  });
+
+  it("does NOT fetch FX when there are no USD sub-accounts (COP-only roster)", async () => {
+    // Delete the seed FX row — if the handler still tries to call
+    // getCurrentFxRate, it would hit the fallback (4000) but we want to prove
+    // we skipped the query entirely. Testing behavior via absence: the result
+    // must still be correct after the FX row is gone AND we have only COP.
+    await db.execute(sql`DELETE FROM fx_rates WHERE source = ${MARKER}`);
+
+    await seedSingleCurrencyTc({
+      userId: USER_A,
+      slug: "cop-only",
+      creditLimitCents: 1_000_000_00,
+      balanceCents: -100_000_00,
+    });
+
+    const res = await misTcsHandler(makeCtx({ userId: USER_A, size: "L" }));
+    expect(res.status).toBeUndefined();
+    const body = res.body as SuccessBody;
+    expect(body.data.cards).toHaveLength(1);
+    expect(body.data.cards[0].utilization_pct).toBe(10);
+
+    // Re-seed FX for subsequent tests (afterEach cleans accounts but not fx).
+    await db.insert(fxRates).values({
+      base: "USD",
+      quote: "COP",
+      rateMicros: BigInt(4_000_000_000),
+      asOf: TEST_FX_DATE,
+      source: MARKER,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Size rules
+// ---------------------------------------------------------------------------
+
+describe("misTcsHandler — size rules", () => {
+  async function seedFiveCards(userId: number): Promise<void> {
+    // Utilizations: 90, 70, 50, 30, 10 — strictly decreasing so the top-3
+    // trim is unambiguous.
+    await seedSingleCurrencyTc({
+      userId,
+      slug: "u90",
+      creditLimitCents: 1_000_000_00,
+      balanceCents: -900_000_00,
+    });
+    await seedSingleCurrencyTc({
+      userId,
+      slug: "u70",
+      creditLimitCents: 1_000_000_00,
+      balanceCents: -700_000_00,
+    });
+    await seedSingleCurrencyTc({
+      userId,
+      slug: "u50",
+      creditLimitCents: 1_000_000_00,
+      balanceCents: -500_000_00,
+    });
+    await seedSingleCurrencyTc({
+      userId,
+      slug: "u30",
+      creditLimitCents: 1_000_000_00,
+      balanceCents: -300_000_00,
+    });
+    await seedSingleCurrencyTc({
+      userId,
+      slug: "u10",
+      creditLimitCents: 1_000_000_00,
+      balanceCents: -100_000_00,
+    });
+  }
+
+  it("size=M returns only the top 3 by utilization DESC", async () => {
+    await seedFiveCards(USER_A);
+    const res = await misTcsHandler(makeCtx({ userId: USER_A, size: "M" }));
+    const body = res.body as SuccessBody;
+    expect(body.size).toBe("M");
+    expect(body.data.cards).toHaveLength(3);
+    expect(body.data.cards.map((c) => c.utilization_pct)).toEqual([90, 70, 50]);
+    // Totals still reflect the FULL roster (5 cards), NOT just the top 3.
+    expect(body.data.total_credit_cop).toBe(5_000_000);
+    expect(body.data.total_available_cop).toBe(2_500_000);
+  });
+
+  it("size=L returns all cards in utilization DESC order", async () => {
+    await seedFiveCards(USER_A);
+    const res = await misTcsHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.size).toBe("L");
+    expect(body.data.cards).toHaveLength(5);
+    expect(body.data.cards.map((c) => c.utilization_pct)).toEqual([90, 70, 50, 30, 10]);
+  });
+
+  it("size=S returns 422 invalid_params", async () => {
+    const res = await misTcsHandler(makeCtx({ userId: USER_A, size: "S" }));
+    expect(res.status).toBe(422);
+    expect((res.body as ErrorBody).error.code).toBe("invalid_params");
+    expect((res.body as ErrorBody).error.message).toContain("size S");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tenancy + soft-delete exclusion
+// ---------------------------------------------------------------------------
+
+describe("misTcsHandler — tenancy + soft-delete", () => {
+  it("does not leak user B's cards to user A", async () => {
+    await seedSingleCurrencyTc({
+      userId: USER_B,
+      slug: "user-b-card",
+      creditLimitCents: 9_999_000_00,
+      balanceCents: -5_000_000_00,
+    });
+    await seedMultiCurrencyTc({
+      userId: USER_B,
+      slug: "user-b-mc",
+      creditLimitCents: 5_000_000_00,
+      copBalanceCents: -1_000_000_00,
+      usdBalanceCents: 0,
+    });
+
+    const res = await misTcsHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.cards).toEqual([]);
+    expect(body.data.total_available_cop).toBe(0);
+    expect(body.data.total_credit_cop).toBe(0);
+  });
+
+  it("excludes soft-deleted single-currency TCs", async () => {
+    const liveId = await seedSingleCurrencyTc({
+      userId: USER_A,
+      slug: "live",
+      creditLimitCents: 2_000_000_00,
+      balanceCents: -500_000_00,
+    });
+    const archivedId = await seedSingleCurrencyTc({
+      userId: USER_A,
+      slug: "archived",
+      creditLimitCents: 3_000_000_00,
+      balanceCents: -1_000_000_00,
+    });
+    await db
+      .update(accounts)
+      .set({ deletedAt: new Date() })
+      .where(sql`${accounts.id} = ${archivedId}`);
+
+    const res = await misTcsHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.cards.map((c) => c.id)).toEqual([liveId]);
+    expect(body.data.total_credit_cop).toBe(2_000_000);
+  });
+
+  it("excludes soft-deleted sub-accounts from a multi-currency card's utilization", async () => {
+    // Seed a card where the USD sub-account carries -$100 debt. If the
+    // archived sub-account is correctly filtered, only the COP debt remains.
+    const pcId = await seedMultiCurrencyTc({
+      userId: USER_A,
+      slug: "mc-archived-sub",
+      creditLimitCents: 10_000_000_00,
+      copBalanceCents: -500_000_00,
+      usdBalanceCents: -100_00,
+    });
+    // Archive the USD sub-account.
+    await db
+      .update(accounts)
+      .set({ deletedAt: new Date() })
+      .where(sql`${accounts.physicalCardId} = ${pcId} AND ${accounts.currency} = 'USD'`);
+
+    const res = await misTcsHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.cards).toHaveLength(1);
+    expect(body.data.cards[0].id).toBe(pcId);
+    // Only COP debt of 500k remains → available 9.5MM, util 5 %.
+    expect(body.data.cards[0].available_cop).toBe(9_500_000);
+    expect(body.data.cards[0].utilization_pct).toBe(5);
+  });
+});

--- a/src/lib/widgets/handlers/mis-tcs.ts
+++ b/src/lib/widgets/handlers/mis-tcs.ts
@@ -1,0 +1,348 @@
+/**
+ * Widget handler: `mis-tcs` — aggregate credit-card roster for the authed user.
+ *
+ * Returns every live credit card the user owns, regardless of card shape:
+ *
+ * - Multi-currency TCs (one `physical_cards` row with 2+ linked `accounts`)
+ *   collapse to a SINGLE entry keyed on `physical_cards.id`. Cupo and
+ *   USD→COP conversion are handled via `getAvailableCreditCOP` using the
+ *   current TRM. Display fields come from the `physical_cards` row.
+ *
+ * - Single-currency TCs (`accounts.physical_card_id IS NULL` AND
+ *   `type='credit_card'`) return as one entry per account, keyed on
+ *   `accounts.id`. Cupo lives on `accounts.metadata.creditLimitCents`, balance
+ *   comes from `derivedBalanceCentsSql` (negative = debt).
+ *
+ * Output is always ordered by `utilization_pct DESC` — most-stressed cards
+ * float to the top so the widget leads with the cards that most need attention.
+ *
+ * Size rules (issue #386):
+ * - `S` → 422 invalid_params (too cramped to show a roster).
+ * - `M` → top 3 cards after sort.
+ * - `L` → all cards.
+ *
+ * Empty-roster case (user has no TCs) returns 200 with `cards: []` and both
+ * totals at 0. This is NOT an error — a new user naturally has zero cards.
+ */
+
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, physicalCards, type AccountMetadata } from "@/lib/db/schema";
+import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
+import { notDeleted } from "@/lib/db/helpers";
+import { getCurrentFxRate } from "@/lib/fx/repo";
+import { toCop } from "@/lib/money";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { createLogger } from "@/lib/logger";
+import type { WidgetHandler, WidgetHandlerResult } from "@/app/api/widget/v1/[id]/registry";
+import { bogotaIsoNow, centsToCop, roundUtilizationPct } from "./_shared";
+
+// Kept for parity with tc-focus: the handler is NOT the final logger call
+// site (DB helpers log themselves), but a fail-soft branch below wants a
+// structured warn. Do not remove even if temporarily unused.
+const log = createLogger({ module: "widget-mis-tcs" });
+
+const BI_ZERO = BigInt(0);
+
+// ---------------------------------------------------------------------------
+// Response shapes
+// ---------------------------------------------------------------------------
+
+type MisTcsCard = {
+  // `string` for multi-currency (UUID from physical_cards), `number` for
+  // single-currency (serial from accounts). The contract keeps them in the
+  // same field — Scriptable treats both as opaque.
+  id: string | number;
+  name: string;
+  network: string | null;
+  last4: string | null;
+  available_cop: number;
+  credit_limit_cop: number;
+  utilization_pct: number;
+};
+
+type MisTcsData = {
+  cards: MisTcsCard[];
+  total_available_cop: number;
+  total_credit_cop: number;
+};
+
+type MisTcsResponse = {
+  widget_id: "mis-tcs";
+  size: "M" | "L";
+  data: MisTcsData;
+  generated_at: string;
+};
+
+type MisTcsErrorCode = "invalid_params";
+
+type MisTcsErrorBody = { error: { code: MisTcsErrorCode; message: string } };
+
+const STATUS_BY_CODE: Record<MisTcsErrorCode, number> = {
+  invalid_params: 422,
+};
+
+function errorResult(code: MisTcsErrorCode, message: string): WidgetHandlerResult {
+  const body: MisTcsErrorBody = { error: { code, message } };
+  return { body, status: STATUS_BY_CODE[code] };
+}
+
+// ---------------------------------------------------------------------------
+// Internal row types produced by the two DB queries. We keep them flat and
+// bigint-typed so the merge step does no runtime coercion gymnastics.
+// ---------------------------------------------------------------------------
+
+type MultiCurrencyRow = {
+  id: string;
+  name: string | null;
+  institution: string;
+  network: string | null;
+  last4: string | null;
+  creditLimitCents: bigint;
+  // sum(COP balances) — negative when the card carries debt.
+  copDebtCents: bigint;
+  // sum(USD balances) — negative when the card carries debt, in USD cents.
+  usdDebtCents: bigint;
+};
+
+type SingleCurrencyRow = {
+  id: number;
+  name: string;
+  institution: string;
+  currency: "COP" | "USD";
+  metadata: AccountMetadata;
+  balanceCents: bigint;
+};
+
+// ---------------------------------------------------------------------------
+// Queries — two round-trips for the whole roster, not N+1. Multi-currency
+// cards aggregate COP/USD sub-account balances inline (same approach as
+// `getAvailableCreditCOP` but for ALL of the user's physical cards in one
+// shot). Single-currency cards are a plain scan of `accounts`.
+// ---------------------------------------------------------------------------
+
+async function fetchMultiCurrencyCards(userId: number): Promise<MultiCurrencyRow[]> {
+  const rows = await db
+    .select({
+      id: physicalCards.id,
+      name: physicalCards.name,
+      institution: physicalCards.institution,
+      network: physicalCards.network,
+      last4: physicalCards.last4,
+      creditLimitCents: physicalCards.creditLimitCents,
+      copDebtCents: sql<string>`
+        COALESCE(SUM(CASE WHEN ${accounts.currency} = 'COP' THEN ${derivedBalanceCentsSql} ELSE 0 END), 0)
+      `,
+      usdDebtCents: sql<string>`
+        COALESCE(SUM(CASE WHEN ${accounts.currency} = 'USD' THEN ${derivedBalanceCentsSql} ELSE 0 END), 0)
+      `,
+    })
+    .from(physicalCards)
+    .leftJoin(
+      accounts,
+      and(
+        eq(accounts.physicalCardId, physicalCards.id),
+        // Tenancy guard on the JOIN (memory #336, #338): per-user table
+        // joins MUST pair user_id in the ON clause, never rely on the FK
+        // alone. Also drop archived sub-accounts so their debt doesn't
+        // linger in the available-credit calc.
+        eq(accounts.userId, physicalCards.userId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .where(eq(physicalCards.userId, userId))
+    .groupBy(
+      physicalCards.id,
+      physicalCards.name,
+      physicalCards.institution,
+      physicalCards.network,
+      physicalCards.last4,
+      physicalCards.creditLimitCents,
+    );
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    institution: r.institution,
+    network: r.network,
+    last4: r.last4,
+    creditLimitCents: r.creditLimitCents,
+    copDebtCents: BigInt(r.copDebtCents),
+    usdDebtCents: BigInt(r.usdDebtCents),
+  }));
+}
+
+async function fetchSingleCurrencyCards(userId: number): Promise<SingleCurrencyRow[]> {
+  const rows = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      institution: accounts.institution,
+      currency: accounts.currency,
+      metadata: accounts.metadata,
+      balanceCents: derivedBalanceCentsSql,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, userId),
+        eq(accounts.type, "credit_card"),
+        // Absence of physicalCardId is what distinguishes "plain" credit
+        // cards from multi-currency sub-accounts. `isNull` + explicit
+        // `notDeleted` also short-circuits the partial index we maintain
+        // on live rows.
+        isNull(accounts.physicalCardId),
+        notDeleted(accounts.deletedAt),
+      ),
+    );
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    institution: r.institution,
+    currency: r.currency as "COP" | "USD",
+    metadata: (r.metadata ?? {}) as AccountMetadata,
+    balanceCents: BigInt(r.balanceCents),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Projections — bigint-math-first. Each branch computes `used` + `available`
+// in COP cents, then delegates the display fields to the shared helpers.
+// ---------------------------------------------------------------------------
+
+function projectMultiCurrency(row: MultiCurrencyRow, copPerUsd: number): MisTcsCard {
+  // Mirrors getAvailableCreditCOP() so the two paths can't drift:
+  //   available = credit_limit + sum(COP bal) + sum(USD bal) * rate
+  // Both bal sums are negative when the card has debt.
+  const usdDebtInCop = toCop(row.usdDebtCents, "USD", copPerUsd);
+  const availableCents = row.creditLimitCents + row.copDebtCents + usdDebtInCop;
+  const usedCents = row.creditLimitCents - availableCents;
+  const usedClamped = usedCents < BI_ZERO ? BI_ZERO : usedCents;
+  const availableClamped = availableCents < BI_ZERO ? BI_ZERO : availableCents;
+
+  // Display name fallback chain: physical_cards.name → "<institution> *last4"
+  // → generic Spanish label. Matches tc-focus so users see the same string
+  // in the tile and in the roster.
+  const name =
+    row.name?.trim() ||
+    [row.institution, row.last4 ? `*${row.last4}` : null].filter(Boolean).join(" ") ||
+    "Tarjeta de crédito";
+
+  return {
+    id: row.id,
+    name,
+    network: row.network,
+    last4: row.last4,
+    available_cop: centsToCop(availableClamped),
+    credit_limit_cop: centsToCop(row.creditLimitCents),
+    utilization_pct: roundUtilizationPct(usedClamped, row.creditLimitCents),
+  };
+}
+
+function projectSingleCurrency(row: SingleCurrencyRow, copPerUsd: number): MisTcsCard {
+  const limitNativeCents = BigInt(row.metadata.creditLimitCents ?? 0);
+  // Credit-card balances are stored as negative debt; absolute value = used.
+  const usedNativeCents = row.balanceCents < BI_ZERO ? -row.balanceCents : BI_ZERO;
+  const availableNativeCents =
+    limitNativeCents - usedNativeCents < BI_ZERO ? BI_ZERO : limitNativeCents - usedNativeCents;
+
+  // The widget contract is COP-only. For a USD-denominated single-currency
+  // card (rare but legal) we convert limit + available at the current TRM.
+  // We deliberately skip used_cop — the contract doesn't expose it, and
+  // utilization stays exact on native cents (ratio is invariant under a
+  // positive-rate scaling).
+  const limitCopCents = toCop(limitNativeCents, row.currency, copPerUsd);
+  const availableCopCents = toCop(availableNativeCents, row.currency, copPerUsd);
+
+  const last4 = row.metadata.last4s?.[0] ?? null;
+  const network = row.metadata.network ?? null;
+
+  const name = formatAccountLabel({
+    name: row.name,
+    currency: row.currency,
+    institution: row.institution,
+    metadata: { last4s: row.metadata.last4s ?? null },
+  });
+
+  return {
+    id: row.id,
+    name,
+    network,
+    last4,
+    available_cop: centsToCop(availableCopCents),
+    credit_limit_cop: centsToCop(limitCopCents),
+    // Utilization on native cents (ratio is invariant under scaling by a
+    // positive rate, so skipping the conversion keeps things exact).
+    utilization_pct: roundUtilizationPct(usedNativeCents, limitNativeCents),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export const misTcsHandler: WidgetHandler = async (ctx) => {
+  if (ctx.size === "S") {
+    return errorResult("invalid_params", "mis-tcs does not support size S");
+  }
+
+  const [multi, single] = await Promise.all([
+    fetchMultiCurrencyCards(ctx.userId),
+    fetchSingleCurrencyCards(ctx.userId),
+  ]);
+
+  // Only fetch FX when at least one card will actually need it. Saves a
+  // round-trip for COP-only users (the common case today).
+  const needsFx =
+    multi.some((m) => m.usdDebtCents !== BI_ZERO) || single.some((s) => s.currency === "USD");
+  const fxRate = needsFx ? (await getCurrentFxRate()).rate : 0;
+
+  if (needsFx && fxRate <= 0) {
+    // Should be impossible — getCurrentFxRate() falls back to a constant.
+    // Log once and continue with 0 so at least COP lines still render.
+    log.warn(
+      { event: "mis_tcs_fx_nonpositive", userId: ctx.userId, fxRate },
+      "mis-tcs got a non-positive fx rate",
+    );
+  }
+
+  const cards: MisTcsCard[] = [
+    ...multi.map((r) => projectMultiCurrency(r, fxRate)),
+    ...single.map((r) => projectSingleCurrency(r, fxRate)),
+  ];
+
+  // Sort by utilization DESC. Tiebreak on available_cop ASC so the card with
+  // less headroom wins when two sit at the same percentage — still lines up
+  // with "most-stressed first".
+  cards.sort((a, b) => {
+    if (b.utilization_pct !== a.utilization_pct) {
+      return b.utilization_pct - a.utilization_pct;
+    }
+    return a.available_cop - b.available_cop;
+  });
+
+  const trimmed = ctx.size === "M" ? cards.slice(0, 3) : cards;
+
+  // Totals are computed over the FULL roster (pre-trim). A `size=M` response
+  // still advertises the user's real total cupo, otherwise the tile would
+  // silently understate headroom whenever the user has more than 3 cards.
+  let totalAvailable = 0;
+  let totalCredit = 0;
+  for (const c of cards) {
+    totalAvailable += c.available_cop;
+    totalCredit += c.credit_limit_cop;
+  }
+
+  const body: MisTcsResponse = {
+    widget_id: "mis-tcs",
+    size: ctx.size,
+    data: {
+      cards: trimmed,
+      total_available_cop: totalAvailable,
+      total_credit_cop: totalCredit,
+    },
+    generated_at: bogotaIsoNow(new Date()),
+  };
+  return { body };
+};

--- a/src/lib/widgets/handlers/tc-focus.ts
+++ b/src/lib/widgets/handlers/tc-focus.ts
@@ -35,6 +35,7 @@ import { getCurrentFxRate } from "@/lib/fx/repo";
 import { createLogger } from "@/lib/logger";
 import { formatAccountLabel } from "@/lib/accounts/format";
 import type { WidgetHandler, WidgetHandlerResult } from "@/app/api/widget/v1/[id]/registry";
+import { bogotaIsoNow, centsToCop, roundUtilizationPct } from "./_shared";
 
 const log = createLogger({ module: "widget-tc-focus" });
 
@@ -142,42 +143,12 @@ export function computeNextCutoff(
   return { next, daysTo };
 }
 
-// Bogota-offset ISO-8601 — e.g. `2026-04-21T17:23:00-05:00`. We format without
-// seconds of precision finer than whole-second and without milliseconds, which
-// matches the issue's sample response.
-function bogotaIsoNow(now: Date): string {
-  const shifted = new Date(now.getTime() - BOGOTA_OFFSET_MS);
-  const y = shifted.getUTCFullYear();
-  const m = String(shifted.getUTCMonth() + 1).padStart(2, "0");
-  const d = String(shifted.getUTCDate()).padStart(2, "0");
-  const hh = String(shifted.getUTCHours()).padStart(2, "0");
-  const mm = String(shifted.getUTCMinutes()).padStart(2, "0");
-  const ss = String(shifted.getUTCSeconds()).padStart(2, "0");
-  return `${y}-${m}-${d}T${hh}:${mm}:${ss}-05:00`;
-}
-
 // ---------------------------------------------------------------------------
-// Money helpers — everything out of the DB is bigint cents. The widget
-// contract exposes COP as integer pesos (no cents shown in the tile).
+// Money helpers — centsToCop / roundUtilizationPct / bogotaIsoNow live in
+// ./_shared.ts. Only the handler-local `BI_ZERO` clamp sentinel stays here.
 // ---------------------------------------------------------------------------
 
 const BI_ZERO = BigInt(0);
-const BI_HUNDRED = BigInt(100);
-const BI_TEN_THOUSAND = BigInt(10000);
-
-function centsToCop(cents: bigint): number {
-  // Integer division in bigint-space, then narrow to number. COP amounts we
-  // expect here (cupo, balances) comfortably fit in Number.MAX_SAFE_INTEGER
-  // after dividing by 100.
-  return Number(cents / BI_HUNDRED);
-}
-
-function roundUtilizationPct(used: bigint, limit: bigint): number {
-  if (limit <= BI_ZERO) return 0;
-  // (used * 10000) / limit yields "percent * 100"; round to integer percent.
-  const scaled = (used * BI_TEN_THOUSAND) / limit;
-  return Math.round(Number(scaled) / 100);
-}
 
 // ---------------------------------------------------------------------------
 // Handler


### PR DESCRIPTION
Closes #386

## Summary

Handler for `widget_id=mis-tcs` at `GET /api/widget/v1/mis-tcs?size=M|L`. Returns every live credit card the authed user owns, collapsed per physical plastic (multi-currency cards → one row keyed on `physical_cards.id`, single-currency cards → one row per `accounts.id`). Ordered by `utilization_pct DESC`. `size=M` trims to the top 3; `size=L` returns all; `size=S` → 422. Totals (`total_available_cop`, `total_credit_cop`) are computed over the full roster regardless of trimming, so the tile never understates headroom.

## Implementation notes

- **Shared helpers** — extracted `bogotaIsoNow`, `centsToCop`, `roundUtilizationPct` into `src/lib/widgets/handlers/_shared.ts` and refactored `tc-focus.ts` to import them. Kept handler-local sentinels (`BI_ZERO`) inline.
- **Two aggregate queries, not N+1** — multi-currency cards use a single `GROUP BY physical_cards.id` with `SUM(CASE currency)` (same shape as `getAvailableCreditCOP`, generalized to the whole roster). Single-currency path is a plain `SELECT ... WHERE physical_card_id IS NULL`. Both run in parallel via `Promise.all`.
- **FX fetched lazily** — `getCurrentFxRate()` only runs when at least one card carries USD exposure. Saves a round-trip for COP-only users (the common case today).
- **Tenancy guards** — `userId` is pinned in every WHERE *and* in the `physicalCards ↔ accounts` JOIN ON clause (per engram `per-user-table-join-tenant-safety`, memory #336/#338).
- **Soft-delete** — `notDeleted(accounts.deletedAt)` is applied to both top-level single-currency selects and to the multi-currency sub-account join.
- **USD-denominated single-currency TCs** — legal but rare. Limit + available are converted to COP at the current TRM; `utilization_pct` is computed on native cents (ratio invariant under positive-rate scaling = exact).

## Spec deviations

None. Contract shapes, status codes, and ordering match issue #386 verbatim.

## Gotchas

- **Totals over full roster, not visible slice** — the issue's sample shows one card + a total of 5.4MM, so the totals must mean "across all the user's cards." I chose that reading; the alternative (sum the 3 returned cards under `size=M`) would silently understate headroom for users with 4+ cards.
- **Tiebreak on util equality** — when two cards have the same `utilization_pct`, the one with lower `available_cop` sorts first. Keeps "most-stressed first" monotonic even in the flat case.
- **`used_cop` NOT in the response** — the contract only exposes `available_cop`, `credit_limit_cop`, `utilization_pct`. I compute `used` internally for the clamp + utilization math but don't surface it.

## Test plan

- [x] `bun run test src/lib/widgets src/app/api/widget` — 42 passed (12 new in `mis-tcs.test.ts`).
- [x] `bun run lint` — clean.
- [x] `bun run typecheck` — clean.
- [x] `bun run format:check` — clean.
- [ ] Manual smoke — deferred to issue #390 (Scriptable + Tasker wiring).

Tests cover: mixed roster ordering, single-currency-only, multi-currency-only, empty roster, size=M top-3 trim + full-roster totals, size=L all cards, size=S → 422, cross-tenant isolation (user A can't see user B's cards), soft-deleted single-currency exclusion, soft-deleted sub-account exclusion from multi-currency debt, COP-only path with no FX row present.