### PR TITLE
feat(finance): installment-schedule helper + intereses-causados job (#407)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ next-env.d.ts
 .claude/
 CLAUDE.md
 MovimientosTusCuentasBancolombia*.xlsx
+
+# local-only personal financial artifacts (statements, simulations, etc)
+.private/

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "db:seed:test": "PGDATABASE=findash_test bun run src/lib/db/seed.ts",
     "db:backfill:users": "bun run scripts/backfill-users-reference.ts",
     "db:migrate:pago-tc": "bun run scripts/migrate-pago-tc-to-transfer.ts",
+    "intereses:run": "bun run scripts/run-intereses-causados.ts",
     "db:bootstrap:invites": "bun run scripts/bootstrap-invites.ts",
     "db:bootstrap:webhook-tokens": "bun run scripts/bootstrap-webhook-tokens.ts",
     "test": "vitest run",

--- a/scripts/run-intereses-causados.ts
+++ b/scripts/run-intereses-causados.ts
@@ -1,0 +1,69 @@
+// #407: CLI wrapper around `applyInteresesCausadosForCycle`. For now we
+// invoke this manually (user runs `bun run intereses:run ...` at each cycle
+// cutoff); a cron trigger can be wired later once the job is battle-tested.
+//
+// Invocation:
+//   bun run intereses:run --user=<id> --account=<id> --cycle=YYYY-MM
+//
+// Required flags:
+//   --user     findash user id (int)
+//   --account  TC account id to run for (int)
+//   --cycle    YYYY-MM of the cycle being closed (e.g. 2026-04)
+//
+// Idempotent: re-running the same (user, account, cycle) triple skips with
+// reason "already-run". Logs the outcome as a structured line — no exit
+// code distinction between inserted / skipped (both are successful paths).
+
+import { applyInteresesCausadosForCycle } from "../src/lib/finance/intereses-causados-job";
+import { db } from "../src/lib/db";
+import { createLogger } from "../src/lib/logger";
+
+const log = createLogger({ module: "run-intereses-causados" });
+
+function parseArgs(argv: string[]): { user: number; account: number; cycle: string } {
+  const out: Record<string, string> = {};
+  for (const arg of argv.slice(2)) {
+    const m = arg.match(/^--([a-z]+)=(.+)$/i);
+    if (m) out[m[1]] = m[2];
+  }
+  const user = Number(out.user);
+  const account = Number(out.account);
+  const cycle = out.cycle;
+  if (!Number.isInteger(user) || user <= 0) {
+    throw new Error("--user=<id> is required and must be a positive integer");
+  }
+  if (!Number.isInteger(account) || account <= 0) {
+    throw new Error("--account=<id> is required and must be a positive integer");
+  }
+  if (!cycle || !/^\d{4}-\d{2}$/.test(cycle)) {
+    throw new Error("--cycle=YYYY-MM is required");
+  }
+  return { user, account, cycle };
+}
+
+async function main() {
+  const { user, account, cycle } = parseArgs(process.argv);
+  const result = await applyInteresesCausadosForCycle({
+    userId: user,
+    accountId: account,
+    cycle,
+  });
+  log.info(
+    {
+      userId: user,
+      accountId: account,
+      cycle,
+      result,
+      event: "intereses_causados_run",
+    },
+    `intereses-causados: status=${result.status}`,
+  );
+  await db.$client.end({ timeout: 1 });
+  if (result.status === "error") process.exit(1);
+}
+
+main().catch(async (err) => {
+  log.error({ err, event: "intereses_causados_failed" }, "intereses-causados CLI failed");
+  await db.$client.end({ timeout: 1 }).catch(() => void 0);
+  process.exit(1);
+});

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -77,6 +77,24 @@ function ArchivedBadge() {
   );
 }
 
+// #407: compact cuota progress badge. We don't currently know the "paid"
+// index for the tx without running the schedule helper on render, so the
+// MVP shows just the total `N cuotas` for N > 1 — enough for the user to
+// spot financed purchases at a glance. Future iteration can compute
+// paid/total via the schedule.
+function InstallmentsBadge({ total }: { total: number }) {
+  if (total <= 1) return null;
+  return (
+    <Badge
+      variant="outline"
+      className="shrink-0 gap-1 border-indigo-300 text-[10px] font-medium tracking-wide text-indigo-700 uppercase dark:border-indigo-700 dark:text-indigo-300"
+      title={`Financiado a ${total} cuotas`}
+    >
+      {total} cuotas
+    </Badge>
+  );
+}
+
 function CounterpartyTypeBadge({ type }: { type: NonNullable<TxRow["counterparty"]>["type"] }) {
   if (type === "person") {
     return (
@@ -205,6 +223,9 @@ export function TransactionTable({
                         </span>
                         {isArchived ? <ArchivedBadge /> : null}
                         {tx.isAdjustment ? <AdjustmentBadge /> : null}
+                        {tx.accountType === "credit_card" && tx.installmentsTotal > 1 ? (
+                          <InstallmentsBadge total={tx.installmentsTotal} />
+                        ) : null}
                         {tx.counterparty ? (
                           <CounterpartyTypeBadge type={tx.counterparty.type} />
                         ) : null}

--- a/src/lib/finance/installment-schedule.test.ts
+++ b/src/lib/finance/installment-schedule.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from "vitest";
+import { installmentSchedule, monthsBetween, periodInterestCents } from "./installment-schedule";
+
+// #407: fixtures + invariants for the installment-schedule helper. Three
+// anchors, each straight from real data per parent #345:
+//
+//   F1 — MercadoPago L on Bancolombia Visa *2575: 2_479_900 pesos at 1.8311%
+//        EM × 12 cuotas, no grace. Extract dated feb-mar 2026. Capital per
+//        period should be 206_658.33, so 206_658 cents + residue on cuota 12.
+//
+//   F2 — Diferido sin intereses: 1_049_900 pesos at 0% × 9 cuotas, no grace.
+//        Capital uniform, interest zero, total-to-pay == amount.
+//
+//   F3 — Compra de cartera TDC Amex: 29_000_000 pesos at 1.39% EM × 60 cuotas
+//        WITH month-1 grace. Source: `.private/statements/Simulacion_
+//        CompraCartera_Amex_29M_1.39EM_60m.md` (gitignored — personal data).
+//        The private doc rounds displays to pesos for legibility; the
+//        assertions here tolerate ±100 cents per row to absorb that drift
+//        and still catch semantic drift (missing grace, wrong bucket, etc).
+
+describe("periodInterestCents", () => {
+  it("returns 0 when rate is 0 (diferido sin intereses — regla 1)", () => {
+    expect(periodInterestCents(BigInt(100_000_000), 0)).toBe(BigInt(0));
+  });
+
+  it("returns 0 when balance is 0 or negative", () => {
+    expect(periodInterestCents(BigInt(0), 191)).toBe(BigInt(0));
+    expect(periodInterestCents(BigInt(-1), 191)).toBe(BigInt(0));
+  });
+
+  it("rounds half-up — balance 2_851_666_667 cents × 139 bps ≈ 39_638_167 cents", () => {
+    expect(periodInterestCents(BigInt("2851666667"), 139)).toBe(BigInt("39638167"));
+  });
+});
+
+describe("monthsBetween", () => {
+  it("returns 0 for end == start", () => {
+    const d = new Date("2026-04-15T00:00:00Z");
+    expect(monthsBetween(d, d)).toBe(0);
+  });
+
+  it("returns 1 after one full calendar month", () => {
+    expect(monthsBetween(new Date("2026-01-15"), new Date("2026-02-15"))).toBe(1);
+  });
+
+  it("does NOT count a month that hasn't hit the anniversary day yet", () => {
+    expect(monthsBetween(new Date("2026-01-15"), new Date("2026-02-14"))).toBe(0);
+  });
+
+  it("handles year boundaries", () => {
+    expect(monthsBetween(new Date("2025-12-15"), new Date("2026-03-15"))).toBe(3);
+  });
+});
+
+describe("installmentSchedule — F1 (purchase 12 cuotas @ 1.8311% EM, no grace)", () => {
+  // MercadoPago L line from the Visa *2575 extract (feb-mar 2026).
+  // amountCents 2_479_900 * 100 = 247_990_000.
+  const input = {
+    amountCents: BigInt(247_990_000),
+    rateEMBps: 183, // 1.83% EM ≈ 1.8311% rounded to integer bps (schema is smallint)
+    installments: 12,
+    graceMonth: false,
+    purchaseDate: new Date("2026-02-15"),
+    today: new Date("2026-04-15"),
+  };
+  const result = installmentSchedule(input);
+
+  it("has N rows", () => {
+    expect(result.rows.length).toBe(12);
+  });
+
+  it("capital per period is floor(amount / N) rounded to whole pesos, last absorbs residue", () => {
+    // Helper rounds capital down to whole pesos (×100 cents) so Σ(capital)
+    // matches what a Bancolombia extract prints.
+    const PESO = BigInt(100);
+    const expectedCapital = (input.amountCents / BigInt(12) / PESO) * PESO;
+    const residue = input.amountCents - expectedCapital * BigInt(12);
+    for (let i = 0; i < 11; i++) {
+      expect(result.rows[i].capitalCents).toBe(expectedCapital);
+    }
+    expect(result.rows[11].capitalCents).toBe(expectedCapital + residue);
+  });
+
+  it("Σ(capitalCents) === amountCents exactly", () => {
+    const total = result.rows.reduce((a, r) => a + r.capitalCents, BigInt(0));
+    expect(total).toBe(input.amountCents);
+  });
+
+  it("balance decreases monotonically and hits 0 at month N", () => {
+    let prev = input.amountCents;
+    for (const row of result.rows) {
+      expect(row.balanceAfterCents).toBeLessThan(prev);
+      prev = row.balanceAfterCents;
+    }
+    expect(result.rows[result.rows.length - 1].balanceAfterCents).toBe(BigInt(0));
+  });
+
+  it("no deferred interest without graceMonth", () => {
+    for (const row of result.rows) {
+      expect(row.deferredInterestCents).toBe(BigInt(0));
+    }
+  });
+
+  it("paid count: 2 months have passed between 2026-02-15 and 2026-04-15", () => {
+    expect(result.paidCount).toBe(2);
+    expect(result.pendingCount).toBe(10);
+  });
+});
+
+describe("installmentSchedule — F2 (diferido sin intereses 9 cuotas @ 0%)", () => {
+  const input = {
+    amountCents: BigInt(104_990_000), // 1_049_900 pesos
+    rateEMBps: 0,
+    installments: 9,
+    graceMonth: false,
+    purchaseDate: new Date("2026-01-10"),
+    today: new Date("2026-04-10"),
+  };
+  const result = installmentSchedule(input);
+
+  it("every interest is exactly 0", () => {
+    expect(result.totalInterestCents).toBe(BigInt(0));
+    for (const row of result.rows) {
+      expect(row.interestCents).toBe(BigInt(0));
+      expect(row.deferredInterestCents).toBe(BigInt(0));
+    }
+  });
+
+  it("cuota === capital when rate is 0", () => {
+    for (const row of result.rows) {
+      expect(row.cuotaCents).toBe(row.capitalCents);
+    }
+  });
+
+  it("Σ(cuotaCents) === amountCents", () => {
+    const total = result.rows.reduce((a, r) => a + r.cuotaCents, BigInt(0));
+    expect(total).toBe(input.amountCents);
+  });
+});
+
+describe("installmentSchedule — F3 (compra de cartera 29M @ 1.39% EM × 60, graceMonth)", () => {
+  const input = {
+    amountCents: BigInt("2900000000"), // 29_000_000 COP
+    rateEMBps: 139,
+    installments: 60,
+    graceMonth: true,
+    purchaseDate: new Date("2026-05-01"),
+    today: new Date("2026-05-01"), // fresh — paidCount should be 0
+  };
+  const result = installmentSchedule(input);
+
+  it("emits 60 rows", () => {
+    expect(result.rows.length).toBe(60);
+  });
+
+  it("month 1 under grace pays only capital — no interest on the cuota", () => {
+    const m1 = result.rows[0];
+    expect(m1.interestCents).toBe(BigInt(0));
+    expect(m1.deferredInterestCents).toBe(BigInt(0));
+    expect(m1.cuotaCents).toBe(m1.capitalCents);
+  });
+
+  it("month 2 under grace absorbs the deferred month-1 interest", () => {
+    const m2 = result.rows[1];
+    // deferred = month-1 interest on the full amount
+    expect(m2.deferredInterestCents).toBe(periodInterestCents(input.amountCents, 139));
+    // own interest computed on balance-entering-month-2 = amount - capital_m1
+    const balanceM2Start = input.amountCents - result.rows[0].capitalCents;
+    expect(m2.interestCents).toBe(periodInterestCents(balanceM2Start, 139));
+  });
+
+  it("balance reaches 0 at month 60 (regla 5: last cuota absorbs residue)", () => {
+    expect(result.rows[59].balanceAfterCents).toBe(BigInt(0));
+  });
+
+  it("Σ(capital) === amount", () => {
+    const total = result.rows.reduce((a, r) => a + r.capitalCents, BigInt(0));
+    expect(total).toBe(input.amountCents);
+  });
+
+  it("Σ(cuota) === amount + totalInterest (cash-flow identity)", () => {
+    const totalCuotas = result.rows.reduce((a, r) => a + r.cuotaCents, BigInt(0));
+    expect(totalCuotas).toBe(input.amountCents + result.totalInterestCents);
+  });
+
+  it("matches the private markdown fixture at ±100 cents per row (rows 1, 2, 3, 60)", () => {
+    // Fixture values from `.private/statements/Simulacion_CompraCartera_
+    // Amex_29M_1.39EM_60m.md` — re-expressed as cents for comparison. The
+    // markdown rounds to pesos for display, hence the ±100 cent tolerance
+    // on each row (roughly ±1 peso). We check rows at the critical anchors:
+    // month 1 (capital only), month 2 (grace absorption), month 3 (first
+    // normal month), month 60 (residue absorbed).
+    const expectedPesos: Record<number, { capital: number; interest: number; cuota: number }> = {
+      1: { capital: 483_333, interest: 0, cuota: 483_333 },
+      // Month 2: markdown lumps `interest + deferred = 799_482` into one
+      // column; we split them apart, so we check the sum instead.
+      2: { capital: 483_333, interest: 799_482, cuota: 1_282_815 },
+      3: { capital: 483_333, interest: 389_663, cuota: 872_996 },
+      60: { capital: 483_353, interest: 6_719, cuota: 490_072 },
+    };
+    for (const [monthStr, exp] of Object.entries(expectedPesos)) {
+      const month = Number(monthStr);
+      const row = result.rows[month - 1];
+      const tolCents = BigInt(100);
+      const interestTotalCents = row.interestCents + row.deferredInterestCents;
+      const expCapital = BigInt(exp.capital * 100);
+      const expInterest = BigInt(exp.interest * 100);
+      const expCuota = BigInt(exp.cuota * 100);
+      expect(absDiff(row.capitalCents, expCapital)).toBeLessThanOrEqual(tolCents);
+      expect(absDiff(interestTotalCents, expInterest)).toBeLessThanOrEqual(tolCents);
+      expect(absDiff(row.cuotaCents, expCuota)).toBeLessThanOrEqual(tolCents);
+    }
+  });
+
+  it("total paid over the life of the loan equals amount + Σ(per-row interest)", () => {
+    // Note: the private markdown has an inconsistency — its "Total a pagar
+    // $35.147.275 / Intereses totales $6.147.275" summary does NOT match the
+    // per-row sum of interests in the same doc. Adding up the interest
+    // column row by row gives ~$12.3M, matching this helper. We test the
+    // invariant (identity of cash flows), not the buggy headline stat.
+    const totalCuotas = result.rows.reduce((a, r) => a + r.cuotaCents, BigInt(0));
+    expect(totalCuotas).toBe(input.amountCents + result.totalInterestCents);
+  });
+
+  it("paid / pending split reflects the today anchor", () => {
+    expect(result.paidCount).toBe(0);
+    expect(result.pendingCount).toBe(60);
+  });
+});
+
+describe("installmentSchedule — edge cases", () => {
+  it("N = 1 behaves as a single-payment purchase", () => {
+    const result = installmentSchedule({
+      amountCents: BigInt(100_000),
+      rateEMBps: 0,
+      installments: 1,
+      graceMonth: false,
+      purchaseDate: new Date("2026-04-01"),
+      today: new Date("2026-04-01"),
+    });
+    expect(result.rows.length).toBe(1);
+    expect(result.rows[0].capitalCents).toBe(BigInt(100_000));
+    expect(result.rows[0].cuotaCents).toBe(BigInt(100_000));
+    expect(result.totalInterestCents).toBe(BigInt(0));
+  });
+
+  it("`today` before `purchaseDate` yields paidCount = 0, not negative", () => {
+    const result = installmentSchedule({
+      amountCents: BigInt(100_000),
+      rateEMBps: 0,
+      installments: 3,
+      graceMonth: false,
+      purchaseDate: new Date("2026-05-01"),
+      today: new Date("2026-01-01"),
+    });
+    expect(result.paidCount).toBe(0);
+  });
+
+  it("`today` long after purchase caps paidCount at N", () => {
+    const result = installmentSchedule({
+      amountCents: BigInt(100_000),
+      rateEMBps: 0,
+      installments: 3,
+      graceMonth: false,
+      purchaseDate: new Date("2020-01-01"),
+      today: new Date("2026-04-01"),
+    });
+    expect(result.paidCount).toBe(3);
+    expect(result.pendingCount).toBe(0);
+  });
+
+  it("throws on zero/negative amount", () => {
+    expect(() =>
+      installmentSchedule({
+        amountCents: BigInt(0),
+        rateEMBps: 0,
+        installments: 1,
+        graceMonth: false,
+        purchaseDate: new Date(),
+        today: new Date(),
+      }),
+    ).toThrow();
+  });
+
+  it("throws on installments < 1 or > 240", () => {
+    const base = {
+      amountCents: BigInt(100),
+      rateEMBps: 0,
+      graceMonth: false,
+      purchaseDate: new Date(),
+      today: new Date(),
+    };
+    expect(() => installmentSchedule({ ...base, installments: 0 })).toThrow();
+    expect(() => installmentSchedule({ ...base, installments: 300 })).toThrow();
+  });
+});
+
+function absDiff(a: bigint, b: bigint): bigint {
+  const d = a - b;
+  return d < BigInt(0) ? -d : d;
+}

--- a/src/lib/finance/installment-schedule.ts
+++ b/src/lib/finance/installment-schedule.ts
@@ -1,0 +1,177 @@
+// #407: pure helper that builds the full installment schedule for a credit-
+// card purchase. Input is a single tx (amount + rate + plan); output is a
+// row per period with capital / interest / balance, plus headline totals.
+//
+// Rules, per parent #345 + scoped validations against real Bancolombia
+// extracts (ver memoria `tc-installments-interest-model`):
+//
+//   - regla 4: when `graceMonth=true`, month 1 pays ONLY capital (interest
+//     is deferred). Month 2 pays its own interest PLUS the deferred month-1
+//     interest. "Francés puro" does NOT apply here.
+//   - regla 5: capital per period is `amountCents / N`, fixed, with the
+//     final period absorbing the rounding residue. Interest is a separate
+//     line per period, never bundled into capital.
+//   - regla 3: the rate snapshot lives on the tx — this helper takes it as
+//     input and does NOT look it up (the caller resolves bucket vs override
+//     via `resolveBucketRateBps`).
+//
+// Rounding: interest is computed as `round(saldo × rate_bps / 10000)` in
+// integer cents, half-up. This matches Bancolombia's display policy close
+// enough to pass the extract-level tests in the sibling test file. If a
+// future extract diverges, update the policy here — do NOT let the helper
+// drift silently.
+
+import type { Currency } from "@/lib/types";
+
+export type InstallmentScheduleInput = {
+  amountCents: bigint; // original purchase amount (positive magnitude)
+  rateEMBps: number; // EM rate in bps (0 = diferido sin intereses, 191 = 1.91% EM)
+  installments: number; // total cuotas, N >= 1
+  graceMonth: boolean; // true = month-1 interest deferred to month 2
+  purchaseDate: Date; // anchor for month counting
+  today: Date; // drives paid vs pending split
+};
+
+export type InstallmentScheduleRow = {
+  month: number; // 1..N
+  capitalCents: bigint;
+  interestCents: bigint; // 0 for month 1 when graceMonth=true
+  deferredInterestCents: bigint; // 0 except for month 2 when graceMonth=true
+  cuotaCents: bigint; // capital + interest + deferred
+  balanceAfterCents: bigint; // never negative, hits 0 at month N
+};
+
+export type InstallmentScheduleOutput = {
+  rows: InstallmentScheduleRow[];
+  paidCount: number;
+  pendingCount: number;
+  // Sum of `cuotaCents` / N. Informational; the actual cuotas are not
+  // uniform once interest enters the picture (only capital is uniform).
+  monthlyPaymentCents: bigint;
+  totalInterestCents: bigint;
+  outstandingBalanceCents: bigint;
+  outstandingInterestCents: bigint;
+  // Optional currency passthrough so consumers that carry through to
+  // Money components don't have to re-thread it.
+  currency?: Currency;
+};
+
+// Round-half-up integer division for `numerator / denominator`. Works on
+// BigInt. Positive inputs only; negatives would break the half-up bias.
+function bigIntRoundHalfUp(numerator: bigint, denominator: bigint): bigint {
+  if (denominator <= BigInt(0)) throw new Error("denominator must be > 0");
+  return (numerator + denominator / BigInt(2)) / denominator;
+}
+
+// Interest for a single period, given a starting balance and the bps rate.
+// Split out so tests can drive it directly when checking specific rows.
+export function periodInterestCents(balanceCents: bigint, rateEMBps: number): bigint {
+  if (rateEMBps === 0) return BigInt(0);
+  if (balanceCents <= BigInt(0)) return BigInt(0);
+  return bigIntRoundHalfUp(balanceCents * BigInt(rateEMBps), BigInt(10000));
+}
+
+export function installmentSchedule(input: InstallmentScheduleInput): InstallmentScheduleOutput {
+  const { amountCents, rateEMBps, installments, graceMonth, purchaseDate, today } = input;
+  if (installments < 1) throw new Error("installments must be >= 1");
+  if (installments > 240) throw new Error("installments > 240 not supported");
+  if (rateEMBps < 0) throw new Error("rateEMBps must be >= 0");
+  if (amountCents <= BigInt(0)) throw new Error("amountCents must be > 0");
+
+  const N = installments;
+  // Capital per period is floored to whole PESOS (multiples of 100 cents) so
+  // Σ(capital) matches what Bancolombia prints on the extract. The last row
+  // absorbs the residue. This is the policy the real 2026 Visa/Mastercard +
+  // Amex-compra-de-cartera extracts use; see `.private/statements/…` for
+  // the source data. If `amountCents % 100 !== 0` (non-whole-peso input),
+  // the final row still absorbs the full residue — but that shape isn't
+  // produced by any real TC purchase we model today.
+  const PESO = BigInt(100);
+  const capitalPerPeriod = (amountCents / BigInt(N) / PESO) * PESO;
+  const residueCents = amountCents - capitalPerPeriod * BigInt(N);
+
+  const rows: InstallmentScheduleRow[] = [];
+  let balance = amountCents;
+  let totalInterest = BigInt(0);
+
+  for (let month = 1; month <= N; month++) {
+    // Last row absorbs the residue so Σ(capital) === amountCents exactly.
+    const isLast = month === N;
+    const capitalThis = isLast ? capitalPerPeriod + residueCents : capitalPerPeriod;
+
+    let interestThis: bigint;
+    let deferredThis: bigint;
+    if (graceMonth && month === 1) {
+      // Month 1: interest is computed but deferred to month 2.
+      interestThis = BigInt(0);
+      deferredThis = BigInt(0);
+    } else if (graceMonth && month === 2) {
+      // Month 2: own interest + the deferred month-1 interest (based on the
+      // original amount, since month 1 paid no capital either — the balance
+      // entering month 2 is `amountCents - capital_month_1`).
+      const deferredBase = amountCents; // month-1 starts with full amount
+      deferredThis = periodInterestCents(deferredBase, rateEMBps);
+      interestThis = periodInterestCents(balance, rateEMBps);
+    } else {
+      interestThis = periodInterestCents(balance, rateEMBps);
+      deferredThis = BigInt(0);
+    }
+
+    const cuota = capitalThis + interestThis + deferredThis;
+    const balanceAfter = balance - capitalThis;
+
+    rows.push({
+      month,
+      capitalCents: capitalThis,
+      interestCents: interestThis,
+      deferredInterestCents: deferredThis,
+      cuotaCents: cuota,
+      balanceAfterCents: balanceAfter,
+    });
+
+    totalInterest += interestThis + deferredThis;
+    balance = balanceAfter;
+  }
+
+  // paid/pending split: count how many period anniversaries have passed since
+  // purchaseDate. The 1st cuota is paid when `today >= purchaseDate + 1mo`.
+  // We compute this by monthly deltas (calendar months) — not by raw 30-day
+  // chunks — so DST-ish edges don't drift.
+  const paidCount = Math.max(0, Math.min(N, monthsBetween(purchaseDate, today)));
+  const pendingCount = N - paidCount;
+
+  // Sum of cuota_i gives the total-to-pay; average cuota is useful in UI.
+  const totalCuotas = rows.reduce((a, r) => a + r.cuotaCents, BigInt(0));
+  const monthlyPaymentCents = totalCuotas / BigInt(N);
+
+  const outstandingBalanceCents =
+    paidCount >= N ? BigInt(0) : (rows[paidCount - 1]?.balanceAfterCents ?? amountCents);
+  const outstandingInterestCents = rows
+    .slice(paidCount)
+    .reduce((a, r) => a + r.interestCents + r.deferredInterestCents, BigInt(0));
+
+  return {
+    rows,
+    paidCount,
+    pendingCount,
+    monthlyPaymentCents,
+    totalInterestCents: totalInterest,
+    outstandingBalanceCents,
+    outstandingInterestCents,
+  };
+}
+
+// Whole-month count between two dates, rounded down. Used only for paid /
+// pending bucketing — precision beyond "has the cuota date passed?" is
+// irrelevant here.
+export function monthsBetween(start: Date, end: Date): number {
+  if (end.getTime() <= start.getTime()) return 0;
+  const years = end.getFullYear() - start.getFullYear();
+  const months = end.getMonth() - start.getMonth();
+  let delta = years * 12 + months;
+  // If the day of `end` is before the day of `start`, the current month
+  // hasn't closed yet — subtract one to keep "paid at or after anniversary"
+  // semantics.
+  if (end.getDate() < start.getDate()) delta -= 1;
+  return Math.max(0, delta);
+}

--- a/src/lib/finance/intereses-causados-job.test.ts
+++ b/src/lib/finance/intereses-causados-job.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { applyInteresesCausadosForCycle, computeInterestForCycle } from "./intereses-causados-job";
+
+// #407: integration tests for the intereses-causados job. Uses the real test
+// DB (findash_test) — seeds a TC account + purchases, runs the job, inspects
+// the synthetic tx. Exercises: happy path, idempotency, zero-interest skip,
+// rate fallback to the account bucket, and tenancy.
+
+const TEST_USER_ID = 1;
+const EXT_PREFIX = "test-intereses:";
+
+async function cleanup() {
+  await db.execute(sql`
+    DELETE FROM transactions
+    WHERE external_id LIKE ${EXT_PREFIX + "%"}
+       OR raw_data ->> 'job' = 'intereses-causados-job'
+  `);
+}
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+async function getVisaId(): Promise<number> {
+  const [row] = await db.execute<{ id: number }>(sql`
+    SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} AND name = 'Bancolombia Visa *2575' LIMIT 1
+  `);
+  return row.id;
+}
+
+async function setBucketRates(
+  accountId: number,
+  buckets: { oneMonth: number; months2to36: number; advances: number },
+) {
+  await db.execute(sql`
+    UPDATE accounts
+    SET metadata = jsonb_set(metadata, '{creditRateBuckets}', ${JSON.stringify(buckets)}::jsonb),
+        updated_at = now()
+    WHERE id = ${accountId}
+  `);
+}
+
+async function seedPurchase(opts: {
+  accountId: number;
+  externalId: string;
+  amountCentsMagnitude: bigint;
+  occurredAt: string; // YYYY-MM-DD
+  installmentsTotal: number;
+  installmentRateBps: number | null;
+}) {
+  const rateSql = opts.installmentRateBps === null ? sql`NULL` : sql`${opts.installmentRateBps}`;
+  const [row] = await db.execute<{ id: number }>(sql`
+    INSERT INTO transactions (
+      user_id, account_id, occurred_at, amount_cents, currency, description_raw,
+      classification_method, source, external_id, installments_total, installment_rate_bps
+    ) VALUES (
+      ${TEST_USER_ID}, ${opts.accountId}, ${`${opts.occurredAt}T12:00:00Z`}::timestamptz,
+      ${(-opts.amountCentsMagnitude).toString()}::bigint, 'COP',
+      ${`test purchase ${opts.externalId}`},
+      'unclassified'::classification_method, 'sms',
+      ${opts.externalId}, ${opts.installmentsTotal}, ${rateSql}
+    )
+    RETURNING id
+  `);
+  return row.id;
+}
+
+describe("computeInterestForCycle", () => {
+  it("returns the interest due on the next unpaid cuota", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 191, advances: 191 });
+
+    // 100_000 pesos @ 191 bps (1.91% EM) × 12 cuotas. Capital per cuota =
+    // 8333 pesos (since 100_000 / 12 = 8333.33 → floor to peso). Interest
+    // on month 1 (no grace for this one): saldo 10_000_000 cents × 191 / 10000
+    // = 191_000 cents = $1_910 pesos.
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}base`,
+      amountCentsMagnitude: BigInt(10_000_000),
+      occurredAt: "2026-03-10",
+      installmentsTotal: 12,
+      installmentRateBps: 191,
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+    expect(run.intereses.length).toBe(1);
+    expect(run.intereses[0].rateEMBps).toBe(191);
+    expect(run.totalInterestCents).toBeGreaterThan(BigInt(0));
+  });
+
+  it("falls back to the account's rate bucket when the tx has no explicit rate", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 200, advances: 200 });
+
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}fallback`,
+      amountCentsMagnitude: BigInt(5_000_000),
+      occurredAt: "2026-03-10",
+      installmentsTotal: 6,
+      installmentRateBps: null, // inherit from bucket
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+    expect(run.intereses.length).toBe(1);
+    expect(run.intereses[0].rateEMBps).toBe(200);
+  });
+
+  it("skips purchases with 1 cuota + 0% oneMonth bucket (diferido nominal)", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 191, advances: 191 });
+
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}zero`,
+      amountCentsMagnitude: BigInt(500_000),
+      occurredAt: "2026-03-10",
+      installmentsTotal: 1,
+      installmentRateBps: null,
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+    expect(run.intereses.length).toBe(0);
+    expect(run.totalInterestCents).toBe(BigInt(0));
+  });
+});
+
+describe("applyInteresesCausadosForCycle", () => {
+  it("inserts a synthetic tx with category intereses-tc on first run", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 191, advances: 191 });
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}ins-1`,
+      amountCentsMagnitude: BigInt(20_000_000),
+      occurredAt: "2026-03-10",
+      installmentsTotal: 12,
+      installmentRateBps: 191,
+    });
+
+    const result = await applyInteresesCausadosForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+    expect(result.status).toBe("inserted");
+    if (result.status !== "inserted") return;
+
+    const [row] = await db.execute<{
+      category_slug: string;
+      amount_cents: string;
+      channel: string;
+      description_raw: string;
+    }>(sql`
+      SELECT category_slug, amount_cents::text, channel, description_raw
+      FROM transactions WHERE id = ${result.txId}
+    `);
+    expect(row.category_slug).toBe("intereses-tc");
+    expect(row.channel).toBe("manual");
+    expect(BigInt(row.amount_cents)).toBeLessThan(BigInt(0)); // expense
+    expect(row.description_raw).toContain("Intereses causados");
+    expect(row.description_raw).toContain("2026-04");
+  });
+
+  it("is idempotent — second call returns skipped/already-run", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 191, advances: 191 });
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}idem`,
+      amountCentsMagnitude: BigInt(10_000_000),
+      occurredAt: "2026-03-10",
+      installmentsTotal: 12,
+      installmentRateBps: 191,
+    });
+
+    const first = await applyInteresesCausadosForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+    expect(first.status).toBe("inserted");
+
+    const second = await applyInteresesCausadosForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+    expect(second.status).toBe("skipped");
+    if (second.status === "skipped") expect(second.reason).toBe("already-run");
+
+    // Still exactly one synthetic row for this (account, cycle).
+    const rows = await db.execute<{ n: string }>(sql`
+      SELECT count(*)::text AS n FROM transactions
+      WHERE user_id = ${TEST_USER_ID}
+        AND account_id = ${visa}
+        AND raw_data ->> 'cycleKey' = ${`${visa}-2026-04`}
+    `);
+    expect(rows[0].n).toBe("1");
+  });
+
+  it("returns skipped/zero-interest when there are no live purchases", async () => {
+    const visa = await getVisaId();
+    // No seeded purchases; existing test DB tx shouldn't match due to cycle.
+    const result = await applyInteresesCausadosForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2099-12", // far-future cycle, nothing will be live
+    });
+    expect(result.status).toBe("skipped");
+  });
+
+  it("errors when the account is not a credit_card", async () => {
+    const [sav] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} AND name = 'Bancolombia Ahorros' LIMIT 1
+    `);
+    await expect(
+      applyInteresesCausadosForCycle({
+        userId: TEST_USER_ID,
+        accountId: sav.id,
+        cycle: "2026-04",
+      }),
+    ).rejects.toThrow(/not a credit card/);
+  });
+});

--- a/src/lib/finance/intereses-causados-job.ts
+++ b/src/lib/finance/intereses-causados-job.ts
@@ -1,0 +1,246 @@
+// #407: monthly job that computes the interest accrued on a credit card for
+// a cycle and persists it as a single synthetic transaction under the
+// `intereses-tc` category (seeded in #405).
+//
+// The expensive bit — the per-purchase schedule — already lives in
+// `installment-schedule.ts`. This module's job is ledger-side:
+//   1. Resolve the live installment purchases on the TC.
+//   2. Compute each one's current balance and interest for the cycle.
+//   3. Sum them and emit ONE synthetic tx.
+//   4. Skip if the cycle already has an interest tx for this account
+//      (idempotency via `raw_data.cycleKey`).
+//
+// The output is intentionally a single tx per cycle (not one per purchase)
+// because that's what Bancolombia extracts do — the user sees a single
+// "INTERESES CORRIENTES $X" line on their statement, not one per compra.
+
+import { and, eq, sql } from "drizzle-orm";
+import { db, type DB } from "@/lib/db";
+import { accounts, transactions, type AccountMetadata } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { installmentSchedule } from "@/lib/finance/installment-schedule";
+import { resolveBucketRateBps } from "@/lib/finance/rates";
+
+export type CycleKey = `${number}-${string}`; // e.g. "5-2026-04"
+
+export type InterestRun = {
+  accountId: number;
+  cycle: string; // YYYY-MM
+  intereses: Array<{
+    txId: number;
+    purchaseAmountCents: bigint;
+    rateEMBps: number;
+    installmentsTotal: number;
+    installmentsPaid: number;
+    outstandingBeforeCents: bigint;
+    interestCents: bigint;
+  }>;
+  totalInterestCents: bigint;
+};
+
+export type ApplyResult =
+  | { status: "inserted"; txId: number; totalInterestCents: bigint }
+  | { status: "skipped"; reason: "zero-interest" | "already-run" }
+  | { status: "error"; reason: string };
+
+function cycleKeyFor(accountId: number, cycle: string): string {
+  return `${accountId}-${cycle}`;
+}
+
+// Convert a "YYYY-MM" cycle string into a UTC mid-month date. Used as the
+// `occurred_at` anchor for the synthetic tx and the `today` input to the
+// schedule helper — being mid-month keeps it insensitive to TZ edges.
+function cycleAnchor(cycle: string): Date {
+  const [y, m] = cycle.split("-").map(Number);
+  if (!Number.isInteger(y) || !Number.isInteger(m)) throw new Error(`invalid cycle: ${cycle}`);
+  return new Date(Date.UTC(y, m - 1, 15, 12, 0, 0, 0));
+}
+
+// For each live installment purchase on the TC, project its schedule as of
+// the cycle anchor and extract the cycle's interest. Purely computational —
+// no DB writes, so it's safe to call from UI handlers for previews.
+export async function computeInterestForCycle(opts: {
+  userId: number;
+  accountId: number;
+  cycle: string; // "YYYY-MM"
+  database?: DB;
+}): Promise<InterestRun> {
+  const { userId, accountId, cycle, database = db } = opts;
+  const anchor = cycleAnchor(cycle);
+
+  const [account] = await database
+    .select({
+      id: accounts.id,
+      type: accounts.type,
+      currency: accounts.currency,
+      metadata: accounts.metadata,
+    })
+    .from(accounts)
+    .where(
+      and(eq(accounts.userId, userId), eq(accounts.id, accountId), notDeleted(accounts.deletedAt)),
+    )
+    .limit(1);
+
+  if (!account) throw new Error(`account ${accountId} not found for user ${userId}`);
+  if (account.type !== "credit_card") {
+    throw new Error(`account ${accountId} is not a credit card`);
+  }
+  const meta = account.metadata as AccountMetadata;
+  const buckets = meta.creditRateBuckets;
+
+  // Live installment purchases: TC txs with installments_total > 0 and
+  // negative amount (purchases, not credits / payments), occurring on or
+  // before the cycle anchor. Soft-deleted rows excluded.
+  const purchases = await database
+    .select({
+      id: transactions.id,
+      amountCents: transactions.amountCents,
+      occurredAt: transactions.occurredAt,
+      installmentsTotal: transactions.installmentsTotal,
+      installmentRateBps: transactions.installmentRateBps,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.accountId, accountId),
+        sql`${transactions.amountCents} < 0`,
+        sql`${transactions.installmentsTotal} >= 1`,
+        sql`${transactions.occurredAt} <= ${anchor.toISOString()}`,
+        notDeleted(transactions.deletedAt),
+        // Exclude txs with no interest potential (rate 0 AND 1 cuota). We
+        // still pull installments_total=1 because it's the default; the
+        // bucket lookup below will return 0 for those under the oneMonth
+        // bucket, producing no-interest rows that we drop downstream.
+      ),
+    );
+
+  const intereses: InterestRun["intereses"] = [];
+  let totalInterestCents = BigInt(0);
+
+  for (const p of purchases) {
+    const rateBps =
+      p.installmentRateBps != null
+        ? p.installmentRateBps
+        : (resolveBucketRateBps(buckets, p.installmentsTotal) ?? 0);
+
+    const schedule = installmentSchedule({
+      amountCents: -p.amountCents, // stored negative, helper expects positive magnitude
+      rateEMBps: rateBps,
+      installments: p.installmentsTotal,
+      graceMonth: true, // Bancolombia default per regla 4; safe for extracts today
+      purchaseDate: p.occurredAt,
+      today: anchor,
+    });
+
+    // The cycle's interest is the interest scheduled for the next unpaid
+    // month. If the loan is fully paid before `anchor`, skip.
+    if (schedule.paidCount >= schedule.rows.length) continue;
+    const nextRow = schedule.rows[schedule.paidCount];
+    const interestCents = nextRow.interestCents + nextRow.deferredInterestCents;
+    if (interestCents === BigInt(0)) continue;
+
+    const outstandingBefore =
+      schedule.paidCount === 0
+        ? -p.amountCents
+        : schedule.rows[schedule.paidCount - 1].balanceAfterCents;
+
+    intereses.push({
+      txId: p.id,
+      purchaseAmountCents: -p.amountCents,
+      rateEMBps: rateBps,
+      installmentsTotal: p.installmentsTotal,
+      installmentsPaid: schedule.paidCount,
+      outstandingBeforeCents: outstandingBefore,
+      interestCents,
+    });
+    totalInterestCents += interestCents;
+  }
+
+  return { accountId, cycle, intereses, totalInterestCents };
+}
+
+// Persist the cycle's interest as a synthetic tx. Idempotent — second call
+// for the same `(accountId, cycle)` returns `skipped / already-run`.
+export async function applyInteresesCausadosForCycle(opts: {
+  userId: number;
+  accountId: number;
+  cycle: string;
+  database?: DB;
+}): Promise<ApplyResult> {
+  const { userId, accountId, cycle, database = db } = opts;
+  const key = cycleKeyFor(accountId, cycle);
+
+  // Idempotency guard — look for a prior synthetic tx on this account+cycle.
+  const existing = await database.execute<{ id: number }>(sql`
+    SELECT id FROM transactions
+    WHERE user_id = ${userId}
+      AND account_id = ${accountId}
+      AND category_slug = 'intereses-tc'
+      AND raw_data ->> 'cycleKey' = ${key}
+      AND deleted_at IS NULL
+    LIMIT 1
+  `);
+  if (existing.length > 0) {
+    return { status: "skipped", reason: "already-run" };
+  }
+
+  const run = await computeInterestForCycle({ userId, accountId, cycle, database });
+  if (run.totalInterestCents === BigInt(0)) {
+    return { status: "skipped", reason: "zero-interest" };
+  }
+
+  try {
+    const anchor = cycleAnchor(cycle);
+    const cycleLabel = cycle; // already YYYY-MM
+    const [accRow] = await database.execute<{ last4s: unknown; currency: "COP" | "USD" }>(sql`
+      SELECT metadata -> 'last4s' AS last4s, currency
+      FROM accounts WHERE id = ${accountId}
+    `);
+    const last4 = Array.isArray(accRow?.last4s)
+      ? ((accRow.last4s as string[])[0] ?? "????")
+      : "????";
+    const accCurrency = accRow?.currency ?? "COP";
+
+    const [inserted] = await database
+      .insert(transactions)
+      .values({
+        userId,
+        accountId,
+        occurredAt: anchor,
+        amountCents: -run.totalInterestCents, // interest is an expense — negative on the TC
+        currency: accCurrency,
+        descriptionRaw: `Intereses causados ciclo ${cycleLabel} — TC *${last4}`,
+        merchant: null,
+        categorySlug: "intereses-tc",
+        classificationMethod: "manual",
+        classificationConfidence: 100,
+        source: "manual",
+        channel: "manual",
+        rawData: {
+          job: "intereses-causados-job",
+          cycleKey: key,
+          cycle: cycleLabel,
+          synthetic: true,
+          breakdown: run.intereses.map((i) => ({
+            txId: i.txId,
+            amountCents: i.purchaseAmountCents.toString(),
+            rateEMBps: i.rateEMBps,
+            installmentsTotal: i.installmentsTotal,
+            installmentsPaid: i.installmentsPaid,
+            outstandingBeforeCents: i.outstandingBeforeCents.toString(),
+            interestCents: i.interestCents.toString(),
+          })),
+        },
+      })
+      .returning({ id: transactions.id });
+
+    return {
+      status: "inserted",
+      txId: inserted.id,
+      totalInterestCents: run.totalInterestCents,
+    };
+  } catch (err) {
+    return { status: "error", reason: err instanceof Error ? err.message : String(err) };
+  }
+}


### PR DESCRIPTION
## Summary

Closes #407 — **last child** in the #345 chain. Consumes the schema/UI from #406 (#409, merged) and the category from #405 (#408, merged) to make per-TC-purchase interest projections real.

With this merge, the epic #345 delivers end-to-end: no more double-counted pago-tc, rate & installments captured per-tx, and monthly interest accrual as a real ledger entry.

## Helpers (`src/lib/finance/`)

- **`installmentSchedule(input)`** — pure, bigint cents, round-half-up on interest per period. Capital is floored to whole pesos so the schedule reproduces Bancolombia extracts line-by-line; the final row absorbs the residue. Regla 4 (gracia mes 1 + intereses diferidos) is modeled explicitly.
- **`periodInterestCents` + `monthsBetween`** — exported so tests and UI previews drive them directly.
- Consumes `resolveBucketRateBps` from the #406 rates module so a tx with `installment_rate_bps = NULL` inherits the account's 1-cuota / 2-36 / advances bucket.

## Monthly interest job (`intereses-causados-job.ts`)

- **`computeInterestForCycle`** — pure read: projects every live installment purchase on a TC as of the cycle anchor and extracts the cycle's due interest. No DB writes, safe to call from UI.
- **`applyInteresesCausadosForCycle`** — idempotent write: inserts ONE synthetic tx per cycle (mirrors the "INTERESES CORRIENTES" line on real extracts) under the `intereses-tc` category. The `raw_data.cycleKey` guard skips already-run cycles.
- CLI wrapper in `scripts/run-intereses-causados.ts`, wired via `bun run intereses:run --user=<id> --account=<id> --cycle=YYYY-MM`.

## UI

- `InstallmentsBadge` in `/transactions`: shows "N cuotas" on any credit_card tx with `installments_total > 1`. Matches the minimum ask in the AC — the full detail-view schedule lands later once you validate the numbers in prod.

## Tests

849 → 886 (+37 new).

- `installment-schedule.test.ts` — three fixtures:
  - **F1**: MercadoPago L — 12 cuotas @ 1.83% EM no grace, Visa *2575.
  - **F2**: diferido sin intereses — 9 cuotas @ 0% (total = amount).
  - **F3**: compra de cartera 29M @ 1.39% EM × 60 con grace. Per-row match at **±100 cents** vs the private markdown simulation (rows 1/2/3/60); cash-flow identity `Σ cuota = amount + Σ interest`. Caught a bug in the simulation's headline stats (the doc claims total interest ≈ \$6.1M but the per-row sum is \$12.3M — our helper matches the rows, which is correct).
- `intereses-causados-job.test.ts` — happy path, rate-bucket fallback when tx rate is null, zero-interest skip, idempotency, savings-account rejection.

## .private/ in gitignore

This PR commits the `.gitignore` entry for `.private/` since the F3 fixture lives in `.private/statements/Simulacion_CompraCartera_Amex_29M_1.39EM_60m.md` (personal data — won't commit the file itself). The test vectors are **inlined** in `installment-schedule.test.ts` so CI has no hidden dependency on the gitignored file.

## Unmarketable discovery worth noting

The model \"capital fijo + interés decreciente\" is NOT French amortization. Total interest on a 60-cuota @ 1.39% EM loan = ~42% of principal. Naive \"cuota_promedio × N - principal\" approximations give half of that (the private markdown doc was off by 2× on headline totals — rows were right). The helper respects the real math; tests assert the cash-flow identity so it stays honest.

## Test plan (user validation in prod)

- [ ] Apply migration 0050 (already part of #406 / deploy flow).
- [ ] Open `/transactions`, confirm TC txs with `installments_total > 1` now show the "N cuotas" badge.
- [ ] From `/transactions` → row menu → "Editar cuotas", set an installments plan on a real purchase.
- [ ] `bun run intereses:run --user=<your-id> --account=<tc-id> --cycle=2026-04` → check that the synthetic "Intereses causados ciclo 2026-04 — TC *XXXX" tx shows up in /transactions under "Intereses TC" category. Amount should match your statement's "INTERESES CORRIENTES" line within a few pesos.
- [ ] Re-run the same CLI — should log "skipped / already-run" and not duplicate the tx.

## Related

- Epic: #345
- Previous siblings: #405 (PR #408, merged), #406 (PR #409, merged)
- Memory updated: `tc-installments-interest-model` → IMPLEMENTED in #405/#406/#407