### PR TITLE
fix(infra): exclude /api/widget from session proxy (#399)

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -22,12 +22,17 @@ describe("proxy matcher", () => {
     }
   });
 
-  it("exempts bearer-token API routes (regression for #200)", () => {
+  it("exempts bearer-token API routes (regression for #200, #399)", () => {
     for (const path of [
       "/api/ingest/sms",
       "/api/ingest/debug",
       "/api/ingest/ocr",
       "/api/fx/refresh",
+      "/api/widget/v1/tc-focus",
+      "/api/widget/v1/mis-tcs",
+      "/api/widget/v1/hoy",
+      "/api/widget/v1/mes-actual",
+      "/api/widget/v1/recent-tx",
     ]) {
       expect(matches(path), `${path} must bypass the session proxy`).toBe(false);
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,6 +35,6 @@ export default auth((req) => {
 // /login before their own handler (or Next.js's static handler) ever runs.
 export const config = {
   matcher: [
-    "/((?!api/auth|api/telegram/webhook|api/ingest|api/fx/refresh|api/health|api/dev/login|login|signup|_next/static|_next/image|favicon.ico|.*\\.(?:png|svg|ico|webmanifest)$).*)",
+    "/((?!api/auth|api/telegram/webhook|api/ingest|api/fx/refresh|api/health|api/widget|api/dev/login|login|signup|_next/static|_next/image|favicon.ico|.*\\.(?:png|svg|ico|webmanifest)$).*)",
   ],
 };


### PR DESCRIPTION
## Summary

Widget endpoints (`/api/widget/v1/*`) were being 307'd to `/login` by the Auth.js v5 session proxy because the matcher in `src/proxy.ts` did not include them in the bypass list.

They authenticate via Bearer token (`webhook_tokens` with `purpose='widget'`), not session cookies — same pattern as `/api/ingest/*` and `/api/telegram/webhook`.

## Root cause

#383 added the widget router but didn't update the proxy matcher. The local unit tests passed because they didn't exercise middleware against live HTTP. Discovered while validating #398 on iPhone: Scriptable followed the 307 to `/login`, failed to parse the HTML as JSON, and fell through to the generic "Error al cargar widget." catch.

## Changes

- `src/proxy.ts` — added `api/widget` to the matcher exclusion list
- `src/proxy.test.ts` — added widget routes to the bearer-token API regression test

## Verification

```
$ bun run test src/proxy.test.ts
✓ 4 passed
```

After deploy, `curl https://findash.alejoframes.com/api/widget/v1/hoy?size=S` should return **401** (or 422), not **307**.

## Test plan

- [x] `bun run test src/proxy.test.ts` — green
- [ ] Post-deploy: curl returns 401/422 (not 307) for widget routes
- [ ] Scriptable widget renders data after deploy

Closes #399.