### PR TITLE
feat(widgets): Scriptable script + Tasker recipe + setup docs (#390)

### DIFF
--- a/docs/widgets/README.md
+++ b/docs/widgets/README.md
@@ -1,0 +1,110 @@
+# Findash — Widgets de pantalla de inicio
+
+Tiles que ves sin desbloquear mucho. Diseñados para leer de un vistazo: cupo
+disponible, gasto de hoy, últimas transacciones, proyección de mes. Se
+conectan a tu instancia Findash vía un **widget token** por usuario, leído
+por cada tile con un `Authorization: Bearer <token>` contra
+`GET /api/widget/v1/<widget_id>`.
+
+## ¿Por qué widgets nativos y no una PWA?
+
+Las pantallas de inicio de iOS y Android NO corren JavaScript. Para tener
+tiles 2×2 y 4×2 que se actualicen en background necesitás el runtime nativo
+del sistema operativo. En iOS eso significa Scriptable (o una app nativa, que
+viene en Fase 5), en Android eso significa Tasker (o una app nativa). Los
+widgets son parte esencial del proyecto — el bot de Telegram cubre el flujo
+conversacional, pero nada reemplaza un tile que mostrás sin desbloquear.
+
+Para el contexto de producto, ver [bot-primary-interface-strategy][memory].
+
+## Widgets disponibles
+
+| ID           | Widget     | Tamaños              | Uso                                                      |
+| ------------ | ---------- | -------------------- | -------------------------------------------------------- |
+| `tc-focus`   | TC Focus   | S (2×2)              | Una tarjeta específica — cupo, utilización, días a corte |
+| `mis-tcs`    | Mis TCs    | M (4×2), L (4×4)     | Roster completo de tarjetas de crédito, ordenado por uso |
+| `hoy`        | Hoy        | S (2×2)              | Gasto de hoy + comparación con promedio diario del mes   |
+| `mes-actual` | Mes actual | M (4×2)              | MTD + proyección fin de mes + delta vs mes pasado        |
+| `recent-tx`  | Últimas 5  | M (3 txs), L (5 txs) | Feed de últimas transacciones en todas las cuentas       |
+
+Ver el JSON que devuelve cada widget en [`api-reference.md`](./api-reference.md).
+
+## Setup por plataforma
+
+| Plataforma | Guía                                     | Requisitos                                                                                             |
+| ---------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| iOS        | [`setup-ios.md`](./setup-ios.md)         | iPhone + [Scriptable](https://scriptable.app) (gratis)                                                 |
+| Android    | [`setup-android.md`](./setup-android.md) | Android + [Tasker](https://play.google.com/store/apps/details?id=net.dinglisch.android.taskerm) (pago) |
+
+Ambos flujos siguen la misma secuencia:
+
+1. Ir a `/settings/widgets` en Findash y **mintear un widget token**.
+   Guardarlo ya — el plaintext se muestra **una sola vez**.
+2. En el dispositivo, correr un script de setup una vez para guardar el
+   token y la base URL en el almacenamiento seguro del OS (Keychain en iOS,
+   vars globales en Tasker).
+3. Pegar el script del widget en la app (Scriptable en iOS, Scenes en
+   Tasker).
+4. Agregar el widget al home screen, configurar qué widget mostrar por su
+   parámetro (`hoy.S`, `tc-focus.S|<card_id>`, etc.).
+5. Opcional: crear múltiples instancias con distintos parámetros para
+   distintos widgets en el mismo home.
+
+## Formato del parámetro
+
+Todos los widgets se seleccionan con un único string en el campo
+**Parameter** del widget (iOS) o **%par1** del Task (Android):
+
+```
+<widget_id>.<size>[|<extra>]
+```
+
+- `<widget_id>`: uno de los IDs de la tabla de arriba.
+- `<size>`: `S` | `M` | `L`. Cada widget soporta un subset — ver la tabla.
+- `<extra>`: opcional, separado por `|`. Hoy sólo `tc-focus` lo usa, para
+  recibir el `target` (UUID de `physical_cards` para TCs multi-currency, o
+  entero de `accounts.id` para TCs single-currency).
+
+Ejemplos válidos:
+
+```
+hoy.S
+mis-tcs.M
+mis-tcs.L
+mes-actual.M
+recent-tx.L
+tc-focus.S|3a4b5c6d-1234-5678-9abc-def012345678
+tc-focus.S|42
+```
+
+## Rotar un token
+
+Si comprometiste el token (ej. quedó en un screenshot, lo perdiste) o lo
+querés rotar por higiene:
+
+1. `/settings/widgets` → revocá el token viejo.
+2. Minteá uno nuevo → copiá el plaintext.
+3. Re-corré el script de setup en el dispositivo (iOS: `findash-set-token.js`;
+   Android: editá la var global `%FINDASH_TOKEN`).
+
+Los widgets existentes en home siguen funcionando — lo único que cambia es el
+valor guardado en el device.
+
+## Troubleshooting rápido
+
+| Error en el widget                             | Causa                              | Solución                                                    |
+| ---------------------------------------------- | ---------------------------------- | ----------------------------------------------------------- |
+| "Sin conexión"                                 | Red caída o URL mal                | Verificá `FINDASH_BASE_URL`; probá en el browser del device |
+| "Token inválido — revisá en /settings/widgets" | Token revocado/vencido             | Mintear uno nuevo + re-run setup                            |
+| "Widget desconocido"                           | Typo en el parameter               | Consultar tabla de arriba                                   |
+| "Parámetros inválidos"                         | Tamaño no soportado por ese widget | Ej. `tc-focus.M` no existe — sólo `S`                       |
+| Muestra "• datos en caché"                     | Última petición falló              | Se reintentará en el próximo refresh (30 min)               |
+
+## Ver también
+
+- [API reference](./api-reference.md) — el JSON exacto que devuelve cada endpoint
+- [iOS setup](./setup-ios.md)
+- [Android setup](./setup-android.md)
+- Issue [#382](https://github.com/ingamartinez/personal-financial-dashboard/issues/382) — epic umbrella
+
+[memory]: #

--- a/docs/widgets/api-reference.md
+++ b/docs/widgets/api-reference.md
@@ -1,0 +1,381 @@
+# Findash Widget API — v1 reference
+
+Contrato HTTP que alimenta los clientes Scriptable (iOS) y Tasker (Android).
+Todos los endpoints viven bajo el mismo route handler genérico con dispatch
+por `widget_id`.
+
+## Base
+
+```
+GET /api/widget/v1/<widget_id>
+```
+
+- **Método**: `GET` únicamente.
+- **Auth**: `Authorization: Bearer <widget_token>`. El token se mintea desde
+  `/settings/widgets` y tiene `purpose = 'widget'`. Tokens con otro purpose
+  (ej. Telegram webhook) reciben `401`.
+- **Content-Type** de la respuesta: `application/json; charset=utf-8`.
+- **Rate limit**: por `tokenId` (no por usuario). 60 rpm en quemadura corta,
+  20 rpm sostenido — ver
+  [`src/app/api/widget/v1/[id]/rate-limit.ts`](../../src/app/api/widget/v1/[id]/rate-limit.ts)
+  para números actuales.
+- **Timezone**: toda fecha/hora en responses está anclada a `America/Bogota`
+  (UTC-5, sin DST). `generated_at` se emite en ISO-8601 con sufijo `-05:00`.
+- **Moneda**: COP-pesos enteros (sin decimales). USD se convierte a COP al
+  TRM actual antes de serializar.
+
+## Query params comunes
+
+| Param | Tipo | Obligatorio | Notas |
+|-------|------|-------------|-------|
+| `size` | `"S" \| "M" \| "L"` | sí | Cada widget soporta un subset — ver tabla |
+
+## Errores
+
+Todos los endpoints comparten esta forma:
+
+```json
+{ "error": { "code": "unauthorized", "message": "Invalid or missing widget token" } }
+```
+
+| Código | HTTP | Significado |
+|--------|------|-------------|
+| `unauthorized` | 401 | Token faltante, mal-formado, revocado o con otro purpose |
+| `forbidden` | 403 | Reservado — no se emite hoy |
+| `widget_not_found` | 404 | `widget_id` no está registrado |
+| `invalid_params` | 422 | `size` no aceptado por ese widget, o un extra requerido falta |
+| `rate_limited` | 429 | Throttle — incluye `Retry-After` header |
+| `internal_error` | 500 | Handler lanzó excepción — ver logs del server |
+
+Los clientes (Scriptable / Tasker) mapean estos códigos a mensajes para el
+usuario — ver `findash-widget.js` → `FindashError`.
+
+## Tabla de widgets
+
+| `widget_id` | Tamaños | Params extra | Fuente |
+|-------------|---------|--------------|--------|
+| `tc-focus` | S | `target=<id>` | [`handlers/tc-focus.ts`](../../src/lib/widgets/handlers/tc-focus.ts) |
+| `mis-tcs` | M, L | — | [`handlers/mis-tcs.ts`](../../src/lib/widgets/handlers/mis-tcs.ts) |
+| `hoy` | S | — | [`handlers/hoy.ts`](../../src/lib/widgets/handlers/hoy.ts) |
+| `mes-actual` | M | — | [`handlers/mes-actual.ts`](../../src/lib/widgets/handlers/mes-actual.ts) |
+| `recent-tx` | M, L | — | [`handlers/recent-tx.ts`](../../src/lib/widgets/handlers/recent-tx.ts) |
+
+---
+
+## `tc-focus`
+
+Snapshot de cupo + utilización para UNA tarjeta de crédito específica.
+Soporta las dos formas de TC del modelo:
+
+- **Single-currency** (una moneda, una `accounts` row): `target` es un
+  entero (`accounts.id`). Cupo vive en `metadata.creditLimitCents`, balance
+  es la suma derivada de transacciones.
+- **Multi-currency** (TC física con sub-accounts COP + USD): `target` es un
+  UUID (`physical_cards.id`). Cupo + cutoff viven en la row física; los
+  balances per-moneda viven en los sub-accounts y se convierten al TRM
+  actual.
+
+### Request
+
+```
+GET /api/widget/v1/tc-focus?size=S&target=<id>
+```
+
+### Response (200)
+
+```json
+{
+  "widget_id": "tc-focus",
+  "size": "S",
+  "data": {
+    "card_name": "Bancolombia *1234",
+    "network": "VISA",
+    "last4": "1234",
+    "credit_limit_cop": 5000000,
+    "used_cop": 1235000,
+    "available_cop": 3765000,
+    "utilization_pct": 25,
+    "next_statement_cutoff": "2026-05-15",
+    "days_to_cutoff": 24
+  },
+  "generated_at": "2026-04-21T14:32:10-05:00"
+}
+```
+
+| Campo | Tipo | Nota |
+|-------|------|------|
+| `card_name` | `string` | Label final (via `formatAccountLabel` o fallback institución + *last4) |
+| `network` | `string \| null` | "VISA", "MASTERCARD", "AMEX", "DINERS" o null |
+| `last4` | `string \| null` | Últimos 4 dígitos si los hay |
+| `credit_limit_cop` | `number` | Pesos enteros |
+| `used_cop` | `number` | Pesos enteros (valor absoluto; clampado ≥ 0) |
+| `available_cop` | `number` | Pesos enteros (clampado ≥ 0) |
+| `utilization_pct` | `number` | Entero 0..100 |
+| `next_statement_cutoff` | `string \| null` | `YYYY-MM-DD`, fecha Bogota del próximo corte |
+| `days_to_cutoff` | `number \| null` | Días desde hoy hasta `next_statement_cutoff` |
+| `generated_at` | `string` | ISO-8601 con offset `-05:00` |
+
+### Errores específicos
+
+- `422 invalid_params` — `size` distinto de `S`, o `target` faltante.
+- `404 target_not_found` — `target` no existe para este usuario (NUNCA revela
+  si existe bajo otro usuario — fail cerrada).
+
+---
+
+## `mis-tcs`
+
+Roster completo de TCs del usuario. Combina multi-currency y single-currency
+en una sola lista ordenada por `utilization_pct DESC`.
+
+### Request
+
+```
+GET /api/widget/v1/mis-tcs?size=M
+GET /api/widget/v1/mis-tcs?size=L
+```
+
+- `size=M` → top 3 por utilización.
+- `size=L` → todas las tarjetas.
+- `size=S` → `422 invalid_params`.
+
+### Response (200)
+
+```json
+{
+  "widget_id": "mis-tcs",
+  "size": "L",
+  "data": {
+    "cards": [
+      {
+        "id": "3a4b5c6d-1234-5678-9abc-def012345678",
+        "name": "Bancolombia Mastercard",
+        "network": "MASTERCARD",
+        "last4": "4321",
+        "available_cop": 2500000,
+        "credit_limit_cop": 5000000,
+        "utilization_pct": 50
+      },
+      {
+        "id": 42,
+        "name": "Colpatria VISA *1234",
+        "network": "VISA",
+        "last4": "1234",
+        "available_cop": 3765000,
+        "credit_limit_cop": 5000000,
+        "utilization_pct": 25
+      }
+    ],
+    "total_available_cop": 6265000,
+    "total_credit_cop": 10000000
+  },
+  "generated_at": "2026-04-21T14:32:10-05:00"
+}
+```
+
+| Campo | Tipo | Nota |
+|-------|------|------|
+| `cards[].id` | `string \| number` | UUID (multi-currency) o entero (single) |
+| `cards[].name` | `string` | Label final |
+| `cards[].network` | `string \| null` | |
+| `cards[].last4` | `string \| null` | |
+| `cards[].available_cop` | `number` | Pesos enteros |
+| `cards[].credit_limit_cop` | `number` | Pesos enteros |
+| `cards[].utilization_pct` | `number` | Entero 0..100 |
+| `total_available_cop` | `number` | Suma sobre **todas** las tarjetas, no solo las trimeadas |
+| `total_credit_cop` | `number` | Idem |
+
+### Notas
+
+- Roster vacío (usuario sin TCs) devuelve `200` con `cards: []` y totales en
+  `0`. No es un error.
+- Los totales se calculan sobre el roster COMPLETO, no sobre `cards[]`
+  trimeados — útil para `size=M` que muestra 3 pero anuncia el total real.
+
+---
+
+## `hoy`
+
+Gasto del día en Bogota TZ, con comparación contra el promedio diario del mes.
+
+### Request
+
+```
+GET /api/widget/v1/hoy?size=S
+```
+
+Sizes distintos de `S` → `422 invalid_params`.
+
+### Response (200)
+
+```json
+{
+  "widget_id": "hoy",
+  "size": "S",
+  "data": {
+    "spent_cop": 85000,
+    "tx_count": 4,
+    "vs_daily_avg_pct": -12,
+    "day_label": "Martes 21 abr"
+  },
+  "generated_at": "2026-04-21T14:32:10-05:00"
+}
+```
+
+| Campo | Tipo | Nota |
+|-------|------|------|
+| `spent_cop` | `number` | Pesos enteros, **outflows** del día (amounts negativos, vueltos positivos) |
+| `tx_count` | `number` | Nº de transacciones que contaron para `spent_cop` |
+| `vs_daily_avg_pct` | `number \| null` | `round((spent_today / avg_daily_MTD - 1) * 100)`. `null` si es día 1 |
+| `day_label` | `string` | Label es-CO: `Martes 21 abr` |
+
+### Exclusiones
+
+No cuentan como gasto:
+
+- Transacciones archivadas (`deleted_at IS NOT NULL`).
+- Balance adjustments (`source = 'balance_adjustment'` OR `is_adjustment`).
+- Transferencias (`channel = 'transfer'`) — incluidos pagos a TC.
+- Inflows (`amount_cents > 0`).
+
+### Semántica de `vs_daily_avg_pct`
+
+- `avg_daily_MTD = |sum(qualifying txs from day 1 through yesterday)| /
+  (today.day - 1)`.
+- Si `today.day === 1` → `null` (no hay días previos).
+- Si `avg_daily_MTD === 0` y `spent_cop === 0` → `0`.
+- Si `avg_daily_MTD === 0` y `spent_cop > 0` → `null` (no se divide por 0).
+- Valor negativo = gastaste MENOS que el promedio MTD.
+- Valor positivo = gastaste MÁS.
+
+---
+
+## `mes-actual`
+
+Gasto MTD + proyección fin de mes + delta vs mes pasado.
+
+### Request
+
+```
+GET /api/widget/v1/mes-actual?size=M
+```
+
+Sizes distintos de `M` → `422 invalid_params`.
+
+### Response (200)
+
+```json
+{
+  "widget_id": "mes-actual",
+  "size": "M",
+  "data": {
+    "month_label": "Abril 2026",
+    "spent_cop": 1250000,
+    "day_of_month": 21,
+    "last_month_same_day_cop": 1400000,
+    "delta_pct": -11,
+    "delta_direction": "down",
+    "projection_month_end_cop": 1785714
+  },
+  "generated_at": "2026-04-21T14:32:10-05:00"
+}
+```
+
+| Campo | Tipo | Nota |
+|-------|------|------|
+| `month_label` | `string` | es-CO: `Abril 2026` |
+| `spent_cop` | `number` | MTD outflows en Bogota TZ |
+| `day_of_month` | `number` | Día actual en Bogota (1..31) |
+| `last_month_same_day_cop` | `number` | Mismo rango del mes pasado, capado al último día |
+| `delta_pct` | `number \| null` | `round((spent / last_month_same_day - 1) * 100)`, `null` si el comparador es 0 |
+| `delta_direction` | `"up" \| "down" \| "flat" \| null` | Sincronizado con `delta_pct` |
+| `projection_month_end_cop` | `number` | Extrapolación lineal `round(spent/day * daysInMonth)` |
+
+### Exclusiones
+
+Mismo set que `hoy`.
+
+### Edge cases
+
+- Día 31 en mes de 31 → `last_month_same_day_cop` se capa al último día del
+  mes pasado (ej. Feb 28).
+- `spent_cop === 0` y `day === 1` → `projection_month_end_cop === 0`.
+- `last_month_same_day_cop === 0` → `delta_pct` y `delta_direction` ambos
+  `null`.
+
+---
+
+## `recent-tx`
+
+Feed de las últimas 3 o 5 transacciones del usuario.
+
+### Request
+
+```
+GET /api/widget/v1/recent-tx?size=M   # 3 txs
+GET /api/widget/v1/recent-tx?size=L   # 5 txs
+```
+
+`size=S` → `422 invalid_params`.
+
+### Response (200)
+
+```json
+{
+  "widget_id": "recent-tx",
+  "size": "L",
+  "data": {
+    "transactions": [
+      {
+        "id": "12345",
+        "occurred_at": "2026-04-21T13:45:00-05:00",
+        "merchant": "Éxito Superstore",
+        "amount_cop": -42500,
+        "category_name": "Mercado",
+        "category_emoji": "shopping-cart",
+        "account_label": "Bancolombia Ahorros *1234"
+      }
+    ]
+  },
+  "generated_at": "2026-04-21T14:32:10-05:00"
+}
+```
+
+| Campo | Tipo | Nota |
+|-------|------|------|
+| `transactions[].id` | `string` | ID de la tx como string |
+| `transactions[].occurred_at` | `string` | ISO-8601 con offset Bogota `-05:00` |
+| `transactions[].merchant` | `string \| null` | Nombre del comercio |
+| `transactions[].amount_cop` | `number` | Firma preservada: negativo = outflow, positivo = inflow/refund |
+| `transactions[].category_name` | `string \| null` | Nombre de la categoría (null si archivada) |
+| `transactions[].category_emoji` | `string \| null` | Hoy: lucide icon name. Cuando category.emoji sea columna-primera-clase, será emoji |
+| `transactions[].account_label` | `string` | Via `formatAccountLabel` |
+
+### Exclusiones
+
+A diferencia de `hoy` / `mes-actual`, este feed SÍ incluye:
+
+- Transferencias (`channel = 'transfer'`) — pagar una TC es actividad real.
+- Inflows — con `amount_cop` positivo.
+
+Sigue excluyendo:
+
+- Archivadas (`deleted_at`).
+- Balance adjustments.
+
+---
+
+## Generación de este doc
+
+Los shapes aquí están hand-rolled a partir de los tipos TS en
+`src/lib/widgets/handlers/*.ts`. Si cambia un handler, actualizar este doc en
+el mismo PR. No hay schema JSON auto-generado todavía — si se adopta Zod en
+el hot path (issue candidate), se puede generar desde ahí.
+
+## Ver también
+
+- [Overview de widgets](./README.md)
+- [Setup iOS](./setup-ios.md)
+- [Setup Android](./setup-android.md)
+- Código: [`src/lib/widgets/handlers/`](../../src/lib/widgets/handlers/)
+- Router: [`src/app/api/widget/v1/[id]/route.ts`](../../src/app/api/widget/v1/%5Bid%5D/route.ts)

--- a/docs/widgets/scriptable/findash-set-token.js
+++ b/docs/widgets/scriptable/findash-set-token.js
@@ -1,0 +1,100 @@
+// Variables used by Scriptable.
+// These must be at the very top of the file. Do not edit.
+// icon-color: teal; icon-glyph: key;
+
+// ============================================================================
+// Findash — one-time setup
+// ----------------------------------------------------------------------------
+// Stores your widget token + base URL in the iOS Keychain under the keys:
+//
+//   FINDASH_TOKEN     — widget token minted at /settings/widgets
+//   FINDASH_BASE_URL  — e.g. https://findash.example.com (no trailing slash)
+//
+// Run this script ONCE from inside the Scriptable app. The main widget script
+// (findash-widget.js) reads from these keys — no need to edit code to change
+// the token or URL, just re-run this helper.
+//
+// Tip: if you rotate the token at /settings/widgets, re-run this script with
+// the new plaintext — the old value is overwritten in place.
+// ============================================================================
+
+const TOKEN_KEY = "FINDASH_TOKEN";
+const BASE_URL_KEY = "FINDASH_BASE_URL";
+
+function keychainGet(key) {
+  return Keychain.contains(key) ? Keychain.get(key) : "";
+}
+
+async function prompt({ title, message, fields }) {
+  const alert = new Alert();
+  alert.title = title;
+  alert.message = message;
+  for (const field of fields) {
+    const tf = alert.addTextField(field.placeholder, field.defaultValue ?? "");
+    if (field.secure) tf.isSecure = true;
+  }
+  alert.addAction("Guardar");
+  alert.addCancelAction("Cancelar");
+  const chosen = await alert.presentAlert();
+  if (chosen === -1) return null;
+  return fields.map((_, i) => alert.textFieldValue(i));
+}
+
+async function main() {
+  const existingBase = keychainGet(BASE_URL_KEY) || "https://findash.example.com";
+  const existingToken = keychainGet(TOKEN_KEY);
+
+  const values = await prompt({
+    title: "Findash — setup",
+    message:
+      "Pegá la URL base de tu instancia Findash y el widget token (generado en /settings/widgets). Se guardan en el Keychain del dispositivo.",
+    fields: [
+      { placeholder: "Base URL (https://findash.example.com)", defaultValue: existingBase },
+      {
+        placeholder: existingToken ? "Token (actual: ••••)" : "Widget token",
+        secure: true,
+      },
+    ],
+  });
+
+  if (!values) {
+    const cancelled = new Alert();
+    cancelled.title = "Cancelado";
+    cancelled.message = "No se guardó nada.";
+    cancelled.addAction("OK");
+    await cancelled.presentAlert();
+    return;
+  }
+
+  const baseUrl = (values[0] || "").trim().replace(/\/$/, "");
+  const token = (values[1] || "").trim() || existingToken; // empty input keeps existing
+
+  if (!baseUrl || !/^https?:\/\//i.test(baseUrl)) {
+    const err = new Alert();
+    err.title = "URL inválida";
+    err.message = "La base URL debe empezar con http:// o https://.";
+    err.addAction("OK");
+    await err.presentAlert();
+    return;
+  }
+  if (!token) {
+    const err = new Alert();
+    err.title = "Falta el token";
+    err.message = "Generá un widget token en /settings/widgets y pegalo aquí.";
+    err.addAction("OK");
+    await err.presentAlert();
+    return;
+  }
+
+  Keychain.set(BASE_URL_KEY, baseUrl);
+  Keychain.set(TOKEN_KEY, token);
+
+  const ok = new Alert();
+  ok.title = "Listo";
+  ok.message = "Credenciales guardadas. Ya podés agregar el widget a la pantalla de inicio.";
+  ok.addAction("OK");
+  await ok.presentAlert();
+}
+
+await main();
+Script.complete();

--- a/docs/widgets/scriptable/findash-widget.js
+++ b/docs/widgets/scriptable/findash-widget.js
@@ -98,16 +98,15 @@ function parseParameter(raw) {
 // ----------------------------------------------------------------------------
 
 async function fetchWidget({ baseUrl, token, widgetId, size, extra }) {
-  const params = new URLSearchParams();
-  params.set("size", size);
-  if (extra) {
+  // Scriptable's JavaScriptCore runtime does not expose URLSearchParams, so
+  // we build the query string by hand with encodeURIComponent.
+  const qs = [`size=${encodeURIComponent(size)}`];
+  if (extra && widgetId === "tc-focus") {
     // tc-focus uses `target=<id>`. Today it is the only widget that takes an
-    // extra. If new widgets add extras, this mapping table grows.
-    if (widgetId === "tc-focus") {
-      params.set("target", extra);
-    }
+    // extra. If new widgets add extras, extend the mapping here.
+    qs.push(`target=${encodeURIComponent(extra)}`);
   }
-  const url = `${baseUrl.replace(/\/$/, "")}/api/widget/v1/${widgetId}?${params.toString()}`;
+  const url = `${baseUrl.replace(/\/$/, "")}/api/widget/v1/${widgetId}?${qs.join("&")}`;
   const req = new Request(url);
   req.method = "GET";
   req.headers = {
@@ -546,6 +545,8 @@ async function main() {
     saveCache(parameterRaw, payload);
     renderPayload(widget, parsed, payload, { stale: false });
   } catch (err) {
+    console.error("findash-widget error:", err);
+    console.error("stack:", err?.stack);
     if (err instanceof FindashError && err.kind === "auth") {
       renderError(widget, err.message);
     } else if (err instanceof FindashError && err.kind === "unknown-widget") {
@@ -557,7 +558,10 @@ async function main() {
       } else if (err instanceof FindashError && err.kind === "network") {
         renderError(widget, "Sin conexión.");
       } else {
-        renderError(widget, err instanceof FindashError ? err.message : "Error al cargar widget.");
+        const name = err?.name || "Error";
+        const msg = err?.message || String(err);
+        const stackLine = (err?.stack || "").split("\n")[0] || "";
+        renderError(widget, `${name}: ${msg}\n${stackLine}`);
       }
     }
   }

--- a/docs/widgets/scriptable/findash-widget.js
+++ b/docs/widgets/scriptable/findash-widget.js
@@ -1,0 +1,580 @@
+// Variables used by Scriptable.
+// These must be at the very top of the file. Do not edit.
+// icon-color: teal; icon-glyph: chart-pie;
+
+// ============================================================================
+// Findash — Scriptable widget
+// ----------------------------------------------------------------------------
+// One script, five widgets. The specific widget to render is picked via the
+// home-screen widget "Parameter" field. Format:
+//
+//   <widget_id>.<size>[|<extra>]
+//
+// Examples:
+//   tc-focus.S|3a4b5c6d-...-uuid   → tc-focus tile with a physical_cards id
+//   tc-focus.S|42                  → tc-focus tile with an accounts.id
+//   mis-tcs.M                      → roster of top-3 credit cards
+//   mis-tcs.L                      → full credit-card roster
+//   hoy.S                          → today's spending tile
+//   mes-actual.M                   → month-to-date spend + projection
+//   recent-tx.M                    → last 3 transactions
+//   recent-tx.L                    → last 5 transactions
+//
+// Before first use, run `findash-set-token.js` once to stash your widget token
+// and base URL in Keychain. Both are read from the keys:
+//   FINDASH_TOKEN     — widget token minted at /settings/widgets
+//   FINDASH_BASE_URL  — e.g. https://findash.example.com
+//
+// The script caches the last-successful payload per parameter in Keychain, so
+// a transient network failure still renders yesterday's numbers with a "stale"
+// marker instead of going blank.
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Config — adjust if you want a different default preview or refresh cadence.
+// ----------------------------------------------------------------------------
+
+const DEFAULT_PREVIEW_PARAM = "hoy.S";
+const REFRESH_MINUTES = 30;
+const REQUEST_TIMEOUT_SECONDS = 10;
+
+// Findash brand palette (keep in sync with tailwind.config / brand tokens).
+const COLOR = {
+  primary: new Color("#14b8a6"),
+  primaryDim: new Color("#0f766e"),
+  danger: new Color("#ef4444"),
+  warning: new Color("#f59e0b"),
+  success: new Color("#22c55e"),
+  muted: new Color("#6b7280"),
+  mutedDim: new Color("#9ca3af"),
+  text: Color.dynamic(new Color("#111827"), new Color("#f9fafb")),
+  subtext: Color.dynamic(new Color("#4b5563"), new Color("#d1d5db")),
+  bgCard: Color.dynamic(new Color("#ffffff"), new Color("#111827")),
+  barTrack: Color.dynamic(new Color("#e5e7eb"), new Color("#374151")),
+};
+
+// ----------------------------------------------------------------------------
+// Keychain helpers — silent when the key is missing.
+// ----------------------------------------------------------------------------
+
+function keychainGet(key) {
+  return Keychain.contains(key) ? Keychain.get(key) : null;
+}
+
+function keychainSet(key, value) {
+  Keychain.set(key, value);
+}
+
+// ----------------------------------------------------------------------------
+// Parameter parser. Accepts "<id>.<size>[|<extra>]" with tolerant whitespace.
+// Returns { widgetId, size, extra } or throws on malformed input.
+// ----------------------------------------------------------------------------
+
+function parseParameter(raw) {
+  if (!raw || typeof raw !== "string") {
+    throw new Error("empty-parameter");
+  }
+  const trimmed = raw.trim();
+  const pipeIdx = trimmed.indexOf("|");
+  const head = pipeIdx === -1 ? trimmed : trimmed.slice(0, pipeIdx);
+  const extra = pipeIdx === -1 ? null : trimmed.slice(pipeIdx + 1).trim();
+  const dotIdx = head.lastIndexOf(".");
+  if (dotIdx === -1) {
+    throw new Error("bad-parameter");
+  }
+  const widgetId = head.slice(0, dotIdx).trim();
+  const size = head
+    .slice(dotIdx + 1)
+    .trim()
+    .toUpperCase();
+  if (!widgetId || !["S", "M", "L"].includes(size)) {
+    throw new Error("bad-parameter");
+  }
+  return { widgetId, size, extra: extra || null };
+}
+
+// ----------------------------------------------------------------------------
+// HTTP client. Bearer-auth GET, JSON decode, mapped errors.
+// ----------------------------------------------------------------------------
+
+async function fetchWidget({ baseUrl, token, widgetId, size, extra }) {
+  const params = new URLSearchParams();
+  params.set("size", size);
+  if (extra) {
+    // tc-focus uses `target=<id>`. Today it is the only widget that takes an
+    // extra. If new widgets add extras, this mapping table grows.
+    if (widgetId === "tc-focus") {
+      params.set("target", extra);
+    }
+  }
+  const url = `${baseUrl.replace(/\/$/, "")}/api/widget/v1/${widgetId}?${params.toString()}`;
+  const req = new Request(url);
+  req.method = "GET";
+  req.headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json",
+  };
+  req.timeoutInterval = REQUEST_TIMEOUT_SECONDS;
+  let payload;
+  try {
+    payload = await req.loadJSON();
+  } catch (e) {
+    throw new FindashError("network", `No se pudo contactar a Findash: ${e.message}`);
+  }
+  const status = req.response?.statusCode ?? 0;
+  if (status === 401 || status === 403) {
+    throw new FindashError("auth", "Token inválido — revisá en /settings/widgets.");
+  }
+  if (status === 404) {
+    const code = payload?.error?.code;
+    if (code === "widget_not_found") {
+      throw new FindashError("unknown-widget", "Widget desconocido.");
+    }
+    throw new FindashError("not-found", payload?.error?.message || "No encontrado.");
+  }
+  if (status === 422) {
+    throw new FindashError("invalid", payload?.error?.message || "Parámetros inválidos.");
+  }
+  if (status === 429) {
+    throw new FindashError("rate", "Demasiadas peticiones — intentá en unos minutos.");
+  }
+  if (status < 200 || status >= 300) {
+    throw new FindashError("server", `Error ${status} en Findash.`);
+  }
+  return payload;
+}
+
+class FindashError extends Error {
+  constructor(kind, message) {
+    super(message);
+    this.kind = kind;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Cache. Per-parameter key in Keychain. Small payloads (< 5 KB) so no need
+// for iCloud / FileManager — Keychain is sufficient and survives reboots.
+// ----------------------------------------------------------------------------
+
+function cacheKey(parameter) {
+  return `FINDASH_CACHE_${parameter}`;
+}
+
+function saveCache(parameter, payload) {
+  try {
+    keychainSet(
+      cacheKey(parameter),
+      JSON.stringify({ cachedAt: new Date().toISOString(), payload }),
+    );
+  } catch (_e) {
+    // Keychain can reject oversized values; cache is a best-effort nicety.
+  }
+}
+
+function loadCache(parameter) {
+  const raw = keychainGet(cacheKey(parameter));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch (_e) {
+    return null;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Money formatting — COP-pesos are the only currency surfaced in widgets.
+// ----------------------------------------------------------------------------
+
+function formatCop(value, { compact = false, signed = false } = {}) {
+  if (value == null || Number.isNaN(value)) return "—";
+  const sign = signed && value > 0 ? "+" : "";
+  const abs = Math.abs(value);
+  if (compact) {
+    if (abs >= 1_000_000) {
+      const m = abs / 1_000_000;
+      const digits = m >= 10 ? 0 : 1;
+      return `${sign}${value < 0 ? "-" : ""}$${m.toFixed(digits)}M`;
+    }
+    if (abs >= 1_000) {
+      return `${sign}${value < 0 ? "-" : ""}$${Math.round(abs / 1_000)}K`;
+    }
+    return `${sign}${value < 0 ? "-" : ""}$${abs}`;
+  }
+  // Long form: $1.234.567
+  const withThousands = Math.round(abs)
+    .toString()
+    .replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  return `${sign}${value < 0 ? "-" : ""}$${withThousands}`;
+}
+
+function utilizationColor(pct) {
+  if (pct >= 90) return COLOR.danger;
+  if (pct >= 70) return COLOR.warning;
+  return COLOR.success;
+}
+
+// ----------------------------------------------------------------------------
+// Rendering primitives — keep small, composable. All layout uses Stack +
+// Text + basic spacers.
+// ----------------------------------------------------------------------------
+
+function setCommonBackground(widget) {
+  widget.backgroundColor = COLOR.bgCard;
+  widget.setPadding(10, 12, 10, 12);
+}
+
+function addHeaderText(stack, text, { size = 10, color = COLOR.muted, bold = false } = {}) {
+  const t = stack.addText(text);
+  t.font = bold ? Font.semiboldSystemFont(size) : Font.systemFont(size);
+  t.textColor = color;
+  t.lineLimit = 1;
+  return t;
+}
+
+function addAmountText(stack, text, { size = 24, color = COLOR.text } = {}) {
+  const t = stack.addText(text);
+  t.font = Font.boldSystemFont(size);
+  t.textColor = color;
+  t.minimumScaleFactor = 0.6;
+  t.lineLimit = 1;
+  return t;
+}
+
+/**
+ * Draws a utilization bar as a sequence of colored squares into `stack`.
+ * Keeps things ListWidget-safe — we don't need DrawContext / WebView.
+ */
+function addUtilizationBar(stack, pct) {
+  const clamped = Math.max(0, Math.min(100, Math.round(pct)));
+  const track = stack.addStack();
+  track.layoutHorizontally();
+  track.spacing = 2;
+  track.cornerRadius = 3;
+  const totalSegments = 10;
+  const filledSegments = Math.round(clamped / 10);
+  for (let i = 0; i < totalSegments; i += 1) {
+    const seg = track.addStack();
+    seg.size = new Size(10, 6);
+    seg.cornerRadius = 2;
+    seg.backgroundColor = i < filledSegments ? utilizationColor(clamped) : COLOR.barTrack;
+  }
+}
+
+function addStaleFooter(widget) {
+  const footer = widget.addStack();
+  footer.layoutHorizontally();
+  footer.addSpacer();
+  const t = footer.addText("• datos en caché");
+  t.font = Font.systemFont(9);
+  t.textColor = COLOR.warning;
+}
+
+// ----------------------------------------------------------------------------
+// Per-widget renderers. Each takes the `data` shape returned by the handler
+// and populates a ListWidget. They accept an opts object carrying layout
+// hints (size, stale flag).
+// ----------------------------------------------------------------------------
+
+function renderTcFocus(widget, data, { stale }) {
+  setCommonBackground(widget);
+  const name = data.card_name || "Tarjeta";
+  addHeaderText(widget, name, { size: 11, color: COLOR.subtext, bold: true });
+  widget.addSpacer(2);
+  addAmountText(widget, formatCop(data.available_cop, { compact: true }), {
+    size: 28,
+    color: COLOR.text,
+  });
+  const sub = widget.addText("disponible");
+  sub.font = Font.systemFont(10);
+  sub.textColor = COLOR.muted;
+  widget.addSpacer(6);
+  addUtilizationBar(widget, data.utilization_pct);
+  widget.addSpacer(2);
+  const pctRow = widget.addStack();
+  pctRow.layoutHorizontally();
+  const pctText = pctRow.addText(`${data.utilization_pct}% usado`);
+  pctText.font = Font.systemFont(10);
+  pctText.textColor = COLOR.muted;
+  pctRow.addSpacer();
+  if (data.days_to_cutoff != null) {
+    const cutoff = pctRow.addText(`corta en ${data.days_to_cutoff}d`);
+    cutoff.font = Font.systemFont(10);
+    cutoff.textColor = COLOR.muted;
+  }
+  if (stale) addStaleFooter(widget);
+}
+
+function renderMisTcs(widget, data, { size, stale }) {
+  setCommonBackground(widget);
+  const header = widget.addStack();
+  header.layoutHorizontally();
+  header.centerAlignContent();
+  addHeaderText(header, "Mis tarjetas", { size: 12, color: COLOR.subtext, bold: true });
+  header.addSpacer();
+  const total = header.addText(formatCop(data.total_available_cop, { compact: true }));
+  total.font = Font.boldSystemFont(12);
+  total.textColor = COLOR.primary;
+  widget.addSpacer(4);
+
+  const rows = size === "M" ? data.cards.slice(0, 3) : data.cards.slice(0, 8);
+  if (rows.length === 0) {
+    const empty = widget.addText("Sin tarjetas de crédito.");
+    empty.font = Font.systemFont(11);
+    empty.textColor = COLOR.muted;
+  }
+  for (const card of rows) {
+    const row = widget.addStack();
+    row.layoutVertically();
+    row.spacing = 2;
+    const top = row.addStack();
+    top.layoutHorizontally();
+    top.centerAlignContent();
+    const nameT = top.addText(card.name);
+    nameT.font = Font.systemFont(11);
+    nameT.textColor = COLOR.text;
+    nameT.lineLimit = 1;
+    top.addSpacer();
+    const amt = top.addText(formatCop(card.available_cop, { compact: true }));
+    amt.font = Font.semiboldSystemFont(11);
+    amt.textColor = COLOR.text;
+    addUtilizationBar(row, card.utilization_pct);
+    widget.addSpacer(4);
+  }
+  if (stale) addStaleFooter(widget);
+}
+
+function renderHoy(widget, data, { stale }) {
+  setCommonBackground(widget);
+  addHeaderText(widget, data.day_label, { size: 10, color: COLOR.muted });
+  widget.addSpacer(2);
+  addAmountText(widget, formatCop(data.spent_cop, { compact: true }), { size: 28 });
+  const txLine = widget.addText(`${data.tx_count} ${data.tx_count === 1 ? "tx" : "txs"} hoy`);
+  txLine.font = Font.systemFont(11);
+  txLine.textColor = COLOR.muted;
+  widget.addSpacer(6);
+  if (data.vs_daily_avg_pct != null) {
+    const up = data.vs_daily_avg_pct > 0;
+    const flat = data.vs_daily_avg_pct === 0;
+    const arrow = flat ? "→" : up ? "↑" : "↓";
+    const color = flat ? COLOR.muted : up ? COLOR.danger : COLOR.success;
+    const cmpRow = widget.addStack();
+    cmpRow.layoutHorizontally();
+    cmpRow.centerAlignContent();
+    const ar = cmpRow.addText(`${arrow} ${Math.abs(data.vs_daily_avg_pct)}%`);
+    ar.font = Font.semiboldSystemFont(11);
+    ar.textColor = color;
+    cmpRow.addSpacer(4);
+    const vs = cmpRow.addText("vs. promedio");
+    vs.font = Font.systemFont(10);
+    vs.textColor = COLOR.muted;
+  } else {
+    const placeholder = widget.addText("sin comparación");
+    placeholder.font = Font.systemFont(10);
+    placeholder.textColor = COLOR.mutedDim;
+  }
+  if (stale) addStaleFooter(widget);
+}
+
+function renderMesActual(widget, data, { stale }) {
+  setCommonBackground(widget);
+  addHeaderText(widget, data.month_label, { size: 11, color: COLOR.subtext, bold: true });
+  widget.addSpacer(2);
+
+  const cols = widget.addStack();
+  cols.layoutHorizontally();
+  cols.spacing = 8;
+
+  // Left column — spent + projection.
+  const left = cols.addStack();
+  left.layoutVertically();
+  left.spacing = 2;
+  const spent = left.addText(formatCop(data.spent_cop, { compact: true }));
+  spent.font = Font.boldSystemFont(26);
+  spent.textColor = COLOR.text;
+  spent.minimumScaleFactor = 0.6;
+  spent.lineLimit = 1;
+  const proj = left.addText(
+    `de ~${formatCop(data.projection_month_end_cop, { compact: true })} proyectado`,
+  );
+  proj.font = Font.systemFont(10);
+  proj.textColor = COLOR.muted;
+  proj.lineLimit = 1;
+  proj.minimumScaleFactor = 0.7;
+
+  cols.addSpacer();
+
+  // Right column — delta vs last month.
+  const right = cols.addStack();
+  right.layoutVertically();
+  right.spacing = 2;
+  if (data.delta_pct != null && data.delta_direction) {
+    const up = data.delta_direction === "up";
+    const flat = data.delta_direction === "flat";
+    const arrow = flat ? "→" : up ? "↑" : "↓";
+    const color = flat ? COLOR.muted : up ? COLOR.danger : COLOR.success;
+    const deltaT = right.addText(`${arrow} ${Math.abs(data.delta_pct)}%`);
+    deltaT.font = Font.boldSystemFont(16);
+    deltaT.textColor = color;
+    const cmp = right.addText("vs mes pasado");
+    cmp.font = Font.systemFont(9);
+    cmp.textColor = COLOR.muted;
+  } else {
+    const placeholder = right.addText("sin comparación");
+    placeholder.font = Font.systemFont(10);
+    placeholder.textColor = COLOR.mutedDim;
+  }
+  const dayT = right.addText(`día ${data.day_of_month}`);
+  dayT.font = Font.systemFont(9);
+  dayT.textColor = COLOR.mutedDim;
+
+  if (stale) addStaleFooter(widget);
+}
+
+function renderRecentTx(widget, data, { size, stale }) {
+  setCommonBackground(widget);
+  addHeaderText(widget, "Últimas transacciones", {
+    size: 11,
+    color: COLOR.subtext,
+    bold: true,
+  });
+  widget.addSpacer(4);
+  const rows = (data.transactions ?? []).slice(0, size === "M" ? 3 : 5);
+  if (rows.length === 0) {
+    const empty = widget.addText("Sin movimientos recientes.");
+    empty.font = Font.systemFont(11);
+    empty.textColor = COLOR.muted;
+  }
+  for (const tx of rows) {
+    const row = widget.addStack();
+    row.layoutHorizontally();
+    row.centerAlignContent();
+
+    const left = row.addStack();
+    left.layoutVertically();
+    left.spacing = 1;
+    const merchT = left.addText(tx.merchant || "—");
+    merchT.font = Font.semiboldSystemFont(11);
+    merchT.textColor = COLOR.text;
+    merchT.lineLimit = 1;
+    const subParts = [];
+    if (tx.category_name) subParts.push(tx.category_name);
+    if (tx.account_label) subParts.push(tx.account_label);
+    const subT = left.addText(subParts.join(" · "));
+    subT.font = Font.systemFont(9);
+    subT.textColor = COLOR.muted;
+    subT.lineLimit = 1;
+
+    row.addSpacer();
+
+    const amount = tx.amount_cop;
+    const amtColor = amount > 0 ? COLOR.success : amount < 0 ? COLOR.danger : COLOR.muted;
+    const amtT = row.addText(formatCop(amount, { compact: true, signed: true }));
+    amtT.font = Font.semiboldSystemFont(11);
+    amtT.textColor = amtColor;
+    widget.addSpacer(4);
+  }
+  if (stale) addStaleFooter(widget);
+}
+
+// ----------------------------------------------------------------------------
+// Dispatcher.
+// ----------------------------------------------------------------------------
+
+function renderPayload(widget, parsed, payload, { stale = false } = {}) {
+  const data = payload?.data ?? {};
+  const opts = { size: parsed.size, stale };
+  switch (parsed.widgetId) {
+    case "tc-focus":
+      return renderTcFocus(widget, data, opts);
+    case "mis-tcs":
+      return renderMisTcs(widget, data, opts);
+    case "hoy":
+      return renderHoy(widget, data, opts);
+    case "mes-actual":
+      return renderMesActual(widget, data, opts);
+    case "recent-tx":
+      return renderRecentTx(widget, data, opts);
+    default:
+      return renderError(widget, "Widget desconocido.");
+  }
+}
+
+function renderError(widget, message) {
+  setCommonBackground(widget);
+  const title = widget.addText("Findash");
+  title.font = Font.semiboldSystemFont(12);
+  title.textColor = COLOR.subtext;
+  widget.addSpacer(6);
+  const msg = widget.addText(message);
+  msg.font = Font.systemFont(11);
+  msg.textColor = COLOR.danger;
+  msg.lineLimit = 4;
+}
+
+// ----------------------------------------------------------------------------
+// Entry point.
+// ----------------------------------------------------------------------------
+
+async function main() {
+  const widget = new ListWidget();
+  widget.refreshAfterDate = new Date(Date.now() + REFRESH_MINUTES * 60 * 1000);
+
+  const token = keychainGet("FINDASH_TOKEN");
+  const baseUrl = keychainGet("FINDASH_BASE_URL");
+  if (!token || !baseUrl) {
+    renderError(widget, "Faltan credenciales. Corré el script findash-set-token.js una vez.");
+    return widget;
+  }
+
+  const parameterRaw = args.widgetParameter || DEFAULT_PREVIEW_PARAM;
+  let parsed;
+  try {
+    parsed = parseParameter(parameterRaw);
+  } catch (_e) {
+    renderError(widget, `Parámetro inválido: "${parameterRaw}". Formato: <id>.<size>[|<extra>]`);
+    return widget;
+  }
+
+  try {
+    const payload = await fetchWidget({
+      baseUrl,
+      token,
+      widgetId: parsed.widgetId,
+      size: parsed.size,
+      extra: parsed.extra,
+    });
+    saveCache(parameterRaw, payload);
+    renderPayload(widget, parsed, payload, { stale: false });
+  } catch (err) {
+    if (err instanceof FindashError && err.kind === "auth") {
+      renderError(widget, err.message);
+    } else if (err instanceof FindashError && err.kind === "unknown-widget") {
+      renderError(widget, err.message);
+    } else {
+      const cached = loadCache(parameterRaw);
+      if (cached?.payload) {
+        renderPayload(widget, parsed, cached.payload, { stale: true });
+      } else if (err instanceof FindashError && err.kind === "network") {
+        renderError(widget, "Sin conexión.");
+      } else {
+        renderError(widget, err instanceof FindashError ? err.message : "Error al cargar widget.");
+      }
+    }
+  }
+
+  return widget;
+}
+
+// ----------------------------------------------------------------------------
+// Scriptable boilerplate — route to the appropriate presentation mode.
+// ----------------------------------------------------------------------------
+
+const widget = await main();
+if (config.runsInWidget) {
+  Script.setWidget(widget);
+} else {
+  // When opened in the Scriptable app we preview as the medium size to give a
+  // reasonable approximation of what the home-screen widget will look like.
+  await widget.presentMedium();
+}
+Script.complete();

--- a/docs/widgets/setup-android.md
+++ b/docs/widgets/setup-android.md
@@ -1,0 +1,74 @@
+# Findash widgets en Android (Tasker)
+
+Para Android la historia es más trabajosa que iOS — Android no tiene una
+app equivalente a Scriptable que corra JS con acceso a widgets, pero
+[Tasker](https://play.google.com/store/apps/details?id=net.dinglisch.android.taskerm)
+cubre el mismo caso de uso: corre Tasks con `HTTP Request`, guarda vars
+globales, y expone Scenes como widgets del home screen.
+
+La guía completa paso a paso vive en [`tasker/setup.md`](./tasker/setup.md).
+
+## Resumen
+
+1. Instalar Tasker desde Play Store (pago).
+2. Mintear un widget token en `/settings/widgets` de Findash.
+3. Crear vars globales `%FINDASH_TOKEN` + `%FINDASH_BASE_URL` en Tasker.
+4. Crear el Task `Findash Fetch Widget` (HTTP Request con Bearer header).
+5. Crear una Scene por widget/tamaño (tc-focus, mis-tcs M/L, hoy, mes-actual,
+   recent-tx M/L).
+6. Anclar cada Scene al home screen vía el widget "Tasker Scene".
+7. Opcional: perfil Time cada 30 min para refresco en background.
+
+## ¿Por qué no un `.prj.xml` plug-and-play?
+
+Los proyectos Tasker se exportan como XML — en teoría podrías importar uno
+ya armado con todo. En la práctica:
+
+- Los XMLs son sensibles a la versión de Tasker y al DPI/tamaño del device.
+- Un XML hecho a mano casi seguro falla en otro device.
+- Mantenerlo actualizado contra cambios de Tasker es un costo alto para el
+  payoff — Findash es para mí + amigos, no tengo un QA team de Android
+  devices.
+
+Por eso la opción oficial hoy es el paso a paso de
+[`tasker/setup.md`](./tasker/setup.md). Si un usuario arma un proyecto con
+diseño lindo y validado, puede contribuirlo — ver la sección "Contribuir" al
+final de esa guía.
+
+## Screenshots de referencia
+
+[screenshot-placeholder: cada widget renderizado en home screen — tc-focus,
+mis-tcs M, hoy, mes-actual, recent-tx L]
+
+## Troubleshooting específico de Android
+
+Ver la sección correspondiente en [`tasker/setup.md`](./tasker/setup.md). Lo
+más común:
+
+- **Tasker no refresca en background**: batería optimizada. Whitelist a
+  Tasker en `Ajustes → Apps → Tasker → Batería → No restringido`.
+- **La Scene se ve cortada**: el tamaño del widget en Android es variable
+  según launcher. Ajustar el tamaño de la Scene matching al canvas que te
+  reserva el launcher (Nova, Pixel Launcher, etc).
+- **HTTP Request 401**: el header `Authorization` tiene espacios trailing —
+  Tasker es puntilloso. Verificá que sea exactamente `Bearer %FINDASH_TOKEN`
+  sin espacios extra.
+
+## Mantenimiento
+
+- Si rotás el token: edit `%FINDASH_TOKEN` en Vars de Tasker.
+- Si cambia la base URL: edit `%FINDASH_BASE_URL`.
+- Los cambios son inmediatos — el próximo trigger del Task los lee.
+
+## Alternativas
+
+- **KWGT** (Kustom Widget Maker): permite widgets complejos pero no tiene
+  un módulo HTTP nativo — necesitás Tasker de todas formas para el fetch.
+- **HTTP Shortcuts**: apto para probar el endpoint manualmente, pero no
+  expone Scenes al home screen.
+- **App nativa Android**: está en el roadmap (Fase 6, ver `PLAN.md`), pero
+  requiere una cadena de validación larga antes de empezar.
+
+El paso intermedio más productivo hoy es Tasker. Si alguien tiene ganas de
+armar una app Android simple con un `AppWidgetProvider` que haga lo mismo,
+abrir un issue citando `#382` y discutimos.

--- a/docs/widgets/setup-ios.md
+++ b/docs/widgets/setup-ios.md
@@ -1,0 +1,173 @@
+# Findash widgets en iPhone (Scriptable)
+
+Setup paso a paso para tener tiles de Findash en la pantalla de inicio del
+iPhone. Usa [Scriptable](https://scriptable.app) — app gratis, mantiene el
+código en iCloud, corre JavaScript nativo con acceso a `Keychain`, `Request`,
+y primitivas de widget (`ListWidget`, `Stack`, `Text`).
+
+## Requisitos
+
+- iPhone con iOS 16+ (widgets en escritorio).
+- [Scriptable](https://apps.apple.com/app/scriptable/id1405459188) instalado.
+- Acceso a tu instancia de Findash (debe estar en una URL alcanzable desde el
+  iPhone — por Tailscale, Cloudflare Tunnel, o público).
+- Un widget token minteado en `/settings/widgets`.
+
+## Paso 1 — Mintear el widget token
+
+1. Abrí Findash en el browser (podés usar el del iPhone, no importa).
+2. Ir a **Settings → Widgets**.
+3. Click en **Nuevo token**. Poné un label descriptivo (`"iPhone — personal"`,
+   `"iPad Emilia"`, lo que sea).
+4. Copiá el **plaintext** que aparece. **Se muestra una sola vez.** Si lo
+   perdés tenés que mintear uno nuevo y revocar el viejo.
+
+[screenshot-placeholder: pantalla /settings/widgets con el modal de token
+minteado mostrando el plaintext]
+
+## Paso 2 — Instalar los scripts en Scriptable
+
+El repo contiene dos scripts en [`docs/widgets/scriptable/`](./scriptable/):
+
+- [`findash-widget.js`](./scriptable/findash-widget.js) — el widget en sí.
+  Uno solo para todos los tamaños y tipos, dispatch por parámetro.
+- [`findash-set-token.js`](./scriptable/findash-set-token.js) — helper
+  one-shot para guardar token + base URL.
+
+### Abrir los scripts en tu iPhone
+
+La forma más rápida es usar el botón "Raw" de GitHub y compartir a
+Scriptable:
+
+1. En el iPhone, abrí
+   <https://github.com/ingamartinez/personal-financial-dashboard/blob/main/docs/widgets/scriptable/findash-widget.js>.
+2. Tocá **Raw**.
+3. Seleccionás todo el código → **Copy**.
+4. Abrí Scriptable → **+** (nuevo script) → pegás el código. Renombrás el
+   script a `Findash Widget` (tocando el título arriba).
+5. Repetís con [`findash-set-token.js`](./scriptable/findash-set-token.js),
+   llamando al script `Findash Set Token`.
+
+> Alternativa: copiar los archivos a iCloud Drive →
+> `Scriptable/` (Scriptable los levanta directo si el folder está linkeado).
+
+[screenshot-placeholder: Scriptable con los dos scripts — "Findash Widget" y
+"Findash Set Token" — listados]
+
+## Paso 3 — Correr el setup una vez
+
+1. Abrí Scriptable → tocá `Findash Set Token`.
+2. Tocá el botón ▶ (arriba a la derecha).
+3. Te aparece un `Alert` con dos campos:
+   - **Base URL**: pegá `https://findash.tu-dominio.com` (sin slash al final).
+   - **Widget token**: pegá el plaintext del paso 1.
+4. Tocá **Guardar**. Aparece "Listo" y listo — las credenciales están en
+   Keychain.
+
+[screenshot-placeholder: alert de `Findash Set Token` con los dos campos]
+
+## Paso 4 — Agregar un widget al home
+
+1. Mantené presionado el home screen hasta que los íconos vibren.
+2. Tocá **+** arriba a la izquierda → buscá **Scriptable**.
+3. Elegí el tamaño de widget (Small, Medium, Large).
+4. Tocá **Add Widget** → sin soltar, tocá el widget para configurarlo:
+   - **Script**: `Findash Widget`
+   - **When Interacting**: `Run Script`
+   - **Parameter**: el parámetro del widget que querés mostrar (ver tabla
+     abajo).
+
+[screenshot-placeholder: pantalla de configuración del widget mostrando los
+tres campos]
+
+### Tabla de parámetros
+
+| Parámetro | Widget | Tamaño recomendado |
+|-----------|--------|--------------------|
+| `hoy.S` | Hoy — gasto del día | Small |
+| `mes-actual.M` | Mes actual — MTD + proyección | Medium |
+| `mis-tcs.M` | Mis TCs — top 3 | Medium |
+| `mis-tcs.L` | Mis TCs — roster completo | Large |
+| `recent-tx.M` | Últimas 3 transacciones | Medium |
+| `recent-tx.L` | Últimas 5 transacciones | Large |
+| `tc-focus.S|<card_id>` | TC focus — una tarjeta | Small |
+
+Para `tc-focus` necesitás el `<card_id>`:
+
+- **TC single-currency** (una moneda): el ID es el `accounts.id` — un entero.
+  Lo podés ver en el URL de la página de detalle de la tarjeta en Findash, o
+  en la respuesta de `/api/widget/v1/mis-tcs?size=L`.
+- **TC multi-currency** (COP + USD en la misma tarjeta física): el ID es un
+  UUID de `physical_cards.id`. Mismo procedimiento para sacarlo.
+
+## Paso 5 — Repetir para cada widget
+
+No hay límite real — podés tener 1 Scriptable widget de cada tamaño por
+pantalla, y múltiples pantallas. Un setup típico:
+
+- Home principal: `hoy.S` + `mes-actual.M` (abajo).
+- Segunda pantalla: `mis-tcs.M` + `recent-tx.L`.
+- `tc-focus.S|...` junto a Apple Wallet para las tarjetas principales.
+
+[screenshot-placeholder: home screen del iPhone con 4 widgets de Findash
+distribuidos]
+
+## Troubleshooting
+
+### "Sin conexión"
+
+- Verificá que la base URL sea alcanzable desde el iPhone: abrí
+  `https://findash.tu-dominio.com/api/widget/v1/hoy?size=S` en Safari — debe
+  devolver un `{"error":{"code":"unauthorized",...}}` (sin token).
+- Si estás en Tailscale, asegurate de que Tailscale esté activo en el
+  iPhone **y** el iPhone tenga permitido el tráfico a ia-server.
+- Si estás en un modal "Always On VPN" corporativo, el request puede estar
+  bloqueado — probá con datos celulares.
+
+### "Token inválido — revisá en /settings/widgets"
+
+- El token fue revocado o tenés un typo. Volvé a correr `Findash Set Token`
+  con el token actualizado.
+- Si el token es reciente y no lo revocaste, verificá en la DB que
+  `webhook_tokens.revoked_at` sea NULL para ese token (Findash server).
+
+### "Widget desconocido"
+
+- Typo en el Parameter — compará contra la tabla de arriba.
+- Tu instancia Findash podría estar en una versión previa que no registra
+  ese widget — ver [registry index](../../src/lib/widgets/handlers/index.ts).
+
+### Widget muestra "• datos en caché"
+
+- La última fetch falló (red intermitente). Los datos son los de la última
+  fetch exitosa. Se reintenta automáticamente en el próximo refresh (cada 30
+  minutos por defecto, configurable en `REFRESH_MINUTES` del script).
+
+### Widget muestra `—` donde debería haber un número
+
+- El handler devolvió `null` legitimamente. Ejemplo: `hoy.vs_daily_avg_pct`
+  es `null` si es el día 1 del mes (no hay días previos para comparar). NO
+  es un bug.
+
+### El refresh es muy lento
+
+- iOS decide cuándo correr el widget en background — Scriptable pide 30
+  minutos pero el OS puede espaciarlos más si el widget no se mira mucho.
+  Tocar el widget fuerza una actualización.
+
+## Mantenimiento
+
+- Si rotás el token en `/settings/widgets`, re-corré `Findash Set Token`.
+- Si la base URL cambia (nuevo dominio, nueva instancia), lo mismo.
+- Si actualizás el script (`findash-widget.js`), copiar el nuevo contenido
+  en Scriptable. Los widgets en home se recargan solos en el próximo
+  refresh con la nueva lógica.
+
+## Privacidad
+
+- Token + base URL viven en el **Keychain** del iPhone — cifrado a nivel
+  OS, no accesible por otras apps.
+- Cada respuesta cachea ~2 KB en Keychain bajo la key `FINDASH_CACHE_<param>`.
+  El cache sobrevive reboots y se overwritea en cada fetch exitoso.
+- Ninguna telemetría sale a Anthropic / OpenAI / Apple a través del script:
+  el único outbound es a tu propia instancia Findash.

--- a/docs/widgets/tasker/findash-widget.prj.xml
+++ b/docs/widgets/tasker/findash-widget.prj.xml
@@ -1,0 +1,16 @@
+<!--
+  Placeholder — a ready-to-import Tasker project is a wishlist item.
+
+  Why this file is empty:
+  - Tasker project XMLs are tightly coupled to Tasker version and device DPI.
+  - A hand-crafted XML would almost certainly fail to import on a different
+    device, so we ship the step-by-step markdown guide instead (./setup.md).
+  - Once one user has a working project and captures screenshots, they can
+    export it via `Projects → Findash → Export → Data Export` and replace this
+    file with the real XML. See CONTRIBUTE section at the bottom of setup.md.
+
+  Tracking: the umbrella epic is #382; the Tasker contribution slot is left
+  open for community. No issue filed yet — open one before contributing so
+  testing expectations are scoped (which Android version, which Tasker
+  version, which DPI class).
+-->

--- a/docs/widgets/tasker/setup.md
+++ b/docs/widgets/tasker/setup.md
@@ -1,0 +1,188 @@
+# Findash widgets en Android (Tasker)
+
+Guía paso a paso para armar el widget de Findash en Android usando Tasker. No
+viene un `.prj.xml` plug-and-play todavía — las versiones de Tasker difieren
+lo suficiente como para que un XML hecho a mano se rompa en campo. La comunidad
+puede contribuir uno una vez validado este flujo; ver
+[`findash-widget.prj.xml`](./findash-widget.prj.xml) (placeholder).
+
+## Requisitos
+
+- [Tasker](https://play.google.com/store/apps/details?id=net.dinglisch.android.taskerm)
+  6.3+ (pagado) O [Tasker Edition](https://tasker.joaoapps.com) en un
+  dispositivo con licencia.
+- Un widget token minteado desde `/settings/widgets` (guardalo, se muestra una
+  sola vez).
+- La base URL de tu instancia Findash (ejemplo: `https://findash.example.com`).
+
+## Arquitectura del proyecto
+
+Vamos a crear un único proyecto Tasker con tres piezas:
+
+1. **Variables globales** — `%FINDASH_TOKEN` y `%FINDASH_BASE_URL`. Globales
+   para que todos los Tasks las lean sin parametrizar.
+2. **Task `Findash Fetch Widget`** — recibe `%par1` (el widget parameter, tipo
+   `hoy.S` o `tc-focus.S|<id>`) y deja en `%FINDASH_OUTPUT` el JSON.
+3. **Scenes** — una Scene por widget. Cada Scene corre el Task al abrirse,
+   parsea el JSON, y pinta los elementos.
+
+La Scene es lo que Tasker expone como "widget" en la home.
+
+## Paso 1 — Guardar credenciales
+
+1. Abrí Tasker → **Vars** (lápiz arriba a la derecha).
+2. Tocá **+** y creá una variable global. Click en la ruedita al lado del
+   nombre para marcarla como **Global**:
+   - Nombre: `%FINDASH_TOKEN`
+   - Valor: _tu widget token_
+3. Repetí con:
+   - Nombre: `%FINDASH_BASE_URL`
+   - Valor: `https://findash.example.com` (sin slash al final)
+
+> **Seguridad**: Tasker guarda las vars globales en claro en `/sdcard/Tasker/`.
+> Si tu device no está cifrado, marcá ambas variables como `Structure Output`
+> deshabilitado y considerá usar un perfil con contraseña de Tasker.
+
+## Paso 2 — Crear el Task "Findash Fetch Widget"
+
+1. Tab **TASKS** → **+** → Nombre: `Findash Fetch Widget`.
+2. Agregar las siguientes **Actions** en este orden:
+
+| # | Category | Action | Config |
+|---|----------|--------|--------|
+| 1 | Variables | Variable Set | `%widget_param` ← `%par1` |
+| 2 | Variables | Variable Split | Name: `%widget_param` · Splitter: `\|` |
+| 3 | Variables | Variable Set | `%widget_head` ← `%widget_param1` |
+| 4 | Variables | Variable Set | `%widget_extra` ← `%widget_param2` (If set) |
+| 5 | Variables | Variable Split | Name: `%widget_head` · Splitter: `.` |
+| 6 | Variables | Variable Set | `%widget_id` ← `%widget_head1` |
+| 7 | Variables | Variable Set | `%widget_size` ← `%widget_head2` |
+| 8 | Variables | Variable Set | `%widget_url_extra` ← `` (vacío) |
+| 9 | Task | If | `%widget_id ~ tc-focus` AND `%widget_extra Set` |
+| 10 | Variables | Variable Set | `%widget_url_extra` ← `&target=%widget_extra` |
+| 11 | Task | End If | |
+| 12 | Net | HTTP Request | Method: `GET` · URL: `%FINDASH_BASE_URL/api/widget/v1/%widget_id?size=%widget_size%widget_url_extra` · Headers: `Authorization: Bearer %FINDASH_TOKEN` · Structure Output: ON · Timeout: 10s |
+| 13 | Task | If | `%http_response_code ~ 2*` |
+| 14 | Variables | Variable Set | `%FINDASH_OUTPUT` ← `%http_data` |
+| 15 | Task | Else | |
+| 16 | Variables | Variable Set | `%FINDASH_OUTPUT` ← `{"error":{"code":"network","message":"HTTP %http_response_code"}}` |
+| 17 | Task | End If | |
+| 18 | Variables | Variable Set | `%FINDASH_STATUS` ← `%http_response_code` |
+
+3. Guardar el Task. Probalo en vacío: tocá el botón ▶ con `Argument: hoy.S` y
+   verificá que `%FINDASH_OUTPUT` contenga JSON válido (pestaña **Vars**).
+
+## Paso 3 — Crear las Scenes
+
+Una Scene por widget. Vamos a detallar la Scene **"Findash Hoy S"** y dejar
+las otras como referencia — la mecánica es idéntica.
+
+### Scene "Findash Hoy S" (2×2)
+
+1. Tab **SCENES** → **+** → Nombre: `Findash Hoy S`. Tamaño: 2×2 (arrastrá los
+   manejadores hasta ~320x320 px).
+2. Agregar elementos:
+   - **Text** `label_day` (arriba): dummy content, color `#6b7280`, tamaño 10.
+   - **Text** `amount` (centro, grande): dummy `$0`, tamaño 28, bold.
+   - **Text** `tx_count` (debajo): dummy `0 txs`, tamaño 12, color `#6b7280`.
+   - **Text** `delta` (abajo): dummy `vs promedio`, tamaño 10.
+3. En **Properties** de la Scene → pestaña **Scene** → **Scene Created** →
+   agregar Task:
+   - Task: `Findash Fetch Widget`
+   - Parameter (%par1): `hoy.S`
+4. **Scene Created**, agregar Actions después del Task:
+
+```
+A1 JavaScriptlet:
+   const p = JSON.parse(local('FINDASH_OUTPUT') || '{}');
+   const d = p.data || {};
+   setLocal('label_day', d.day_label || '—');
+   setLocal('amount', '$' + ((d.spent_cop||0).toLocaleString('es-CO')));
+   setLocal('tx_count', (d.tx_count||0) + ' txs');
+   const v = d.vs_daily_avg_pct;
+   setLocal('delta', v==null ? 'sin comparación'
+     : (v>0?'↑':v<0?'↓':'→') + ' ' + Math.abs(v) + '% vs promedio');
+
+A2 Element Text Set Text:  Element label_day  — To: %label_day
+A3 Element Text Set Text:  Element amount     — To: %amount
+A4 Element Text Set Text:  Element tx_count   — To: %tx_count
+A5 Element Text Set Text:  Element delta      — To: %delta
+```
+
+5. Tocá el pin (arriba a la derecha) para colocarla en el home. Tasker la
+   expone como "Scene Widget". Mantené presionado sobre el home → Widgets →
+   Tasker → Scene → `Findash Hoy S`.
+
+### Scenes restantes
+
+Repetí el patrón arriba con los siguientes parámetros y campos:
+
+| Scene | Tamaño | %par1 | Campos (data shape) |
+|-------|--------|-------|---------------------|
+| `Findash TC Focus` | 2×2 | `tc-focus.S\|<card_id>` | `card_name`, `available_cop`, `utilization_pct`, `days_to_cutoff` |
+| `Findash Mis TCs M` | 4×2 | `mis-tcs.M` | `total_available_cop` + loop sobre `cards[0..2]` |
+| `Findash Mis TCs L` | 4×4 | `mis-tcs.L` | `total_available_cop` + loop sobre `cards` |
+| `Findash Hoy S` | 2×2 | `hoy.S` | arriba |
+| `Findash Mes Actual M` | 4×2 | `mes-actual.M` | `month_label`, `spent_cop`, `projection_month_end_cop`, `delta_pct`, `delta_direction` |
+| `Findash Recent TX M` | 3×2 | `recent-tx.M` | loop sobre `transactions[0..2]` — `merchant`, `amount_cop`, `category_name`, `account_label` |
+| `Findash Recent TX L` | 3×3 | `recent-tx.L` | idem con `transactions[0..4]` |
+
+Para los widgets que listan ítems (`mis-tcs`, `recent-tx`) agregá un
+contenedor **Rect** o **Image** por fila y poné el JavaScriptlet para que
+rellene cada fila desde el array.
+
+## Paso 4 — Refresco automático
+
+Los widgets Scene de Tasker se refrescan cuando se abre el Scene. Para
+actualizar cada 30 minutos:
+
+1. Tab **PROFILES** → **+** → **Time** → cada 30 minutos, todo el día.
+2. Linkear a un Task nuevo `Findash Refresh All`.
+3. Ese Task llama `Perform Task` → `Findash Fetch Widget` con cada parámetro
+   que tengas en home, luego `Element Text Set Text` para cada elemento
+   (como en el paso 3-A2/A5) apuntando al Scene correspondiente.
+
+> **Gotcha**: Tasker 6.x limita los triggers de tiempo cuando la batería está
+> optimizada. Ponelo en la lista blanca de batería (`Ajustes → Apps → Tasker
+> → Batería → No restringido`), si no vas a ver refrescos salteados.
+
+## Paso 5 — Manejo de errores
+
+Agregá al final del Task **Findash Fetch Widget**:
+
+```
+If %FINDASH_STATUS !~ 2*
+  JavaScriptlet:
+    const p = JSON.parse(local('FINDASH_OUTPUT') || '{}');
+    const code = p.error?.code;
+    let msg = 'Sin conexión';
+    if (code === 'unauthorized' || code === 'forbidden')
+      msg = 'Token inválido — /settings/widgets';
+    else if (code === 'widget_not_found')
+      msg = 'Widget desconocido';
+    else if (code === 'rate_limited')
+      msg = 'Demasiadas peticiones';
+    setLocal('FINDASH_ERROR', msg);
+End If
+```
+
+Después en cada Scene, si `%FINDASH_ERROR` está seteado, mostrá ese mensaje en
+el elemento principal en lugar de los datos.
+
+## Troubleshooting
+
+| Síntoma | Causa probable | Fix |
+|---------|----------------|-----|
+| Widget siempre muestra `$0` | JavaScriptlet no corrió | Chequear que el orden en Scene Created sea: HTTP Request → JavaScriptlet → Set Text |
+| `401` en los logs | Token expirado o copiado mal | Re-generar en `/settings/widgets`, actualizar `%FINDASH_TOKEN` |
+| `404` en widget desconocido | Typo en `%par1` | Ver cheatsheet en `/settings/widgets` |
+| No refresca | Batería optimizada | Ponele no-restringido a Tasker |
+| USD no se muestra | Esperado | Widgets convierten USD→COP al fetch |
+
+## Contribuir
+
+Si armás la Scene con un diseño lindo y querés contribuirla al proyecto:
+
+1. Exportá el proyecto completo (`Projects → Findash → Export → Data Export`).
+2. Abrí un PR reemplazando [`findash-widget.prj.xml`](./findash-widget.prj.xml).
+3. Adjuntá capturas de pantalla de cada widget en funcionamiento.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,11 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Scriptable widget scripts — they run in Scriptable's own JS runtime on
+    // iOS with its own globals (Keychain, Request, Color, ListWidget, …) and
+    // are shipped as documentation artifacts, not Next.js source. Linting
+    // them against next-ts rules produces false positives.
+    "docs/widgets/scriptable/**",
   ]),
 ]);
 

--- a/src/app/(app)/settings/widgets/page.tsx
+++ b/src/app/(app)/settings/widgets/page.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "lucide-react";
 import { getSessionUser } from "@/lib/auth/session";
 import { listWidgetTokensForUser } from "@/lib/webhook-tokens";
 import { WidgetCheatsheet } from "./widget-cheatsheet";
@@ -5,21 +6,35 @@ import { WidgetTokensManager } from "./widget-tokens-manager";
 
 export const dynamic = "force-dynamic";
 
+const SETUP_GUIDE_URL =
+  "https://github.com/ingamartinez/personal-financial-dashboard/blob/main/docs/widgets/README.md";
+
 export default async function WidgetsPage() {
   const session = await getSessionUser();
   const tokens = await listWidgetTokensForUser(session.id);
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
-      <header>
-        <h1 className="text-h1">Widgets</h1>
-        <p className="text-body text-muted-foreground">
-          Tokens per-usuario para alimentar los widgets de pantalla de inicio (Scriptable en iOS,
-          Tasker en Android). Cada token habilita el endpoint{" "}
-          <code className="font-mono">/api/widget/v1/&lt;id&gt;</code>. El plaintext se muestra{" "}
-          <strong>una sola vez</strong> al generarlo — guardalo antes de salir.
-        </p>
-        {/* TODO(#390): link a /docs/widgets cuando la guía de setup esté publicada. */}
+      <header className="flex flex-col gap-3">
+        <div>
+          <h1 className="text-h1">Widgets</h1>
+          <p className="text-body text-muted-foreground">
+            Tokens per-usuario para alimentar los widgets de pantalla de inicio (Scriptable en iOS,
+            Tasker en Android). Cada token habilita el endpoint{" "}
+            <code className="font-mono">/api/widget/v1/&lt;id&gt;</code>. El plaintext se muestra{" "}
+            <strong>una sola vez</strong> al generarlo — guardalo antes de salir.
+          </p>
+        </div>
+        <a
+          href={SETUP_GUIDE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:text-primary/80 inline-flex w-fit items-center gap-1.5 text-sm font-medium underline underline-offset-4"
+        >
+          <span aria-hidden>📱</span>
+          Guía de configuración (iOS + Android)
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
       </header>
       <WidgetTokensManager
         tokens={tokens.map((t) => ({

--- a/src/app/(app)/settings/widgets/widget-cheatsheet.tsx
+++ b/src/app/(app)/settings/widgets/widget-cheatsheet.tsx
@@ -15,8 +15,7 @@ type CheatsheetRow = {
   example: string;
 };
 
-// TODO(#390): once the setup guide lands at /docs/widgets, link to it from
-// the header description here and from the main page.
+// Setup guide lives at /docs/widgets/README.md (linked from the page header).
 const ROWS: readonly CheatsheetRow[] = [
   { widget: "TC Focus", id: "tc-focus", sizes: "S", example: "tc-focus.S|<card_id>" },
   { widget: "Mis TCs", id: "mis-tcs", sizes: "M, L", example: "mis-tcs.M" },


### PR DESCRIPTION
Closes #390

> ⚠️ **Not ready to merge — requires on-device validation (iPhone + Android).**
> The user must test the Scriptable script on iPhone and walk through the Tasker
> setup guide on Android before this can flip to "ready for review". Screenshot
> placeholders in the setup guides also need to be replaced with real captures
> after testing.

## Summary

Phase 4 widget program — the LAST issue of the epic #382 series. Ships the
client scripts + setup documentation for the five widget endpoints that
landed in #385-#389.

- **iOS (Scriptable)** — single-script dispatcher for all five widgets
  (\`docs/widgets/scriptable/findash-widget.js\`). Route via widget
  \`Parameter\` string (\`<id>.<size>[|<extra>]\`). Bearer auth from Keychain
  (\`FINDASH_TOKEN\`, \`FINDASH_BASE_URL\`). Dark-mode aware via
  \`Color.dynamic\`. Per-parameter cache in Keychain so transient failures
  render stale-but-useful tiles. 30-minute timeline refresh. Plus a one-shot
  \`findash-set-token.js\` helper to prompt + persist credentials.
- **Android (Tasker)** — step-by-step markdown guide at
  \`docs/widgets/tasker/setup.md\`. No pre-built \`.prj.xml\` — versions of
  Tasker differ enough that a hand-crafted XML would be more harmful than
  helpful. Covers vars, Task \`Findash Fetch Widget\`, Scenes per widget,
  time-based refresh profile, error handling, and troubleshooting.
- **Docs**
  - \`docs/widgets/README.md\` — overview + parameter format + rotation + common errors
  - \`docs/widgets/setup-ios.md\` — iPhone step-by-step
  - \`docs/widgets/setup-android.md\` — Android step-by-step (links to \`tasker/setup.md\`)
  - \`docs/widgets/api-reference.md\` — per-widget JSON shape generated by hand from the handler TS types
- **Settings link** — \`/settings/widgets\` now shows a "📱 Guía de configuración"
  link pointing at the GitHub blob. Removed the two \`TODO(#390)\` markers.
- **Lint** — ignored \`docs/widgets/scriptable/**\` in \`eslint.config.mjs\`
  since those scripts run in Scriptable's runtime (own globals:
  \`Keychain\`, \`Request\`, \`Color\`, \`ListWidget\`, \`Font\`, \`args\`,
  \`config\`, \`Script\`) and are not Next.js source.

## Spec deviations

None of substance. Calls to note:

- Parameter parser uses \`lastIndexOf('.')\` for the size separator so a
  widget id that ever contains a dot still dispatches correctly today. No
  current widget id has one, but the split is future-proof.
- Scriptable cache uses Keychain (small payloads, survives reboots) instead
  of \`FileManager.local().iCloudDocumentsDirectory\`. The spec said "or
  simpler: Keychain" — taking the simpler path.
- Tasker ships as markdown guide only, not as a \`.prj.xml\`. Spec explicitly
  permitted this. The XML file exists as a commented placeholder pointing
  at a future community contribution.

## Manual validation the user must run before merge

### iOS (Scriptable)

- [ ] Install Scriptable on an iPhone.
- [ ] Mint a widget token at \`/settings/widgets\` (verify the new guide
      link opens correctly).
- [ ] Paste \`findash-set-token.js\` into Scriptable and run it once.
      Confirm both credentials save to Keychain without errors.
- [ ] Paste \`findash-widget.js\` into Scriptable. Hit ▶ from inside the
      app to preview with default parameter (\`hoy.S\`).
- [ ] Add each widget to the home screen and confirm each one renders
      correctly:
  - [ ] \`hoy.S\` (Small)
  - [ ] \`mes-actual.M\` (Medium)
  - [ ] \`mis-tcs.M\` (Medium)
  - [ ] \`mis-tcs.L\` (Large)
  - [ ] \`recent-tx.M\` (Medium)
  - [ ] \`recent-tx.L\` (Large)
  - [ ] \`tc-focus.S|<card_id>\` — try both a single-currency account id and a multi-currency UUID
- [ ] Verify dark mode looks right (toggle iOS appearance).
- [ ] Simulate network failure (Airplane mode) and confirm the "datos en
      caché" footer shows with the last payload.
- [ ] Revoke the token in \`/settings/widgets\` and confirm the widget shows
      "Token inválido — revisá en /settings/widgets".
- [ ] Test a bogus parameter (\`hoy.X\`) and confirm the widget shows
      "Parámetro inválido".
- [ ] Replace the four \`[screenshot-placeholder: ...]\` markers in
      \`docs/widgets/setup-ios.md\` with real screenshots.

### Android (Tasker)

- [ ] Follow \`docs/widgets/tasker/setup.md\` end-to-end on a real device.
- [ ] Verify each widget renders correctly (same list as iOS).
- [ ] Confirm the time-based refresh profile actually triggers every 30 min
      with battery whitelisting.
- [ ] Replace the single \`[screenshot-placeholder: ...]\` marker in
      \`docs/widgets/setup-android.md\` with real screenshots.

### Settings page wire-up

- [ ] Visit \`/settings/widgets\` and confirm the new "📱 Guía de
      configuración (iOS + Android)" link is visible under the description.
- [ ] Click it and verify it opens the README on GitHub in a new tab.

## Test plan (automated)

- [x] \`bun run lint\` — green
- [x] \`bun run format:check\` — green
- [x] \`bun run test src/app/\(app\)/settings/widgets\` — 7/7 green
- [x] Pre-push hook ran full suite — 787/787 green
- [ ] CI on this PR — to be confirmed once checks run

## Gotchas future devs should know

- The Scriptable runtime treats top-level \`await\` as supported even though
  regular JS files don't — that is why the script ends with
  \`const widget = await main()\` without wrapping in an IIFE.
- \`Keychain.set\` on iOS has a size cap (~a few KB). The per-parameter
  cache writes compact JSON; if we ever expand payload sizes, move cache to
  \`FileManager\`.
- Tasker HTTP Request trims the response body into \`%http_data\` only when
  "Structure Output" is ON. It defaults to OFF on older Tasker versions —
  the guide calls it out.
- The tile screenshots need a **physical device** — running \`bun run
  test:e2e\` won't help because widgets don't run in Chromium.