### PR TITLE
feat(widget): Hoy endpoint (#387)

### DIFF
--- a/src/lib/widgets/handlers/hoy.test.ts
+++ b/src/lib/widgets/handlers/hoy.test.ts
@@ -1,0 +1,445 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, fxRates, transactions, users } from "@/lib/db/schema";
+import { formatDayLabel, hoyHandler } from "./hoy";
+
+// Cleanup gate: everything this suite touches is tagged so the delete queries
+// only remove what we own. Mirrors the convention used by tc-focus / mis-tcs.
+const MARKER = "__widget_hoy_test";
+
+// Stable, far-future FX date so getCurrentFxRate() returns our seeded row
+// (it ORDERs BY as_of DESC) regardless of any other rates in findash_test.
+const TEST_FX_DATE = "9999-01-01";
+
+// Bogota is UTC-5 year-round. A "today" near midday locally is easiest to
+// reason about — no matter what real-world time the suite runs, we stamp
+// transactions with absolute offsets from this fake "now".
+const FAKE_NOW_UTC = new Date("2026-04-21T18:00:00Z"); // 13:00 Bogota
+// On 2026-04-21, Bogota "today" spans 2026-04-21 05:00Z..2026-04-22 05:00Z.
+const BOGOTA_TODAY_MIDDAY = new Date("2026-04-21T17:00:00Z"); // 12:00 Bogota
+const BOGOTA_YESTERDAY_MIDDAY = new Date("2026-04-20T17:00:00Z"); // 12:00 Bogota
+const BOGOTA_DAY_10_MIDDAY = new Date("2026-04-10T17:00:00Z");
+// A tx at 23:30 Bogota on 2026-04-21 → 04:30 UTC on 2026-04-22 (still Bogota today).
+const BOGOTA_TODAY_LATE_NIGHT = new Date("2026-04-22T04:30:00Z");
+
+let USER_A = 0;
+let USER_B = 0;
+let ACCT_A_COP = 0;
+let ACCT_A_USD = 0;
+let ACCT_B_COP = 0;
+
+async function cleanup() {
+  await db.execute(
+    sql`DELETE FROM transactions WHERE account_id IN (SELECT id FROM accounts WHERE name LIKE ${MARKER + "%"})`,
+  );
+}
+
+beforeAll(async () => {
+  const [a] = await db
+    .insert(users)
+    .values({ email: `${MARKER}-a@test.local`, name: "A" })
+    .returning({ id: users.id });
+  const [b] = await db
+    .insert(users)
+    .values({ email: `${MARKER}-b@test.local`, name: "B" })
+    .returning({ id: users.id });
+  USER_A = a.id;
+  USER_B = b.id;
+
+  const [acopA] = await db
+    .insert(accounts)
+    .values({
+      userId: USER_A,
+      name: `${MARKER}-a-cop`,
+      institution: "Bancolombia",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  const [ausdA] = await db
+    .insert(accounts)
+    .values({
+      userId: USER_A,
+      name: `${MARKER}-a-usd`,
+      institution: "Nu",
+      type: "savings",
+      currency: "USD",
+    })
+    .returning({ id: accounts.id });
+  const [acopB] = await db
+    .insert(accounts)
+    .values({
+      userId: USER_B,
+      name: `${MARKER}-b-cop`,
+      institution: "Bancolombia",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+
+  ACCT_A_COP = acopA.id;
+  ACCT_A_USD = ausdA.id;
+  ACCT_B_COP = acopB.id;
+
+  // TRM = 4000 for deterministic math on USD txs.
+  await db
+    .insert(fxRates)
+    .values({
+      base: "USD",
+      quote: "COP",
+      rateMicros: BigInt(4_000_000_000),
+      asOf: TEST_FX_DATE,
+      source: MARKER,
+    })
+    .onConflictDoUpdate({
+      target: [fxRates.base, fxRates.quote, fxRates.asOf],
+      set: { rateMicros: BigInt(4_000_000_000), source: MARKER },
+    });
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM fx_rates WHERE source = ${MARKER}`);
+  await db.execute(
+    sql`DELETE FROM transactions WHERE account_id IN (SELECT id FROM accounts WHERE name LIKE ${MARKER + "%"})`,
+  );
+  await db.execute(sql`DELETE FROM accounts WHERE name LIKE ${MARKER + "%"}`);
+  await db.execute(sql`DELETE FROM users WHERE email LIKE ${MARKER + "%"}`);
+  await db.$client.end({ timeout: 1 });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(params: { userId: number; size?: "S" | "M" | "L" }) {
+  return {
+    userId: params.userId,
+    size: (params.size ?? "S") as "S" | "M" | "L",
+    searchParams: new URLSearchParams(),
+  };
+}
+
+type InsertTxOpts = {
+  userId: number;
+  accountId: number;
+  occurredAt: Date;
+  amountCents: number;
+  currency?: "COP" | "USD";
+  source?:
+    | "apple_pay"
+    | "sms"
+    | "ocr"
+    | "csv"
+    | "recurring"
+    | "manual"
+    | "telegram"
+    | "balance_adjustment"
+    | "csv_reconcile";
+  channel?: "bank" | "manual" | "transfer";
+  isAdjustment?: boolean;
+  deletedAt?: Date;
+};
+
+async function insertTx(opts: InsertTxOpts): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId: opts.userId,
+      accountId: opts.accountId,
+      occurredAt: opts.occurredAt,
+      amountCents: BigInt(opts.amountCents),
+      currency: opts.currency ?? "COP",
+      descriptionRaw: `${MARKER} tx`,
+      classificationMethod: "manual",
+      source: opts.source ?? "manual",
+      channel: opts.channel ?? "bank",
+      isAdjustment: opts.isAdjustment ?? false,
+      deletedAt: opts.deletedAt,
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+type SuccessBody = {
+  widget_id: "hoy";
+  size: "S";
+  data: {
+    spent_cop: number;
+    tx_count: number;
+    vs_daily_avg_pct: number | null;
+    day_label: string;
+  };
+  generated_at: string;
+};
+
+type ErrorBody = { error: { code: string; message: string } };
+
+// ---------------------------------------------------------------------------
+// Happy path — today spent vs MTD avg
+// ---------------------------------------------------------------------------
+
+describe("hoyHandler — spending + MTD comparison", () => {
+  beforeAll(() => {
+    // Only mock Date — leaving setTimeout/setInterval alone so postgres.js
+    // socket timers and other async plumbing keep working. `vi.useFakeTimers()`
+    // without `toFake` freezes those too and causes DB queries to hang.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(FAKE_NOW_UTC);
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns today's spend, tx count, and vs_daily_avg_pct vs MTD daily avg", async () => {
+    // 4 outflows today totaling 85.000 COP.
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -20_000_00,
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -25_000_00,
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -15_000_00,
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -25_000_00,
+    });
+
+    // Prior-MTD: 1.900.000 COP spread over days 1..20 (20 days) → avg 95.000/day.
+    // Today (85.000) vs avg (95.000) → (85/95 - 1) * 100 = -10.526... → -11.
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_DAY_10_MIDDAY,
+      amountCents: -1_000_000_00,
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_YESTERDAY_MIDDAY,
+      amountCents: -900_000_00,
+    });
+
+    const res = await hoyHandler(makeCtx({ userId: USER_A }));
+    expect(res.status).toBeUndefined();
+    const body = res.body as SuccessBody;
+    expect(body.widget_id).toBe("hoy");
+    expect(body.size).toBe("S");
+    expect(body.data.spent_cop).toBe(85_000);
+    expect(body.data.tx_count).toBe(4);
+    expect(body.data.vs_daily_avg_pct).toBe(-11);
+    expect(body.data.day_label).toBe("Martes 21 abr");
+    expect(body.generated_at).toMatch(/-05:00$/);
+  });
+
+  it("returns vs_daily_avg_pct null on day 1 of the month", async () => {
+    // Pin clock to 2026-04-01 midday Bogota.
+    vi.setSystemTime(new Date("2026-04-01T17:00:00Z"));
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: new Date("2026-04-01T18:00:00Z"),
+      amountCents: -50_000_00,
+    });
+    const res = await hoyHandler(makeCtx({ userId: USER_A }));
+    const body = res.body as SuccessBody;
+    expect(body.data.spent_cop).toBe(50_000);
+    expect(body.data.tx_count).toBe(1);
+    expect(body.data.vs_daily_avg_pct).toBeNull();
+    // Restore clock for the rest of the block.
+    vi.setSystemTime(FAKE_NOW_UTC);
+  });
+
+  it("returns zeros when no txs today and null vs_avg when avg is 0", async () => {
+    // No prior MTD, no today → avg = 0 → spec says vs_daily_avg_pct should
+    // reflect the comparison; with no prior data and no today spend, we
+    // treat "0 vs 0" as 0% (no change), and "non-zero vs 0" as null.
+    const res = await hoyHandler(makeCtx({ userId: USER_A }));
+    const body = res.body as SuccessBody;
+    expect(body.data.spent_cop).toBe(0);
+    expect(body.data.tx_count).toBe(0);
+    expect(body.data.vs_daily_avg_pct).toBe(0);
+  });
+
+  it("returns -100 when today is 0 but MTD avg > 0", async () => {
+    // Prior MTD of 1.000.000 COP across 20 days → avg 50.000/day.
+    // Today = 0 → (0/50k - 1) * 100 = -100.
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_DAY_10_MIDDAY,
+      amountCents: -1_000_000_00,
+    });
+    const res = await hoyHandler(makeCtx({ userId: USER_A }));
+    const body = res.body as SuccessBody;
+    expect(body.data.spent_cop).toBe(0);
+    expect(body.data.tx_count).toBe(0);
+    expect(body.data.vs_daily_avg_pct).toBe(-100);
+  });
+
+  it("excludes transfers and balance adjustments from spent and tx_count", async () => {
+    // A real outflow (counts).
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -10_000_00,
+    });
+    // A transfer (excluded).
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -500_000_00,
+      channel: "transfer",
+    });
+    // A balance adjustment via source (excluded).
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -100_000_00,
+      source: "balance_adjustment",
+      channel: "manual",
+      isAdjustment: true,
+    });
+    const res = await hoyHandler(makeCtx({ userId: USER_A }));
+    const body = res.body as SuccessBody;
+    expect(body.data.spent_cop).toBe(10_000);
+    expect(body.data.tx_count).toBe(1);
+  });
+
+  it("excludes soft-deleted transactions", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -10_000_00,
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -80_000_00,
+      deletedAt: BOGOTA_TODAY_MIDDAY,
+    });
+    const res = await hoyHandler(makeCtx({ userId: USER_A }));
+    const body = res.body as SuccessBody;
+    expect(body.data.spent_cop).toBe(10_000);
+    expect(body.data.tx_count).toBe(1);
+  });
+
+  it("excludes positive amounts (credits / refunds) from spent and tx_count", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -10_000_00,
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: 50_000_00, // refund / income
+    });
+    const res = await hoyHandler(makeCtx({ userId: USER_A }));
+    const body = res.body as SuccessBody;
+    expect(body.data.spent_cop).toBe(10_000);
+    expect(body.data.tx_count).toBe(1);
+  });
+
+  it("is isolated per user (cross-tenant)", async () => {
+    // User B spends a fortune today — must not leak into USER_A's widget.
+    await insertTx({
+      userId: USER_B,
+      accountId: ACCT_B_COP,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -9_999_999_00,
+    });
+    const res = await hoyHandler(makeCtx({ userId: USER_A }));
+    const body = res.body as SuccessBody;
+    expect(body.data.spent_cop).toBe(0);
+    expect(body.data.tx_count).toBe(0);
+  });
+
+  it("converts USD txs at the current FX rate", async () => {
+    // $25 USD @ TRM 4000 = 100.000 COP.
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_USD,
+      occurredAt: BOGOTA_TODAY_MIDDAY,
+      amountCents: -25_00,
+      currency: "USD",
+    });
+    const res = await hoyHandler(makeCtx({ userId: USER_A }));
+    const body = res.body as SuccessBody;
+    expect(body.data.spent_cop).toBe(100_000);
+    expect(body.data.tx_count).toBe(1);
+  });
+
+  it("counts a tx at 23:30 Bogota local time as TODAY even if UTC rolled over", async () => {
+    // 04:30 UTC on the 22nd == 23:30 Bogota on the 21st → still today.
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: BOGOTA_TODAY_LATE_NIGHT,
+      amountCents: -40_000_00,
+    });
+    const res = await hoyHandler(makeCtx({ userId: USER_A }));
+    const body = res.body as SuccessBody;
+    expect(body.data.spent_cop).toBe(40_000);
+    expect(body.data.tx_count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
+
+describe("hoyHandler — errors", () => {
+  it("returns 422 invalid_params when size is M", async () => {
+    const res = await hoyHandler(makeCtx({ userId: USER_A, size: "M" }));
+    expect(res.status).toBe(422);
+    expect((res.body as ErrorBody).error.code).toBe("invalid_params");
+  });
+
+  it("returns 422 invalid_params when size is L", async () => {
+    const res = await hoyHandler(makeCtx({ userId: USER_A, size: "L" }));
+    expect(res.status).toBe(422);
+    expect((res.body as ErrorBody).error.code).toBe("invalid_params");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatDayLabel — pure, locale-dependent but timezone-anchored
+// ---------------------------------------------------------------------------
+
+describe("formatDayLabel", () => {
+  it("formats as '<Weekday> <day> <mes>' in Bogota, with capitalized weekday", () => {
+    // 2026-04-21 midday UTC is still 2026-04-21 in Bogota (UTC-5).
+    const out = formatDayLabel(new Date("2026-04-21T18:00:00Z"));
+    expect(out).toBe("Martes 21 abr");
+  });
+
+  it("rolls back to the Bogota-local date even when the UTC clock has rolled over", () => {
+    // 03:00 UTC on the 22nd == 22:00 Bogota on the 21st.
+    const out = formatDayLabel(new Date("2026-04-22T03:00:00Z"));
+    expect(out).toBe("Martes 21 abr");
+  });
+});

--- a/src/lib/widgets/handlers/hoy.ts
+++ b/src/lib/widgets/handlers/hoy.ts
@@ -1,0 +1,287 @@
+/**
+ * Widget handler: `hoy` — today's spending snapshot (#387).
+ *
+ * Single small tile: "how much did you spend TODAY, on how many transactions,
+ * and how does that compare to your daily average so far this month". All
+ * timestamps are anchored to America/Bogota — Colombia has no DST, so a
+ * fixed UTC-5 offset is exact, which keeps the SQL simple and deterministic.
+ *
+ * NOTE: the timezone is hard-coded to America/Bogota for this first pass.
+ * When user preferences (#TBD) land, this should read from
+ * `users.timezone` (or equivalent) — see the `BOGOTA_TZ` constant below.
+ *
+ * Exclusions — what does NOT count as "gasto":
+ *   - Soft-deleted transactions (`notDeleted`).
+ *   - Balance adjustments (`source = 'balance_adjustment'` OR
+ *     `is_adjustment = true`). These are reconciliation artifacts, not spend.
+ *   - Transfers (`channel = 'transfer'`). Payments to a credit card and
+ *     internal moves are excluded — see memory `pago-tc-modeled-as-expense`
+ *     for why this is the right shape.
+ *   - Credits / refunds (positive `amount_cents`). Only outflows count
+ *     towards the "spent" figure.
+ *
+ * All surviving rows are currency-converted to COP at the current TRM, then
+ * summed in bigint cents and narrowed to integer pesos for the response.
+ *
+ * `vs_daily_avg_pct` semantics:
+ *   avg_daily_MTD = |sum(qualifying txs from day-1 through yesterday)|
+ *                   / (today.day - 1)
+ *   If today is day 1 → `null` (no prior days yet).
+ *   Else             → round((spent_today / avg_daily_MTD - 1) * 100).
+ *   Negative means you spent LESS than the MTD daily average.
+ *
+ * Size: tile-only. Any size other than `S` → 422 invalid_params.
+ */
+
+import { and, eq, gte, lt, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { transactions } from "@/lib/db/schema";
+import { notAdjustment, notDeleted } from "@/lib/db/helpers";
+import { getCurrentFxRate } from "@/lib/fx/repo";
+import { toCop } from "@/lib/money";
+import type { Currency } from "@/lib/types";
+import type { WidgetHandler, WidgetHandlerResult } from "@/app/api/widget/v1/[id]/registry";
+import { bogotaIsoNow, centsToCop } from "./_shared";
+
+// ---------------------------------------------------------------------------
+// Response shapes
+// ---------------------------------------------------------------------------
+
+type HoyData = {
+  spent_cop: number;
+  tx_count: number;
+  /** null when today is day 1 of the month (no prior days to compare). */
+  vs_daily_avg_pct: number | null;
+  /** Spanish-locale human label, e.g. "Martes 21 abr". */
+  day_label: string;
+};
+
+type HoyResponse = {
+  widget_id: "hoy";
+  size: "S";
+  data: HoyData;
+  generated_at: string;
+};
+
+type HoyErrorCode = "invalid_params";
+
+type HoyErrorBody = { error: { code: HoyErrorCode; message: string } };
+
+const STATUS_BY_CODE: Record<HoyErrorCode, number> = {
+  invalid_params: 422,
+};
+
+function errorResult(code: HoyErrorCode, message: string): WidgetHandlerResult {
+  const body: HoyErrorBody = { error: { code, message } };
+  return { body, status: STATUS_BY_CODE[code] };
+}
+
+// ---------------------------------------------------------------------------
+// Bogota-aware date helpers. Colombia has no DST → fixed UTC-5 offset. We
+// keep the wall-clock math in JS millis to avoid `Date#getXxx` surprises at
+// month boundaries, then hand Postgres only a stable date string.
+// ---------------------------------------------------------------------------
+
+const BOGOTA_TZ = "America/Bogota";
+const BOGOTA_OFFSET_MS = 5 * 60 * 60 * 1000;
+
+type BogotaYmd = { year: number; month: number; day: number };
+
+function nowInBogota(now: Date): BogotaYmd {
+  const shifted = new Date(now.getTime() - BOGOTA_OFFSET_MS);
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1, // 1..12
+    day: shifted.getUTCDate(),
+  };
+}
+
+/**
+ * Capitalizes the first grapheme of `s`. Intentionally simple — day labels
+ * are always Spanish weekday names, never emoji / RTL / surrogate-pair text.
+ */
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/**
+ * Returns "Martes 21 abr" style label for `now` in Bogota. Uses
+ * `Intl.DateTimeFormat` because the project doesn't ship date-fns.
+ *
+ * We build from `formatToParts` rather than reading a single formatted string
+ * so we can:
+ *   - capitalize the weekday (es-CO returns lowercase),
+ *   - drop the connective "," and "de " so the output matches the spec.
+ */
+export function formatDayLabel(now: Date): string {
+  const fmt = new Intl.DateTimeFormat("es-CO", {
+    weekday: "long",
+    day: "numeric",
+    month: "short",
+    timeZone: BOGOTA_TZ,
+  });
+  const parts = fmt.formatToParts(now);
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((p) => p.type === type)?.value ?? "";
+  const weekday = capitalize(get("weekday"));
+  const day = get("day");
+  // Some ICU builds append a trailing "." to the short month ("abr."). The
+  // spec calls for "abr" without punctuation, so strip it uniformly.
+  const month = get("month").replace(/\.$/, "");
+  return `${weekday} ${day} ${month}`;
+}
+
+// ---------------------------------------------------------------------------
+// SQL expression shared by both aggregation queries — converts native cents
+// to COP cents using the current TRM, so COP-only users pay nothing for the
+// USD path. Kept inline (not in money.ts) because it mixes SQL and JS state:
+// the rate comes from JS and drops into the query as a literal.
+// ---------------------------------------------------------------------------
+
+// Bogota date of a tx — applies the timezone at Postgres so a tx at
+// 23:30 Bogota (which is 04:30 UTC the next day) still lands on the
+// Bogota "yesterday" when we compare.
+const txBogotaDateSql = sql`((${transactions.occurredAt}) AT TIME ZONE ${sql.raw(
+  `'${BOGOTA_TZ}'`,
+)})::date`;
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export const hoyHandler: WidgetHandler = async (ctx) => {
+  if (ctx.size !== "S") {
+    return errorResult("invalid_params", "hoy only supports size S");
+  }
+
+  const now = new Date();
+  const today = nowInBogota(now);
+  const todayStr = `${today.year}-${String(today.month).padStart(2, "0")}-${String(today.day).padStart(2, "0")}`;
+  const firstOfMonthStr = `${today.year}-${String(today.month).padStart(2, "0")}-01`;
+
+  // The MTD range in SQL uses `occurredAt >= startOfMonthUtc AND < startOfNextMonthUtc`
+  // AS A PRE-FILTER so the index on `(user_id, occurred_at)` helps; the
+  // Bogota-date comparison in the CASE WHEN refines it. The pre-filter is
+  // deliberately generous by the TZ offset so a 23:59 Bogota tx on the last
+  // day of the month (04:59 UTC next day) isn't missed.
+  const prefilterStart = new Date(Date.UTC(today.year, today.month - 1, 1) - BOGOTA_OFFSET_MS);
+  const prefilterEnd = new Date(Date.UTC(today.year, today.month, 1) + 24 * 60 * 60 * 1000);
+
+  // One round-trip: per-currency totals split into "today" vs "MTD-before-today".
+  // Keeping it in a single query avoids a second index scan and a second FX
+  // fetch. Sums are always ABSOLUTE (we pre-negate) so callers just add.
+  const rows = await db
+    .select({
+      currency: transactions.currency,
+      spentTodayCents: sql<string>`
+        COALESCE(
+          SUM(
+            CASE
+              WHEN ${txBogotaDateSql} = ${todayStr}::date
+                AND ${transactions.amountCents} < 0
+              THEN -${transactions.amountCents}
+              ELSE 0
+            END
+          ),
+          0
+        )
+      `,
+      txCountToday: sql<string>`
+        COALESCE(
+          SUM(
+            CASE
+              WHEN ${txBogotaDateSql} = ${todayStr}::date
+                AND ${transactions.amountCents} < 0
+              THEN 1
+              ELSE 0
+            END
+          ),
+          0
+        )
+      `,
+      spentPriorMtdCents: sql<string>`
+        COALESCE(
+          SUM(
+            CASE
+              WHEN ${txBogotaDateSql} >= ${firstOfMonthStr}::date
+                AND ${txBogotaDateSql} < ${todayStr}::date
+                AND ${transactions.amountCents} < 0
+              THEN -${transactions.amountCents}
+              ELSE 0
+            END
+          ),
+          0
+        )
+      `,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, ctx.userId),
+        gte(transactions.occurredAt, prefilterStart),
+        lt(transactions.occurredAt, prefilterEnd),
+        // Exclusions — see file header for the rationale.
+        notDeleted(transactions.deletedAt),
+        notAdjustment(transactions.isAdjustment),
+        sql`${transactions.source} <> 'balance_adjustment'`,
+        sql`${transactions.channel} <> 'transfer'`,
+      ),
+    )
+    .groupBy(transactions.currency);
+
+  // FX is only fetched when at least one USD row survived the filters —
+  // same optimization as `mis-tcs`. The fallback of 0 is safe because
+  // `toCop` won't be called for COP rows, and a 0 rate on USD rows would
+  // drop them silently, which is preferable to crashing.
+  const needsFx = rows.some(
+    (r) =>
+      r.currency === "USD" &&
+      (BigInt(r.spentTodayCents) !== BigInt(0) || BigInt(r.spentPriorMtdCents) !== BigInt(0)),
+  );
+  const fxRate = needsFx ? (await getCurrentFxRate()).rate : 0;
+
+  let spentTodayCopCents = BigInt(0);
+  let spentPriorMtdCopCents = BigInt(0);
+  let txCountToday = 0;
+  for (const r of rows) {
+    const currency = r.currency as Currency;
+    spentTodayCopCents += toCop(BigInt(r.spentTodayCents), currency, fxRate);
+    spentPriorMtdCopCents += toCop(BigInt(r.spentPriorMtdCents), currency, fxRate);
+    // tx_count is a pure count — same across all currencies, just summed.
+    txCountToday += Number(r.txCountToday);
+  }
+
+  const spentCop = centsToCop(spentTodayCopCents);
+
+  // Compare vs MTD daily average. Day 1 → null (no prior days).
+  let vsDailyAvgPct: number | null;
+  if (today.day === 1) {
+    vsDailyAvgPct = null;
+  } else {
+    const priorDays = today.day - 1;
+    // Keep the division in Number-space (we're dividing small COP-pesos
+    // counts, never within the hot path of balance math).
+    const priorMtdCop = centsToCop(spentPriorMtdCopCents);
+    const avgDaily = priorMtdCop / priorDays;
+    if (avgDaily === 0) {
+      // No prior spend to compare against. The cleanest signal is null —
+      // "infinite percent over 0" is not information the tile can render.
+      vsDailyAvgPct = spentCop === 0 ? 0 : null;
+    } else {
+      vsDailyAvgPct = Math.round((spentCop / avgDaily - 1) * 100);
+    }
+  }
+
+  const body: HoyResponse = {
+    widget_id: "hoy",
+    size: "S",
+    data: {
+      spent_cop: spentCop,
+      tx_count: txCountToday,
+      vs_daily_avg_pct: vsDailyAvgPct,
+      day_label: formatDayLabel(now),
+    },
+    generated_at: bogotaIsoNow(now),
+  };
+  return { body };
+};

--- a/src/lib/widgets/handlers/index.ts
+++ b/src/lib/widgets/handlers/index.ts
@@ -11,8 +11,10 @@
  */
 
 import { registerWidgetHandler } from "@/app/api/widget/v1/[id]/registry";
+import { hoyHandler } from "./hoy";
 import { misTcsHandler } from "./mis-tcs";
 import { tcFocusHandler } from "./tc-focus";
 
+registerWidgetHandler("hoy", hoyHandler);
 registerWidgetHandler("mis-tcs", misTcsHandler);
 registerWidgetHandler("tc-focus", tcFocusHandler);


### PR DESCRIPTION
Closes #387

## Summary

Implements `GET /api/widget/v1/hoy?size=S` — a single-tile widget showing today's spend, tx count, and a comparison vs the month-to-date daily average. All dates are anchored to `America/Bogota` (Colombia has no DST, so a fixed UTC-5 offset is exact).

- `spent_cop`: absolute sum of today's negative `amount_cents`, COP-normalised at current TRM
- `tx_count`: number of qualifying outflows today
- `vs_daily_avg_pct`: rounded `(spent_today / avg_daily_MTD - 1) * 100`; `null` on day 1 or when MTD avg is 0 and today is non-zero
- `day_label`: `Intl.DateTimeFormat('es-CO')` with `formatToParts` to produce "Martes 21 abr" — weekday capitalised, trailing `.` on the short month stripped

## Exclusions applied

- Soft-deleted (`notDeleted`)
- Balance adjustments (`source = 'balance_adjustment'` and `is_adjustment = true`)
- Transfers (`channel = 'transfer'`)
- Credits / positive amounts (refunds) are not spend

## Size

Only `S` is supported — `M`/`L` return 422 `invalid_params`.

## Tests (14, all passing — full widget suite 56/56)

- happy path: 4 outflows today + known MTD avg => correct `vs_daily_avg_pct`
- day 1 of the month => `vs_daily_avg_pct: null`
- zero txs and zero MTD => 0% (no change)
- zero txs today, MTD avg > 0 => `-100`
- transfers + balance adjustments excluded
- soft-deleted excluded
- positive amounts (credits) excluded
- cross-tenant isolation (User B's spend must not leak to User A)
- `size=M` / `size=L` => 422
- USD tx conversion at TRM 4000 => correct COP
- Bogota TZ: a tx at 23:30 Bogota (04:30 UTC next day) counts as TODAY
- `formatDayLabel` unit tests for weekday capitalisation and TZ rollover

## Notes / deviations

- `vs_daily_avg_pct` when MTD avg is 0 but spent_today > 0 returns `null` rather than an undefined "infinite percent" — tile can't render that cleanly, and `null` is what day-1 already uses.
- TZ is hardcoded to `America/Bogota` with a code comment marking it as a future user preference.
- Fetches FX only when at least one surviving USD row exists (same optimisation as `mis-tcs`).

## Test plan

- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test src/lib/widgets src/app/api/widget` (56/56)
- [ ] Smoke test against a real widget token once merged (deferred, per the issue: only open a PR, do not merge)