### PR TITLE
feat(widget): Últimas 5 endpoint (#389)

### DIFF
--- a/src/lib/widgets/handlers/index.ts
+++ b/src/lib/widgets/handlers/index.ts
@@ -14,9 +14,11 @@ import { registerWidgetHandler } from "@/app/api/widget/v1/[id]/registry";
 import { hoyHandler } from "./hoy";
 import { mesActualHandler } from "./mes-actual";
 import { misTcsHandler } from "./mis-tcs";
+import { recentTxHandler } from "./recent-tx";
 import { tcFocusHandler } from "./tc-focus";
 
 registerWidgetHandler("hoy", hoyHandler);
 registerWidgetHandler("mes-actual", mesActualHandler);
 registerWidgetHandler("mis-tcs", misTcsHandler);
+registerWidgetHandler("recent-tx", recentTxHandler);
 registerWidgetHandler("tc-focus", tcFocusHandler);

--- a/src/lib/widgets/handlers/recent-tx.test.ts
+++ b/src/lib/widgets/handlers/recent-tx.test.ts
@@ -1,0 +1,605 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, categories, fxRates, transactions, users } from "@/lib/db/schema";
+import { recentTxHandler } from "./recent-tx";
+
+// Cleanup gate: everything this suite touches is tagged so the delete queries
+// only remove what we own. Matches the hoy / mis-tcs / tc-focus pattern.
+const MARKER = "__widget_recent_tx_test";
+
+// Stable, far-future FX date so getCurrentFxRate() returns our seeded row
+// (it ORDERs BY as_of DESC) regardless of any other rates in findash_test.
+const TEST_FX_DATE = "9999-01-01";
+
+let USER_A = 0;
+let USER_B = 0;
+let ACCT_A_COP = 0;
+let ACCT_A_USD = 0;
+let ACCT_B_COP = 0;
+
+async function cleanup() {
+  await db.execute(
+    sql`DELETE FROM transactions WHERE account_id IN (SELECT id FROM accounts WHERE name LIKE ${MARKER + "%"})`,
+  );
+}
+
+beforeAll(async () => {
+  const [a] = await db
+    .insert(users)
+    .values({ email: `${MARKER}-a@test.local`, name: "A" })
+    .returning({ id: users.id });
+  const [b] = await db
+    .insert(users)
+    .values({ email: `${MARKER}-b@test.local`, name: "B" })
+    .returning({ id: users.id });
+  USER_A = a.id;
+  USER_B = b.id;
+
+  const [acopA] = await db
+    .insert(accounts)
+    .values({
+      userId: USER_A,
+      name: `${MARKER}-a-cop`,
+      institution: "Bancolombia",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  const [ausdA] = await db
+    .insert(accounts)
+    .values({
+      userId: USER_A,
+      name: `${MARKER}-a-usd`,
+      institution: "Amex",
+      type: "credit_card",
+      currency: "USD",
+      metadata: { last4s: ["1234"], network: "amex" },
+    })
+    .returning({ id: accounts.id });
+  const [acopB] = await db
+    .insert(accounts)
+    .values({
+      userId: USER_B,
+      name: `${MARKER}-b-cop`,
+      institution: "Bancolombia",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  ACCT_A_COP = acopA.id;
+  ACCT_A_USD = ausdA.id;
+  ACCT_B_COP = acopB.id;
+
+  // Both users get a `mercado` category with identical slug but different
+  // names + icons. This is the heart of the cross-tenant guard: the JOIN
+  // on slug alone would collide these, the JOIN on (userId, slug) won't.
+  await db
+    .insert(categories)
+    .values({
+      userId: USER_A,
+      slug: "mercado",
+      name: "Supermercado",
+      icon: "shopping-cart",
+      sortOrder: 10,
+    })
+    .onConflictDoNothing({ target: [categories.userId, categories.slug] });
+  await db
+    .insert(categories)
+    .values({
+      userId: USER_B,
+      slug: "mercado",
+      // Deliberately different name/icon to detect tenant leaks.
+      name: "USER_B_MERCADO_NAME",
+      icon: "USER_B_MERCADO_ICON",
+      sortOrder: 10,
+    })
+    .onConflictDoNothing({ target: [categories.userId, categories.slug] });
+
+  // TRM = 4000 for deterministic math on USD txs.
+  await db
+    .insert(fxRates)
+    .values({
+      base: "USD",
+      quote: "COP",
+      rateMicros: BigInt(4_000_000_000),
+      asOf: TEST_FX_DATE,
+      source: MARKER,
+    })
+    .onConflictDoUpdate({
+      target: [fxRates.base, fxRates.quote, fxRates.asOf],
+      set: { rateMicros: BigInt(4_000_000_000), source: MARKER },
+    });
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM fx_rates WHERE source = ${MARKER}`);
+  await db.execute(
+    sql`DELETE FROM transactions WHERE account_id IN (SELECT id FROM accounts WHERE name LIKE ${MARKER + "%"})`,
+  );
+  await db.execute(sql`DELETE FROM accounts WHERE name LIKE ${MARKER + "%"}`);
+  // Drop the categories we seeded — if another suite seeds the same (userId,
+  // slug), it will still be safe because our users are ephemeral.
+  await db.delete(categories).where(
+    // Restrict cleanup to the test users only.
+    and(eq(categories.slug, "mercado"), eq(categories.userId, USER_A)),
+  );
+  await db
+    .delete(categories)
+    .where(and(eq(categories.slug, "mercado"), eq(categories.userId, USER_B)));
+  await db.execute(sql`DELETE FROM users WHERE email LIKE ${MARKER + "%"}`);
+  await db.$client.end({ timeout: 1 });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(params: { userId: number; size?: "S" | "M" | "L" }) {
+  return {
+    userId: params.userId,
+    size: (params.size ?? "L") as "S" | "M" | "L",
+    searchParams: new URLSearchParams(),
+  };
+}
+
+type InsertTxOpts = {
+  userId: number;
+  accountId: number;
+  occurredAt: Date;
+  amountCents: number;
+  currency?: "COP" | "USD";
+  merchant?: string | null;
+  categorySlug?: string | null;
+  source?:
+    | "apple_pay"
+    | "sms"
+    | "ocr"
+    | "csv"
+    | "recurring"
+    | "manual"
+    | "telegram"
+    | "balance_adjustment"
+    | "csv_reconcile";
+  channel?: "bank" | "manual" | "transfer";
+  isAdjustment?: boolean;
+  deletedAt?: Date;
+};
+
+async function insertTx(opts: InsertTxOpts): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId: opts.userId,
+      accountId: opts.accountId,
+      occurredAt: opts.occurredAt,
+      amountCents: BigInt(opts.amountCents),
+      currency: opts.currency ?? "COP",
+      descriptionRaw: `${MARKER} tx`,
+      merchant: opts.merchant ?? null,
+      categorySlug: opts.categorySlug ?? null,
+      classificationMethod: "manual",
+      source: opts.source ?? "manual",
+      channel: opts.channel ?? "bank",
+      isAdjustment: opts.isAdjustment ?? false,
+      deletedAt: opts.deletedAt,
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+type RecentTxItem = {
+  id: string;
+  occurred_at: string;
+  merchant: string | null;
+  amount_cop: number;
+  category_name: string | null;
+  category_emoji: string | null;
+  account_label: string;
+};
+
+type SuccessBody = {
+  widget_id: "recent-tx";
+  size: "M" | "L";
+  data: { transactions: RecentTxItem[] };
+  generated_at: string;
+};
+
+type ErrorBody = { error: { code: string; message: string } };
+
+// Canonical timestamps — ordering must be preserved by the handler.
+const T6 = new Date("2026-04-21T18:00:00Z"); // newest
+const T5 = new Date("2026-04-21T17:00:00Z");
+const T4 = new Date("2026-04-21T16:00:00Z");
+const T3 = new Date("2026-04-21T15:00:00Z");
+const T2 = new Date("2026-04-21T14:00:00Z");
+const T1 = new Date("2026-04-21T13:00:00Z"); // oldest
+
+// ---------------------------------------------------------------------------
+// Happy paths — size + ordering
+// ---------------------------------------------------------------------------
+
+describe("recentTxHandler — happy path", () => {
+  it("returns 3 txs for size=M ordered occurred_at DESC", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T1,
+      amountCents: -10_000_00,
+      merchant: "M1",
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T2,
+      amountCents: -20_000_00,
+      merchant: "M2",
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T3,
+      amountCents: -30_000_00,
+      merchant: "M3",
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T4,
+      amountCents: -40_000_00,
+      merchant: "M4",
+    });
+
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "M" }));
+    expect(res.status).toBeUndefined();
+    const body = res.body as SuccessBody;
+    expect(body.widget_id).toBe("recent-tx");
+    expect(body.size).toBe("M");
+    expect(body.data.transactions).toHaveLength(3);
+    // Newest first → M4, M3, M2.
+    expect(body.data.transactions.map((t) => t.merchant)).toEqual(["M4", "M3", "M2"]);
+    expect(body.generated_at).toMatch(/-05:00$/);
+  });
+
+  it("returns 5 txs for size=L ordered occurred_at DESC", async () => {
+    // Seed 6 so we can confirm the limit trims to 5 AND the oldest is dropped.
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T1,
+      amountCents: -10_000_00,
+      merchant: "M1",
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T2,
+      amountCents: -20_000_00,
+      merchant: "M2",
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T3,
+      amountCents: -30_000_00,
+      merchant: "M3",
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T4,
+      amountCents: -40_000_00,
+      merchant: "M4",
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T5,
+      amountCents: -50_000_00,
+      merchant: "M5",
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T6,
+      amountCents: -60_000_00,
+      merchant: "M6",
+    });
+
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.size).toBe("L");
+    expect(body.data.transactions).toHaveLength(5);
+    expect(body.data.transactions.map((t) => t.merchant)).toEqual(["M6", "M5", "M4", "M3", "M2"]);
+  });
+
+  it("returns what's available when user has fewer txs than size asks for", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T1,
+      amountCents: -10_000_00,
+      merchant: "only",
+    });
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "M" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.transactions).toHaveLength(1);
+    expect(body.data.transactions[0]?.merchant).toBe("only");
+  });
+
+  it("returns an empty array when the user has no txs", async () => {
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+    expect(res.status).toBeUndefined();
+    const body = res.body as SuccessBody;
+    expect(body.data.transactions).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exclusions & inclusions — feed-specific rules
+// ---------------------------------------------------------------------------
+
+describe("recentTxHandler — exclusions", () => {
+  it("excludes soft-deleted transactions", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T2,
+      amountCents: -10_000_00,
+      merchant: "live",
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T3, // newer, but archived
+      amountCents: -99_000_00,
+      merchant: "archived",
+      deletedAt: T3,
+    });
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.transactions).toHaveLength(1);
+    expect(body.data.transactions[0]?.merchant).toBe("live");
+  });
+
+  it("excludes balance adjustments (is_adjustment flag)", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T2,
+      amountCents: -10_000_00,
+      merchant: "real",
+    });
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T3,
+      amountCents: -99_000_00,
+      merchant: "adjustment",
+      source: "balance_adjustment",
+      channel: "manual",
+      isAdjustment: true,
+    });
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.transactions).toHaveLength(1);
+    expect(body.data.transactions[0]?.merchant).toBe("real");
+  });
+});
+
+describe("recentTxHandler — inclusions (feed, not spend)", () => {
+  it("INCLUDES transfers", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T2,
+      amountCents: -100_000_00,
+      merchant: "pago TC",
+      channel: "transfer",
+    });
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.transactions).toHaveLength(1);
+    expect(body.data.transactions[0]?.merchant).toBe("pago TC");
+    expect(body.data.transactions[0]?.amount_cop).toBe(-100_000);
+  });
+
+  it("INCLUDES credits / refunds (positive amounts) and preserves sign", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T2,
+      amountCents: 50_000_00, // refund
+      merchant: "refund",
+    });
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.transactions).toHaveLength(1);
+    expect(body.data.transactions[0]?.amount_cop).toBe(50_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-tenant safety (memory: per-user-table-join-tenant-safety)
+// ---------------------------------------------------------------------------
+
+describe("recentTxHandler — tenant safety", () => {
+  it("scopes the tx list to the authed user", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T2,
+      amountCents: -10_000_00,
+      merchant: "mine",
+    });
+    await insertTx({
+      userId: USER_B,
+      accountId: ACCT_B_COP,
+      occurredAt: T3, // newer — must still NOT appear in A's feed
+      amountCents: -999_999_00,
+      merchant: "theirs",
+    });
+
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.transactions).toHaveLength(1);
+    expect(body.data.transactions[0]?.merchant).toBe("mine");
+  });
+
+  it("resolves category name/emoji from the authed user's row (never the other user's)", async () => {
+    // USER_A has category `mercado` → "Supermercado" / "shopping-cart".
+    // USER_B has category `mercado` → "USER_B_MERCADO_NAME" / "USER_B_MERCADO_ICON".
+    // A tx on USER_A's account with categorySlug=mercado MUST resolve to A's
+    // row, not B's. This is exactly #336 / #338 regressed against.
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T2,
+      amountCents: -10_000_00,
+      merchant: "exito",
+      categorySlug: "mercado",
+    });
+
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.transactions).toHaveLength(1);
+    const row = body.data.transactions[0];
+    expect(row?.category_name).toBe("Supermercado");
+    expect(row?.category_emoji).toBe("shopping-cart");
+    // Explicit guard — ensures we catch a leak even if "Supermercado" changes.
+    expect(row?.category_name).not.toBe("USER_B_MERCADO_NAME");
+    expect(row?.category_emoji).not.toBe("USER_B_MERCADO_ICON");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
+
+describe("recentTxHandler — errors", () => {
+  it("returns 422 invalid_params when size is S", async () => {
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "S" }));
+    expect(res.status).toBe(422);
+    expect((res.body as ErrorBody).error.code).toBe("invalid_params");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FX conversion (USD → COP at current TRM)
+// ---------------------------------------------------------------------------
+
+describe("recentTxHandler — USD conversion", () => {
+  it("converts USD txs to COP at the current FX rate, preserving sign", async () => {
+    // -$25 USD @ TRM 4000 = -100.000 COP.
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_USD,
+      occurredAt: T2,
+      amountCents: -25_00,
+      currency: "USD",
+      merchant: "amazon",
+    });
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.transactions).toHaveLength(1);
+    expect(body.data.transactions[0]?.amount_cop).toBe(-100_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing category (orphan slug) — tx still returned, null cat fields
+// ---------------------------------------------------------------------------
+
+describe("recentTxHandler — missing category", () => {
+  // The FK `transactions_user_category_fk` blocks a tx from pointing at a
+  // slug that has no row at all. The real-world "orphan" we care about is
+  // when a category gets archived AFTER the tx was classified — the row
+  // still exists (so the FK holds) but the JOIN filters it out via
+  // `notDeleted`. We reproduce that state here, then restore the category
+  // at the end so downstream tests (if any) see a clean slate.
+  const ORPHAN_SLUG = "__widget_recent_tx_orphan";
+
+  beforeAll(async () => {
+    await db.insert(categories).values({
+      userId: USER_A,
+      slug: ORPHAN_SLUG,
+      name: "Orphan",
+      icon: "trash",
+    });
+  });
+
+  afterAll(async () => {
+    await db
+      .delete(categories)
+      .where(and(eq(categories.userId, USER_A), eq(categories.slug, ORPHAN_SLUG)));
+  });
+
+  it("returns null category fields when the slug points at an archived (soft-deleted) category", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T2,
+      amountCents: -10_000_00,
+      merchant: "unknown cat",
+      categorySlug: ORPHAN_SLUG,
+    });
+    // Soft-delete the category — the JOIN filters on `notDeleted`, so the
+    // tx should come back with null category name/emoji but still render.
+    await db
+      .update(categories)
+      .set({ deletedAt: new Date() })
+      .where(and(eq(categories.userId, USER_A), eq(categories.slug, ORPHAN_SLUG)));
+
+    try {
+      const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+      const body = res.body as SuccessBody;
+      expect(body.data.transactions).toHaveLength(1);
+      expect(body.data.transactions[0]?.category_name).toBeNull();
+      expect(body.data.transactions[0]?.category_emoji).toBeNull();
+      expect(body.data.transactions[0]?.merchant).toBe("unknown cat");
+    } finally {
+      // Restore so afterAll can DELETE the row without FK drama.
+      await db
+        .update(categories)
+        .set({ deletedAt: null })
+        .where(and(eq(categories.userId, USER_A), eq(categories.slug, ORPHAN_SLUG)));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Account label — formatAccountLabel output
+// ---------------------------------------------------------------------------
+
+describe("recentTxHandler — account label", () => {
+  it("uses formatAccountLabel for account_label (name + currency)", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_COP,
+      occurredAt: T2,
+      amountCents: -10_000_00,
+      merchant: "cop tx",
+    });
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.transactions).toHaveLength(1);
+    // `formatAccountLabel` default output is `${name} (${currency})`.
+    expect(body.data.transactions[0]?.account_label).toBe(`${MARKER}-a-cop (COP)`);
+  });
+
+  it("account_label reflects the tx's account currency (USD vs COP)", async () => {
+    await insertTx({
+      userId: USER_A,
+      accountId: ACCT_A_USD,
+      occurredAt: T2,
+      amountCents: -10_00,
+      currency: "USD",
+      merchant: "usd tx",
+    });
+    const res = await recentTxHandler(makeCtx({ userId: USER_A, size: "L" }));
+    const body = res.body as SuccessBody;
+    expect(body.data.transactions[0]?.account_label).toBe(`${MARKER}-a-usd (USD)`);
+  });
+});

--- a/src/lib/widgets/handlers/recent-tx.ts
+++ b/src/lib/widgets/handlers/recent-tx.ts
@@ -1,0 +1,232 @@
+/**
+ * Widget handler: `recent-tx` — most recent transactions for the authed user (#389).
+ *
+ * Feed tile: last 3 (`size=M`) or last 5 (`size=L`) live transactions. Unlike
+ * `hoy` / `mes-actual`, this is a RECENT-ACTIVITY feed — the user wants to see
+ * everything that happened on their accounts, not just "gasto". So the
+ * exclusions are intentionally shorter:
+ *
+ *   - Soft-deleted rows (`notDeleted`) drop out — archived txs aren't activity.
+ *   - Balance adjustments drop out (both `source = 'balance_adjustment'` AND
+ *     `is_adjustment = true`). These are reconciliation artifacts, not real
+ *     financial events; surfacing them in a feed would confuse the user.
+ *
+ * What stays IN (differs from the spend-centric widgets):
+ *   - Transfers (`channel = 'transfer'`) — paying a credit card is real activity.
+ *   - Credits / refunds (positive `amount_cents`) — the sign is preserved in
+ *     `amount_cop` so the widget can render inflows vs outflows.
+ *
+ * Currency: `amount_cop` is an INTEGER COP-pesos value with the original sign
+ * preserved. USD transactions are converted at the current TRM in JS (after
+ * the DB round-trip) so we stay on the same FX source used elsewhere. This
+ * keeps the SQL simple at the cost of one FX fetch per USD-present response.
+ *
+ * Category lookup: per-user categories are unique on `(user_id, slug)` — the
+ * JOIN MUST pair on both columns (memory `per-user-table-join-tenant-safety`,
+ * incidents #336 / #338). Missing category (orphan slug after an archive)
+ * returns `null` for both name and emoji without dropping the tx.
+ *
+ * `category_emoji`: the spec sample uses emoji ("🛒") but the categories
+ * table stores a lucide icon name in `icon` (e.g. "shopping-cart"). For now
+ * we pass `icon` through verbatim — the widget client decides how to render
+ * it. When category emoji becomes a first-class column (separate issue),
+ * swap this mapping.
+ *
+ * `account_label` uses `formatAccountLabel` — never concatenate inline
+ * (memory `prod-accounts-seeded-2026-04-19`).
+ *
+ * Size rules:
+ *   - `S` → 422 invalid_params (a single-row tile isn't useful for a feed).
+ *   - `M` → 3 rows.
+ *   - `L` → 5 rows.
+ */
+
+import { and, desc, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, categories, transactions, type AccountMetadata } from "@/lib/db/schema";
+import { notAdjustment, notDeleted } from "@/lib/db/helpers";
+import { getCurrentFxRate } from "@/lib/fx/repo";
+import { toCop } from "@/lib/money";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import type { Currency } from "@/lib/types";
+import type { WidgetHandler, WidgetHandlerResult } from "@/app/api/widget/v1/[id]/registry";
+import { bogotaIsoNow } from "./_shared";
+
+// ---------------------------------------------------------------------------
+// Response shapes
+// ---------------------------------------------------------------------------
+
+type RecentTxItem = {
+  id: string;
+  occurred_at: string;
+  merchant: string | null;
+  amount_cop: number;
+  category_name: string | null;
+  category_emoji: string | null;
+  account_label: string;
+};
+
+type RecentTxData = {
+  transactions: RecentTxItem[];
+};
+
+type RecentTxResponse = {
+  widget_id: "recent-tx";
+  size: "M" | "L";
+  data: RecentTxData;
+  generated_at: string;
+};
+
+type RecentTxErrorCode = "invalid_params";
+
+type RecentTxErrorBody = { error: { code: RecentTxErrorCode; message: string } };
+
+const STATUS_BY_CODE: Record<RecentTxErrorCode, number> = {
+  invalid_params: 422,
+};
+
+function errorResult(code: RecentTxErrorCode, message: string): WidgetHandlerResult {
+  const body: RecentTxErrorBody = { error: { code, message } };
+  return { body, status: STATUS_BY_CODE[code] };
+}
+
+// ---------------------------------------------------------------------------
+// Bogota ISO formatter for a given UTC Date. Colombia is UTC-5 year-round
+// (no DST) so we shift by a constant and format by hand — mirrors the style
+// of `bogotaIsoNow` in `_shared.ts` but anchored to an arbitrary occurredAt,
+// not "now".
+// ---------------------------------------------------------------------------
+
+const BOGOTA_OFFSET_MS = 5 * 60 * 60 * 1000;
+
+function bogotaIso(occurredAt: Date): string {
+  const shifted = new Date(occurredAt.getTime() - BOGOTA_OFFSET_MS);
+  const y = shifted.getUTCFullYear();
+  const m = String(shifted.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(shifted.getUTCDate()).padStart(2, "0");
+  const hh = String(shifted.getUTCHours()).padStart(2, "0");
+  const mm = String(shifted.getUTCMinutes()).padStart(2, "0");
+  const ss = String(shifted.getUTCSeconds()).padStart(2, "0");
+  return `${y}-${m}-${d}T${hh}:${mm}:${ss}-05:00`;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+const BI_ZERO = BigInt(0);
+const BI_HUNDRED = BigInt(100);
+
+/**
+ * Narrows signed COP cents to an integer peso value, preserving sign. A
+ * negative `amountCents` rounds TOWARDS ZERO under BigInt division — which
+ * drops the sub-peso remainder the same way positive values do, so the sign
+ * is preserved and the magnitude stays consistent across inflows/outflows.
+ */
+function centsToCopSigned(cents: bigint): number {
+  return Number(cents / BI_HUNDRED);
+}
+
+export const recentTxHandler: WidgetHandler = async (ctx) => {
+  if (ctx.size === "S") {
+    return errorResult("invalid_params", "recent-tx does not support size S");
+  }
+
+  const limit = ctx.size === "M" ? 3 : 5;
+
+  // Single round-trip. LEFT JOIN to accounts (not INNER) because a tx always
+  // has an account, but an outer join lets the query planner skip a nested
+  // lookup when `accounts` is small. LEFT JOIN to categories so a tx whose
+  // category was archived still shows up with null name/emoji.
+  //
+  // CRITICAL: both JOINs pair userId into the ON clause. Category slug is
+  // unique per-user (#336, #338), and while account_id is already globally
+  // unique, matching on userId too keeps the query defensively tenant-safe
+  // and matches the project-wide convention.
+  const rows = await db
+    .select({
+      id: transactions.id,
+      occurredAt: transactions.occurredAt,
+      merchant: transactions.merchant,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      categoryName: categories.name,
+      categoryIcon: categories.icon,
+      accountName: accounts.name,
+      accountCurrency: accounts.currency,
+      accountInstitution: accounts.institution,
+      accountMetadata: accounts.metadata,
+    })
+    .from(transactions)
+    .leftJoin(
+      accounts,
+      and(eq(accounts.id, transactions.accountId), eq(accounts.userId, transactions.userId)),
+    )
+    .leftJoin(
+      categories,
+      and(
+        eq(categories.slug, transactions.categorySlug),
+        eq(categories.userId, transactions.userId),
+        notDeleted(categories.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(transactions.userId, ctx.userId),
+        notDeleted(transactions.deletedAt),
+        // Balance-adjustment filter uses BOTH signals — `source =
+        // 'balance_adjustment'` is the provenance marker used by the
+        // reconciliation writer, `is_adjustment` is the query-time flag
+        // for YNAB-style balance corrections. Either one disqualifies.
+        notAdjustment(transactions.isAdjustment),
+        sql`${transactions.source} <> 'balance_adjustment'`,
+      ),
+    )
+    .orderBy(desc(transactions.occurredAt), desc(transactions.id))
+    .limit(limit);
+
+  // FX: only fetch when a USD row survived the filters. COP-only users pay
+  // nothing — same optimization as `hoy` / `mis-tcs` / `mes-actual`.
+  const needsFx = rows.some((r) => r.currency === "USD" && BigInt(r.amountCents) !== BI_ZERO);
+  const fxRate = needsFx ? (await getCurrentFxRate()).rate : 0;
+
+  const items: RecentTxItem[] = rows.map((r) => {
+    const currency = r.currency as Currency;
+    const amountCopCents = toCop(BigInt(r.amountCents), currency, fxRate);
+
+    // Account label uses the centralized formatter. The row MUST have an
+    // account (FK is NOT NULL on transactions.account_id), but the left
+    // join typing forces us to guard against null. Fall back to a minimal
+    // shape on the theoretical miss — preserves the response rather than
+    // 500ing on a now-impossible edge.
+    const accountLabel =
+      r.accountName && r.accountCurrency
+        ? formatAccountLabel({
+            name: r.accountName,
+            currency: r.accountCurrency,
+            institution: r.accountInstitution ?? null,
+            metadata: (r.accountMetadata ?? {}) as AccountMetadata,
+          })
+        : "—";
+
+    return {
+      id: String(r.id),
+      occurred_at: bogotaIso(r.occurredAt),
+      merchant: r.merchant,
+      amount_cop: centsToCopSigned(amountCopCents),
+      category_name: r.categoryName,
+      category_emoji: r.categoryIcon,
+      account_label: accountLabel,
+    };
+  });
+
+  const body: RecentTxResponse = {
+    widget_id: "recent-tx",
+    size: ctx.size,
+    data: {
+      transactions: items,
+    },
+    generated_at: bogotaIsoNow(new Date()),
+  };
+  return { body };
+};


### PR DESCRIPTION
Closes #389.

## Summary

Handler for `widget_id=recent-tx` — recent-activity feed for the Scriptable / Tasker widget contract. Size `M` returns the 3 most recent transactions, size `L` returns 5. Size `S` is 422.

## Contract

```
GET /api/widget/v1/recent-tx?size=M|L
Authorization: Bearer <widget_token>
```

Body shape mirrors the spec in #389 — `transactions[]` ordered by `occurred_at DESC`, each item carrying `id`, `occurred_at` (Bogota ISO), `merchant`, `amount_cop` (signed integer, USD→COP at current TRM), `category_name`, `category_emoji`, `account_label`.

## Rules honored

- Soft-deleted txs excluded (`notDeleted`).
- Balance adjustments excluded (both `source = 'balance_adjustment'` AND `is_adjustment = true`).
- Transfers **INCLUDED** — this is a recent-activity feed, not a spend widget.
- Credits / refunds (positive amounts) **INCLUDED** — sign preserved in `amount_cop`.
- Category JOIN pairs `(userId, slug)` and filters archived categories (memory `per-user-table-join-tenant-safety`, incidents #336 / #338).
- `account_label` uses `formatAccountLabel()` — never inline `account.name`.
- `occurred_at` rendered as ISO8601 with `-05:00` offset (Bogota, no DST).
- USD → COP conversion via `toCop()` at the current FX rate; FX is only fetched when a USD row actually survived the filters.

## Spec deviation

`category_emoji` currently passes through `categories.icon` verbatim. The spec example shows an emoji (\`"🛒"\`) but the schema stores lucide icon names (\`"shopping-cart"\`). There is no emoji column today — swapping is a separate issue. Flagged in the file header.

## Test plan

- [x] Happy path size M → 3 txs, size L → 5 txs, correct DESC ordering
- [x] User with <3 txs → returns what's available, no padding
- [x] User with no txs → empty array, 200
- [x] Soft-deleted txs excluded
- [x] Balance adjustments excluded
- [x] Transfers INCLUDED
- [x] Credits (positive) INCLUDED, sign preserved
- [x] Cross-tenant: category lookup resolves to user A's (user_id, slug) even when user B has the same slug with different name/emoji
- [x] Cross-tenant: tx list scoped to user
- [x] size=S → 422
- [x] USD tx: amount_cop reflects COP conversion at current FX (TRM 4000 in test)
- [x] Missing category (archived) → category_name: null, category_emoji: null, tx still returned
- [x] Account label uses formatAccountLabel output
- [x] 15/15 recent-tx tests pass; 93/93 widget tests pass; full suite 787/787
- [x] bun run lint clean