### PR TITLE
fix(infra): exclude /widgets/* from session proxy (#403)

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -57,4 +57,13 @@ describe("proxy matcher", () => {
       expect(matches(path), `${path} should be exempt`).toBe(false);
     }
   });
+
+  it("exempts /widgets/* public scripts (regression for #403)", () => {
+    for (const path of [
+      "/widgets/scriptable/findash-widget.js",
+      "/widgets/scriptable/findash-set-token.js",
+    ]) {
+      expect(matches(path), `${path} must be publicly servable`).toBe(false);
+    }
+  });
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,6 +35,6 @@ export default auth((req) => {
 // /login before their own handler (or Next.js's static handler) ever runs.
 export const config = {
   matcher: [
-    "/((?!api/auth|api/telegram/webhook|api/ingest|api/fx/refresh|api/health|api/widget|api/dev/login|login|signup|_next/static|_next/image|favicon.ico|.*\\.(?:png|svg|ico|webmanifest)$).*)",
+    "/((?!api/auth|api/telegram/webhook|api/ingest|api/fx/refresh|api/health|api/widget|api/dev/login|login|signup|_next/static|_next/image|favicon.ico|widgets|.*\\.(?:png|svg|ico|webmanifest)$).*)",
   ],
 };


### PR DESCRIPTION
## Summary

Static Scriptable scripts at `public/widgets/scriptable/*.js` (shipped in #402) were being 307'd to `/login` by the Auth.js v5 middleware. Same pattern as the `/api/widget` fix in #399/#400.

These scripts are public by design — intended for users to install on personal devices, contain no secrets.

## Changes

- `src/proxy.ts` — added `widgets` to the matcher exclusion
- `src/proxy.test.ts` — regression coverage

## Verification post-deploy

```bash
curl -sI https://findash.alejoframes.com/widgets/scriptable/findash-widget.js
# expect: HTTP/2 200, content-type: application/javascript (or text/javascript)
```

## Test plan

- [x] `bun run test src/proxy.test.ts` — 5 passed
- [ ] Post-deploy: curl returns 200 with JS content
- [ ] In-app wizard copy button works

Closes #403.