### PR TITLE
fix(accounting): pago-tc as transfer group (1-to-N) + Intereses TC (#405)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,8 @@ jobs:
           mkdir -p "$STAGE/scripts" "$STAGE/src/lib/db" "$STAGE/src/lib/auth"
           cp scripts/migrate-prod.ts "$STAGE/scripts/migrate-prod.ts"
           cp scripts/backfill-users-reference.ts "$STAGE/scripts/backfill-users-reference.ts"
+          # #405: migrate-prod also calls the pago-tc → transfer-group backfill.
+          cp scripts/migrate-pago-tc-to-transfer.ts "$STAGE/scripts/migrate-pago-tc-to-transfer.ts"
           # migrate-prod imports these for reference-data seeding + per-user
           # backfill; they live under src/ and are NOT traced by Next
           # standalone, so overlay them explicitly.

--- a/drizzle/0049_marvelous_dreaming_celestial.sql
+++ b/drizzle/0049_marvelous_dreaming_celestial.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "transactions" ADD COLUMN "transfer_group_id" uuid;--> statement-breakpoint
+CREATE INDEX "transactions_transfer_group_idx" ON "transactions" USING btree ("transfer_group_id") WHERE "transactions"."transfer_group_id" IS NOT NULL;

--- a/drizzle/meta/0049_snapshot.json
+++ b/drizzle/meta/0049_snapshot.json
@@ -1,0 +1,4277 @@
+{
+  "id": "22df8463-807b-4d54-aad6-7b46ad41aef1",
+  "prevId": "77fe6456-01d5-48f8-8533-fb9d2c2b5c66",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_physical_card_id_physical_cards_id_fk": {
+          "name": "accounts_physical_card_id_physical_cards_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "physical_cards",
+          "columnsFrom": [
+            "physical_card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_corrections": {
+      "name": "classification_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_category_slug": {
+          "name": "new_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_corrections_learning_idx": {
+          "name": "classification_corrections_learning_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "new_category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_corrections_user_id_users_id_fk": {
+          "name": "classification_corrections_user_id_users_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_corrections_transaction_id_transactions_id_fk": {
+          "name": "classification_corrections_transaction_id_transactions_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_from_corrections": {
+          "name": "generated_from_corrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.physical_cards": {
+      "name": "physical_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_limit_cents": {
+          "name": "credit_limit_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "statement_cutoff_day": {
+          "name": "statement_cutoff_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "physical_cards_user_idx": {
+          "name": "physical_cards_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "physical_cards_user_institution_idx": {
+          "name": "physical_cards_user_institution_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "physical_cards_user_id_users_id_fk": {
+          "name": "physical_cards_user_id_users_id_fk",
+          "tableFrom": "physical_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_proposals": {
+      "name": "rule_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_txn_ids": {
+          "name": "correction_txn_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rule_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rule_proposals_user_merchant_category_pending_unique": {
+          "name": "rule_proposals_user_merchant_category_pending_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rule_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rule_proposals_user_status_idx": {
+          "name": "rule_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_proposals_user_id_users_id_fk": {
+          "name": "rule_proposals_user_id_users_id_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_proposals_user_category_fk": {
+          "name": "rule_proposals_user_category_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slo_alerts": {
+      "name": "slo_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slo_key": {
+          "name": "slo_key",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slo_alerts_open_idx": {
+          "name": "slo_alerts_open_idx",
+          "columns": [
+            {
+              "expression": "slo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"slo_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retroactive_rule_id": {
+          "name": "retroactive_rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group_id": {
+          "name": "transfer_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_group_idx": {
+          "name": "transactions_transfer_group_idx",
+          "columns": [
+            {
+              "expression": "transfer_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"transfer_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_occurred_live_idx": {
+          "name": "transactions_account_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_live_idx": {
+          "name": "transactions_user_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_retroactive_rule_id_classification_rules_id_fk": {
+          "name": "transactions_retroactive_rule_id_classification_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "classification_rules",
+          "columnsFrom": [
+            "retroactive_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ui_preferences": {
+          "name": "ui_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "classification_context": {
+          "name": "classification_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "rule_retroactive",
+        "ai",
+        "manual",
+        "manual_confirmed",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.rule_proposal_status": {
+      "name": "rule_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug",
+        "widget"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1776751094995,
       "tag": "0048_black_albert_cleary",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1776809825899,
+      "tag": "0049_marvelous_dreaming_celestial",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:migrate:test": "PGDATABASE=findash_test drizzle-kit migrate",
     "db:seed:test": "PGDATABASE=findash_test bun run src/lib/db/seed.ts",
     "db:backfill:users": "bun run scripts/backfill-users-reference.ts",
+    "db:migrate:pago-tc": "bun run scripts/migrate-pago-tc-to-transfer.ts",
     "db:bootstrap:invites": "bun run scripts/bootstrap-invites.ts",
     "db:bootstrap:webhook-tokens": "bun run scripts/bootstrap-webhook-tokens.ts",
     "test": "vitest run",

--- a/scripts/migrate-pago-tc-to-transfer.test.ts
+++ b/scripts/migrate-pago-tc-to-transfer.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "../src/lib/db";
+import { migratePagoTcToTransfer } from "./migrate-pago-tc-to-transfer";
+
+// #405: integration tests for the historical backfill script. Verifies that
+// it converts legacy `pago-tc` rows into transfer groups and that it is
+// idempotent (re-runs do not double-migrate or touch already-migrated rows).
+
+const TEST_USER_ID = 1;
+const EXT_PREFIX = "test-migrate-pagotc:";
+
+async function cleanup() {
+  await db.execute(sql`
+    DELETE FROM transactions
+    WHERE external_id LIKE ${EXT_PREFIX + "%"}
+       OR raw_data ->> 'source' = 'migrate-pago-tc-to-transfer'
+  `);
+}
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+async function savingsId(): Promise<number> {
+  const [row] = await db.execute<{ id: number }>(sql`
+    SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} AND name = 'Bancolombia Ahorros' LIMIT 1
+  `);
+  return row.id;
+}
+async function visaId(): Promise<number> {
+  const [row] = await db.execute<{ id: number }>(sql`
+    SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} AND name = 'Bancolombia Visa *2575' LIMIT 1
+  `);
+  return row.id;
+}
+
+async function seedLegacyPagoTc(opts: {
+  externalId: string;
+  accountId: number;
+  amountCents: bigint;
+  description: string;
+}): Promise<number> {
+  const [row] = await db.execute<{ id: number }>(sql`
+    INSERT INTO transactions (
+      user_id, account_id, occurred_at, amount_cents, currency,
+      description_raw, category_slug, classification_method, source, external_id
+    ) VALUES (
+      ${TEST_USER_ID}, ${opts.accountId}, now(), ${opts.amountCents.toString()}::bigint,
+      'COP', ${opts.description}, 'pago-tc', 'manual'::classification_method,
+      'sms'::tx_source, ${opts.externalId}
+    )
+    RETURNING id
+  `);
+  return row.id;
+}
+
+describe("migratePagoTcToTransfer (#405)", () => {
+  it("converts a legacy payment (amount < 0 + parseable description) into a paired group", async () => {
+    const savings = await savingsId();
+    const visa = await visaId();
+    const legacyId = await seedLegacyPagoTc({
+      externalId: `${EXT_PREFIX}paired`,
+      accountId: savings,
+      amountCents: BigInt(-250000),
+      description: "Pago TC *2575",
+    });
+
+    const report = await migratePagoTcToTransfer();
+    expect(report.migratedPaired).toBeGreaterThanOrEqual(1);
+
+    const [origin] = await db.execute<{
+      category_slug: string | null;
+      channel: string;
+      transfer_group_id: string | null;
+    }>(sql`
+      SELECT category_slug, channel, transfer_group_id
+      FROM transactions WHERE id = ${legacyId}
+    `);
+    expect(origin.category_slug).toBeNull();
+    expect(origin.channel).toBe("transfer");
+    expect(origin.transfer_group_id).not.toBeNull();
+
+    const companions = await db.execute<{
+      account_id: number;
+      amount_cents: string;
+    }>(sql`
+      SELECT account_id, amount_cents::text
+      FROM transactions
+      WHERE transfer_group_id = ${origin.transfer_group_id}::uuid
+        AND id <> ${legacyId}
+    `);
+    expect(companions.length).toBe(1);
+    expect(companions[0].account_id).toBe(visa);
+    expect(BigInt(companions[0].amount_cents)).toBe(BigInt(250000));
+  });
+
+  it("strips the category and sets channel=transfer for unpaired abonos (amount > 0)", async () => {
+    const visa = await visaId();
+    const abonoId = await seedLegacyPagoTc({
+      externalId: `${EXT_PREFIX}abono`,
+      accountId: visa,
+      amountCents: BigInt(150000),
+      description: "Abono de FULANO a TC *2575",
+    });
+
+    const report = await migratePagoTcToTransfer();
+    expect(report.migratedUnpaired).toBeGreaterThanOrEqual(1);
+
+    const [row] = await db.execute<{
+      category_slug: string | null;
+      channel: string;
+      transfer_group_id: string | null;
+    }>(
+      sql`SELECT category_slug, channel, transfer_group_id FROM transactions WHERE id = ${abonoId}`,
+    );
+    expect(row.category_slug).toBeNull();
+    expect(row.channel).toBe("transfer");
+    expect(row.transfer_group_id).toBeNull();
+  });
+
+  it("leaves rows untouched when the TC destination cannot be inferred from the description", async () => {
+    const savings = await savingsId();
+    const weirdId = await seedLegacyPagoTc({
+      externalId: `${EXT_PREFIX}weird`,
+      accountId: savings,
+      amountCents: BigInt(-10000),
+      description: "Pago manual TC genérica",
+    });
+
+    const report = await migratePagoTcToTransfer();
+    expect(report.skippedNoDestination).toBeGreaterThanOrEqual(1);
+
+    const [row] = await db.execute<{
+      category_slug: string | null;
+      transfer_group_id: string | null;
+    }>(sql`SELECT category_slug, transfer_group_id FROM transactions WHERE id = ${weirdId}`);
+    expect(row.category_slug).toBe("pago-tc");
+    expect(row.transfer_group_id).toBeNull();
+  });
+
+  it("is idempotent — second run processes zero rows for already-migrated payments", async () => {
+    const savings = await savingsId();
+    await seedLegacyPagoTc({
+      externalId: `${EXT_PREFIX}idem`,
+      accountId: savings,
+      amountCents: BigInt(-30000),
+      description: "Pago TC *2575",
+    });
+
+    const first = await migratePagoTcToTransfer();
+    expect(first.migratedPaired).toBeGreaterThanOrEqual(1);
+
+    const second = await migratePagoTcToTransfer();
+    // Rows migrated in the first pass have transfer_group_id set, so the
+    // WHERE clause skips them — the second pass sees nothing new from ours.
+    expect(second.processed).toBeLessThan(first.processed);
+  });
+});

--- a/scripts/migrate-pago-tc-to-transfer.ts
+++ b/scripts/migrate-pago-tc-to-transfer.ts
@@ -1,0 +1,264 @@
+// #405: one-shot backfill that converts historical pago-tc transactions into
+// transfer groups. Motivation: before #405, `tc_payment` SMS were inserted in
+// savings as `category_slug="pago-tc"` (child of `deudas`, i.e. spend), which
+// double-counted against the original TC purchases. This script rewrites them
+// as proper transfer groups (savings debit + TC credit) so the taxonomy is
+// consistent with the new ingest path.
+//
+// For each historical `pago-tc` tx:
+//   - amount < 0 → it's a statement PAYMENT. Parse the description for the TC
+//     last4 (`Pago TC *XXXX`), resolve the destination account for this user,
+//     and create the paired credit leg on the TC (amount = |x|). Both legs get
+//     the same transfer_group_id, channel="transfer", category_slug=null.
+//   - amount > 0 → it's an abono RECEIVED on a TC. No paired leg — origin is
+//     external. Just strip the category and flip channel to "transfer" so it
+//     stops being counted as spend.
+//   - amount = 0 → skipped with a warning.
+//
+// Idempotent: only processes rows where `category_slug = 'pago-tc'` AND
+// `transfer_group_id IS NULL`. Safe to re-run.
+//
+// Relative imports on purpose — this file is overlaid to $STAGE/scripts/ on
+// prod deploys (see deploy-overlay-must-track-script-imports memory).
+
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { db } from "../src/lib/db";
+import { createLogger } from "../src/lib/logger";
+
+const log = createLogger({ module: "migrate-pago-tc-to-transfer" });
+
+type TxRow = {
+  id: number;
+  user_id: number;
+  account_id: number;
+  amount_cents: string;
+  currency: "COP" | "USD";
+  // postgres.js returns timestamptz as a string when using db.execute(sql`…`)
+  // — the drizzle schema-aware select would give us a Date. We pass it back as
+  // a string to avoid a needless parse.
+  occurred_at: string;
+  description_raw: string;
+  external_id: string | null;
+  raw_data: unknown;
+  merchant: string | null;
+};
+
+type AccountRow = {
+  id: number;
+  user_id: number;
+  last4s: string[] | null;
+  currency: "COP" | "USD";
+};
+
+function extractTcLast4(description: string): string | null {
+  // Match shapes like "Pago TC *9425", "Pago TC * 9425", tolerating whitespace.
+  const m = description.match(/Pago TC \*\s*(\d{4})/i);
+  return m?.[1] ?? null;
+}
+
+function findTcAccount(
+  userAccounts: AccountRow[],
+  last4: string,
+  currency: "COP" | "USD",
+): AccountRow | null {
+  return (
+    userAccounts.find((a) => a.currency === currency && (a.last4s ?? []).includes(last4)) ?? null
+  );
+}
+
+export type MigrationReport = {
+  processed: number;
+  migratedPaired: number;
+  migratedUnpaired: number;
+  skippedNoDestination: number;
+  skippedZero: number;
+};
+
+export async function migratePagoTcToTransfer(): Promise<MigrationReport> {
+  const targets = await db.execute<TxRow>(sql`
+    SELECT t.id, t.user_id, t.account_id, t.amount_cents::text as amount_cents,
+           t.currency, t.occurred_at, t.description_raw, t.external_id, t.raw_data,
+           t.merchant
+    FROM transactions t
+    WHERE t.category_slug = 'pago-tc'
+      AND t.transfer_group_id IS NULL
+  `);
+
+  if (targets.length === 0) {
+    log.info({ event: "migrate_pago_tc_noop" }, "nothing to migrate");
+    return {
+      processed: 0,
+      migratedPaired: 0,
+      migratedUnpaired: 0,
+      skippedNoDestination: 0,
+      skippedZero: 0,
+    };
+  }
+
+  // Load every TC account for the users involved so we can resolve destinations
+  // locally without re-querying per row.
+  const userIds = Array.from(new Set(targets.map((r) => r.user_id)));
+  const accountsResult = await db.execute<AccountRow>(sql`
+    SELECT a.id, a.user_id, a.metadata->'last4s' AS last4s, a.currency
+    FROM accounts a
+    WHERE a.type = 'credit_card'
+      AND a.user_id = ANY(${sql`ARRAY[${sql.join(
+        userIds.map((u) => sql`${u}`),
+        sql`, `,
+      )}]::int[]`})
+  `);
+  const tcByUser = new Map<number, AccountRow[]>();
+  for (const acc of accountsResult) {
+    const list = tcByUser.get(acc.user_id) ?? [];
+    // Drizzle returns JSONB as already-parsed JS values.
+    list.push({ ...acc, last4s: Array.isArray(acc.last4s) ? acc.last4s : null });
+    tcByUser.set(acc.user_id, list);
+  }
+
+  const report: MigrationReport = {
+    processed: 0,
+    migratedPaired: 0,
+    migratedUnpaired: 0,
+    skippedNoDestination: 0,
+    skippedZero: 0,
+  };
+
+  for (const row of targets) {
+    report.processed += 1;
+    const amount = BigInt(row.amount_cents);
+
+    if (amount === BigInt(0)) {
+      log.warn(
+        { txId: row.id, event: "migrate_pago_tc_skip_zero" },
+        "tx has zero amount — skipped",
+      );
+      report.skippedZero += 1;
+      continue;
+    }
+
+    if (amount > BigInt(0)) {
+      // Abono received on TC — unpaired transfer leg. Just strip the category
+      // and flip the channel. No counter-leg is inserted.
+      await db.execute(sql`
+        UPDATE transactions
+        SET category_slug = NULL,
+            channel = 'transfer'::tx_channel,
+            updated_at = now()
+        WHERE id = ${row.id}
+      `);
+      log.info(
+        { txId: row.id, event: "migrate_pago_tc_unpaired" },
+        "converted to unpaired transfer (abono)",
+      );
+      report.migratedUnpaired += 1;
+      continue;
+    }
+
+    // Statement payment path: find the destination TC via description.
+    const last4 = extractTcLast4(row.description_raw);
+    if (!last4) {
+      log.warn(
+        {
+          txId: row.id,
+          description: row.description_raw,
+          event: "migrate_pago_tc_no_last4",
+        },
+        "could not infer TC last4 from description — left untouched",
+      );
+      report.skippedNoDestination += 1;
+      continue;
+    }
+
+    const userTcs = tcByUser.get(row.user_id) ?? [];
+    const dest = findTcAccount(userTcs, last4, row.currency);
+    if (!dest) {
+      log.warn(
+        {
+          txId: row.id,
+          last4,
+          currency: row.currency,
+          userId: row.user_id,
+          event: "migrate_pago_tc_no_destination",
+        },
+        "no TC account matches last4+currency for this user — left untouched",
+      );
+      report.skippedNoDestination += 1;
+      continue;
+    }
+
+    const transferGroupId = randomUUID();
+    await db.transaction(async (trx) => {
+      // Update origin leg in place — keep the row stable so any FKs on it
+      // (reconciliation_decisions, ingestion_logs.resolvedTxnId) stay valid.
+      await trx.execute(sql`
+        UPDATE transactions
+        SET category_slug = NULL,
+            channel = 'transfer'::tx_channel,
+            transfer_group_id = ${transferGroupId}::uuid,
+            updated_at = now()
+        WHERE id = ${row.id}
+      `);
+
+      // Insert the paired credit leg. Reuses the same external_id so a future
+      // re-ingest of the SMS dedupes against both legs.
+      await trx.execute(sql`
+        INSERT INTO transactions (
+          user_id, account_id, occurred_at, amount_cents, currency,
+          description_raw, description_clean, merchant, category_slug,
+          classification_method, classification_confidence,
+          source, channel, transfer_group_id, external_id, raw_data, created_at, updated_at
+        )
+        VALUES (
+          ${row.user_id}, ${dest.id}, ${row.occurred_at}::timestamptz,
+          ${(-amount).toString()}::bigint, ${row.currency}::currency,
+          ${row.description_raw}, NULL, ${row.merchant}, NULL,
+          'manual'::classification_method, NULL,
+          'manual'::tx_source, 'transfer'::tx_channel,
+          ${transferGroupId}::uuid, ${row.external_id},
+          ${JSON.stringify({
+            migratedFromTxId: row.id,
+            migratedAt: new Date().toISOString(),
+            role: "credit",
+            source: "migrate-pago-tc-to-transfer",
+          })}::jsonb,
+          now(), now()
+        )
+        ON CONFLICT (account_id, external_id) WHERE external_id IS NOT NULL DO NOTHING
+      `);
+    });
+
+    log.info(
+      {
+        txId: row.id,
+        destAccountId: dest.id,
+        transferGroupId,
+        event: "migrate_pago_tc_paired",
+      },
+      "converted to paired transfer group",
+    );
+    report.migratedPaired += 1;
+  }
+
+  return report;
+}
+
+if (import.meta.main) {
+  migratePagoTcToTransfer()
+    .then(async (report) => {
+      log.info(
+        {
+          ...report,
+          event: "migrate_pago_tc_done",
+        },
+        `processed=${report.processed} paired=${report.migratedPaired} unpaired=${report.migratedUnpaired} skipped_no_dest=${report.skippedNoDestination} skipped_zero=${report.skippedZero}`,
+      );
+      await db.$client.end({ timeout: 1 });
+      process.exit(0);
+    })
+    .catch(async (err) => {
+      log.error({ err, event: "migrate_pago_tc_failed" }, "migration failed");
+      await db.$client.end({ timeout: 1 }).catch(() => void 0);
+      process.exit(1);
+    });
+}

--- a/scripts/migrate-prod.ts
+++ b/scripts/migrate-prod.ts
@@ -19,6 +19,7 @@ import { db } from "../src/lib/db";
 import { seedReferenceData } from "../src/lib/db/seed-reference-data";
 import { createLogger } from "../src/lib/logger";
 import { backfillUsersReferenceData } from "./backfill-users-reference";
+import { migratePagoTcToTransfer } from "./migrate-pago-tc-to-transfer";
 
 const log = createLogger({ module: "migrate-prod" });
 
@@ -61,6 +62,17 @@ for (const r of backfill) {
 log.info(
   { count: backfill.length, event: "migrate_prod_backfill_done" },
   "backfill complete — processed active users",
+);
+
+// #405: data-only migration that retrofits historical `pago-tc` transactions
+// into transfer groups. Idempotent: only touches rows where
+// `category_slug = 'pago-tc' AND transfer_group_id IS NULL`, so every deploy
+// after the first is a no-op for already-migrated rows.
+log.info({ event: "migrate_prod_pago_tc_start" }, "backfilling pago-tc → transfer groups");
+const pagoTcReport = await migratePagoTcToTransfer();
+log.info(
+  { ...pagoTcReport, event: "migrate_prod_pago_tc_done" },
+  "pago-tc transfer-group backfill complete",
 );
 
 await db.$client.end();

--- a/src/app/(app)/transactions/actions.test.ts
+++ b/src/app/(app)/transactions/actions.test.ts
@@ -41,6 +41,7 @@ const {
   confirmClassification,
   archiveTransaction,
   restoreTransaction,
+  createManualTransferGroup,
 } = await import("./actions");
 const { classifySingleWithAi: classifySingleWithAiLib } = await import("@/lib/classification/ai");
 const mockAiClassifySingle = vi.mocked(classifySingleWithAiLib);
@@ -1331,5 +1332,245 @@ describe("archiveTransaction / restoreTransaction (#375)", () => {
     const state = await accountState(acc.id);
     expect(state.totalCount).toBe(1);
     expect(state.liveCount).toBe(0);
+  });
+});
+
+// #405: archive / restore cascade across transfer_group_id. Prevents "half-
+// archived" groups that would break the Σ=0 invariant and leave account
+// balances internally inconsistent.
+describe("archiveTransaction / restoreTransaction over transfer groups (#405)", () => {
+  const EXT_PREFIX = "test-cp-action:tgarchive";
+  async function cleanup() {
+    await db.execute(sql`DELETE FROM transactions WHERE external_id LIKE ${EXT_PREFIX + "%"}`);
+  }
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  async function seedPairedGroup(suffix: string): Promise<{
+    originId: number;
+    destId: number;
+    groupId: string;
+  }> {
+    const [savings] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} AND name = 'Bancolombia Ahorros' LIMIT 1
+    `);
+    const [tc] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} AND name = 'Bancolombia Visa *2575' LIMIT 1
+    `);
+    const [groupRow] = await db.execute<{ id: string }>(sql`SELECT gen_random_uuid()::text AS id`);
+    const groupId = groupRow.id;
+
+    const [origin] = await db.execute<{ id: number }>(sql`
+      INSERT INTO transactions (
+        user_id, account_id, occurred_at, amount_cents, currency, description_raw,
+        classification_method, source, channel, transfer_group_id, external_id
+      ) VALUES (
+        ${TEST_USER_ID}, ${savings.id}, now(), -500000, 'COP', 'Pago TC *2575',
+        'manual'::classification_method, 'sms', 'transfer'::tx_channel,
+        ${groupId}::uuid, ${`${EXT_PREFIX}:${suffix}`}
+      )
+      RETURNING id
+    `);
+    const [dest] = await db.execute<{ id: number }>(sql`
+      INSERT INTO transactions (
+        user_id, account_id, occurred_at, amount_cents, currency, description_raw,
+        classification_method, source, channel, transfer_group_id, external_id
+      ) VALUES (
+        ${TEST_USER_ID}, ${tc.id}, now(), 500000, 'COP', 'Pago TC *2575',
+        'manual'::classification_method, 'sms', 'transfer'::tx_channel,
+        ${groupId}::uuid, ${`${EXT_PREFIX}:${suffix}`}
+      )
+      RETURNING id
+    `);
+    return { originId: origin.id, destId: dest.id, groupId };
+  }
+
+  it("archiving one leg archives every sibling in the group atomically", async () => {
+    const { originId, destId, groupId } = await seedPairedGroup("cascade-archive");
+
+    const result = await archiveTransaction({ txId: originId });
+    expect(result).toEqual({ status: "ok" });
+
+    const liveLegs = await db.execute<{ n: string }>(sql`
+      SELECT count(*)::text AS n FROM transactions
+      WHERE transfer_group_id = ${groupId}::uuid AND deleted_at IS NULL
+    `);
+    expect(liveLegs[0].n).toBe("0");
+
+    // And the sibling is actually archived (not just filtered).
+    const [sibling] = await db.execute<{ deleted_at: string | null }>(sql`
+      SELECT deleted_at FROM transactions WHERE id = ${destId}
+    `);
+    expect(sibling.deleted_at).not.toBeNull();
+  });
+
+  it("restoring one leg restores every sibling in the group atomically", async () => {
+    const { originId, destId, groupId } = await seedPairedGroup("cascade-restore");
+    await archiveTransaction({ txId: originId });
+
+    const result = await restoreTransaction({ txId: destId });
+    expect(result).toEqual({ status: "ok" });
+
+    const liveLegs = await db.execute<{ n: string }>(sql`
+      SELECT count(*)::text AS n FROM transactions
+      WHERE transfer_group_id = ${groupId}::uuid AND deleted_at IS NULL
+    `);
+    expect(liveLegs[0].n).toBe("2");
+  });
+
+  it("cascade does NOT touch transactions outside the group", async () => {
+    const { originId } = await seedPairedGroup("cascade-isolation");
+    const standaloneId = await seedTx({
+      counterpartyId: await seedBareCounterparty({ displayName: "test-cp-archive-isolation" }),
+      externalId: `${EXT_PREFIX}:standalone`,
+    });
+
+    await archiveTransaction({ txId: originId });
+
+    const [standalone] = await db.execute<{ deleted_at: string | null }>(sql`
+      SELECT deleted_at FROM transactions WHERE id = ${standaloneId}
+    `);
+    expect(standalone.deleted_at).toBeNull();
+  });
+});
+
+// #405: manual transfer-group creation via /transactions UI. Covers the
+// balance / currency / account-distinctness invariants and the happy paths
+// for 1-to-1 and 1-to-N.
+describe("createManualTransferGroup (#405)", () => {
+  async function cleanup() {
+    await db.execute(sql`
+      DELETE FROM transactions WHERE raw_data @> '{"manualTransfer": true}'
+    `);
+  }
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  async function savingsId(): Promise<number> {
+    const [row] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} AND name = 'Bancolombia Ahorros' LIMIT 1
+    `);
+    return row.id;
+  }
+  async function visaId(): Promise<number> {
+    const [row] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} AND name = 'Bancolombia Visa *2575' LIMIT 1
+    `);
+    return row.id;
+  }
+  async function mastercardCopId(): Promise<number> {
+    const [row] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts
+      WHERE user_id = ${TEST_USER_ID} AND name = 'Bancolombia Mastercard *7291' AND currency = 'COP'
+      LIMIT 1
+    `);
+    return row.id;
+  }
+  async function usdId(): Promise<number> {
+    const [row] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} AND name = 'ARQ Ahorros' LIMIT 1
+    `);
+    return row.id;
+  }
+
+  it("creates a 1-to-1 group with Σ=0 and channel=transfer on every leg", async () => {
+    const origin = await savingsId();
+    const dest = await visaId();
+    const result = await createManualTransferGroup({
+      origin: { accountId: origin, amount: "50000" },
+      destinations: [{ accountId: dest, amount: "50000" }],
+      occurredOn: "2026-04-15",
+      description: "Manual pago TC",
+      notes: null,
+    });
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+
+    const legs = await db.execute<{
+      amount_cents: string;
+      channel: string;
+      category_slug: string | null;
+    }>(sql`
+      SELECT amount_cents::text, channel, category_slug
+      FROM transactions WHERE transfer_group_id = ${result.transferGroupId}::uuid
+      ORDER BY amount_cents ASC
+    `);
+    expect(legs.length).toBe(2);
+    for (const leg of legs) {
+      expect(leg.channel).toBe("transfer");
+      expect(leg.category_slug).toBeNull();
+    }
+    expect(BigInt(legs[0].amount_cents) + BigInt(legs[1].amount_cents)).toBe(BigInt(0));
+  });
+
+  it("creates a 1-to-N group (compra de cartera shape: 1 debit + 2 credits)", async () => {
+    const origin = await savingsId();
+    const [destA, destB] = [await visaId(), await mastercardCopId()];
+    const result = await createManualTransferGroup({
+      origin: { accountId: origin, amount: "100000" },
+      destinations: [
+        { accountId: destA, amount: "40000" },
+        { accountId: destB, amount: "60000" },
+      ],
+      occurredOn: "2026-04-15",
+      description: "Compra de cartera",
+      notes: null,
+    });
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.txIds.length).toBe(3);
+  });
+
+  it("rejects an unbalanced group (|debit| ≠ Σ|credit|)", async () => {
+    const origin = await savingsId();
+    const dest = await visaId();
+    const result = await createManualTransferGroup({
+      origin: { accountId: origin, amount: "50000" },
+      destinations: [{ accountId: dest, amount: "49000" }],
+      occurredOn: "2026-04-15",
+      description: "Bad",
+      notes: null,
+    });
+    expect(result.status).toBe("error");
+  });
+
+  it("rejects a group whose origin matches one of the destinations", async () => {
+    const origin = await savingsId();
+    const result = await createManualTransferGroup({
+      origin: { accountId: origin, amount: "1000" },
+      destinations: [{ accountId: origin, amount: "1000" }],
+      occurredOn: "2026-04-15",
+      description: "Self",
+      notes: null,
+    });
+    expect(result.status).toBe("error");
+  });
+
+  it("rejects a cross-currency group", async () => {
+    const originCop = await savingsId();
+    const destUsd = await usdId();
+    const result = await createManualTransferGroup({
+      origin: { accountId: originCop, amount: "1000" },
+      destinations: [{ accountId: destUsd, amount: "1000" }],
+      occurredOn: "2026-04-15",
+      description: "FX",
+      notes: null,
+    });
+    expect(result.status).toBe("error");
+    if (result.status === "error") expect(result.message).toMatch(/currency/i);
+  });
+
+  it("rejects a future-dated group", async () => {
+    const origin = await savingsId();
+    const dest = await visaId();
+    const future = new Date(Date.now() + 30 * 86_400_000).toISOString().slice(0, 10);
+    const result = await createManualTransferGroup({
+      origin: { accountId: origin, amount: "1000" },
+      destinations: [{ accountId: dest, amount: "1000" }],
+      occurredOn: future,
+      description: "Future",
+      notes: null,
+    });
+    expect(result.status).toBe("error");
   });
 });

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -25,6 +25,11 @@ import { autoLinkTransaction } from "@/lib/recurring/auto-link";
 import { keyForParsed } from "@/lib/counterparties/alias-key";
 import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
 import { decimalStringToCents } from "@/lib/money";
+import {
+  insertTransferGroup,
+  validateTransferGroupLegs,
+  type TransferLeg,
+} from "@/lib/transactions/transfer-groups";
 import type { CounterpartyKind, CounterpartyType } from "@/lib/types";
 
 const updateSchema = z.object({
@@ -843,30 +848,63 @@ export type ArchiveResult = { status: "ok" } | { status: "not-found" };
  * The derived balance excludes archived rows (see `derivedBalanceCentsSql`),
  * so archiving moves the account balance immediately. Restore reverses it.
  *
- * Trailing `notDeleted()` in the WHERE makes the update idempotent — a second
- * archive call no-ops instead of refreshing the timestamp.
- *
- * Transfer-pair caveat (pre-requisite of #345A): once transfer pairs land,
- * archiving one side should warn / archive the other. Today there are no
- * paired transfers in the schema, so this is a no-op concern.
+ * #405: when the row belongs to a transfer group (transfer_group_id IS NOT NULL),
+ * the archive cascades to every live sibling leg in the same transaction. This
+ * preserves the group invariant (Σ=0) — archiving half a transfer would leave
+ * the account balances inconsistent.
  */
 export async function archiveTransaction(input: { txId: number }): Promise<ArchiveResult> {
   const session = await getSessionUser();
   const { txId } = txIdSchema.parse(input);
 
-  const updated = await db
-    .update(transactions)
-    .set({ deletedAt: sql`NOW()`, updatedAt: new Date() })
-    .where(
-      and(
-        eq(transactions.userId, session.id),
-        eq(transactions.id, txId),
-        notDeleted(transactions.deletedAt),
-      ),
-    )
-    .returning({ id: transactions.id });
+  const archivedIds = await db.transaction(async (trx) => {
+    const [target] = await trx
+      .select({
+        id: transactions.id,
+        transferGroupId: transactions.transferGroupId,
+      })
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.userId, session.id),
+          eq(transactions.id, txId),
+          notDeleted(transactions.deletedAt),
+        ),
+      )
+      .limit(1);
 
-  if (updated.length === 0) return { status: "not-found" };
+    if (!target) return [];
+
+    if (target.transferGroupId) {
+      const rows = await trx
+        .update(transactions)
+        .set({ deletedAt: sql`NOW()`, updatedAt: new Date() })
+        .where(
+          and(
+            eq(transactions.userId, session.id),
+            eq(transactions.transferGroupId, target.transferGroupId),
+            notDeleted(transactions.deletedAt),
+          ),
+        )
+        .returning({ id: transactions.id });
+      return rows.map((r) => r.id);
+    }
+
+    const rows = await trx
+      .update(transactions)
+      .set({ deletedAt: sql`NOW()`, updatedAt: new Date() })
+      .where(
+        and(
+          eq(transactions.userId, session.id),
+          eq(transactions.id, txId),
+          notDeleted(transactions.deletedAt),
+        ),
+      )
+      .returning({ id: transactions.id });
+    return rows.map((r) => r.id);
+  });
+
+  if (archivedIds.length === 0) return { status: "not-found" };
 
   revalidatePath("/");
   revalidatePath("/transactions");
@@ -879,30 +917,214 @@ export async function archiveTransaction(input: { txId: number }): Promise<Archi
  * Restore a previously archived transaction (#375). Clears `deleted_at` so the
  * row becomes visible again and the derived balance re-includes it.
  *
- * The trailing `isNotNull(deletedAt)` filter makes it idempotent and prevents
- * restoring a row that was never archived (can't happen via UI, but defensive).
+ * #405: transfer group siblings restore together for the same Σ=0 reason.
  */
 export async function restoreTransaction(input: { txId: number }): Promise<ArchiveResult> {
   const session = await getSessionUser();
   const { txId } = txIdSchema.parse(input);
 
-  const updated = await db
-    .update(transactions)
-    .set({ deletedAt: null, updatedAt: new Date() })
-    .where(
-      and(
-        eq(transactions.userId, session.id),
-        eq(transactions.id, txId),
-        isNotNull(transactions.deletedAt),
-      ),
-    )
-    .returning({ id: transactions.id });
+  const restoredIds = await db.transaction(async (trx) => {
+    const [target] = await trx
+      .select({
+        id: transactions.id,
+        transferGroupId: transactions.transferGroupId,
+      })
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.userId, session.id),
+          eq(transactions.id, txId),
+          isNotNull(transactions.deletedAt),
+        ),
+      )
+      .limit(1);
 
-  if (updated.length === 0) return { status: "not-found" };
+    if (!target) return [];
+
+    if (target.transferGroupId) {
+      const rows = await trx
+        .update(transactions)
+        .set({ deletedAt: null, updatedAt: new Date() })
+        .where(
+          and(
+            eq(transactions.userId, session.id),
+            eq(transactions.transferGroupId, target.transferGroupId),
+            isNotNull(transactions.deletedAt),
+          ),
+        )
+        .returning({ id: transactions.id });
+      return rows.map((r) => r.id);
+    }
+
+    const rows = await trx
+      .update(transactions)
+      .set({ deletedAt: null, updatedAt: new Date() })
+      .where(
+        and(
+          eq(transactions.userId, session.id),
+          eq(transactions.id, txId),
+          isNotNull(transactions.deletedAt),
+        ),
+      )
+      .returning({ id: transactions.id });
+    return rows.map((r) => r.id);
+  });
+
+  if (restoredIds.length === 0) return { status: "not-found" };
 
   revalidatePath("/");
   revalidatePath("/transactions");
   revalidatePath("/accounts");
 
   return { status: "ok" };
+}
+
+// #405: manual transfer-group creation (1-to-N). Used by the "Nueva
+// transferencia" dialog in /transactions. Accepts 1 origin (debit) + N
+// destinations (credits); validates balance invariants; inserts atomically.
+//
+// Currency is taken from each leg's account — the UI must clamp credit
+// currencies to match the debit, since cross-currency transfer groups would
+// require an FX pairing we don't model today.
+const manualTransferLegSchema = z.object({
+  accountId: z.coerce.number().int().positive(),
+  amount: z
+    .string()
+    .trim()
+    .transform((value, ctx) => {
+      try {
+        const cents = decimalStringToCents(value);
+        if (cents <= BigInt(0)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Amount must be greater than zero",
+          });
+          return z.NEVER;
+        }
+        return cents;
+      } catch {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Amount must be a positive decimal" });
+        return z.NEVER;
+      }
+    }),
+});
+
+const manualTransferGroupSchema = z
+  .object({
+    origin: manualTransferLegSchema,
+    destinations: z.array(manualTransferLegSchema).min(1).max(10),
+    occurredOn: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD")
+      .refine((d) => d <= new Date().toISOString().slice(0, 10), {
+        message: "Date cannot be in the future",
+      }),
+    description: z.string().trim().min(1).max(200),
+    notes: z.string().max(500).nullable(),
+  })
+  .refine(
+    (v) => {
+      const creditsSum = v.destinations.reduce((acc, d) => acc + d.amount, BigInt(0));
+      return creditsSum === v.origin.amount;
+    },
+    { message: "Total of destination amounts must equal origin amount" },
+  )
+  .refine(
+    (v) => {
+      const originId = v.origin.accountId;
+      return v.destinations.every((d) => d.accountId !== originId);
+    },
+    { message: "Origin and destination accounts must differ" },
+  );
+
+export type ManualTransferGroupInput = z.input<typeof manualTransferGroupSchema>;
+export type ManualTransferGroupResult =
+  | { status: "ok"; transferGroupId: string; txIds: number[] }
+  | { status: "error"; message: string };
+
+export async function createManualTransferGroup(
+  input: ManualTransferGroupInput,
+): Promise<ManualTransferGroupResult> {
+  const session = await getSessionUser();
+  const result = manualTransferGroupSchema.safeParse(input);
+  if (!result.success) {
+    return { status: "error", message: result.error.issues[0]?.message ?? "Invalid input" };
+  }
+  const parsed = result.data;
+
+  const involvedAccountIds = Array.from(
+    new Set([parsed.origin.accountId, ...parsed.destinations.map((d) => d.accountId)]),
+  );
+
+  const accountRows = await db
+    .select({ id: accounts.id, currency: accounts.currency })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        inArray(accounts.id, involvedAccountIds),
+        notDeleted(accounts.deletedAt),
+      ),
+    );
+
+  if (accountRows.length !== involvedAccountIds.length) {
+    return { status: "error", message: "One or more accounts not found" };
+  }
+  const accountById = new Map(accountRows.map((a) => [a.id, a]));
+  const originAcc = accountById.get(parsed.origin.accountId);
+  const originCurrency = originAcc?.currency;
+  if (!originCurrency) return { status: "error", message: "Origin account not found" };
+  if (parsed.destinations.some((d) => accountById.get(d.accountId)?.currency !== originCurrency)) {
+    return {
+      status: "error",
+      message: "All legs must share the same currency",
+    };
+  }
+
+  const occurredAt = new Date(`${parsed.occurredOn}T12:00:00Z`);
+  const legs: TransferLeg[] = [
+    {
+      accountId: parsed.origin.accountId,
+      amountCents: -parsed.origin.amount,
+      currency: originCurrency,
+      descriptionRaw: parsed.description,
+      source: "manual",
+      occurredAt,
+      rawData: { role: "debit", manualTransfer: true },
+      notes: parsed.notes,
+    },
+    ...parsed.destinations.map<TransferLeg>((d) => ({
+      accountId: d.accountId,
+      amountCents: d.amount,
+      currency: originCurrency,
+      descriptionRaw: parsed.description,
+      source: "manual",
+      occurredAt,
+      rawData: { role: "credit", manualTransfer: true },
+      notes: parsed.notes,
+    })),
+  ];
+
+  const validation = validateTransferGroupLegs(legs);
+  if (!validation.ok) {
+    return { status: "error", message: `invalid transfer group: ${validation.reason}` };
+  }
+
+  const insertResult = await insertTransferGroup({ userId: session.id, legs });
+  if (insertResult.status === "error") {
+    return { status: "error", message: insertResult.reason };
+  }
+  if (insertResult.status === "duplicated") {
+    return { status: "error", message: "One or more legs conflict with existing transactions" };
+  }
+
+  for (const txId of insertResult.txIds) {
+    emit({ type: "transaction:created", id: txId, source: "manual", timestamp: Date.now() });
+  }
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+  revalidatePath("/accounts");
+
+  return { status: "ok", transferGroupId: insertResult.transferGroupId, txIds: insertResult.txIds };
 }

--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { AiClassifyButton } from "@/components/transactions/ai-classify-button";
 import { Filters } from "@/components/transactions/filters";
 import { TransactionTable } from "@/components/transactions/transaction-table";
+import { TransferGroupDialog } from "@/components/transactions/transfer-group-dialog";
 import { getSessionUser } from "@/lib/auth/session";
 import {
   countTotal,
@@ -97,7 +98,10 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
             {PAGE_SIZE} per page
           </p>
         </div>
-        <AiClassifyButton unclassified={unclassified} />
+        <div className="flex items-center gap-2">
+          <TransferGroupDialog accounts={accounts} />
+          <AiClassifyButton unclassified={unclassified} />
+        </div>
       </header>
 
       <Filters accounts={accounts} categories={categories} />

--- a/src/app/api/ingest/sms/route.test.ts
+++ b/src/app/api/ingest/sms/route.test.ts
@@ -265,7 +265,7 @@ describe("POST /api/ingest/sms", () => {
     expect(rows[0].classification_method).toBe("rule");
   });
 
-  it("inserts a TC payment as pago-tc expense from *6126", async () => {
+  it("inserts a TC payment as a paired transfer group — savings debit + TC credit (#405)", async () => {
     const body =
       "Bancolombia: Pagaste $1,320,564 en la tarjeta de credito *7291 desde la cuenta *6126, el 14/04/2026 21:48. ¿Dudas? Llamanos al 018000912345. Estamos cerca.";
     const res = await POST(
@@ -277,17 +277,39 @@ describe("POST /api/ingest/sms", () => {
     const json = (await res.json()) as { status: string; txId?: number };
     expect(json.status).toBe("inserted");
 
-    const rows = await db.execute<{
+    // The returned txId is the origin (debit) leg. Both legs share the same
+    // transfer_group_id, so we fetch them together to assert the invariants.
+    const [originRow] = await db.execute<{
+      transfer_group_id: string | null;
+    }>(sql`SELECT transfer_group_id FROM transactions WHERE id = ${json.txId!}`);
+    expect(originRow.transfer_group_id).toBeTruthy();
+
+    const legs = await db.execute<{
       amount_cents: string;
       category_slug: string | null;
-      classification_method: string;
+      channel: string;
+      transfer_group_id: string | null;
+      account_id: number;
     }>(sql`
-      SELECT amount_cents, category_slug, classification_method
-      FROM transactions WHERE id = ${json.txId!}
+      SELECT t.amount_cents, t.category_slug, t.channel, t.transfer_group_id, t.account_id
+      FROM transactions t
+      WHERE t.transfer_group_id = ${originRow.transfer_group_id}
+      ORDER BY t.amount_cents ASC
     `);
-    expect(BigInt(rows[0].amount_cents)).toBe(BigInt(-132056400));
-    expect(rows[0].category_slug).toBe("pago-tc");
-    expect(rows[0].classification_method).toBe("manual");
+    expect(legs.length).toBe(2);
+    // Debit leg (savings): negative amount, category null, channel transfer.
+    expect(BigInt(legs[0].amount_cents)).toBe(BigInt(-132056400));
+    // Credit leg (TC): positive amount, reduces debt.
+    expect(BigInt(legs[1].amount_cents)).toBe(BigInt(132056400));
+    // Both legs: no spend/income category, channel="transfer".
+    for (const leg of legs) {
+      expect(leg.category_slug).toBeNull();
+      expect(leg.channel).toBe("transfer");
+    }
+    // Σ = 0 — the core invariant of transfer groups.
+    expect(BigInt(legs[0].amount_cents) + BigInt(legs[1].amount_cents)).toBe(BigInt(0));
+    // Origin savings *6126 and destination TC *7291 are distinct accounts.
+    expect(legs[0].account_id).not.toBe(legs[1].account_id);
   });
 
   it("inserts a transfer_received as income into Ahorros", async () => {
@@ -351,7 +373,7 @@ describe("POST /api/ingest/sms", () => {
     expect(accs[0].currency).toBe("COP");
   });
 
-  it("inserts a tc_credit_received as positive abono on the TC account", async () => {
+  it("inserts a tc_credit_received as an unpaired transfer leg on the TC (#405)", async () => {
     const body =
       "Bancolombia: AIDA MALDONADO hizo un abono por $2,125,092 a tu tarjeta de credito terminada en **2575, el 03/12/2025 13:40. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
     const res = await POST(
@@ -370,13 +392,20 @@ describe("POST /api/ingest/sms", () => {
       category_slug: string | null;
       classification_method: string;
       description_raw: string;
+      channel: string;
+      transfer_group_id: string | null;
     }>(sql`
-      SELECT amount_cents, merchant, account_id, category_slug, classification_method, description_raw
+      SELECT amount_cents, merchant, account_id, category_slug, classification_method,
+             description_raw, channel, transfer_group_id
       FROM transactions WHERE id = ${json.txId!}
     `);
     expect(BigInt(rows[0].amount_cents)).toBe(BigInt(212509200)); // positive — reduces TC debt
     expect(rows[0].merchant).toBe("AIDA MALDONADO");
-    expect(rows[0].category_slug).toBe("pago-tc");
+    // #405: no category (origin is external — not spend/income), channel="transfer",
+    // and no transfer_group_id since there's no companion leg.
+    expect(rows[0].category_slug).toBeNull();
+    expect(rows[0].channel).toBe("transfer");
+    expect(rows[0].transfer_group_id).toBeNull();
     expect(rows[0].classification_method).toBe("manual");
     expect(rows[0].description_raw).toBe("Abono de AIDA MALDONADO a TC *2575");
 

--- a/src/components/transactions/transfer-group-dialog.tsx
+++ b/src/components/transactions/transfer-group-dialog.tsx
@@ -1,0 +1,412 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { ArrowLeftRightIcon, PlusIcon, Trash2Icon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { createManualTransferGroup } from "@/app/(app)/transactions/actions";
+import type { Currency } from "@/lib/types";
+
+export type TransferAccountOption = {
+  id: number;
+  name: string;
+  currency: Currency;
+};
+
+type DestinationLeg = {
+  key: string;
+  accountId: string;
+  amount: string;
+};
+
+function todayLocalISO(): string {
+  const d = new Date();
+  const tz = d.getTimezoneOffset() * 60000;
+  return new Date(d.getTime() - tz).toISOString().slice(0, 10);
+}
+
+function newKey() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+// Parse an input like "1.234,56" / "1234.56" / "1,234" / "56" into cents as a
+// BigInt. Returns null when input is invalid. Mirrors decimalStringToCents on
+// the server but we only need a loose client-side version to drive the running
+// total / validation feedback.
+function parseToCents(v: string): bigint | null {
+  const trimmed = v.trim();
+  if (!trimmed) return null;
+  // Normalize: if there's both "." and "," take the LAST as decimal.
+  const hasDot = trimmed.includes(".");
+  const hasComma = trimmed.includes(",");
+  let normalized = trimmed;
+  if (hasDot && hasComma) {
+    const lastDot = trimmed.lastIndexOf(".");
+    const lastComma = trimmed.lastIndexOf(",");
+    if (lastComma > lastDot) {
+      normalized = trimmed.replace(/\./g, "").replace(",", ".");
+    } else {
+      normalized = trimmed.replace(/,/g, "");
+    }
+  } else if (hasComma) {
+    // Lone comma — treat as decimal.
+    normalized = trimmed.replace(",", ".");
+  }
+  const n = Number(normalized);
+  if (!Number.isFinite(n) || n < 0) return null;
+  // 2-decimal fixed point via string to avoid float drift on .995 etc.
+  const [intPart, decPart = ""] = normalized.split(".");
+  const paddedDec = (decPart + "00").slice(0, 2);
+  try {
+    return BigInt(intPart || "0") * BigInt(100) + BigInt(paddedDec);
+  } catch {
+    return null;
+  }
+}
+
+function formatCents(cents: bigint, currency: Currency): string {
+  const abs = cents < BigInt(0) ? -cents : cents;
+  const whole = abs / BigInt(100);
+  const frac = (abs % BigInt(100)).toString().padStart(2, "0");
+  const wholeStr = whole.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return `${currency === "USD" ? "USD " : "$"}${wholeStr}.${frac}`;
+}
+
+export function TransferGroupDialog({ accounts }: { accounts: TransferAccountOption[] }) {
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  const defaultAccount = accounts.find((a) => a.currency === "COP") ?? accounts[0];
+  const [originAccountId, setOriginAccountId] = useState<string>(
+    defaultAccount?.id.toString() ?? "",
+  );
+  const [originAmount, setOriginAmount] = useState("");
+  const [occurredOn, setOccurredOn] = useState(todayLocalISO());
+  const [description, setDescription] = useState("");
+  const [notes, setNotes] = useState("");
+  const [destinations, setDestinations] = useState<DestinationLeg[]>([
+    { key: newKey(), accountId: "", amount: "" },
+  ]);
+
+  const originAccount = accounts.find((a) => a.id.toString() === originAccountId);
+  const currency: Currency = originAccount?.currency ?? "COP";
+
+  // Only show destinations in the same currency as origin. Cross-currency
+  // transfer groups are out of scope until we model the FX leg explicitly.
+  const eligibleDestinations = useMemo(
+    () => accounts.filter((a) => a.currency === currency && a.id.toString() !== originAccountId),
+    [accounts, currency, originAccountId],
+  );
+
+  const originCents = parseToCents(originAmount) ?? BigInt(0);
+  const destinationsCents = destinations.map((d) => parseToCents(d.amount) ?? BigInt(0));
+  const destinationsSum = destinationsCents.reduce((a, b) => a + b, BigInt(0));
+  const remaining = originCents - destinationsSum;
+  const balanced = originCents > BigInt(0) && remaining === BigInt(0);
+
+  function reset() {
+    setOriginAmount("");
+    setDescription("");
+    setNotes("");
+    setOccurredOn(todayLocalISO());
+    setDestinations([{ key: newKey(), accountId: "", amount: "" }]);
+  }
+
+  function updateDestination(key: string, patch: Partial<DestinationLeg>) {
+    setDestinations((prev) => prev.map((d) => (d.key === key ? { ...d, ...patch } : d)));
+  }
+
+  function addDestination() {
+    setDestinations((prev) => [...prev, { key: newKey(), accountId: "", amount: "" }]);
+  }
+
+  function removeDestination(key: string) {
+    setDestinations((prev) => (prev.length === 1 ? prev : prev.filter((d) => d.key !== key)));
+  }
+
+  function splitRemainingEvenly() {
+    if (originCents <= BigInt(0) || destinations.length === 0) return;
+    const n = BigInt(destinations.length);
+    const base = originCents / n;
+    const rem = originCents % n;
+    setDestinations((prev) =>
+      prev.map((d, idx) => {
+        const cents = base + (idx === 0 ? rem : BigInt(0));
+        // Render as decimal with 2dp, stripping trailing zeros for COP nicety.
+        const whole = cents / BigInt(100);
+        const frac = (cents % BigInt(100)).toString().padStart(2, "0");
+        const value = currency === "USD" ? `${whole}.${frac}` : whole.toString();
+        return { ...d, amount: value };
+      }),
+    );
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!originAccountId) {
+      toast.error("Elegí la cuenta de origen");
+      return;
+    }
+    if (!description.trim()) {
+      toast.error("Agregá una descripción");
+      return;
+    }
+    if (!balanced) {
+      toast.error("El total de destinos debe ser igual al origen");
+      return;
+    }
+    if (destinations.some((d) => !d.accountId || !d.amount.trim())) {
+      toast.error("Completá cada destino (cuenta + monto)");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await createManualTransferGroup({
+        origin: {
+          accountId: Number(originAccountId),
+          amount: originAmount.trim(),
+        },
+        destinations: destinations.map((d) => ({
+          accountId: Number(d.accountId),
+          amount: d.amount.trim(),
+        })),
+        occurredOn,
+        description: description.trim(),
+        notes: notes.trim() || null,
+      });
+      if (result.status === "error") {
+        toast.error(result.message);
+        return;
+      }
+      toast.success(`Transferencia creada (${result.txIds.length} tx)`);
+      reset();
+      setOpen(false);
+    });
+  }
+
+  if (accounts.length < 2) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <ArrowLeftRightIcon className="mr-1 size-4" />
+          Nueva transferencia
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Nueva transferencia</DialogTitle>
+          <DialogDescription>
+            Movimiento entre cuentas tuyas (1 origen → N destinos). No suma ni resta al gasto.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={onSubmit} className="flex flex-col gap-4">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="tg-date">Fecha</Label>
+              <Input
+                id="tg-date"
+                type="date"
+                value={occurredOn}
+                onChange={(e) => setOccurredOn(e.target.value)}
+                required
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="tg-description">Descripción</Label>
+              <Input
+                id="tg-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Ej: Pago TC *9425"
+                maxLength={200}
+                required
+              />
+            </div>
+          </div>
+
+          <fieldset className="flex flex-col gap-2 rounded-md border p-3">
+            <legend className="px-1 text-xs font-medium">Origen (débito)</legend>
+            <div className="grid grid-cols-[1fr_auto] gap-3">
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="tg-origin">Cuenta</Label>
+                <select
+                  id="tg-origin"
+                  value={originAccountId}
+                  onChange={(e) => {
+                    setOriginAccountId(e.target.value);
+                    // When currency changes, any destinations in the old
+                    // currency would become invalid. Reset them to a blank row.
+                    setDestinations([{ key: newKey(), accountId: "", amount: "" }]);
+                  }}
+                  className="bg-background chevron-select h-9 rounded-md border text-sm"
+                  required
+                >
+                  {accounts.map((a) => (
+                    <option key={a.id} value={a.id}>
+                      {formatAccountLabel(a)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="tg-origin-amt">Monto</Label>
+                <div className="relative">
+                  <span className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-sm">
+                    $
+                  </span>
+                  <Input
+                    id="tg-origin-amt"
+                    type="text"
+                    inputMode="decimal"
+                    placeholder="0"
+                    value={originAmount}
+                    onChange={(e) => setOriginAmount(e.target.value)}
+                    className="w-36 pr-14 pl-6 tabular-nums"
+                    required
+                  />
+                  <span
+                    className={cn(
+                      "pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 rounded px-1.5 py-0.5 text-xs font-medium",
+                      currency === "USD"
+                        ? "bg-amber-500/15 text-amber-700"
+                        : "bg-muted text-muted-foreground",
+                    )}
+                  >
+                    {currency}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+
+          <fieldset className="flex flex-col gap-2 rounded-md border p-3">
+            <legend className="px-1 text-xs font-medium">Destinos (crédito)</legend>
+            {eligibleDestinations.length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                No hay otras cuentas en {currency} para destino. Cambiá el origen o creá una cuenta.
+              </p>
+            ) : (
+              <>
+                <div className="flex flex-col gap-2">
+                  {destinations.map((d) => (
+                    <div key={d.key} className="grid grid-cols-[1fr_auto_auto] items-end gap-2">
+                      <select
+                        value={d.accountId}
+                        onChange={(e) => updateDestination(d.key, { accountId: e.target.value })}
+                        className="bg-background chevron-select h-9 rounded-md border text-sm"
+                        required
+                      >
+                        <option value="">— elegí cuenta —</option>
+                        {eligibleDestinations.map((a) => (
+                          <option key={a.id} value={a.id}>
+                            {formatAccountLabel(a)}
+                          </option>
+                        ))}
+                      </select>
+                      <Input
+                        type="text"
+                        inputMode="decimal"
+                        placeholder="0"
+                        value={d.amount}
+                        onChange={(e) => updateDestination(d.key, { amount: e.target.value })}
+                        className="w-32 tabular-nums"
+                        required
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => removeDestination(d.key)}
+                        disabled={destinations.length === 1}
+                        aria-label="Quitar destino"
+                      >
+                        <Trash2Icon className="size-4" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                  <Button type="button" variant="outline" size="sm" onClick={addDestination}>
+                    <PlusIcon className="mr-1 size-4" />
+                    Agregar destino
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={splitRemainingEvenly}
+                    disabled={originCents === BigInt(0)}
+                  >
+                    Dividir en partes iguales
+                  </Button>
+                </div>
+              </>
+            )}
+          </fieldset>
+
+          <div
+            className={cn(
+              "flex items-center justify-between rounded-md border px-3 py-2 text-sm tabular-nums",
+              !balanced && originCents > BigInt(0)
+                ? "border-amber-500/40 bg-amber-500/5 text-amber-700"
+                : balanced
+                  ? "border-emerald-500/40 bg-emerald-500/5 text-emerald-700"
+                  : "text-muted-foreground",
+            )}
+          >
+            <span>
+              Total destinos: <strong>{formatCents(destinationsSum, currency)}</strong>
+            </span>
+            <span>
+              {balanced
+                ? "✓ Balanceado"
+                : remaining === BigInt(0)
+                  ? "—"
+                  : `Falta: ${formatCents(remaining, currency)}`}
+            </span>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="tg-notes">Notas</Label>
+            <Input
+              id="tg-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Opcional"
+              maxLength={500}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={pending}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={pending || !balanced}>
+              {pending ? "Guardando…" : "Crear transferencia"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -404,6 +404,12 @@ export const transactions = pgTable(
       onDelete: "set null",
     }),
     recurringYearMonth: varchar("recurring_year_month", { length: 7 }),
+    // Transfer group id (#405 / parent #345). When set, this tx is one leg of
+    // a multi-leg transfer (e.g. TC statement payment = savings debit + TC
+    // credit). App-level invariants: (a) every tx in the group has the same
+    // user_id, (b) Σ(amount_cents) = 0, (c) soft-delete is atomic across the
+    // group. Validated in tests / action layer, not the DB.
+    transferGroupId: uuid("transfer_group_id"),
     rawData: jsonb("raw_data").notNull().default({}),
     notes: text("notes"),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
@@ -416,6 +422,9 @@ export const transactions = pgTable(
     index("transactions_user_category_idx").on(t.userId, t.categorySlug),
     index("transactions_user_counterparty_idx").on(t.userId, t.counterpartyId),
     index("transactions_account_recon_idx").on(t.accountId, t.reconciliationStatus, t.occurredAt),
+    index("transactions_transfer_group_idx")
+      .on(t.transferGroupId)
+      .where(sql`${t.transferGroupId} IS NOT NULL`),
     index("transactions_flagged_idx")
       .on(t.userId, t.occurredAt)
       .where(sql`${t.reconciliationStatus} = 'flagged'`),
@@ -791,6 +800,14 @@ export type TelegramDraft = {
   accountId?: number;
   categorySlug?: string;
   notes?: string;
+  // #405: when set, the confirm inserts with channel="transfer" and
+  // category_slug=null. If `destinationAccountId` is also set, a companion
+  // credit leg is inserted atomically as a transfer group (used for
+  // tc_payment). Without destination, a single unpaired transfer leg is
+  // inserted (used for tc_credit_received — origin is external).
+  transfer?: {
+    destinationAccountId?: number;
+  };
 };
 
 export type TelegramSessionState = {

--- a/src/lib/db/seed-reference-data.ts
+++ b/src/lib/db/seed-reference-data.ts
@@ -83,7 +83,17 @@ export const categorySeedRows: CategorySeed[] = [
   { slug: "cdts", name: "CDTs", parentSlug: "inversiones" },
   { slug: "fics", name: "FICs", parentSlug: "inversiones" },
   { slug: "deudas", name: "Deudas", icon: "credit-card", color: "#dc2626", sortOrder: 100 },
+  // Kept for historical data only. Since #405, TC statement payments are
+  // modeled as transfer groups (savings debit + TC credit, category_slug = null,
+  // channel = "transfer"). New tc_payment / tc_credit_received SMS should no
+  // longer be inserted with this slug. The seed stays so existing rows still
+  // resolve their FK; archived rows and pre-migration data keep working.
   { slug: "pago-tc", name: "Pago Tarjeta de Crédito", parentSlug: "deudas" },
+  // Used by the monthly "intereses causados" job (#407). The job inserts one
+  // synthetic tx per TC per cycle summing Σ(balance × rate) across live
+  // installment purchases. Interest accrued IS an expense, so this category is
+  // a real child of `deudas` (not a transfer like `pago-tc`).
+  { slug: "intereses-tc", name: "Intereses TC", parentSlug: "deudas" },
   { slug: "pago-prestamo", name: "Pago Préstamo", parentSlug: "deudas" },
   { slug: "ropa", name: "Ropa", icon: "shirt", color: "#8b5cf6", sortOrder: 110 },
   { slug: "tecnologia", name: "Tecnología", icon: "laptop", color: "#06b6d4", sortOrder: 120 },

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -5,6 +5,7 @@ import { notDeleted } from "@/lib/db/helpers";
 import { classifyByRule } from "@/lib/classification/rules";
 import { emit } from "@/lib/events/bus";
 import { autoLinkTransaction } from "@/lib/recurring/auto-link";
+import { insertTransferGroup } from "@/lib/transactions/transfer-groups";
 import {
   resolveAccountFromLast4,
   type ParseResult,
@@ -131,6 +132,20 @@ async function ingestParsedSms(
     .where(and(eq(accounts.userId, userId), notDeleted(accounts.deletedAt)))) as Array<
     RoutableAccount & { institution: string; type: string }
   >;
+
+  // TC statement payment (#405): origin savings ↔ TC destination are both
+  // user accounts, so insert as a paired transfer group. Ingest-level, not
+  // through the generic single-insert path below.
+  if (parsed.kind === "tc_payment") {
+    return ingestTcStatementPayment(userId, parsed, allAccounts, forceAccountId);
+  }
+  // TC credit received (#405): the SMS tells us ONLY the TC destination; the
+  // origin account is external (another bank, Nequi, cash deposit, 3rd-party
+  // transfer). Insert as a single unpaired transfer leg — user can pair
+  // manually from /transactions if the other side is also a findash account.
+  if (parsed.kind === "tc_credit_received") {
+    return ingestTcCreditReceived(userId, parsed, allAccounts, forceAccountId);
+  }
 
   let account: RoutableAccount | null;
   if (forceAccountId !== undefined) {
@@ -285,7 +300,7 @@ export async function resolveCounterparty(
 }
 
 function resolveAccountForParsed(
-  parsed: ParsedSms,
+  parsed: Exclude<ParsedSms, { kind: "tc_payment" | "tc_credit_received" }>,
   allAccounts: Array<RoutableAccount & { institution: string; type: string }>,
 ): RoutableAccount | null {
   switch (parsed.kind) {
@@ -293,15 +308,12 @@ function resolveAccountForParsed(
       return resolveAccountFromLast4(parsed.cardLast4, parsed.currency, allAccounts);
     case "transfer_sent":
     case "qr_payment":
-    case "tc_payment":
     case "provider_payment_sent":
     case "atm_withdrawal":
     case "bre_b_transfer":
       return resolveAccountFromLast4(parsed.fromLast4, parsed.currency, allAccounts);
     case "transfer_received":
       return resolveAccountFromLast4(parsed.toLast4, parsed.currency, allAccounts);
-    case "tc_credit_received":
-      return resolveAccountFromLast4(parsed.toCardLast4, parsed.currency, allAccounts);
     case "provider_payment": {
       return (
         allAccounts.find(
@@ -315,7 +327,173 @@ function resolveAccountForParsed(
   }
 }
 
-function buildTxFields(parsed: ParsedSms): {
+// #405: TC statement payment — paired transfer group (savings debit + TC credit).
+// Both accounts must exist in findash; otherwise we bail with an explicit error
+// so the ingestion-inbox retry path can surface it. The old single-tx path used
+// to insert into savings with categorySlug="pago-tc" (a child of "deudas"),
+// which double-counted the original TC purchases as debt. This replaces it.
+async function ingestTcStatementPayment(
+  userId: number,
+  parsed: ParsedSms & { kind: "tc_payment" },
+  allAccounts: Array<RoutableAccount & { institution: string; type: string }>,
+  forceAccountId: number | undefined,
+): Promise<IngestOutcome> {
+  let fromAcc: RoutableAccount | null;
+  if (forceAccountId !== undefined) {
+    const forced = allAccounts.find((a) => a.id === forceAccountId);
+    if (!forced) {
+      return { status: "error", reason: `account ${forceAccountId} not found for user` };
+    }
+    if (forced.currency !== parsed.currency) {
+      return {
+        status: "error",
+        reason: `currency mismatch: parsed=${parsed.currency}, account=${forced.currency}`,
+      };
+    }
+    fromAcc = forced;
+  } else {
+    fromAcc = resolveAccountFromLast4(parsed.fromLast4, parsed.currency, allAccounts);
+  }
+  if (!fromAcc) {
+    return {
+      status: "error",
+      reason: `no source account matches last4=${parsed.fromLast4} currency=${parsed.currency}`,
+    };
+  }
+
+  const toAcc = resolveAccountFromLast4(parsed.toCardLast4, parsed.currency, allAccounts);
+  if (!toAcc) {
+    return {
+      status: "error",
+      reason: `no TC account matches last4=${parsed.toCardLast4} currency=${parsed.currency} — add the card in /settings/accounts before ingesting`,
+    };
+  }
+
+  const occurredAt = new Date(
+    `${parsed.occurredOn}T${parsed.occurredTime}:00${COP_TIMEZONE_OFFSET}`,
+  );
+  const descriptionRaw = `Pago TC *${parsed.toCardLast4}`;
+  const result = await insertTransferGroup({
+    userId,
+    legs: [
+      {
+        accountId: fromAcc.id,
+        amountCents: -parsed.amountCents,
+        currency: parsed.currency,
+        descriptionRaw,
+        source: "sms",
+        occurredAt,
+        externalId: parsed.externalId,
+        rawData: { kind: parsed.kind, sms: parsed.raw, role: "debit" },
+      },
+      {
+        accountId: toAcc.id,
+        amountCents: parsed.amountCents,
+        currency: parsed.currency,
+        descriptionRaw,
+        source: "sms",
+        occurredAt,
+        externalId: parsed.externalId,
+        rawData: { kind: parsed.kind, sms: parsed.raw, role: "credit" },
+      },
+    ],
+  });
+
+  if (result.status === "duplicated") return { status: "duplicated" };
+  if (result.status === "error") return { status: "error", reason: result.reason };
+
+  for (const txId of result.txIds) {
+    emit({ type: "transaction:created", id: txId, source: "sms", timestamp: Date.now() });
+  }
+  // Contract: IngestOutcome carries a single txId. Return the origin (debit)
+  // leg — it's the one users recognize as "their payment" in logs and UI.
+  return { status: "inserted", txId: result.txIds[0] };
+}
+
+// #405: TC credit received — an abono landing on a TC from an external source.
+// The SMS gives us the TC destination (toCardLast4) and the senderName, but no
+// origin account we can route to. We insert a single transfer leg (channel =
+// "transfer", category_slug = null) so the balance moves correctly without
+// polluting spend/income. If the user later identifies the origin as one of
+// their accounts, they can pair it manually from /transactions.
+async function ingestTcCreditReceived(
+  userId: number,
+  parsed: ParsedSms & { kind: "tc_credit_received" },
+  allAccounts: Array<RoutableAccount & { institution: string; type: string }>,
+  forceAccountId: number | undefined,
+): Promise<IngestOutcome> {
+  let toAcc: RoutableAccount | null;
+  if (forceAccountId !== undefined) {
+    const forced = allAccounts.find((a) => a.id === forceAccountId);
+    if (!forced) {
+      return { status: "error", reason: `account ${forceAccountId} not found for user` };
+    }
+    if (forced.currency !== parsed.currency) {
+      return {
+        status: "error",
+        reason: `currency mismatch: parsed=${parsed.currency}, account=${forced.currency}`,
+      };
+    }
+    toAcc = forced;
+  } else {
+    toAcc = resolveAccountFromLast4(parsed.toCardLast4, parsed.currency, allAccounts);
+  }
+  if (!toAcc) {
+    return {
+      status: "error",
+      reason: `no TC account matches last4=${parsed.toCardLast4} currency=${parsed.currency}`,
+    };
+  }
+
+  const occurredAt = new Date(
+    `${parsed.occurredOn}T${parsed.occurredTime}:00${COP_TIMEZONE_OFFSET}`,
+  );
+  const descriptionRaw = `Abono de ${parsed.senderName} a TC *${parsed.toCardLast4}`;
+
+  try {
+    const result = await db
+      .insert(transactions)
+      .values({
+        userId,
+        accountId: toAcc.id,
+        occurredAt,
+        amountCents: parsed.amountCents,
+        currency: parsed.currency,
+        descriptionRaw,
+        descriptionClean: null,
+        merchant: parsed.senderName,
+        categorySlug: null,
+        counterpartyId: null,
+        classificationMethod: "manual",
+        classificationConfidence: null,
+        source: "sms",
+        channel: "transfer",
+        externalId: parsed.externalId,
+        rawData: { kind: parsed.kind, sms: parsed.raw },
+      })
+      .onConflictDoNothing({
+        target: [transactions.accountId, transactions.externalId],
+        where: sql`${transactions.externalId} IS NOT NULL`,
+      })
+      .returning({ id: transactions.id });
+
+    if (result.length === 0) return { status: "duplicated" };
+    emit({
+      type: "transaction:created",
+      id: result[0].id,
+      source: "sms",
+      timestamp: Date.now(),
+    });
+    return { status: "inserted", txId: result[0].id };
+  } catch (err) {
+    return {
+      status: "error",
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function buildTxFields(parsed: Exclude<ParsedSms, { kind: "tc_payment" | "tc_credit_received" }>): {
   amountCents: bigint;
   descriptionRaw: string;
   merchant: string | null;
@@ -346,14 +524,6 @@ function buildTxFields(parsed: ParsedSms): {
         merchant: null,
         categorySlug: null,
         method: "unclassified",
-      };
-    case "tc_payment":
-      return {
-        amountCents: -parsed.amountCents,
-        descriptionRaw: `Pago TC *${parsed.toCardLast4}`,
-        merchant: null,
-        categorySlug: "pago-tc",
-        method: "manual",
       };
     case "transfer_received":
       return {
@@ -386,14 +556,6 @@ function buildTxFields(parsed: ParsedSms): {
         merchant: null,
         categorySlug: null,
         method: "unclassified",
-      };
-    case "tc_credit_received":
-      return {
-        amountCents: parsed.amountCents,
-        descriptionRaw: `Abono de ${parsed.senderName} a TC *${parsed.toCardLast4}`,
-        merchant: parsed.senderName,
-        categorySlug: "pago-tc",
-        method: "manual",
       };
     case "bre_b_transfer":
       return {

--- a/src/lib/telegram/confirm.ts
+++ b/src/lib/telegram/confirm.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/db/schema";
 import { classifyByRule } from "@/lib/classification/rules";
 import { emit } from "@/lib/events/bus";
+import { insertTransferGroup } from "@/lib/transactions/transfer-groups";
 
 export type ConfirmResult =
   | { status: "inserted"; txId: number }
@@ -44,6 +45,27 @@ export async function insertFromDraft(opts: {
   const descriptionRaw = draft.description ?? draft.merchant ?? "Telegram entry";
   const occurredAt = draft.occurredOn ? new Date(`${draft.occurredOn}T12:00:00-05:00`) : new Date();
 
+  const externalId =
+    externalIdOverride ?? (sourceMessageId ? `tg:${chatId}:${sourceMessageId}` : null);
+
+  // #405: `draft.transfer` forces channel="transfer", category_slug=null, and
+  // — when `destinationAccountId` is set — inserts a paired group atomically.
+  // Category rules do not run for transfers (they're not spend/income).
+  if (draft.transfer) {
+    const outcome = await insertTransferFromDraft({
+      userId,
+      draft,
+      signed,
+      descriptionRaw,
+      occurredAt,
+      externalId,
+      chatId,
+      sourceMessageId,
+      startedAt,
+    });
+    return outcome;
+  }
+
   let categorySlug = draft.categorySlug ?? null;
   let classificationMethod: "rule" | "manual" | "unclassified" = categorySlug
     ? "manual"
@@ -61,9 +83,6 @@ export async function insertFromDraft(opts: {
       confidence = match.confidence;
     }
   }
-
-  const externalId =
-    externalIdOverride ?? (sourceMessageId ? `tg:${chatId}:${sourceMessageId}` : null);
 
   let outcome: ConfirmResult;
   try {
@@ -128,6 +147,166 @@ export async function insertFromDraft(opts: {
         currency: draft.currency,
         direction: draft.direction,
         accountId: draft.accountId,
+      },
+    },
+    startedAt,
+    finishedAt: new Date(),
+  });
+
+  return outcome;
+}
+
+// Branches off `insertFromDraft` when the draft is marked as a transfer.
+// Factored out to keep the main path linear — the two flows share input
+// validation and ingestion logging but nothing else.
+async function insertTransferFromDraft(opts: {
+  userId: number;
+  draft: TelegramDraft;
+  signed: bigint;
+  descriptionRaw: string;
+  occurredAt: Date;
+  externalId: string | null;
+  chatId: number;
+  sourceMessageId?: number;
+  startedAt: Date;
+}): Promise<ConfirmResult> {
+  const {
+    userId,
+    draft,
+    signed,
+    descriptionRaw,
+    occurredAt,
+    externalId,
+    chatId,
+    sourceMessageId,
+    startedAt,
+  } = opts;
+  const accountId = draft.accountId as number;
+  const currency = draft.currency as "COP" | "USD";
+  const destinationAccountId = draft.transfer?.destinationAccountId;
+
+  let outcome: ConfirmResult;
+  if (typeof destinationAccountId === "number") {
+    // Paired group: origin debit + destination credit. Origin leg carries the
+    // sign from `direction`; the counter-leg flips it. tc_payment typical
+    // flow: origin savings -X, destination TC +X.
+    const result = await insertTransferGroup({
+      userId,
+      legs: [
+        {
+          accountId,
+          amountCents: signed,
+          currency,
+          descriptionRaw,
+          merchant: draft.merchant ?? null,
+          source: "telegram",
+          occurredAt,
+          externalId,
+          rawData: {
+            source: "telegram",
+            chatId,
+            sourceMessageId,
+            notes: draft.notes,
+            role: signed < BigInt(0) ? "debit" : "credit",
+          },
+        },
+        {
+          accountId: destinationAccountId,
+          amountCents: -signed,
+          currency,
+          descriptionRaw,
+          merchant: draft.merchant ?? null,
+          source: "telegram",
+          occurredAt,
+          externalId,
+          rawData: {
+            source: "telegram",
+            chatId,
+            sourceMessageId,
+            notes: draft.notes,
+            role: signed < BigInt(0) ? "credit" : "debit",
+          },
+        },
+      ],
+    });
+    if (result.status === "duplicated") outcome = { status: "duplicated" };
+    else if (result.status === "error") outcome = { status: "error", reason: result.reason };
+    else {
+      for (const txId of result.txIds) {
+        emit({ type: "transaction:created", id: txId, source: "telegram", timestamp: Date.now() });
+      }
+      outcome = { status: "inserted", txId: result.txIds[0] };
+    }
+  } else {
+    // Unpaired single-leg transfer (tc_credit_received from the bot). The
+    // counterpart is external; user can pair manually later from /transactions.
+    try {
+      const result = await db
+        .insert(transactions)
+        .values({
+          userId,
+          accountId,
+          occurredAt,
+          amountCents: signed,
+          currency,
+          descriptionRaw,
+          descriptionClean: null,
+          merchant: draft.merchant ?? null,
+          categorySlug: null,
+          counterpartyId: null,
+          classificationMethod: "manual",
+          classificationConfidence: null,
+          source: "telegram",
+          channel: "transfer",
+          externalId,
+          rawData: {
+            source: "telegram",
+            chatId,
+            sourceMessageId,
+            notes: draft.notes,
+          },
+        })
+        .onConflictDoNothing({
+          target: [transactions.accountId, transactions.externalId],
+          where: sql`${transactions.externalId} IS NOT NULL`,
+        })
+        .returning({ id: transactions.id });
+
+      if (result.length === 0) {
+        outcome = { status: "duplicated" };
+      } else {
+        emit({
+          type: "transaction:created",
+          id: result[0].id,
+          source: "telegram",
+          timestamp: Date.now(),
+        });
+        outcome = { status: "inserted", txId: result[0].id };
+      }
+    } catch (err) {
+      outcome = { status: "error", reason: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  await db.insert(ingestionLogs).values({
+    userId,
+    source: "telegram",
+    status: outcome.status,
+    itemsReceived: 1,
+    itemsInserted: outcome.status === "inserted" ? 1 : 0,
+    itemsDuplicated: outcome.status === "duplicated" ? 1 : 0,
+    errorMessage: outcome.status === "error" ? outcome.reason : null,
+    payload: {
+      chatId,
+      sourceMessageId,
+      draft: {
+        amountCents: draft.amountCents,
+        currency: draft.currency,
+        direction: draft.direction,
+        accountId: draft.accountId,
+      },
+      transfer: {
+        destinationAccountId: destinationAccountId ?? null,
       },
     },
     startedAt,

--- a/src/lib/telegram/sms-draft.test.ts
+++ b/src/lib/telegram/sms-draft.test.ts
@@ -137,14 +137,38 @@ describe("buildDraftFromParsedSms", () => {
     expect(result.draft.accountId).toBe(1);
   });
 
-  it("maps tc_payment to expense with 'pago-tc' category", () => {
+  it("maps tc_payment to a transfer group draft (savings → TC) with no category (#405)", () => {
     const parsed = parseOrThrow(
       "Bancolombia: Pagaste $500.000,00 en la tarjeta de credito *2575 desde la cuenta *1234, el 15/04/2026 a las 10:00",
     );
     const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
     expect(result.draft.direction).toBe("expense");
-    expect(result.draft.categorySlug).toBe("pago-tc");
+    // #405: transfers don't carry a spend/income category.
+    expect(result.draft.categorySlug).toBeUndefined();
+    // Origin is the savings account matched by fromLast4.
     expect(result.draft.accountId).toBe(1);
+    // Destination TC is resolved from toCardLast4 + currency.
+    expect(result.draft.transfer).toEqual({ destinationAccountId: 2 });
+  });
+
+  it("tc_payment leaves destination undefined when the TC isn't in findash", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: Pagaste $500.000,00 en la tarjeta de credito *7777 desde la cuenta *1234, el 15/04/2026 a las 10:00",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.transfer).toEqual({ destinationAccountId: undefined });
+  });
+
+  it("tc_credit_received produces an unpaired transfer-leg draft (#405)", () => {
+    const parsed = parseOrThrow(
+      "Bancolombia: AIDA MALDONADO hizo un abono por $2,125,092 a tu tarjeta de credito terminada en **2575, el 03/12/2025 13:40. Si tienes dudas, llamanos al 018000931987. Estamos cerca.",
+    );
+    const result = buildDraftFromParsedSms(parsed, ACCOUNTS);
+    expect(result.draft.categorySlug).toBeUndefined();
+    // Empty transfer marker → confirm will insert a single leg with
+    // channel="transfer" and transfer_group_id=null (origin is external).
+    expect(result.draft.transfer).toEqual({});
+    expect(result.draft.accountId).toBe(2);
   });
 
   it("maps atm_withdrawal with resolved account but no category", () => {

--- a/src/lib/telegram/sms-draft.ts
+++ b/src/lib/telegram/sms-draft.ts
@@ -85,10 +85,11 @@ function describe(parsed: ParsedSms): {
         direction: "expense",
       };
     case "tc_payment":
+      // #405: no category — transfers live outside spend/income taxonomy.
+      // The confirm flow reads `draft.transfer` to know to insert as a group.
       return {
         description: `Pago TC *${parsed.toCardLast4}`,
         direction: "expense",
-        categorySlug: "pago-tc",
       };
     case "transfer_received":
       return {
@@ -116,11 +117,13 @@ function describe(parsed: ParsedSms): {
         direction: "expense",
       };
     case "tc_credit_received":
+      // #405: single unpaired transfer leg — origin is external (we don't have
+      // it in the SMS), so there's no companion credit. Direction is "income"
+      // only in the cosmetic sense (money arrives at the TC reducing debt).
       return {
         merchant: parsed.senderName,
         description: `Abono de ${parsed.senderName} a TC *${parsed.toCardLast4}`,
         direction: "income",
-        categorySlug: "pago-tc",
       };
     case "bre_b_transfer":
       return {
@@ -138,6 +141,18 @@ export function buildDraftFromParsedSms(
   const accountId = resolveAccountId(parsed, accounts);
   const { merchant, description, direction, categorySlug } = describe(parsed);
 
+  // #405: `tc_payment` → paired transfer group (destination resolved from
+  // `toCardLast4`). `tc_credit_received` → single unpaired transfer leg
+  // (origin is external / unknown).
+  let transfer: TelegramDraft["transfer"];
+  if (parsed.kind === "tc_payment") {
+    const routable = toRoutable(accounts);
+    const dest = resolveAccountFromLast4(parsed.toCardLast4, parsed.currency, routable);
+    transfer = { destinationAccountId: dest?.id };
+  } else if (parsed.kind === "tc_credit_received") {
+    transfer = {};
+  }
+
   const draft: TelegramDraft = {
     amountCents: parsed.amountCents.toString(),
     currency: parsed.currency,
@@ -147,6 +162,7 @@ export function buildDraftFromParsedSms(
     occurredOn: parsed.occurredOn,
     accountId,
     categorySlug,
+    transfer,
   };
 
   return {

--- a/src/lib/transactions/transfer-groups.test.ts
+++ b/src/lib/transactions/transfer-groups.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  archiveTransferGroup,
+  insertTransferGroup,
+  listTransferGroupLegs,
+  restoreTransferGroup,
+  validateTransferGroupLegs,
+  type TransferLeg,
+} from "./transfer-groups";
+
+// #405: Unit + DB tests for the transfer-group primitive. Covers the core
+// invariants (Σ=0, opposite signs, ≥2 legs), atomic multi-leg insert with
+// duplicate rollback, and the cascading archive/restore helpers.
+//
+// Tenancy: every assertion scopes on user_id — never relies on id alone, in
+// line with the per-user-table-join-tenant-safety memory.
+
+const TEST_USER_ID = 1;
+const SAVINGS_COP_ID = 1;
+const VISA_COP_ID = 5;
+const MASTERCARD_COP_ID = 6;
+
+function leg(
+  override: Partial<TransferLeg> & Pick<TransferLeg, "accountId" | "amountCents">,
+): TransferLeg {
+  return {
+    currency: "COP",
+    descriptionRaw: "test transfer",
+    source: "manual",
+    occurredAt: new Date("2026-04-15T12:00:00Z"),
+    rawData: { test: true },
+    ...override,
+  };
+}
+
+async function cleanup() {
+  await db.execute(sql`
+    DELETE FROM transactions
+    WHERE external_id LIKE 'test-tg:%' OR raw_data @> '{"test": true}'
+  `);
+}
+
+afterEach(async () => {
+  await cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("validateTransferGroupLegs (pure)", () => {
+  it("rejects an empty leg list", () => {
+    expect(validateTransferGroupLegs([])).toEqual({ ok: false, reason: "empty" });
+  });
+
+  it("rejects a single-leg group", () => {
+    const result = validateTransferGroupLegs([leg({ accountId: 1, amountCents: BigInt(-1000) })]);
+    expect(result).toEqual({ ok: false, reason: "single-leg" });
+  });
+
+  it("rejects when all legs share the same sign (no debit + credit pair)", () => {
+    const result = validateTransferGroupLegs([
+      leg({ accountId: 1, amountCents: BigInt(-500) }),
+      leg({ accountId: 2, amountCents: BigInt(-500) }),
+    ]);
+    expect(result).toEqual({ ok: false, reason: "missing-opposite-signs" });
+  });
+
+  it("rejects an unbalanced group (Σ ≠ 0)", () => {
+    const result = validateTransferGroupLegs([
+      leg({ accountId: 1, amountCents: BigInt(-1000) }),
+      leg({ accountId: 2, amountCents: BigInt(900) }),
+    ]);
+    expect(result).toEqual({ ok: false, reason: "unbalanced" });
+  });
+
+  it("accepts a valid 2-leg group (debit + credit, Σ=0)", () => {
+    const result = validateTransferGroupLegs([
+      leg({ accountId: 1, amountCents: BigInt(-1000) }),
+      leg({ accountId: 2, amountCents: BigInt(1000) }),
+    ]);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts a valid 1-to-N group (one debit, many credits summing to |debit|)", () => {
+    const result = validateTransferGroupLegs([
+      leg({ accountId: 1, amountCents: BigInt(-10000) }),
+      leg({ accountId: 2, amountCents: BigInt(4000) }),
+      leg({ accountId: 3, amountCents: BigInt(6000) }),
+    ]);
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+describe("insertTransferGroup", () => {
+  it("inserts every leg atomically with the same transfer_group_id", async () => {
+    const result = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(-50000),
+          externalId: "test-tg:basic:1",
+        }),
+        leg({
+          accountId: VISA_COP_ID,
+          amountCents: BigInt(50000),
+          externalId: "test-tg:basic:1",
+        }),
+      ],
+    });
+    expect(result.status).toBe("inserted");
+    if (result.status !== "inserted") return;
+
+    const rows = await db.execute<{
+      id: number;
+      account_id: number;
+      amount_cents: string;
+      transfer_group_id: string;
+      channel: string;
+      category_slug: string | null;
+    }>(sql`
+      SELECT id, account_id, amount_cents::text, transfer_group_id, channel, category_slug
+      FROM transactions
+      WHERE transfer_group_id = ${result.transferGroupId}::uuid
+      ORDER BY amount_cents ASC
+    `);
+    expect(rows.length).toBe(2);
+    expect(rows[0].transfer_group_id).toBe(result.transferGroupId);
+    expect(rows[1].transfer_group_id).toBe(result.transferGroupId);
+    // Both legs share channel="transfer" and no category.
+    for (const row of rows) {
+      expect(row.channel).toBe("transfer");
+      expect(row.category_slug).toBeNull();
+    }
+    // Σ = 0
+    expect(BigInt(rows[0].amount_cents) + BigInt(rows[1].amount_cents)).toBe(BigInt(0));
+  });
+
+  it("returns `duplicated` and rolls back when a leg conflicts on (account, external_id)", async () => {
+    const first = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(-25000),
+          externalId: "test-tg:dedup:1",
+        }),
+        leg({ accountId: VISA_COP_ID, amountCents: BigInt(25000), externalId: "test-tg:dedup:1" }),
+      ],
+    });
+    expect(first.status).toBe("inserted");
+
+    const second = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(-25000),
+          externalId: "test-tg:dedup:1",
+        }),
+        leg({ accountId: VISA_COP_ID, amountCents: BigInt(25000), externalId: "test-tg:dedup:1" }),
+      ],
+    });
+    expect(second.status).toBe("duplicated");
+
+    // Exactly 2 rows exist — the second group was rolled back in full.
+    const rows = await db.execute<{ n: string }>(sql`
+      SELECT count(*)::text AS n FROM transactions WHERE external_id = 'test-tg:dedup:1'
+    `);
+    expect(rows[0].n).toBe("2");
+  });
+
+  it("rejects invalid groups before touching the DB", async () => {
+    const result = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({ accountId: SAVINGS_COP_ID, amountCents: BigInt(-1000) }),
+        leg({ accountId: VISA_COP_ID, amountCents: BigInt(500) }),
+      ],
+    });
+    expect(result.status).toBe("error");
+    if (result.status === "error") expect(result.reason).toContain("unbalanced");
+  });
+
+  it("supports 1-to-N groups (one debit, many credits)", async () => {
+    const result = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(-100000),
+          externalId: "test-tg:1ton:1",
+        }),
+        leg({
+          accountId: VISA_COP_ID,
+          amountCents: BigInt(40000),
+          externalId: "test-tg:1ton:1",
+        }),
+        leg({
+          accountId: MASTERCARD_COP_ID,
+          amountCents: BigInt(60000),
+          externalId: "test-tg:1ton:1",
+        }),
+      ],
+    });
+    expect(result.status).toBe("inserted");
+    if (result.status !== "inserted") return;
+    expect(result.txIds.length).toBe(3);
+  });
+});
+
+describe("archiveTransferGroup / restoreTransferGroup", () => {
+  it("archives every live leg in a group atomically", async () => {
+    const result = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(-7000),
+          externalId: "test-tg:arch:1",
+        }),
+        leg({ accountId: VISA_COP_ID, amountCents: BigInt(7000), externalId: "test-tg:arch:1" }),
+      ],
+    });
+    expect(result.status).toBe("inserted");
+    if (result.status !== "inserted") return;
+
+    const archived = await archiveTransferGroup({
+      userId: TEST_USER_ID,
+      transferGroupId: result.transferGroupId,
+    });
+    expect(archived).toBe(2);
+
+    const liveCount = await db.execute<{ n: string }>(sql`
+      SELECT count(*)::text AS n FROM transactions
+      WHERE transfer_group_id = ${result.transferGroupId}::uuid AND deleted_at IS NULL
+    `);
+    expect(liveCount[0].n).toBe("0");
+
+    // Idempotent re-archive: already-archived rows are skipped.
+    const again = await archiveTransferGroup({
+      userId: TEST_USER_ID,
+      transferGroupId: result.transferGroupId,
+    });
+    expect(again).toBe(0);
+  });
+
+  it("restore flips deleted_at back to NULL on every leg", async () => {
+    const result = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(-3000),
+          externalId: "test-tg:rest:1",
+        }),
+        leg({ accountId: VISA_COP_ID, amountCents: BigInt(3000), externalId: "test-tg:rest:1" }),
+      ],
+    });
+    if (result.status !== "inserted") throw new Error("seed failed");
+
+    await archiveTransferGroup({ userId: TEST_USER_ID, transferGroupId: result.transferGroupId });
+    const restored = await restoreTransferGroup({
+      userId: TEST_USER_ID,
+      transferGroupId: result.transferGroupId,
+    });
+    expect(restored).toBe(2);
+
+    const liveCount = await db.execute<{ n: string }>(sql`
+      SELECT count(*)::text AS n FROM transactions
+      WHERE transfer_group_id = ${result.transferGroupId}::uuid AND deleted_at IS NULL
+    `);
+    expect(liveCount[0].n).toBe("2");
+  });
+
+  it("never cascades across user_id (tenancy)", async () => {
+    const result = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({ accountId: SAVINGS_COP_ID, amountCents: BigInt(-1000), externalId: "test-tg:ten:1" }),
+        leg({ accountId: VISA_COP_ID, amountCents: BigInt(1000), externalId: "test-tg:ten:1" }),
+      ],
+    });
+    if (result.status !== "inserted") throw new Error("seed failed");
+
+    // A different (nonexistent-in-test) user trying to archive the same group
+    // must not touch any of the rows — the user_id filter is the guard.
+    const archived = await archiveTransferGroup({
+      userId: 999_999,
+      transferGroupId: result.transferGroupId,
+    });
+    expect(archived).toBe(0);
+
+    const legs = await listTransferGroupLegs({
+      userId: TEST_USER_ID,
+      transferGroupIds: [result.transferGroupId],
+    });
+    expect(legs.every((l) => l.deletedAt === null)).toBe(true);
+  });
+});
+
+describe("no double-counting of debts after the refactor", () => {
+  it("a TC statement payment via transfer group does NOT add to `deudas`-sum", async () => {
+    // Compute the baseline spend in "deudas" children (real debt servicing).
+    const baseline = await db.execute<{ total: string | null }>(sql`
+      SELECT COALESCE(SUM(amount_cents), 0)::text AS total
+      FROM transactions t
+      LEFT JOIN categories c
+        ON c.user_id = t.user_id AND c.slug = t.category_slug
+      WHERE t.user_id = ${TEST_USER_ID}
+        AND t.deleted_at IS NULL
+        AND (t.category_slug = 'deudas' OR c.parent_slug = 'deudas')
+    `);
+    const baselineTotal = BigInt(baseline[0].total ?? "0");
+
+    // Insert a 500k TC payment as a transfer group. If it leaked into a
+    // category under `deudas`, the sum would move. With the #405 refactor
+    // it must NOT.
+    const result = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(-50000000),
+          externalId: "test-tg:dbl:1",
+        }),
+        leg({ accountId: VISA_COP_ID, amountCents: BigInt(50000000), externalId: "test-tg:dbl:1" }),
+      ],
+    });
+    expect(result.status).toBe("inserted");
+
+    const after = await db.execute<{ total: string | null }>(sql`
+      SELECT COALESCE(SUM(amount_cents), 0)::text AS total
+      FROM transactions t
+      LEFT JOIN categories c
+        ON c.user_id = t.user_id AND c.slug = t.category_slug
+      WHERE t.user_id = ${TEST_USER_ID}
+        AND t.deleted_at IS NULL
+        AND (t.category_slug = 'deudas' OR c.parent_slug = 'deudas')
+    `);
+    const afterTotal = BigInt(after[0].total ?? "0");
+
+    expect(afterTotal).toBe(baselineTotal);
+  });
+});

--- a/src/lib/transactions/transfer-groups.ts
+++ b/src/lib/transactions/transfer-groups.ts
@@ -1,0 +1,232 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { DB } from "@/lib/db";
+import { db as defaultDb } from "@/lib/db";
+import { transactions } from "@/lib/db/schema";
+import type { Currency } from "@/lib/types";
+
+// Single leg of a transfer group — one INSERT into `transactions`. Sign matters:
+// a debit is negative, a credit is positive. Category is NEVER carried on a
+// transfer leg; channel is always forced to "transfer" by `insertTransferGroup`.
+//
+// `externalId` is the dedup key shared with the non-transfer path: a second
+// ingest attempt of the same SMS hits the unique (account_id, external_id)
+// index and rolls the group back (status="duplicated"). Callers that don't
+// dedupe (manual UI) pass `null`.
+export type TransferLeg = {
+  accountId: number;
+  amountCents: bigint;
+  currency: Currency;
+  descriptionRaw: string;
+  descriptionClean?: string | null;
+  merchant?: string | null;
+  counterpartyId?: number | null;
+  source: "sms" | "telegram" | "manual" | "csv" | "csv_reconcile";
+  occurredAt: Date;
+  externalId?: string | null;
+  rawData?: Record<string, unknown>;
+  notes?: string | null;
+};
+
+export type TransferGroupValidationError =
+  | "empty"
+  | "single-leg"
+  | "unbalanced"
+  | "missing-opposite-signs";
+
+export type TransferGroupValidationResult =
+  | { ok: true }
+  | { ok: false; reason: TransferGroupValidationError };
+
+// Pure. Shared by the insert helper, the manual UI action, and tests so the
+// invariant definition lives in exactly one place.
+export function validateTransferGroupLegs(legs: TransferLeg[]): TransferGroupValidationResult {
+  if (legs.length === 0) return { ok: false, reason: "empty" };
+  if (legs.length === 1) return { ok: false, reason: "single-leg" };
+
+  let sum = BigInt(0);
+  let hasPositive = false;
+  let hasNegative = false;
+  for (const leg of legs) {
+    sum += leg.amountCents;
+    if (leg.amountCents > BigInt(0)) hasPositive = true;
+    else if (leg.amountCents < BigInt(0)) hasNegative = true;
+  }
+
+  if (!hasPositive || !hasNegative) return { ok: false, reason: "missing-opposite-signs" };
+  if (sum !== BigInt(0)) return { ok: false, reason: "unbalanced" };
+  return { ok: true };
+}
+
+export type InsertTransferGroupResult =
+  | { status: "inserted"; transferGroupId: string; txIds: number[] }
+  | { status: "duplicated" }
+  | { status: "error"; reason: string };
+
+// Inserts every leg atomically with a shared transfer_group_id. `channel` is
+// always forced to "transfer" and `categorySlug` to null — transfers are not
+// spend or income. Invariants (Σ=0, opposite signs, ≥2 legs) are validated
+// before touching the DB.
+//
+// If any leg conflicts on (account_id, external_id), the transaction rolls
+// back and we return "duplicated" — partial groups are never persisted.
+export async function insertTransferGroup(opts: {
+  userId: number;
+  legs: TransferLeg[];
+  existingGroupId?: string;
+  database?: DB;
+}): Promise<InsertTransferGroupResult> {
+  const { userId, legs, existingGroupId, database = defaultDb } = opts;
+
+  const validation = validateTransferGroupLegs(legs);
+  if (!validation.ok) {
+    return { status: "error", reason: `invalid transfer group: ${validation.reason}` };
+  }
+
+  const transferGroupId = existingGroupId ?? randomUUID();
+
+  try {
+    const txIds = await database.transaction(async (trx) => {
+      const inserted: number[] = [];
+      for (const leg of legs) {
+        const result = await trx
+          .insert(transactions)
+          .values({
+            userId,
+            accountId: leg.accountId,
+            occurredAt: leg.occurredAt,
+            amountCents: leg.amountCents,
+            currency: leg.currency,
+            descriptionRaw: leg.descriptionRaw,
+            descriptionClean: leg.descriptionClean ?? null,
+            merchant: leg.merchant ?? null,
+            categorySlug: null,
+            counterpartyId: leg.counterpartyId ?? null,
+            classificationMethod: "manual",
+            classificationConfidence: null,
+            source: leg.source,
+            channel: "transfer",
+            transferGroupId,
+            externalId: leg.externalId ?? null,
+            rawData: leg.rawData ?? {},
+            notes: leg.notes ?? null,
+          })
+          .onConflictDoNothing({
+            target: [transactions.accountId, transactions.externalId],
+            where: sql`${transactions.externalId} IS NOT NULL`,
+          })
+          .returning({ id: transactions.id });
+
+        if (result.length === 0) {
+          // A duplicate on one leg means the whole group is duplicated
+          // — rollback by throwing a sentinel we catch outside.
+          throw new TransferGroupDuplicate();
+        }
+        inserted.push(result[0].id);
+      }
+      return inserted;
+    });
+
+    return { status: "inserted", transferGroupId, txIds };
+  } catch (err) {
+    if (err instanceof TransferGroupDuplicate) return { status: "duplicated" };
+    return { status: "error", reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+class TransferGroupDuplicate extends Error {
+  constructor() {
+    super("transfer-group-duplicate");
+    this.name = "TransferGroupDuplicate";
+  }
+}
+
+// Soft-deletes every leg of a transfer group atomically. Called by the
+// archive action when the tx being archived belongs to a group — keeps the
+// Σ=0 invariant intact (archiving half a transfer would make archived totals
+// wrong). Pass `transferGroupId = null` to no-op.
+//
+// Returns the count of newly archived rows (rows already archived are skipped
+// via the `deleted_at IS NULL` filter so the call is idempotent).
+export async function archiveTransferGroup(opts: {
+  userId: number;
+  transferGroupId: string;
+  database?: DB;
+}): Promise<number> {
+  const { userId, transferGroupId, database = defaultDb } = opts;
+  const result = await database
+    .update(transactions)
+    .set({ deletedAt: sql`NOW()`, updatedAt: new Date() })
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.transferGroupId, transferGroupId),
+        sql`${transactions.deletedAt} IS NULL`,
+      ),
+    )
+    .returning({ id: transactions.id });
+  return result.length;
+}
+
+// Inverse of `archiveTransferGroup`. Used by the restore path so the user
+// can un-archive the whole group, not just the leg they clicked.
+export async function restoreTransferGroup(opts: {
+  userId: number;
+  transferGroupId: string;
+  database?: DB;
+}): Promise<number> {
+  const { userId, transferGroupId, database = defaultDb } = opts;
+  const result = await database
+    .update(transactions)
+    .set({ deletedAt: null, updatedAt: new Date() })
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.transferGroupId, transferGroupId),
+        sql`${transactions.deletedAt} IS NOT NULL`,
+      ),
+    )
+    .returning({ id: transactions.id });
+  return result.length;
+}
+
+// Fetches the sibling txs that share a transfer_group_id. Used by the
+// `/transactions` row renderer to show the counter-leg badge and by the
+// archive action to know whether to cascade. Always scoped to `userId`
+// per tenancy rules (memory: per-user-table-join-tenant-safety).
+export async function listTransferGroupLegs(opts: {
+  userId: number;
+  transferGroupIds: string[];
+  database?: DB;
+}): Promise<
+  Array<{
+    id: number;
+    transferGroupId: string;
+    accountId: number;
+    amountCents: bigint;
+    deletedAt: Date | null;
+  }>
+> {
+  const { userId, transferGroupIds, database = defaultDb } = opts;
+  if (transferGroupIds.length === 0) return [];
+  return database
+    .select({
+      id: transactions.id,
+      transferGroupId: transactions.transferGroupId,
+      accountId: transactions.accountId,
+      amountCents: transactions.amountCents,
+      deletedAt: transactions.deletedAt,
+    })
+    .from(transactions)
+    .where(
+      and(eq(transactions.userId, userId), inArray(transactions.transferGroupId, transferGroupIds)),
+    ) as Promise<
+    Array<{
+      id: number;
+      transferGroupId: string;
+      accountId: number;
+      amountCents: bigint;
+      deletedAt: Date | null;
+    }>
+  >;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
     testTimeout: 10_000,
     setupFiles: ["./vitest.setup.ts"],
     // Integration tests share a single Postgres database and INSERT/DELETE


### PR DESCRIPTION
## Summary

Closes #405 — first of the three #345 children.

Historical `tc_payment` / `tc_credit_received` SMS inserted a `pago-tc` tx under `deudas`, **double-counting** TC statement payments against the original purchases. This PR replaces that with a proper transfer-group model so the #407 insights can trust the taxonomy.

## What changed

- **schema**: `transactions.transfer_group_id uuid` + partial index (migration 0049)
- **helper** `src/lib/transactions/transfer-groups.ts`:
  - `validateTransferGroupLegs` — pure invariants (Σ=0, opposite signs, ≥2 legs)
  - `insertTransferGroup` — atomic multi-leg insert; full rollback if any leg conflicts on `(account_id, external_id)`
  - `archiveTransferGroup` / `restoreTransferGroup` — cascading soft-delete
- **SMS pipeline** (`src/lib/ingestion/sms-pipeline.ts`):
  - `tc_payment` → paired transfer group: origin savings (`fromLast4`) debit + destination TC (`toCardLast4`) credit
  - `tc_credit_received` → single unpaired transfer leg on the TC (origin is external / unknown; user can pair later from `/transactions`)
- **bot** (`sms-draft.ts` + `confirm.ts`): `draft.transfer = { destinationAccountId?: number }` drives the same flow
- **archive/restore actions** in `src/app/(app)/transactions/actions.ts` cascade across the group to keep Σ=0 intact
- **manual UI**: `<TransferGroupDialog />` mounted in the `/transactions` header for 1-to-N manual creation (unblocks compra de cartera bank-to-bank from finding F2)
- **seed**: new `intereses-tc` category (child of `deudas`) reserved for the #407 monthly interest job; legacy `pago-tc` stays for FK compatibility with historical rows
- **historical data migration**: `scripts/migrate-pago-tc-to-transfer.ts` (idempotent — only touches rows where `category_slug='pago-tc' AND transfer_group_id IS NULL`), wired into `scripts/migrate-prod.ts` + `deploy.yml` overlay so every deploy self-heals

## Tests

822 / 822 pass (up from 795; added 27 new tests).

- `src/lib/transactions/transfer-groups.test.ts` — invariants, dedup rollback, cascade archive/restore, tenancy, no-double-counting assertion
- `src/app/(app)/transactions/actions.test.ts` — archive cascade over groups + `createManualTransferGroup` happy paths + rejection cases (unbalanced, cross-currency, self-destination, future date)
- `scripts/migrate-pago-tc-to-transfer.test.ts` — paired / unpaired / no-destination / idempotency
- Updated `src/app/api/ingest/sms/route.test.ts` and `src/lib/telegram/sms-draft.test.ts` to assert the new behavior (paired group for tc_payment, unpaired transfer leg for tc_credit_received)

## Test plan (user validation in prod)

- [ ] Apply migration 0049 + run `bun run db:migrate:pago-tc` (or let deploy do it) — verify historical `pago-tc` rows converted to transfer groups
- [ ] Send a real `tc_payment` SMS and confirm the DB has 2 rows sharing a `transfer_group_id`, both `channel="transfer"`, both `category_slug=NULL`
- [ ] Archive one leg from `/transactions` and confirm both legs disappear from the balance
- [ ] Create a 1-to-N manual transfer group (e.g. compra de cartera fake) from the dialog and confirm the invariants hold
- [ ] Confirm `/insights` no longer shows TC statement payments as `deudas` spend

## Related

- Parent epic: #345
- Siblings (next up): #406 (schema: rate buckets + installments), #407 (helper + interest job — depends on this)
- Memory updated: `pago-tc-modeled-as-expense` → FIXED in #405