### PR TITLE
feat(schema): bump TC rate precision to 4 decimals (#411)

### DIFF
--- a/drizzle/0051_daily_molten_man.sql
+++ b/drizzle/0051_daily_molten_man.sql
@@ -1,0 +1,34 @@
+-- #411: TC rate precision bump from 2→4 decimals.
+--
+-- Before: `installment_rate_bps smallint` stored EM in basis points (1 bps =
+-- 0.01%), so values like Bancolombia's `1.9110%` lost the last two decimals
+-- (stored as 191, printed back as 1.9100%).
+--
+-- After: `installment_rate_bps integer` stores EM as "percent × 10000" (so
+-- 1.9110% → 19110). The column NAME stays for compatibility with the #406
+-- snapshot; the unit meaning changes, documented in schema.ts.
+--
+-- Data migration: pre-existing rows are rescaled by × 100 on both the column
+-- and the `creditRateBuckets` JSONB keys — lossless for values that were
+-- already whole bps integers.
+
+ALTER TABLE "transactions"
+  ALTER COLUMN "installment_rate_bps" SET DATA TYPE integer
+  USING "installment_rate_bps" * 100;
+--> statement-breakpoint
+UPDATE "accounts"
+SET "metadata" = jsonb_set(
+  jsonb_set(
+    jsonb_set(
+      "metadata",
+      '{creditRateBuckets,oneMonth}',
+      to_jsonb(COALESCE(("metadata"->'creditRateBuckets'->>'oneMonth')::int, 0) * 100)
+    ),
+    '{creditRateBuckets,months2to36}',
+    to_jsonb(COALESCE(("metadata"->'creditRateBuckets'->>'months2to36')::int, 0) * 100)
+  ),
+  '{creditRateBuckets,advances}',
+  to_jsonb(COALESCE(("metadata"->'creditRateBuckets'->>'advances')::int, 0) * 100)
+)
+WHERE "type" = 'credit_card'
+  AND "metadata" ? 'creditRateBuckets';

--- a/drizzle/meta/0051_snapshot.json
+++ b/drizzle/meta/0051_snapshot.json
@@ -1,0 +1,4290 @@
+{
+  "id": "bbecc670-379e-4630-9312-b52f8476532d",
+  "prevId": "9d9f5b3f-05b2-4090-bb3c-8b839b6ff8cc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_physical_card_id_physical_cards_id_fk": {
+          "name": "accounts_physical_card_id_physical_cards_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "physical_cards",
+          "columnsFrom": [
+            "physical_card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_corrections": {
+      "name": "classification_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_category_slug": {
+          "name": "new_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_corrections_learning_idx": {
+          "name": "classification_corrections_learning_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "new_category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_corrections_user_id_users_id_fk": {
+          "name": "classification_corrections_user_id_users_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_corrections_transaction_id_transactions_id_fk": {
+          "name": "classification_corrections_transaction_id_transactions_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_from_corrections": {
+          "name": "generated_from_corrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.physical_cards": {
+      "name": "physical_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_limit_cents": {
+          "name": "credit_limit_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "statement_cutoff_day": {
+          "name": "statement_cutoff_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "physical_cards_user_idx": {
+          "name": "physical_cards_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "physical_cards_user_institution_idx": {
+          "name": "physical_cards_user_institution_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "physical_cards_user_id_users_id_fk": {
+          "name": "physical_cards_user_id_users_id_fk",
+          "tableFrom": "physical_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_proposals": {
+      "name": "rule_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_txn_ids": {
+          "name": "correction_txn_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rule_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rule_proposals_user_merchant_category_pending_unique": {
+          "name": "rule_proposals_user_merchant_category_pending_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rule_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rule_proposals_user_status_idx": {
+          "name": "rule_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_proposals_user_id_users_id_fk": {
+          "name": "rule_proposals_user_id_users_id_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_proposals_user_category_fk": {
+          "name": "rule_proposals_user_category_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slo_alerts": {
+      "name": "slo_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slo_key": {
+          "name": "slo_key",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slo_alerts_open_idx": {
+          "name": "slo_alerts_open_idx",
+          "columns": [
+            {
+              "expression": "slo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"slo_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installments_total": {
+          "name": "installments_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "installment_rate_bps": {
+          "name": "installment_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retroactive_rule_id": {
+          "name": "retroactive_rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group_id": {
+          "name": "transfer_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_group_idx": {
+          "name": "transactions_transfer_group_idx",
+          "columns": [
+            {
+              "expression": "transfer_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"transfer_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_occurred_live_idx": {
+          "name": "transactions_account_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_live_idx": {
+          "name": "transactions_user_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_retroactive_rule_id_classification_rules_id_fk": {
+          "name": "transactions_retroactive_rule_id_classification_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "classification_rules",
+          "columnsFrom": [
+            "retroactive_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ui_preferences": {
+          "name": "ui_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "classification_context": {
+          "name": "classification_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "rule_retroactive",
+        "ai",
+        "manual",
+        "manual_confirmed",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.rule_proposal_status": {
+      "name": "rule_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug",
+        "widget"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1776811523737,
       "tag": "0050_sour_silvermane",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1776822575554,
+      "tag": "0051_daily_molten_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/settings/accounts/accounts-manager.tsx
+++ b/src/app/(app)/settings/accounts/accounts-manager.tsx
@@ -29,10 +29,11 @@ import type { Currency } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import type { AccountMetadata } from "@/lib/db/schema";
 import {
-  formatBpsEmAsEaPercent,
-  parsePercentToBps,
-  validateInstallmentRateBps,
+  EM_X10K_SCALE,
+  formatEmX10kAsEaPercent,
+  parsePercentToEmX10k,
   rateValidationMessage,
+  validateInstallmentRate,
 } from "@/lib/finance/rates";
 import {
   adjustAccountBalance,
@@ -593,21 +594,17 @@ function metadataFromForm(values: {
     const n = Number(values.monthlyPayment);
     if (Number.isFinite(n) && n >= 0) md.monthlyPaymentCents = Math.round(n * 100);
   }
-  // #406: assemble the rate buckets only when the user filled at least one.
-  // An empty form leaves `creditRateBuckets` undefined so we don't overwrite
-  // an account that already has sane values.
+  // #406/#411: assemble the rate buckets only when the user filled at
+  // least one. An empty form leaves `creditRateBuckets` undefined so we
+  // don't overwrite an account that already has sane values.
   const anyRateFilled =
     values.rateOneMonth?.trim() || values.rateMonths2to36?.trim() || values.rateAdvances?.trim();
   if (anyRateFilled) {
-    const oneMonthBps = parsePercentToBps(values.rateOneMonth ?? "0") ?? 0;
-    const months2to36Bps = parsePercentToBps(values.rateMonths2to36 ?? "0") ?? 0;
-    const advancesBps =
-      parsePercentToBps(values.rateAdvances ?? values.rateMonths2to36 ?? "0") ?? 0;
-    md.creditRateBuckets = {
-      oneMonth: oneMonthBps,
-      months2to36: months2to36Bps,
-      advances: advancesBps,
-    };
+    const oneMonth = parsePercentToEmX10k(values.rateOneMonth ?? "0") ?? 0;
+    const months2to36 = parsePercentToEmX10k(values.rateMonths2to36 ?? "0") ?? 0;
+    const advances =
+      parsePercentToEmX10k(values.rateAdvances ?? values.rateMonths2to36 ?? "0") ?? 0;
+    md.creditRateBuckets = { oneMonth, months2to36, advances };
   }
   return md;
 }
@@ -664,23 +661,24 @@ function AccountEditor({
       ? (initialMeta.monthlyPaymentCents / 100).toString()
       : "",
   );
-  // #406: EM rate buckets for credit cards. Show the typed percent (e.g.
-  // "1.9110") so the user can eyeball it against their statement; persist as
-  // bps on submit. Default display for a fresh TC is blank to avoid implying
-  // a value was stored.
+  // #406/#411: EM rate buckets for credit cards. Show the typed percent
+  // (e.g. "1.9110") so the user can eyeball it against their statement;
+  // persist as EM×10000 (4-decimal precision) on submit. Default display
+  // for a fresh TC is blank so the placeholder can surface Bancolombia's
+  // defaults as a hint without implying the value was already stored.
   const [rateOneMonth, setRateOneMonth] = useState(
     initialMeta.creditRateBuckets?.oneMonth != null
-      ? (initialMeta.creditRateBuckets.oneMonth / 100).toFixed(4)
+      ? (initialMeta.creditRateBuckets.oneMonth / EM_X10K_SCALE).toFixed(4)
       : "",
   );
   const [rateMonths2to36, setRateMonths2to36] = useState(
     initialMeta.creditRateBuckets?.months2to36 != null
-      ? (initialMeta.creditRateBuckets.months2to36 / 100).toFixed(4)
+      ? (initialMeta.creditRateBuckets.months2to36 / EM_X10K_SCALE).toFixed(4)
       : "",
   );
   const [rateAdvances, setRateAdvances] = useState(
     initialMeta.creditRateBuckets?.advances != null
-      ? (initialMeta.creditRateBuckets.advances / 100).toFixed(4)
+      ? (initialMeta.creditRateBuckets.advances / EM_X10K_SCALE).toFixed(4)
       : "",
   );
 
@@ -712,17 +710,17 @@ function AccountEditor({
       rateMonths2to36: type === "credit_card" ? rateMonths2to36 : "",
       rateAdvances: type === "credit_card" ? rateAdvances : "",
     });
-    // #406: client-side validation so the "too-low" EM/EA confusion message
-    // lands next to the field instead of bubbling up as a server 500. Server
-    // still re-validates via zod — this is UX, not security.
+    // #406/#411: client-side validation so the "too-low" EM/EA confusion
+    // message lands next to the field instead of bubbling up as a server
+    // 500. Server still re-validates via zod — this is UX, not security.
     if (primaryMd.creditRateBuckets) {
       const b = primaryMd.creditRateBuckets;
-      for (const [label, bps] of [
+      for (const [label, stored] of [
         ["1 cuota", b.oneMonth],
         ["2-36 cuotas", b.months2to36],
         ["avances", b.advances],
       ] as const) {
-        const v = validateInstallmentRateBps(bps);
+        const v = validateInstallmentRate(stored);
         if (!v.ok) {
           toast.error(`Tasa ${label}: ${rateValidationMessage(v.reason)}`);
           return;
@@ -1262,14 +1260,30 @@ function RateBucketsSection({
         vacío si no sabés — las compras heredan 0% por defecto.
       </p>
       <div className="grid grid-cols-3 gap-3">
-        <RateInput id="rate-one-month" label="1 cuota" value={oneMonth} onChange={onOneMonth} />
+        {/* #411: each bucket's placeholder shows Bancolombia's default for that
+            category — hints the user with 0.0000 / 1.9110 / 1.9110 without
+            actually persisting those until they type. */}
+        <RateInput
+          id="rate-one-month"
+          label="1 cuota"
+          value={oneMonth}
+          onChange={onOneMonth}
+          placeholder="0.0000"
+        />
         <RateInput
           id="rate-months-2-36"
           label="2-36 cuotas"
           value={months2to36}
           onChange={onMonths2to36}
+          placeholder="1.9110"
         />
-        <RateInput id="rate-advances" label="Avances" value={advances} onChange={onAdvances} />
+        <RateInput
+          id="rate-advances"
+          label="Avances"
+          value={advances}
+          onChange={onAdvances}
+          placeholder="1.9110"
+        />
       </div>
     </fieldset>
   );
@@ -1280,14 +1294,27 @@ function RateInput({
   label,
   value,
   onChange,
+  placeholder,
 }: {
   id: string;
   label: string;
   value: string;
   onChange: (v: string) => void;
+  placeholder?: string;
 }) {
-  const bps = parsePercentToBps(value);
-  const eaDisplay = bps != null && bps > 0 ? formatBpsEmAsEaPercent(bps) : null;
+  // #411: the EA preview has two sources:
+  //   - typed value  → bright, authoritative ("what you're about to save")
+  //   - placeholder  → faded, suggestive ("what the default would give you")
+  // Showing the placeholder's EA while the input is empty gives the user
+  // context before they type — previously the row collapsed to "—".
+  const storedTyped = parsePercentToEmX10k(value);
+  const storedPlaceholder = placeholder ? parsePercentToEmX10k(placeholder) : null;
+  const typedEa =
+    storedTyped != null && storedTyped > 0 ? formatEmX10kAsEaPercent(storedTyped) : null;
+  const placeholderEa =
+    storedPlaceholder != null && storedPlaceholder > 0
+      ? formatEmX10kAsEaPercent(storedPlaceholder)
+      : null;
   return (
     <div className="flex flex-col gap-1.5">
       <Label htmlFor={id}>{label}</Label>
@@ -1298,16 +1325,20 @@ function RateInput({
           inputMode="decimal"
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          placeholder="0.0000"
+          placeholder={placeholder ?? "0.0000"}
           className="pr-10 tabular-nums"
         />
         <span className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-xs">
           %
         </span>
       </div>
-      <p className="text-muted-foreground text-xs tabular-nums">
-        {eaDisplay ? `≈ ${eaDisplay} EA` : "—"}
-      </p>
+      {typedEa ? (
+        <p className="text-muted-foreground text-xs tabular-nums">≈ {typedEa} EA</p>
+      ) : placeholderEa ? (
+        <p className="text-muted-foreground/60 text-xs italic tabular-nums">≈ {placeholderEa} EA</p>
+      ) : (
+        <p className="text-muted-foreground text-xs tabular-nums">—</p>
+      )}
     </div>
   );
 }

--- a/src/app/(app)/settings/accounts/actions.ts
+++ b/src/app/(app)/settings/accounts/actions.ts
@@ -20,36 +20,36 @@ import { convertCents } from "@/lib/money";
 
 const ADJUSTMENT_CATEGORY_SLUG = "adjustments";
 
-// #406: each bucket is an EM bps value; 0 is a valid case (diferido sin
-// intereses on the 1-cuota bucket). The validator allowing [0 OR >= 50]
-// matches `validateInstallmentRateBps` in src/lib/finance/rates.ts — they
-// enforce the same convention at different layers.
+// #406/#411: each bucket is stored as "percent × 10000" so the schema can
+// hold Bancolombia's 4-decimal display (e.g. "1.9110%" → 19110). The limits
+// match `validateInstallmentRate` in src/lib/finance/rates.ts — same
+// convention enforced at both layers.
 const creditRateBucketsSchema = z
   .object({
     oneMonth: z
       .number()
       .int()
       .nonnegative()
-      .refine((v) => v === 0 || v >= 50, {
+      .refine((v) => v === 0 || v >= 5000, {
         message: "Tasa EM sospechosamente baja (¿EA mal etiquetada como EM?)",
       })
-      .refine((v) => v < 10000, { message: "Tasa EM fuera de rango razonable" }),
+      .refine((v) => v < 1_000_000, { message: "Tasa EM fuera de rango razonable" }),
     months2to36: z
       .number()
       .int()
       .nonnegative()
-      .refine((v) => v === 0 || v >= 50, {
+      .refine((v) => v === 0 || v >= 5000, {
         message: "Tasa EM sospechosamente baja (¿EA mal etiquetada como EM?)",
       })
-      .refine((v) => v < 10000, { message: "Tasa EM fuera de rango razonable" }),
+      .refine((v) => v < 1_000_000, { message: "Tasa EM fuera de rango razonable" }),
     advances: z
       .number()
       .int()
       .nonnegative()
-      .refine((v) => v === 0 || v >= 50, {
+      .refine((v) => v === 0 || v >= 5000, {
         message: "Tasa EM sospechosamente baja (¿EA mal etiquetada como EM?)",
       })
-      .refine((v) => v < 10000, { message: "Tasa EM fuera de rango razonable" }),
+      .refine((v) => v < 1_000_000, { message: "Tasa EM fuera de rango razonable" }),
   })
   .strict();
 

--- a/src/app/(app)/transactions/actions.test.ts
+++ b/src/app/(app)/transactions/actions.test.ts
@@ -1626,7 +1626,7 @@ describe("updateTransactionInstallments (#406)", () => {
     const result = await updateTransactionInstallments({
       txId,
       installmentsTotal: 12,
-      installmentRateBps: 191,
+      installmentRateEmX10k: 19110,
     });
     expect(result.status).toBe("ok");
 
@@ -1637,7 +1637,9 @@ describe("updateTransactionInstallments (#406)", () => {
       SELECT installments_total, installment_rate_bps FROM transactions WHERE id = ${txId}
     `);
     expect(row.installments_total).toBe(12);
-    expect(row.installment_rate_bps).toBe(191);
+    // #411: the DB column name stays `installment_rate_bps`, but the unit
+    // is now percent × 10000 — 19110 = 1.9110% EM.
+    expect(row.installment_rate_bps).toBe(19110);
   });
 
   it("accepts a null rate (inherit from account bucket at compute time)", async () => {
@@ -1645,7 +1647,7 @@ describe("updateTransactionInstallments (#406)", () => {
     const result = await updateTransactionInstallments({
       txId,
       installmentsTotal: 3,
-      installmentRateBps: null,
+      installmentRateEmX10k: null,
     });
     expect(result.status).toBe("ok");
 
@@ -1664,7 +1666,7 @@ describe("updateTransactionInstallments (#406)", () => {
     const result = await updateTransactionInstallments({
       txId,
       installmentsTotal: 3,
-      installmentRateBps: 25, // 0.25% EM — almost certainly EA mistaken as EM
+      installmentRateEmX10k: 2500, // 0.25% EM — almost certainly EA mistaken as EM
     });
     expect(result.status).toBe("error");
     if (result.status === "error") expect(result.message).toMatch(/EM/);
@@ -1675,7 +1677,7 @@ describe("updateTransactionInstallments (#406)", () => {
     const result = await updateTransactionInstallments({
       txId,
       installmentsTotal: 9,
-      installmentRateBps: 0,
+      installmentRateEmX10k: 0,
     });
     expect(result.status).toBe("ok");
   });
@@ -1685,7 +1687,7 @@ describe("updateTransactionInstallments (#406)", () => {
     const result = await updateTransactionInstallments({
       txId,
       installmentsTotal: 3,
-      installmentRateBps: 191,
+      installmentRateEmX10k: 19110,
     });
     expect(result.status).toBe("error");
     if (result.status === "error") expect(result.message).toMatch(/tarjeta/i);
@@ -1696,13 +1698,13 @@ describe("updateTransactionInstallments (#406)", () => {
     const zero = await updateTransactionInstallments({
       txId,
       installmentsTotal: 0,
-      installmentRateBps: null,
+      installmentRateEmX10k: null,
     });
     expect(zero.status).toBe("error");
     const tooMany = await updateTransactionInstallments({
       txId,
       installmentsTotal: 500,
-      installmentRateBps: null,
+      installmentRateEmX10k: null,
     });
     expect(tooMany.status).toBe("error");
   });

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -30,7 +30,7 @@ import {
   validateTransferGroupLegs,
   type TransferLeg,
 } from "@/lib/transactions/transfer-groups";
-import { validateInstallmentRateBps, rateValidationMessage } from "@/lib/finance/rates";
+import { validateInstallmentRate, rateValidationMessage } from "@/lib/finance/rates";
 import type { CounterpartyKind, CounterpartyType } from "@/lib/types";
 
 const updateSchema = z.object({
@@ -1134,7 +1134,7 @@ export async function createManualTransferGroup(
 // cuota count and the optional rate override are mutable — the account, the
 // amount, and the occurred date are intentionally locked, because any true
 // re-financing should be modeled as the modo-B split (ver #345 regla 6)
-// and that's a separate, explicit flow. Leaving `installment_rate_bps` as
+// and that's a separate, explicit flow. Leaving `installmentRateEmX10k` as
 // `null` means "inherit from the account's bucket at compute time".
 const updateInstallmentsSchema = z
   .object({
@@ -1143,18 +1143,18 @@ const updateInstallmentsSchema = z
     // Union order matters — zod tries variants in order, and
     // `z.coerce.number()` would coerce `null` to 0 if it came first.
     // Handle explicit null / empty string before the number coercion.
-    installmentRateBps: z
+    installmentRateEmX10k: z
       .union([z.null(), z.literal(""), z.coerce.number().int()])
       .transform((v) => (v === "" ? null : v)),
   })
   .superRefine((v, ctx) => {
-    if (v.installmentRateBps === null) return;
-    const res = validateInstallmentRateBps(v.installmentRateBps);
+    if (v.installmentRateEmX10k === null) return;
+    const res = validateInstallmentRate(v.installmentRateEmX10k);
     if (!res.ok) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: rateValidationMessage(res.reason),
-        path: ["installmentRateBps"],
+        path: ["installmentRateEmX10k"],
       });
     }
   });
@@ -1170,7 +1170,7 @@ export async function updateTransactionInstallments(
   if (!parsed.success) {
     return { status: "error", message: parsed.error.issues[0]?.message ?? "Input inválido" };
   }
-  const { txId, installmentsTotal, installmentRateBps } = parsed.data;
+  const { txId, installmentsTotal, installmentRateEmX10k } = parsed.data;
 
   // Scope hard to credit_card accounts — installments on savings/loan would be
   // a bug elsewhere, surface it loudly rather than silently writing.
@@ -1202,7 +1202,7 @@ export async function updateTransactionInstallments(
     .update(transactions)
     .set({
       installmentsTotal,
-      installmentRateBps,
+      installmentRateEmX10k,
       updatedAt: new Date(),
     })
     .where(and(eq(transactions.userId, session.id), eq(transactions.id, txId)));

--- a/src/components/transactions/tc-installments-dialog.tsx
+++ b/src/components/transactions/tc-installments-dialog.tsx
@@ -14,7 +14,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Money } from "@/components/display/money";
-import { formatBpsEmAsEaPercent, parsePercentToBps } from "@/lib/finance/rates";
+import { EM_X10K_SCALE, formatEmX10kAsEaPercent, parsePercentToEmX10k } from "@/lib/finance/rates";
 import { updateTransactionInstallments } from "@/app/(app)/transactions/actions";
 import type { Currency } from "@/lib/types";
 
@@ -29,12 +29,13 @@ export type TcInstallmentsDialogProps = {
   amountCents: bigint;
   currency: Currency;
   installmentsTotal: number;
-  installmentRateBps: number | null;
+  installmentRateEmX10k: number | null;
 };
 
-function initialRateInput(bps: number | null): string {
-  if (bps == null) return "";
-  return (bps / 100).toFixed(4);
+function initialRateInput(emX10k: number | null): string {
+  if (emX10k == null) return "";
+  // stored EM is percent × 10000; show 4 decimals so "19110" → "1.9110"
+  return (emX10k / EM_X10K_SCALE).toFixed(4);
 }
 
 export function TcInstallmentsDialog({
@@ -44,10 +45,10 @@ export function TcInstallmentsDialog({
   amountCents,
   currency,
   installmentsTotal,
-  installmentRateBps,
+  installmentRateEmX10k,
 }: TcInstallmentsDialogProps) {
   const [installments, setInstallments] = useState(installmentsTotal.toString());
-  const [rate, setRate] = useState(initialRateInput(installmentRateBps));
+  const [rate, setRate] = useState(initialRateInput(installmentRateEmX10k));
   const [pending, startTransition] = useTransition();
 
   const installmentsNum = Number(installments);
@@ -59,8 +60,9 @@ export function TcInstallmentsDialog({
     return magnitude / BigInt(installmentsNum);
   }, [amountCents, installmentsNum]);
 
-  const rateBps = rate.trim() === "" ? null : parsePercentToBps(rate);
-  const eaPreview = rateBps != null && rateBps > 0 ? formatBpsEmAsEaPercent(rateBps) : null;
+  const rateEmX10k = rate.trim() === "" ? null : parsePercentToEmX10k(rate);
+  const eaPreview =
+    rateEmX10k != null && rateEmX10k > 0 ? formatEmX10kAsEaPercent(rateEmX10k) : null;
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -72,7 +74,7 @@ export function TcInstallmentsDialog({
       const result = await updateTransactionInstallments({
         txId,
         installmentsTotal: installmentsNum,
-        installmentRateBps: rate.trim() === "" ? null : (parsePercentToBps(rate) ?? 0),
+        installmentRateEmX10k: rate.trim() === "" ? null : (parsePercentToEmX10k(rate) ?? 0),
       });
       if (result.status === "error") {
         toast.error(result.message);

--- a/src/components/transactions/transaction-row-actions.tsx
+++ b/src/components/transactions/transaction-row-actions.tsx
@@ -33,7 +33,7 @@ type Props = {
   amountCents: bigint;
   currency: Currency;
   installmentsTotal: number;
-  installmentRateBps: number | null;
+  installmentRateEmX10k: number | null;
 };
 
 export function TransactionRowActions({
@@ -43,7 +43,7 @@ export function TransactionRowActions({
   amountCents,
   currency,
   installmentsTotal,
-  installmentRateBps,
+  installmentRateEmX10k,
 }: Props) {
   const [pending, startTransition] = useTransition();
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -136,7 +136,7 @@ export function TransactionRowActions({
           amountCents={amountCents}
           currency={currency}
           installmentsTotal={installmentsTotal}
-          installmentRateBps={installmentRateBps}
+          installmentRateEmX10k={installmentRateEmX10k}
         />
       ) : null}
 

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -291,7 +291,7 @@ export function TransactionTable({
                         amountCents={tx.amountCents}
                         currency={tx.currency}
                         installmentsTotal={tx.installmentsTotal}
-                        installmentRateBps={tx.installmentRateBps}
+                        installmentRateEmX10k={tx.installmentRateEmX10k}
                       />
                     </TableCell>
                   </motion.tr>
@@ -365,7 +365,7 @@ export function TransactionTable({
                       amountCents={tx.amountCents}
                       currency={tx.currency}
                       installmentsTotal={tx.installmentsTotal}
-                      installmentRateBps={tx.installmentRateBps}
+                      installmentRateEmX10k={tx.installmentRateEmX10k}
                     />
                   </div>
                 </div>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -205,22 +205,24 @@ export const accounts = pgTable(
   ],
 );
 
-// #406: per-bucket monthly effective interest rates for a credit card.
-// Values are ALWAYS Efectiva Mensual Vencida (EM / MV) in basis points
-// (10000 = 100%). Display as EA is computed on read only — NEVER store EA here.
-// Conversion: EA = (1 + EM/10000)^12 - 1.
+// #406/#411: per-bucket monthly effective interest rates for a credit card.
+// Values are ALWAYS Efectiva Mensual Vencida (EM / MV), stored as
+// "percent × 10000" to preserve the 4 decimals Bancolombia prints on real
+// extracts (e.g. "1.9110%" → 19110). Display as EA is computed on read only
+// — NEVER store EA here. Conversion: fractional = stored / 1_000_000;
+// EA = (1 + fractional)^12 - 1.
 //
 // Why per-bucket: Bancolombia extracts show distinct rates for
 //   - compra a 1 cuota (typically 0% — diferido sin intereses)
 //   - compra a 2-36 cuotas (the "full" rate)
 //   - advances / impuestos / mora (often the same as 2-36)
 // Purchase-time rate is snapshotted on the transaction (see
-// `transactions.installment_rate_bps`); a null on the tx falls back to the
-// bucket that matches `installments_total` at compute time.
+// `transactions.installment_rate_em_x10k`); a null on the tx falls back to
+// the bucket that matches `installments_total` at compute time.
 export type CreditRateBucketsEM = {
-  oneMonth: number; // bps EM — typical 0 (diferido sin intereses)
-  months2to36: number; // bps EM — typical 180-210 (e.g. 191 bps = 1.91% EM ≈ 25.49% EA)
-  advances: number; // bps EM — typical == months2to36 at this bank
+  oneMonth: number; // stored = percent × 10000 — typical 0 (diferido sin intereses)
+  months2to36: number; // stored = percent × 10000 — typical 19110 (= 1.9110% EM ≈ 25.50% EA)
+  advances: number; // stored = percent × 10000 — typical == months2to36 at this bank
 };
 
 export type AccountMetadata = {
@@ -409,13 +411,17 @@ export const transactions = pgTable(
     // not a mutation — see parent #345). Default 1 means "single payment, no
     // financing".
     installmentsTotal: integer("installments_total").notNull().default(1),
-    // #406: ALWAYS Efectiva Mensual Vencida (EM / MV) in basis points.
-    // Display as EA is computed on read; NEVER store EA here. Null falls back
-    // to the bucket on `accounts.metadata.creditRateBuckets` matching
-    // `installments_total` at compute time (see #407). Validator rejects
-    // suspiciously low non-zero values (< 50 bps) that are almost certainly
-    // EA mislabeled as EM.
-    installmentRateBps: smallint("installment_rate_bps"),
+    // #406/#411: Efectiva Mensual Vencida (EM / MV) stored as percent × 10000
+    // (so "1.9110%" → 19110). Preserves the 4-decimal precision Bancolombia
+    // prints on real extracts. Null falls back to the bucket on
+    // `accounts.metadata.creditRateBuckets` matching `installments_total` at
+    // compute time (see #407). Validator rejects non-zero values < 5000
+    // (< 0.5% EM), almost certainly EA mislabeled as EM.
+    //
+    // NOTE: DB column is still named `installment_rate_bps` (from #406's
+    // original smallint scheme) to avoid a rename in #411's migration.
+    // The stored unit CHANGED — it's now "percent × 10000", not bps.
+    installmentRateEmX10k: integer("installment_rate_bps"),
     previousCategorySlug: varchar("previous_category_slug", { length: 60 }),
     retroactiveRuleId: integer("retroactive_rule_id").references(
       (): AnyPgColumn => classificationRules.id,

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -79,13 +79,14 @@ const seedAccounts: Array<{
     institutionSlug: "bancolombia",
     type: "credit_card",
     currency: "COP",
-    // #406: default EM rate buckets observed on Bancolombia 2026 extracts.
-    // 191 bps = 1.91% EM ≈ 25.49% EA for the 2-36 cuota bucket; 0 for
-    // diferido-sin-intereses. User can override per-account from /settings.
+    // #406/#411: default EM rate buckets observed on Bancolombia 2026 extracts.
+    // Stored as percent × 10000 — 19110 = 1.9110% EM ≈ 25.50% EA for the
+    // 2-36 cuota bucket; 0 for diferido-sin-intereses. User can override
+    // per-account from /settings.
     metadata: {
       last4s: ["2575"],
       network: "visa",
-      creditRateBuckets: { oneMonth: 0, months2to36: 191, advances: 191 },
+      creditRateBuckets: { oneMonth: 0, months2to36: 19110, advances: 19110 },
     },
   },
   {
@@ -97,7 +98,7 @@ const seedAccounts: Array<{
     metadata: {
       last4s: ["7291"],
       network: "mastercard",
-      creditRateBuckets: { oneMonth: 0, months2to36: 191, advances: 191 },
+      creditRateBuckets: { oneMonth: 0, months2to36: 19110, advances: 19110 },
     },
     physicalCardGroup: "bancolombia-mc-7291",
   },
@@ -110,7 +111,7 @@ const seedAccounts: Array<{
     metadata: {
       last4s: ["7291"],
       network: "mastercard",
-      creditRateBuckets: { oneMonth: 0, months2to36: 191, advances: 191 },
+      creditRateBuckets: { oneMonth: 0, months2to36: 19110, advances: 19110 },
     },
     physicalCardGroup: "bancolombia-mc-7291",
   },

--- a/src/lib/finance/installment-schedule.test.ts
+++ b/src/lib/finance/installment-schedule.test.ts
@@ -24,12 +24,12 @@ describe("periodInterestCents", () => {
   });
 
   it("returns 0 when balance is 0 or negative", () => {
-    expect(periodInterestCents(BigInt(0), 191)).toBe(BigInt(0));
-    expect(periodInterestCents(BigInt(-1), 191)).toBe(BigInt(0));
+    expect(periodInterestCents(BigInt(0), 19110)).toBe(BigInt(0));
+    expect(periodInterestCents(BigInt(-1), 19110)).toBe(BigInt(0));
   });
 
-  it("rounds half-up — balance 2_851_666_667 cents × 139 bps ≈ 39_638_167 cents", () => {
-    expect(periodInterestCents(BigInt("2851666667"), 139)).toBe(BigInt("39638167"));
+  it("rounds half-up — 2_851_666_667 cents × 13900 x10k ≈ 39_638_167 cents (1.39% EM)", () => {
+    expect(periodInterestCents(BigInt("2851666667"), 13900)).toBe(BigInt("39638167"));
   });
 });
 
@@ -57,7 +57,7 @@ describe("installmentSchedule — F1 (purchase 12 cuotas @ 1.8311% EM, no grace)
   // amountCents 2_479_900 * 100 = 247_990_000.
   const input = {
     amountCents: BigInt(247_990_000),
-    rateEMBps: 183, // 1.83% EM ≈ 1.8311% rounded to integer bps (schema is smallint)
+    rateEmX10k: 18311, // 1.8311% EM exact — the actual extract rate at 4-decimal precision
     installments: 12,
     graceMonth: false,
     purchaseDate: new Date("2026-02-15"),
@@ -110,7 +110,7 @@ describe("installmentSchedule — F1 (purchase 12 cuotas @ 1.8311% EM, no grace)
 describe("installmentSchedule — F2 (diferido sin intereses 9 cuotas @ 0%)", () => {
   const input = {
     amountCents: BigInt(104_990_000), // 1_049_900 pesos
-    rateEMBps: 0,
+    rateEmX10k: 0,
     installments: 9,
     graceMonth: false,
     purchaseDate: new Date("2026-01-10"),
@@ -141,7 +141,7 @@ describe("installmentSchedule — F2 (diferido sin intereses 9 cuotas @ 0%)", ()
 describe("installmentSchedule — F3 (compra de cartera 29M @ 1.39% EM × 60, graceMonth)", () => {
   const input = {
     amountCents: BigInt("2900000000"), // 29_000_000 COP
-    rateEMBps: 139,
+    rateEmX10k: 13900, // 1.39% EM exact at 4-decimal precision (#411)
     installments: 60,
     graceMonth: true,
     purchaseDate: new Date("2026-05-01"),
@@ -163,10 +163,10 @@ describe("installmentSchedule — F3 (compra de cartera 29M @ 1.39% EM × 60, gr
   it("month 2 under grace absorbs the deferred month-1 interest", () => {
     const m2 = result.rows[1];
     // deferred = month-1 interest on the full amount
-    expect(m2.deferredInterestCents).toBe(periodInterestCents(input.amountCents, 139));
+    expect(m2.deferredInterestCents).toBe(periodInterestCents(input.amountCents, 13900));
     // own interest computed on balance-entering-month-2 = amount - capital_m1
     const balanceM2Start = input.amountCents - result.rows[0].capitalCents;
-    expect(m2.interestCents).toBe(periodInterestCents(balanceM2Start, 139));
+    expect(m2.interestCents).toBe(periodInterestCents(balanceM2Start, 13900));
   });
 
   it("balance reaches 0 at month 60 (regla 5: last cuota absorbs residue)", () => {
@@ -232,7 +232,7 @@ describe("installmentSchedule — edge cases", () => {
   it("N = 1 behaves as a single-payment purchase", () => {
     const result = installmentSchedule({
       amountCents: BigInt(100_000),
-      rateEMBps: 0,
+      rateEmX10k: 0,
       installments: 1,
       graceMonth: false,
       purchaseDate: new Date("2026-04-01"),
@@ -247,7 +247,7 @@ describe("installmentSchedule — edge cases", () => {
   it("`today` before `purchaseDate` yields paidCount = 0, not negative", () => {
     const result = installmentSchedule({
       amountCents: BigInt(100_000),
-      rateEMBps: 0,
+      rateEmX10k: 0,
       installments: 3,
       graceMonth: false,
       purchaseDate: new Date("2026-05-01"),
@@ -259,7 +259,7 @@ describe("installmentSchedule — edge cases", () => {
   it("`today` long after purchase caps paidCount at N", () => {
     const result = installmentSchedule({
       amountCents: BigInt(100_000),
-      rateEMBps: 0,
+      rateEmX10k: 0,
       installments: 3,
       graceMonth: false,
       purchaseDate: new Date("2020-01-01"),
@@ -273,7 +273,7 @@ describe("installmentSchedule — edge cases", () => {
     expect(() =>
       installmentSchedule({
         amountCents: BigInt(0),
-        rateEMBps: 0,
+        rateEmX10k: 0,
         installments: 1,
         graceMonth: false,
         purchaseDate: new Date(),
@@ -285,7 +285,7 @@ describe("installmentSchedule — edge cases", () => {
   it("throws on installments < 1 or > 240", () => {
     const base = {
       amountCents: BigInt(100),
-      rateEMBps: 0,
+      rateEmX10k: 0,
       graceMonth: false,
       purchaseDate: new Date(),
       today: new Date(),

--- a/src/lib/finance/installment-schedule.ts
+++ b/src/lib/finance/installment-schedule.ts
@@ -13,19 +13,20 @@
 //     line per period, never bundled into capital.
 //   - regla 3: the rate snapshot lives on the tx — this helper takes it as
 //     input and does NOT look it up (the caller resolves bucket vs override
-//     via `resolveBucketRateBps`).
+//     via `resolveBucketRateX10k`).
 //
-// Rounding: interest is computed as `round(saldo × rate_bps / 10000)` in
-// integer cents, half-up. This matches Bancolombia's display policy close
+// Rounding: interest is computed as `round(saldo × rateEmX10k / 1_000_000)`
+// in integer cents, half-up. Matches Bancolombia's display policy close
 // enough to pass the extract-level tests in the sibling test file. If a
 // future extract diverges, update the policy here — do NOT let the helper
 // drift silently.
 
 import type { Currency } from "@/lib/types";
+import { EM_X10K_PER_FRACTIONAL } from "./rates";
 
 export type InstallmentScheduleInput = {
   amountCents: bigint; // original purchase amount (positive magnitude)
-  rateEMBps: number; // EM rate in bps (0 = diferido sin intereses, 191 = 1.91% EM)
+  rateEmX10k: number; // EM rate stored as percent × 10000 (0 = 0%, 19110 = 1.9110% EM)
   installments: number; // total cuotas, N >= 1
   graceMonth: boolean; // true = month-1 interest deferred to month 2
   purchaseDate: Date; // anchor for month counting
@@ -63,19 +64,20 @@ function bigIntRoundHalfUp(numerator: bigint, denominator: bigint): bigint {
   return (numerator + denominator / BigInt(2)) / denominator;
 }
 
-// Interest for a single period, given a starting balance and the bps rate.
-// Split out so tests can drive it directly when checking specific rows.
-export function periodInterestCents(balanceCents: bigint, rateEMBps: number): bigint {
-  if (rateEMBps === 0) return BigInt(0);
+// Interest for a single period, given a starting balance and the stored
+// EM rate (percent × 10000). Split out so tests can drive it directly when
+// checking specific rows.
+export function periodInterestCents(balanceCents: bigint, rateEmX10k: number): bigint {
+  if (rateEmX10k === 0) return BigInt(0);
   if (balanceCents <= BigInt(0)) return BigInt(0);
-  return bigIntRoundHalfUp(balanceCents * BigInt(rateEMBps), BigInt(10000));
+  return bigIntRoundHalfUp(balanceCents * BigInt(rateEmX10k), BigInt(EM_X10K_PER_FRACTIONAL));
 }
 
 export function installmentSchedule(input: InstallmentScheduleInput): InstallmentScheduleOutput {
-  const { amountCents, rateEMBps, installments, graceMonth, purchaseDate, today } = input;
+  const { amountCents, rateEmX10k, installments, graceMonth, purchaseDate, today } = input;
   if (installments < 1) throw new Error("installments must be >= 1");
   if (installments > 240) throw new Error("installments > 240 not supported");
-  if (rateEMBps < 0) throw new Error("rateEMBps must be >= 0");
+  if (rateEmX10k < 0) throw new Error("rateEmX10k must be >= 0");
   if (amountCents <= BigInt(0)) throw new Error("amountCents must be > 0");
 
   const N = installments;
@@ -110,10 +112,10 @@ export function installmentSchedule(input: InstallmentScheduleInput): Installmen
       // original amount, since month 1 paid no capital either — the balance
       // entering month 2 is `amountCents - capital_month_1`).
       const deferredBase = amountCents; // month-1 starts with full amount
-      deferredThis = periodInterestCents(deferredBase, rateEMBps);
-      interestThis = periodInterestCents(balance, rateEMBps);
+      deferredThis = periodInterestCents(deferredBase, rateEmX10k);
+      interestThis = periodInterestCents(balance, rateEmX10k);
     } else {
-      interestThis = periodInterestCents(balance, rateEMBps);
+      interestThis = periodInterestCents(balance, rateEmX10k);
       deferredThis = BigInt(0);
     }
 

--- a/src/lib/finance/intereses-causados-job.test.ts
+++ b/src/lib/finance/intereses-causados-job.test.ts
@@ -47,9 +47,10 @@ async function seedPurchase(opts: {
   amountCentsMagnitude: bigint;
   occurredAt: string; // YYYY-MM-DD
   installmentsTotal: number;
-  installmentRateBps: number | null;
+  installmentRateEmX10k: number | null;
 }) {
-  const rateSql = opts.installmentRateBps === null ? sql`NULL` : sql`${opts.installmentRateBps}`;
+  const rateSql =
+    opts.installmentRateEmX10k === null ? sql`NULL` : sql`${opts.installmentRateEmX10k}`;
   const [row] = await db.execute<{ id: number }>(sql`
     INSERT INTO transactions (
       user_id, account_id, occurred_at, amount_cents, currency, description_raw,
@@ -69,19 +70,20 @@ async function seedPurchase(opts: {
 describe("computeInterestForCycle", () => {
   it("returns the interest due on the next unpaid cuota", async () => {
     const visa = await getVisaId();
-    await setBucketRates(visa, { oneMonth: 0, months2to36: 191, advances: 191 });
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
 
-    // 100_000 pesos @ 191 bps (1.91% EM) × 12 cuotas. Capital per cuota =
-    // 8333 pesos (since 100_000 / 12 = 8333.33 → floor to peso). Interest
-    // on month 1 (no grace for this one): saldo 10_000_000 cents × 191 / 10000
-    // = 191_000 cents = $1_910 pesos.
+    // 100_000 pesos @ 19110 x10k (1.9110% EM) × 12 cuotas. Capital per cuota
+    // = 8333 pesos (since 100_000 / 12 = 8333.33 → floor to peso). Interest
+    // on month 1 (grace=true so month-1 cuota only covers capital; the
+    // scheduled interest the job reports is month-2's, which folds the
+    // deferred month-1 interest in).
     await seedPurchase({
       accountId: visa,
       externalId: `${EXT_PREFIX}base`,
       amountCentsMagnitude: BigInt(10_000_000),
       occurredAt: "2026-03-10",
       installmentsTotal: 12,
-      installmentRateBps: 191,
+      installmentRateEmX10k: 19110,
     });
 
     const run = await computeInterestForCycle({
@@ -90,13 +92,13 @@ describe("computeInterestForCycle", () => {
       cycle: "2026-04",
     });
     expect(run.intereses.length).toBe(1);
-    expect(run.intereses[0].rateEMBps).toBe(191);
+    expect(run.intereses[0].rateEmX10k).toBe(19110);
     expect(run.totalInterestCents).toBeGreaterThan(BigInt(0));
   });
 
   it("falls back to the account's rate bucket when the tx has no explicit rate", async () => {
     const visa = await getVisaId();
-    await setBucketRates(visa, { oneMonth: 0, months2to36: 200, advances: 200 });
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 20000, advances: 20000 });
 
     await seedPurchase({
       accountId: visa,
@@ -104,7 +106,7 @@ describe("computeInterestForCycle", () => {
       amountCentsMagnitude: BigInt(5_000_000),
       occurredAt: "2026-03-10",
       installmentsTotal: 6,
-      installmentRateBps: null, // inherit from bucket
+      installmentRateEmX10k: null, // inherit from bucket
     });
 
     const run = await computeInterestForCycle({
@@ -113,12 +115,12 @@ describe("computeInterestForCycle", () => {
       cycle: "2026-04",
     });
     expect(run.intereses.length).toBe(1);
-    expect(run.intereses[0].rateEMBps).toBe(200);
+    expect(run.intereses[0].rateEmX10k).toBe(20000);
   });
 
   it("skips purchases with 1 cuota + 0% oneMonth bucket (diferido nominal)", async () => {
     const visa = await getVisaId();
-    await setBucketRates(visa, { oneMonth: 0, months2to36: 191, advances: 191 });
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
 
     await seedPurchase({
       accountId: visa,
@@ -126,7 +128,7 @@ describe("computeInterestForCycle", () => {
       amountCentsMagnitude: BigInt(500_000),
       occurredAt: "2026-03-10",
       installmentsTotal: 1,
-      installmentRateBps: null,
+      installmentRateEmX10k: null,
     });
 
     const run = await computeInterestForCycle({
@@ -142,14 +144,14 @@ describe("computeInterestForCycle", () => {
 describe("applyInteresesCausadosForCycle", () => {
   it("inserts a synthetic tx with category intereses-tc on first run", async () => {
     const visa = await getVisaId();
-    await setBucketRates(visa, { oneMonth: 0, months2to36: 191, advances: 191 });
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
     await seedPurchase({
       accountId: visa,
       externalId: `${EXT_PREFIX}ins-1`,
       amountCentsMagnitude: BigInt(20_000_000),
       occurredAt: "2026-03-10",
       installmentsTotal: 12,
-      installmentRateBps: 191,
+      installmentRateEmX10k: 19110,
     });
 
     const result = await applyInteresesCausadosForCycle({
@@ -178,14 +180,14 @@ describe("applyInteresesCausadosForCycle", () => {
 
   it("is idempotent — second call returns skipped/already-run", async () => {
     const visa = await getVisaId();
-    await setBucketRates(visa, { oneMonth: 0, months2to36: 191, advances: 191 });
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
     await seedPurchase({
       accountId: visa,
       externalId: `${EXT_PREFIX}idem`,
       amountCentsMagnitude: BigInt(10_000_000),
       occurredAt: "2026-03-10",
       installmentsTotal: 12,
-      installmentRateBps: 191,
+      installmentRateEmX10k: 19110,
     });
 
     const first = await applyInteresesCausadosForCycle({

--- a/src/lib/finance/intereses-causados-job.ts
+++ b/src/lib/finance/intereses-causados-job.ts
@@ -19,7 +19,7 @@ import { db, type DB } from "@/lib/db";
 import { accounts, transactions, type AccountMetadata } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { installmentSchedule } from "@/lib/finance/installment-schedule";
-import { resolveBucketRateBps } from "@/lib/finance/rates";
+import { resolveBucketRateX10k } from "@/lib/finance/rates";
 
 export type CycleKey = `${number}-${string}`; // e.g. "5-2026-04"
 
@@ -29,7 +29,7 @@ export type InterestRun = {
   intereses: Array<{
     txId: number;
     purchaseAmountCents: bigint;
-    rateEMBps: number;
+    rateEmX10k: number; // #411: percent × 10000
     installmentsTotal: number;
     installmentsPaid: number;
     outstandingBeforeCents: bigint;
@@ -97,7 +97,7 @@ export async function computeInterestForCycle(opts: {
       amountCents: transactions.amountCents,
       occurredAt: transactions.occurredAt,
       installmentsTotal: transactions.installmentsTotal,
-      installmentRateBps: transactions.installmentRateBps,
+      installmentRateEmX10k: transactions.installmentRateEmX10k,
     })
     .from(transactions)
     .where(
@@ -119,14 +119,14 @@ export async function computeInterestForCycle(opts: {
   let totalInterestCents = BigInt(0);
 
   for (const p of purchases) {
-    const rateBps =
-      p.installmentRateBps != null
-        ? p.installmentRateBps
-        : (resolveBucketRateBps(buckets, p.installmentsTotal) ?? 0);
+    const rateEmX10k =
+      p.installmentRateEmX10k != null
+        ? p.installmentRateEmX10k
+        : (resolveBucketRateX10k(buckets, p.installmentsTotal) ?? 0);
 
     const schedule = installmentSchedule({
       amountCents: -p.amountCents, // stored negative, helper expects positive magnitude
-      rateEMBps: rateBps,
+      rateEmX10k,
       installments: p.installmentsTotal,
       graceMonth: true, // Bancolombia default per regla 4; safe for extracts today
       purchaseDate: p.occurredAt,
@@ -148,7 +148,7 @@ export async function computeInterestForCycle(opts: {
     intereses.push({
       txId: p.id,
       purchaseAmountCents: -p.amountCents,
-      rateEMBps: rateBps,
+      rateEmX10k,
       installmentsTotal: p.installmentsTotal,
       installmentsPaid: schedule.paidCount,
       outstandingBeforeCents: outstandingBefore,
@@ -225,7 +225,7 @@ export async function applyInteresesCausadosForCycle(opts: {
           breakdown: run.intereses.map((i) => ({
             txId: i.txId,
             amountCents: i.purchaseAmountCents.toString(),
-            rateEMBps: i.rateEMBps,
+            rateEmX10k: i.rateEmX10k,
             installmentsTotal: i.installmentsTotal,
             installmentsPaid: i.installmentsPaid,
             outstandingBeforeCents: i.outstandingBeforeCents.toString(),

--- a/src/lib/finance/rates.test.ts
+++ b/src/lib/finance/rates.test.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
-  bpsEmToEa,
-  eaToEm,
   emToEa,
-  formatBpsEmAsEaPercent,
-  formatBpsEmAsPercent,
-  MAX_EM_BPS,
-  MIN_NON_ZERO_EM_BPS,
-  parsePercentToBps,
+  eaToEm,
+  emX10kToEa,
+  EM_X10K_PER_FRACTIONAL,
+  EM_X10K_SCALE,
+  formatEmX10kAsEaPercent,
+  formatEmX10kAsPercent,
+  MAX_EM_X10K,
+  MIN_NON_ZERO_EM_X10K,
+  parsePercentToEmX10k,
   rateValidationMessage,
-  resolveBucketRateBps,
-  validateInstallmentRateBps,
+  resolveBucketRateX10k,
+  validateInstallmentRate,
 } from "./rates";
 
 describe("rates: EM ↔ EA conversion", () => {
@@ -19,86 +21,94 @@ describe("rates: EM ↔ EA conversion", () => {
     expect(eaToEm(0)).toBe(0);
   });
 
-  it("EM 1.91% ≈ EA 25.49% (Bancolombia's 2-36 cuota bucket)", () => {
-    const ea = emToEa(0.0191);
-    // Exact: (1.0191)^12 - 1 ≈ 0.25488 → 25.49% rounded
-    expect(ea).toBeCloseTo(0.25488, 4);
+  it("EM 1.9110% ≈ EA 25.50% (Bancolombia's 2-36 cuota bucket at 4 decimals)", () => {
+    const ea = emToEa(0.01911);
+    // Exact: (1.019110)^12 - 1 ≈ 0.25503 → 25.50% rounded
+    expect(ea).toBeCloseTo(0.25503, 4);
   });
 
   it("round-trip: eaToEm ∘ emToEa ≈ identity", () => {
-    for (const em of [0.005, 0.01, 0.0191, 0.05]) {
+    for (const em of [0.005, 0.01, 0.01911, 0.05]) {
       expect(eaToEm(emToEa(em))).toBeCloseTo(em, 10);
     }
   });
 
-  it("bpsEmToEa(191) matches the typical Bancolombia extract display", () => {
-    // 191 bps = 1.91% EM → ~25.49% EA
-    expect(bpsEmToEa(191)).toBeCloseTo(0.25488, 4);
+  it("emX10kToEa(19110) matches the 4-decimal Bancolombia extract display", () => {
+    // 19110 stored (percent × 10000) = 1.9110% EM → ~25.50% EA
+    expect(emX10kToEa(19110)).toBeCloseTo(0.25503, 4);
+  });
+
+  it("EM_X10K_PER_FRACTIONAL exports the divisor so callers don't invent scale factors", () => {
+    expect(EM_X10K_PER_FRACTIONAL).toBe(1_000_000);
+    expect(EM_X10K_SCALE).toBe(10000);
   });
 });
 
 describe("rates: formatters", () => {
-  it("formatBpsEmAsPercent keeps 4 decimals so rates like 1.8311% stay lossless", () => {
-    expect(formatBpsEmAsPercent(1831)).toBe("18.3100%");
-    expect(formatBpsEmAsPercent(191)).toBe("1.9100%");
+  it("formatEmX10kAsPercent keeps 4 decimals for lossless display", () => {
+    expect(formatEmX10kAsPercent(19110)).toBe("1.9110%");
+    expect(formatEmX10kAsPercent(18311)).toBe("1.8311%");
+    expect(formatEmX10kAsPercent(0)).toBe("0.0000%");
   });
 
-  it("formatBpsEmAsEaPercent prints the EA equivalent for display", () => {
-    // 191 bps = 1.91% EM → 25.49% EA rounded to 2 decimals
-    expect(formatBpsEmAsEaPercent(191)).toBe("25.49%");
-    expect(formatBpsEmAsEaPercent(0)).toBe("0.00%");
+  it("formatEmX10kAsEaPercent prints the EA equivalent at 2 decimals", () => {
+    // 19110 stored = 1.9110% EM → 25.5026% EA → 25.50% rounded
+    expect(formatEmX10kAsEaPercent(19110)).toBe("25.50%");
+    expect(formatEmX10kAsEaPercent(0)).toBe("0.00%");
   });
 });
 
-describe("rates: parsePercentToBps", () => {
-  it("parses plain decimal", () => {
-    expect(parsePercentToBps("1.9110")).toBe(191);
-    expect(parsePercentToBps("0")).toBe(0);
-    expect(parsePercentToBps("25.5")).toBe(2550);
+describe("rates: parsePercentToEmX10k", () => {
+  it("parses 4-decimal percent to the exact stored unit", () => {
+    expect(parsePercentToEmX10k("1.9110")).toBe(19110);
+    expect(parsePercentToEmX10k("0")).toBe(0);
+    expect(parsePercentToEmX10k("25.5")).toBe(255000);
   });
 
   it("accepts comma as decimal separator and strips the % suffix", () => {
-    expect(parsePercentToBps("1,9110%")).toBe(191);
-    expect(parsePercentToBps("1,91")).toBe(191);
+    expect(parsePercentToEmX10k("1,9110%")).toBe(19110);
+    expect(parsePercentToEmX10k("1,91")).toBe(19100);
   });
 
   it("rejects negative, NaN, and empty", () => {
-    expect(parsePercentToBps("-1")).toBeNull();
-    expect(parsePercentToBps("abc")).toBeNull();
-    expect(parsePercentToBps("   ")).toBeNull();
+    expect(parsePercentToEmX10k("-1")).toBeNull();
+    expect(parsePercentToEmX10k("abc")).toBeNull();
+    expect(parsePercentToEmX10k("   ")).toBeNull();
   });
 });
 
-describe("rates: validateInstallmentRateBps", () => {
+describe("rates: validateInstallmentRate", () => {
   it("accepts 0 (diferido sin intereses — regla 1 de #345)", () => {
-    expect(validateInstallmentRateBps(0)).toEqual({ ok: true });
+    expect(validateInstallmentRate(0)).toEqual({ ok: true });
   });
 
-  it("accepts typical TC rates", () => {
-    // 191 bps = 1.91% EM — the classic 2-36 cuota Bancolombia rate.
-    expect(validateInstallmentRateBps(191)).toEqual({ ok: true });
+  it("accepts typical TC rates at 4-decimal precision", () => {
+    // 19110 stored = 1.9110% EM, the canonical Bancolombia bucket.
+    expect(validateInstallmentRate(19110)).toEqual({ ok: true });
     // Avance/mora at some banks ~2-3% EM.
-    expect(validateInstallmentRateBps(250)).toEqual({ ok: true });
-    expect(validateInstallmentRateBps(MIN_NON_ZERO_EM_BPS)).toEqual({ ok: true });
+    expect(validateInstallmentRate(25000)).toEqual({ ok: true });
+    expect(validateInstallmentRate(MIN_NON_ZERO_EM_X10K)).toEqual({ ok: true });
   });
 
-  it("rejects non-zero values < MIN_NON_ZERO_EM_BPS (likely EA mislabeled as EM)", () => {
-    // 0.25% EM would give ~3% EA — nonsensical for TC Colombia; more likely
-    // the user typed 0.25 thinking of EA.
-    expect(validateInstallmentRateBps(25)).toEqual({ ok: false, reason: "too-low" });
+  it("rejects non-zero values < MIN_NON_ZERO_EM_X10K (likely EA mislabeled as EM)", () => {
+    // 191 stored = 0.0191% EM — this is what a legacy bps value would look
+    // like if someone forgot to rescale after #411.
+    expect(validateInstallmentRate(191)).toEqual({ ok: false, reason: "too-low" });
+    // 2500 stored = 0.25% EM — also ambiguous / too low.
+    expect(validateInstallmentRate(2500)).toEqual({ ok: false, reason: "too-low" });
   });
 
   it("rejects negative", () => {
-    expect(validateInstallmentRateBps(-100)).toEqual({ ok: false, reason: "negative" });
+    expect(validateInstallmentRate(-100)).toEqual({ ok: false, reason: "negative" });
   });
 
   it("rejects ≥ 100% EM (almost certainly a typo)", () => {
-    expect(validateInstallmentRateBps(MAX_EM_BPS)).toEqual({ ok: false, reason: "too-high" });
-    expect(validateInstallmentRateBps(99999)).toEqual({ ok: false, reason: "too-high" });
+    expect(validateInstallmentRate(MAX_EM_X10K)).toEqual({ ok: false, reason: "too-high" });
+    expect(validateInstallmentRate(9_999_999)).toEqual({ ok: false, reason: "too-high" });
   });
 
   it("rejects non-integers", () => {
-    expect(validateInstallmentRateBps(1.5)).toEqual({ ok: false, reason: "not-integer" });
+    expect(validateInstallmentRate(19110.5)).toEqual({ ok: false, reason: "not-integer" });
   });
 
   it("messages mention EM vs EA explicitly for too-low (most common mistake)", () => {
@@ -108,29 +118,29 @@ describe("rates: validateInstallmentRateBps", () => {
   });
 });
 
-describe("rates: resolveBucketRateBps", () => {
-  const buckets = { oneMonth: 0, months2to36: 191, advances: 191 };
+describe("rates: resolveBucketRateX10k", () => {
+  const buckets = { oneMonth: 0, months2to36: 19110, advances: 19110 };
 
   it("returns oneMonth bucket when installments = 1", () => {
-    expect(resolveBucketRateBps(buckets, 1)).toBe(0);
+    expect(resolveBucketRateX10k(buckets, 1)).toBe(0);
   });
 
   it("returns months2to36 bucket for [2, 36]", () => {
-    expect(resolveBucketRateBps(buckets, 2)).toBe(191);
-    expect(resolveBucketRateBps(buckets, 12)).toBe(191);
-    expect(resolveBucketRateBps(buckets, 36)).toBe(191);
+    expect(resolveBucketRateX10k(buckets, 2)).toBe(19110);
+    expect(resolveBucketRateX10k(buckets, 12)).toBe(19110);
+    expect(resolveBucketRateX10k(buckets, 36)).toBe(19110);
   });
 
   it("returns months2to36 bucket for > 36 installments (no distinct bucket in the extract)", () => {
-    expect(resolveBucketRateBps(buckets, 60)).toBe(191);
+    expect(resolveBucketRateX10k(buckets, 60)).toBe(19110);
   });
 
   it("returns the advances bucket when isAdvance=true regardless of installments", () => {
-    expect(resolveBucketRateBps(buckets, 1, true)).toBe(191);
+    expect(resolveBucketRateX10k(buckets, 1, true)).toBe(19110);
   });
 
   it("returns null when buckets are undefined / missing the relevant bucket", () => {
-    expect(resolveBucketRateBps(undefined, 12)).toBeNull();
-    expect(resolveBucketRateBps({ months2to36: 191 }, 1)).toBeNull();
+    expect(resolveBucketRateX10k(undefined, 12)).toBeNull();
+    expect(resolveBucketRateX10k({ months2to36: 19110 }, 1)).toBeNull();
   });
 });

--- a/src/lib/finance/rates.ts
+++ b/src/lib/finance/rates.ts
@@ -1,6 +1,8 @@
-// #406: interest-rate conversion + validation helpers for credit-card
-// financials. Every `*_bps` value the app ingests, stores, or renders is
-// Efectiva Mensual Vencida (EM / MV). Display as EA is computed on read only.
+// #406/#411: interest-rate conversion + validation helpers for credit-card
+// financials. Every rate value the app ingests, stores, or renders is
+// Efectiva Mensual Vencida (EM / MV), stored as PERCENT × 10000 so the app
+// preserves the 4 decimals Bancolombia prints on real extracts (e.g.
+// "1.9110%" → 19110). Display as EA is computed on read only.
 //
 // Rationale for the hard convention: during #345 scoping we caught a bank
 // agent verbally conflating EM and EA; the two differ by ~12× in cuota
@@ -8,20 +10,25 @@
 // cuota ≈ 1/12 of the real one) with no runtime error. See finding F3 of
 // #345 and memory `findash/convention/interest-rate-unit`.
 //
-// Basis points (bps): 10000 bps = 100%. So 1.9110% EM = 191 bps. We pick bps
-// over floats because the storage column is smallint — exact, small, and
-// free of rounding.
+// Scale: stored = percent × 10000. Equivalent terms: "basis points × 100",
+// "hundredths of a basis point", "permyriad × 100". We picked x10000
+// because it maps 1-to-1 with Bancolombia's 4-decimal extract display:
+// `1.9110%` → 19110 with no rounding.
 
-// Minimum non-zero EM we accept. 50 bps = 0.5% EM = ~6.17% EA. TC rates in
-// Colombia sit around 1.9% EM (~25% EA) — anything under 0.5% EM is almost
-// certainly an EA value mislabeled as EM. 0 stays valid (diferido sin
-// intereses — Bancolombia's 1-cuota bucket).
-export const MIN_NON_ZERO_EM_BPS = 50;
+// Conversion constants. Stored integer ÷ EM_PER_FRACTIONAL = fractional rate.
+export const EM_X10K_SCALE = 10000; // multiplier from percent to stored units
+export const EM_X10K_PER_FRACTIONAL = 1_000_000; // stored ÷ this = fractional (e.g. 0.019110)
 
-// Upper sanity bound. 10000 bps = 100% EM (which as EA is absurd). If someone
-// types a rate ≥ this, it's almost certainly a typo. Validator catches it so
-// the schedule helper in #407 never sees garbage.
-export const MAX_EM_BPS = 10000;
+// Minimum non-zero EM we accept. 5000 (x10k) = 0.5% EM ≈ 6.17% EA. TC rates
+// in Colombia sit around 1.9% EM (~25% EA) — anything under 0.5% EM is
+// almost certainly an EA value mislabeled as EM. 0 stays valid (diferido
+// sin intereses — Bancolombia's 1-cuota bucket).
+export const MIN_NON_ZERO_EM_X10K = 5000;
+
+// Upper sanity bound. 1_000_000 (x10k) = 100% EM (which as EA is absurd).
+// If someone types a rate ≥ this, it's almost certainly a typo. Validator
+// catches it so the schedule helper in #407 never sees garbage.
+export const MAX_EM_X10K = 1_000_000;
 
 export type RateValidationResult =
   | { ok: true }
@@ -29,11 +36,13 @@ export type RateValidationResult =
 
 // Pure validation. Returns a specific reason so callers (server action,
 // form) can surface a useful message — not just "invalid".
-export function validateInstallmentRateBps(bps: number): RateValidationResult {
-  if (!Number.isInteger(bps)) return { ok: false, reason: "not-integer" };
-  if (bps < 0) return { ok: false, reason: "negative" };
-  if (bps > 0 && bps < MIN_NON_ZERO_EM_BPS) return { ok: false, reason: "too-low" };
-  if (bps >= MAX_EM_BPS) return { ok: false, reason: "too-high" };
+export function validateInstallmentRate(storedX10k: number): RateValidationResult {
+  if (!Number.isInteger(storedX10k)) return { ok: false, reason: "not-integer" };
+  if (storedX10k < 0) return { ok: false, reason: "negative" };
+  if (storedX10k > 0 && storedX10k < MIN_NON_ZERO_EM_X10K) {
+    return { ok: false, reason: "too-low" };
+  }
+  if (storedX10k >= MAX_EM_X10K) return { ok: false, reason: "too-high" };
   return { ok: true };
 }
 
@@ -50,59 +59,61 @@ export function rateValidationMessage(
     case "too-high":
       return "Tasa fuera de rango razonable (≥ 100% EM).";
     case "not-integer":
-      return "La tasa debe estar expresada en basis points (número entero).";
+      return "La tasa debe estar expresada como entero (percent × 10000).";
   }
 }
 
-// Convert EM (as a decimal fraction — 0.0191 = 1.91% monthly) to EA. Formula:
+// Convert EM (fractional — 0.0191 = 1.91% monthly) to EA. Formula:
 // EA = (1 + EM)^12 - 1. Uses JS Math so result is a plain number — fine for
 // DISPLAY (we never persist EA).
 export function emToEa(em: number): number {
   return Math.pow(1 + em, 12) - 1;
 }
 
-// Inverse of `emToEa`. EA as decimal → EM as decimal.
+// Inverse of `emToEa`. EA fractional → EM fractional.
 // EM = (1 + EA)^(1/12) - 1.
 export function eaToEm(ea: number): number {
   return Math.pow(1 + ea, 1 / 12) - 1;
 }
 
-// Convenience: bps EM → decimal EA. Example: 1910 bps EM → 0.2550 EA.
-export function bpsEmToEa(bps: number): number {
-  return emToEa(bps / 10000);
+// Convenience: stored EM (x10k) → fractional EA. Example: 19110 → 0.25503
+// (= 25.5026% rounded).
+export function emX10kToEa(storedX10k: number): number {
+  return emToEa(storedX10k / EM_X10K_PER_FRACTIONAL);
 }
 
-// Convenience: bps EM → formatted "X.XXXX%" (mirrors how Bancolombia prints
-// these on statements). 4 decimals keeps historical rates like 1.8311%
-// lossless; the input box should use the same precision.
-export function formatBpsEmAsPercent(bps: number, decimals = 4): string {
-  return `${(bps / 100).toFixed(decimals)}%`;
+// Convenience: stored EM (x10k) → formatted "X.XXXX%" (mirrors how
+// Bancolombia prints these on statements). 4 decimals keeps historical
+// rates like 1.8311% lossless; the input box should use the same precision.
+export function formatEmX10kAsPercent(storedX10k: number, decimals = 4): string {
+  return `${(storedX10k / EM_X10K_SCALE).toFixed(decimals)}%`;
 }
 
-// Convenience: bps EM → formatted "X.XX%" EA for read-only display next to
-// the EM input (the "1.91% EM · 25.50% EA" pattern the UI uses).
-export function formatBpsEmAsEaPercent(bps: number, decimals = 2): string {
-  const ea = bpsEmToEa(bps);
+// Convenience: stored EM (x10k) → formatted "X.XX%" EA for read-only display
+// next to the EM input (the "1.9110% EM · 25.50% EA" pattern the UI uses).
+export function formatEmX10kAsEaPercent(storedX10k: number, decimals = 2): string {
+  const ea = emX10kToEa(storedX10k);
   return `${(ea * 100).toFixed(decimals)}%`;
 }
 
-// Parses the user's typed percent ("1.9110", "1,9110", "1.9110%") into
-// bps as an integer. Returns null when the input is invalid. Used by the
-// account + tx edit forms.
-export function parsePercentToBps(input: string): number | null {
+// Parses the user's typed percent ("1.9110", "1,9110", "1.9110%") into the
+// stored integer. Returns null when the input is invalid. Rounds half-up to
+// the 4th decimal — anything finer is noise the schema can't represent.
+export function parsePercentToEmX10k(input: string): number | null {
   const trimmed = input.trim().replace(/%\s*$/, "");
   if (!trimmed) return null;
   const normalized = trimmed.replace(",", ".");
   const n = Number(normalized);
   if (!Number.isFinite(n) || n < 0) return null;
-  return Math.round(n * 100);
+  return Math.round(n * EM_X10K_SCALE);
 }
 
-// Bucket resolver for the #407 schedule helper. Returns the EM bps that a
-// purchase of `installmentsTotal` cuotas should use when the transaction
-// row has no explicit `installment_rate_bps`. Null when the bucket isn't
-// populated — the caller decides between 0 (best-effort) and an error.
-export function resolveBucketRateBps(
+// Bucket resolver for the #407 schedule helper. Returns the stored EM x10k
+// that a purchase of `installmentsTotal` cuotas should use when the
+// transaction row has no explicit `installment_rate_em_x10k`. Null when
+// the bucket isn't populated — the caller decides between 0 (best-effort)
+// and an error.
+export function resolveBucketRateX10k(
   buckets: { oneMonth?: number; months2to36?: number; advances?: number } | undefined,
   installmentsTotal: number,
   isAdvance = false,
@@ -113,6 +124,6 @@ export function resolveBucketRateBps(
   if (installmentsTotal <= 36) return buckets.months2to36 ?? null;
   // Beyond 36 cuotas the extract doesn't show a distinct bucket — use the
   // same rate as 2-36. Real-world exceptions (e.g. compra de cartera at a
-  // preferential rate) go on the per-tx `installment_rate_bps` override.
+  // preferential rate) go on the per-tx `installment_rate_em_x10k`.
   return buckets.months2to36 ?? null;
 }

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -100,7 +100,7 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
       accountName: accounts.name,
       accountType: accounts.type,
       installmentsTotal: transactions.installmentsTotal,
-      installmentRateBps: transactions.installmentRateBps,
+      installmentRateEmX10k: transactions.installmentRateEmX10k,
       deletedAt: transactions.deletedAt,
       cpId: counterparties.id,
       cpDisplayName: counterparties.displayName,
@@ -145,7 +145,7 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
     accountName: r.accountName,
     accountType: r.accountType,
     installmentsTotal: r.installmentsTotal,
-    installmentRateBps: r.installmentRateBps,
+    installmentRateEmX10k: r.installmentRateEmX10k,
     deletedAt: r.deletedAt,
     counterparty: r.cpId
       ? {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,10 +56,11 @@ export type TxRow = {
   // #406: account type surfaces in the table so the row-actions menu can
   // gate the "Editar cuotas" option to TC rows only.
   accountType: AccountType;
-  // #406: installment fields. `installmentRateBps` is null when the tx
-  // inherits from the account's bucket (see rates.resolveBucketRateBps).
+  // #406/#411: installment fields. `installmentRateEmX10k` is null when the
+  // tx inherits from the account's bucket (see rates.resolveBucketRateX10k).
+  // Stored unit: percent × 10000 (e.g. "1.9110%" → 19110).
   installmentsTotal: number;
-  installmentRateBps: number | null;
+  installmentRateEmX10k: number | null;
   counterparty: CounterpartyValue | null;
   deletedAt: Date | null;
 };


### PR DESCRIPTION
Closes #411. Follow-up a #406/#407 — Bancolombia usa 4 decimales en las tasas (1.9110%, 25.5026%), pero el schema original las guardaba en bps smallint = 2 decimales. Rescate de precision exacta + UI con placeholders que muestran los defaults Bancolombia.

## Qué cambia

- **Schema (migration 0051)**: `installment_rate_bps smallint → integer`, unit cambiado de 'bps' a 'percent × 10000' (`1.9110%` → `19110`). El nombre del column SQL queda para simplicidad de migration; unit documentado. Data migration lossless via `USING × 100` + `jsonb_set` en buckets.
- **Helpers (`rates.ts`)**: rename sistemático — `validateInstallmentRateBps → validateInstallmentRate`, `parsePercentToBps → parsePercentToEmX10k`, `resolveBucketRateBps → resolveBucketRateX10k`, etc. Nuevas constantes `EM_X10K_SCALE=10000` y `EM_X10K_PER_FRACTIONAL=1_000_000`. Validator limits rescalados (0.5% EM → 5000, 100% EM → 1_000_000).
- **UI**:
  - Account editor: placeholders `0.0000 / 1.9110 / 1.9110` en cada bucket para guiar al user con los defaults Bancolombia sin pretender que ya están guardados.
  - EA preview aparece también para el placeholder (faded + italic) — antes solo cuando el user escribía. Ahora ves `≈ 25.50% EA` al abrir el dialog.
- **Seed**: defaults 19110 (= 1.9110% exacto).

## Tests

886 → 887 (+1 nuevo caso: validator rechaza un valor 191 que antes era válido como bps y ahora sería 0.0191% — catcho en MIN_NON_ZERO).

## Validated

- typecheck ✓
- lint ✓
- prettier ✓
- 887/887 tests ✓
- Migration aplicada a dev + test DB sin errores. Data existente: 0 txs con installment_rate no nulo, 0 accounts con creditRateBuckets previos, así que el rescale no tuvo que convertir nada real todavía.

Parent epic: #345 (cerrado tras #405/#406/#407).