### PR TITLE
fix(finance): use per-account statement cut day as cycle anchor (#413)

### DIFF
--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -87,6 +87,10 @@ const seedAccounts: Array<{
       last4s: ["2575"],
       network: "visa",
       creditRateBuckets: { oneMonth: 0, months2to36: 19110, advances: 19110 },
+      // #413: statement cut day drives the intereses-causados job's anchor.
+      // 30 matches the observed Bancolombia 2026 extracts; users edit per TC
+      // from /settings/accounts.
+      cutoffDay: 30,
     },
   },
   {
@@ -216,6 +220,9 @@ export async function runSeed() {
       network: acc.metadata?.network,
       last4: acc.metadata?.last4s?.[0],
       creditLimitCents: BigInt(0),
+      // #413: default statement cut day from observed Bancolombia 2026
+      // extracts. Users edit per TC from /settings/accounts.
+      statementCutoffDay: 30,
     });
   }
   if (newPhysicalCardRows.length > 0) {

--- a/src/lib/finance/intereses-causados-job.test.ts
+++ b/src/lib/finance/intereses-causados-job.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { applyInteresesCausadosForCycle, computeInterestForCycle } from "./intereses-causados-job";
+import {
+  applyInteresesCausadosForCycle,
+  computeInterestForCycle,
+  cycleAnchor,
+} from "./intereses-causados-job";
 
 // #407: integration tests for the intereses-causados job. Uses the real test
 // DB (findash_test) — seeds a TC account + purchases, runs the job, inspects
@@ -41,6 +45,23 @@ async function setBucketRates(
   `);
 }
 
+async function setCutoffDay(accountId: number, day: number | null) {
+  if (day === null) {
+    await db.execute(sql`
+      UPDATE accounts
+      SET metadata = metadata - 'cutoffDay', updated_at = now()
+      WHERE id = ${accountId}
+    `);
+  } else {
+    await db.execute(sql`
+      UPDATE accounts
+      SET metadata = jsonb_set(metadata, '{cutoffDay}', ${day.toString()}::jsonb),
+          updated_at = now()
+      WHERE id = ${accountId}
+    `);
+  }
+}
+
 async function seedPurchase(opts: {
   accountId: number;
   externalId: string;
@@ -66,6 +87,40 @@ async function seedPurchase(opts: {
   `);
   return row.id;
 }
+
+describe("cycleAnchor (#413)", () => {
+  it("anchors at end-of-day UTC on the requested cut day", () => {
+    const d = cycleAnchor("2026-03", 30);
+    expect(d.toISOString()).toBe("2026-03-30T23:00:00.000Z");
+  });
+
+  it("clamps cutDay=31 to Feb 28 in a non-leap year", () => {
+    expect(cycleAnchor("2026-02", 31).getUTCDate()).toBe(28);
+  });
+
+  it("clamps cutDay=31 to Feb 29 in a leap year", () => {
+    expect(cycleAnchor("2024-02", 31).getUTCDate()).toBe(29);
+  });
+
+  it("clamps cutDay=31 to April 30", () => {
+    expect(cycleAnchor("2026-04", 31).getUTCDate()).toBe(30);
+  });
+
+  it("keeps the nominal day when it exists in the month", () => {
+    expect(cycleAnchor("2026-03", 15).getUTCDate()).toBe(15);
+  });
+
+  it("rejects invalid cut days", () => {
+    expect(() => cycleAnchor("2026-03", 0)).toThrow(/invalid cutDay/);
+    expect(() => cycleAnchor("2026-03", 32)).toThrow(/invalid cutDay/);
+    expect(() => cycleAnchor("2026-03", 1.5)).toThrow(/invalid cutDay/);
+  });
+
+  it("rejects malformed cycles", () => {
+    expect(() => cycleAnchor("bad", 15)).toThrow(/invalid cycle/);
+    expect(() => cycleAnchor("2026", 15)).toThrow(/invalid cycle/);
+  });
+});
 
 describe("computeInterestForCycle", () => {
   it("returns the interest due on the next unpaid cuota", async () => {
@@ -116,6 +171,72 @@ describe("computeInterestForCycle", () => {
     });
     expect(run.intereses.length).toBe(1);
     expect(run.intereses[0].rateEmX10k).toBe(20000);
+  });
+
+  it("picks up the account's cutoffDay — a later cut → one more cuota paid → less interest (#413)", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
+
+    // Purchase on Jan 20 with an explicit per-tx rate. Cycle "2026-03".
+    // With cutDay=15 the anchor is Mar 15 and monthsBetween(Jan 20, Mar 15)
+    // decrements by one (15 < 20) → paidCount=1 → charges cuota 2 on a high
+    // balance. With cutDay=30 the anchor is Mar 30 and the decrement doesn't
+    // happen (30 >= 20) → paidCount=2 → charges cuota 3 on a lower balance.
+    // This is the exact scenario that #413 fixes.
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}cutoff-drives-paidcount`,
+      amountCentsMagnitude: BigInt(247_990_000), // 2_479_900 pesos
+      occurredAt: "2026-01-20",
+      installmentsTotal: 12,
+      installmentRateEmX10k: 18311,
+    });
+
+    await setCutoffDay(visa, 15);
+    const early = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-03",
+    });
+    expect(early.intereses[0].installmentsPaid).toBe(1);
+
+    await setCutoffDay(visa, 30);
+    const late = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-03",
+    });
+    expect(late.intereses[0].installmentsPaid).toBe(2);
+
+    // A later cut means more cuotas have been paid → smaller outstanding
+    // balance → smaller interest this cycle.
+    expect(late.totalInterestCents).toBeLessThan(early.totalInterestCents);
+    expect(late.anchor.getUTCDate()).toBe(30);
+    expect(early.anchor.getUTCDate()).toBe(15);
+  });
+
+  it("falls back to last-day-of-month when cutoffDay is missing (#413)", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
+    await setCutoffDay(visa, null);
+
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}cutoff-missing`,
+      amountCentsMagnitude: BigInt(1_000_000),
+      occurredAt: "2026-03-10",
+      installmentsTotal: 6,
+      installmentRateEmX10k: 19110,
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+    // April has 30 days, so cutDay=31 clamps to 30.
+    expect(run.anchor.getUTCMonth()).toBe(3); // April (0-indexed)
+    expect(run.anchor.getUTCDate()).toBe(30);
   });
 
   it("skips purchases with 1 cuota + 0% oneMonth bucket (diferido nominal)", async () => {

--- a/src/lib/finance/intereses-causados-job.ts
+++ b/src/lib/finance/intereses-causados-job.ts
@@ -16,16 +16,30 @@
 
 import { and, eq, sql } from "drizzle-orm";
 import { db, type DB } from "@/lib/db";
-import { accounts, transactions, type AccountMetadata } from "@/lib/db/schema";
+import { accounts, physicalCards, transactions, type AccountMetadata } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { installmentSchedule } from "@/lib/finance/installment-schedule";
 import { resolveBucketRateX10k } from "@/lib/finance/rates";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "intereses-causados-job" });
+
+// Fallback cut day when neither the account nor its linked physical card has
+// one configured. 31 clamps to each month's last day, so a misconfigured
+// account still produces end-of-cycle behavior (the safest generic for
+// Bancolombia-style TCs). A warning is logged so the gap is visible.
+const DEFAULT_CUT_DAY = 31;
 
 export type CycleKey = `${number}-${string}`; // e.g. "5-2026-04"
 
 export type InterestRun = {
   accountId: number;
   cycle: string; // YYYY-MM
+  // Anchor used to split paid vs pending cuotas — end-of-day on the account's
+  // statement cut day, clamped to the month's last day. Surfaced so the
+  // apply-path can reuse it as the synthetic tx's `occurred_at` without
+  // re-resolving the cut day. See #413.
+  anchor: Date;
   intereses: Array<{
     txId: number;
     purchaseAmountCents: bigint;
@@ -47,13 +61,25 @@ function cycleKeyFor(accountId: number, cycle: string): string {
   return `${accountId}-${cycle}`;
 }
 
-// Convert a "YYYY-MM" cycle string into a UTC mid-month date. Used as the
-// `occurred_at` anchor for the synthetic tx and the `today` input to the
-// schedule helper — being mid-month keeps it insensitive to TZ edges.
-function cycleAnchor(cycle: string): Date {
+// Convert a "YYYY-MM" cycle string into the anchor Date for that cycle's
+// statement cut. `cutDay` (1-31) is the account's statement close day; values
+// past the month's actual length are clamped to the last day (e.g. cutDay=31
+// in February becomes Feb 28/29). End-of-day UTC (23:00) so purchases made
+// earlier in that same day still count as paid for `monthsBetween` checks.
+//
+// Why this drives correctness: `installmentSchedule`'s paid-vs-pending split
+// calls `monthsBetween(purchaseDate, anchor)` — anchoring mid-month would
+// decrement the count whenever a purchase's day-of-month falls in the second
+// half, producing a one-cuota-behind interest calc. See #413.
+export function cycleAnchor(cycle: string, cutDay: number): Date {
   const [y, m] = cycle.split("-").map(Number);
   if (!Number.isInteger(y) || !Number.isInteger(m)) throw new Error(`invalid cycle: ${cycle}`);
-  return new Date(Date.UTC(y, m - 1, 15, 12, 0, 0, 0));
+  if (!Number.isInteger(cutDay) || cutDay < 1 || cutDay > 31) {
+    throw new Error(`invalid cutDay: ${cutDay}`);
+  }
+  const lastDayOfMonth = new Date(Date.UTC(y, m, 0)).getUTCDate();
+  const day = Math.min(cutDay, lastDayOfMonth);
+  return new Date(Date.UTC(y, m - 1, day, 23, 0, 0, 0));
 }
 
 // For each live installment purchase on the TC, project its schedule as of
@@ -66,16 +92,20 @@ export async function computeInterestForCycle(opts: {
   database?: DB;
 }): Promise<InterestRun> {
   const { userId, accountId, cycle, database = db } = opts;
-  const anchor = cycleAnchor(cycle);
 
+  // Left-join physical_cards so shared-cupo multi-currency cards (Mastercard
+  // Internacional, Amex) pick up the cut day from the shared row rather than
+  // duplicating it in every linked account's metadata.
   const [account] = await database
     .select({
       id: accounts.id,
       type: accounts.type,
       currency: accounts.currency,
       metadata: accounts.metadata,
+      physicalCardCutoffDay: physicalCards.statementCutoffDay,
     })
     .from(accounts)
+    .leftJoin(physicalCards, eq(physicalCards.id, accounts.physicalCardId))
     .where(
       and(eq(accounts.userId, userId), eq(accounts.id, accountId), notDeleted(accounts.deletedAt)),
     )
@@ -87,6 +117,20 @@ export async function computeInterestForCycle(opts: {
   }
   const meta = account.metadata as AccountMetadata;
   const buckets = meta.creditRateBuckets;
+
+  // Prefer the physical card's cut day (shared across linked currency pairs)
+  // then the per-account override in metadata, falling back to last-day-of-
+  // month when nothing is configured. The fallback path logs so the config
+  // gap is observable — see #413.
+  let cutDay = account.physicalCardCutoffDay ?? meta.cutoffDay ?? null;
+  if (cutDay == null) {
+    log.warn(
+      { userId, accountId, cycle, event: "cutoff_day_missing" },
+      "account has no cutoffDay configured — defaulting to last day of month",
+    );
+    cutDay = DEFAULT_CUT_DAY;
+  }
+  const anchor = cycleAnchor(cycle, cutDay);
 
   // Live installment purchases: TC txs with installments_total > 0 and
   // negative amount (purchases, not credits / payments), occurring on or
@@ -157,7 +201,7 @@ export async function computeInterestForCycle(opts: {
     totalInterestCents += interestCents;
   }
 
-  return { accountId, cycle, intereses, totalInterestCents };
+  return { accountId, cycle, anchor, intereses, totalInterestCents };
 }
 
 // Persist the cycle's interest as a synthetic tx. Idempotent — second call
@@ -191,7 +235,7 @@ export async function applyInteresesCausadosForCycle(opts: {
   }
 
   try {
-    const anchor = cycleAnchor(cycle);
+    const anchor = run.anchor;
     const cycleLabel = cycle; // already YYYY-MM
     const [accRow] = await database.execute<{ last4s: unknown; currency: "COP" | "USD" }>(sql`
       SELECT metadata -> 'last4s' AS last4s, currency


### PR DESCRIPTION
Closes #413.

## Summary

`cycleAnchor()` in `src/lib/finance/intereses-causados-job.ts` hardcoded day 15 of the cycle month as the anchor used to split paid vs pending cuotas. Real Bancolombia statement cuts vary per account (user's Visa *2575 cuts on day 30). Mid-month anchoring caused `monthsBetween()` to decrement `paidCount` for any purchase in the second half of a previous month → charged interest on a balance one cuota behind reality.

The fix threads the per-account `cutoffDay` (already in `AccountMetadata`, also on `physical_cards.statement_cutoff_day` for shared-cupo cards) through `computeInterestForCycle`, which now passes it into `cycleAnchor(cycle, cutDay)`. Missing values fall back to `31`, which clamps to each month's last day — graceful and logged.

## Validation (real March 2026 Visa extract)

Ground truth from `.private/statements/Extracto_202603_Visa_Detallado_2575.xlsx`:
`INTERESES CORRIENTES = 79.918,36 COP`

Projection of the 9 live installment purchases (cut day = 30, rates per extract):

| | Before (mid-month 15) | After (cut day 30) | Extracto |
|---|---:|---:|---:|
| Total | 125.473,00 | 76.279,46 | 79.918,36 |
| Δ | +45.554,64 (+57%) | −3.638,90 (−4.55%) | — |

The remaining −4.55% is rounding policy / precision loss (e.g. AMAZON amount lost 0.35 pesos in SMS ingestion). Not an anchor issue.

Breakdown of the biggest offender: MP `2.479.900 × 12 @ 1.8311%` purchased 20/01. Extract shows `3/12` → paidCount=2. Old anchor (15/mar) clamped to paidCount=1, charging cuota 2 on balance 2.27M for `~87.035` COP. New anchor (30/mar) gives paidCount=2, charging cuota 3 on balance 2.07M for `~37.841` COP. 49k of drift erased by the fix.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint src/lib/finance/intereses-causados-job.ts src/lib/finance/intereses-causados-job.test.ts`
- [x] `bun run test src/lib/finance/` → 68/68 green (7 new cycleAnchor unit tests + 2 new cut-day integration tests)
- [x] Local preview against dev DB → `|Δ| = 4.55%` vs extract (was +57%)

## Prod data note

Existing TC accounts in prod don't have `cutoffDay` set. The job's fallback-to-31 keeps them running correctly (end-of-month anchor) but logs a warning. User should populate via `/settings/accounts` (UI already exists for this field). One-off SQL if preferred:

```sql
UPDATE accounts
SET metadata = metadata || jsonb_build_object('cutoffDay', 30), updated_at = now()
WHERE type = 'credit_card' AND deleted_at IS NULL AND physical_card_id IS NULL;

UPDATE physical_cards
SET statement_cutoff_day = 30, updated_at = now()
WHERE statement_cutoff_day IS NULL;
```

## Scope

- `cycleAnchor(cycle, cutDay)` signature change + clamping to month-last-day.
- `computeInterestForCycle` joins `physical_cards` to pick up shared cut day, falls back to `metadata.cutoffDay`, then to 31 with a warn log. Returns the resolved `anchor` in `InterestRun` so `applyInteresesCausadosForCycle` reuses it (single source of truth for the cycle's `occurred_at`).
- Seed updated to populate `cutoffDay: 30` for the three Bancolombia TCs (matches observed extract cut).