### PR TITLE
fix(accounts): derive available credit from ledger, deprecate metadata.availableCreditCents (#420)

### DIFF
--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -278,10 +278,10 @@ function CreditCardTile({
     const limit = primary.metadata.creditLimitCents;
     if (limit !== undefined && limit > 0) {
       limitCents = BigInt(limit);
-      availableCents =
-        primary.metadata.availableCreditCents !== undefined
-          ? BigInt(primary.metadata.availableCreditCents)
-          : limitCents + primary.balanceCents;
+      // #420: always derive from limit + ledger. The old
+      // `metadata.availableCreditCents` snapshot path went stale whenever a
+      // purchase landed via SMS/manual without a balance-adjust.
+      availableCents = limitCents + primary.balanceCents;
     }
     meterCurrency = primary.currency;
   }

--- a/src/app/(app)/settings/accounts/actions.test.ts
+++ b/src/app/(app)/settings/accounts/actions.test.ts
@@ -691,7 +691,46 @@ describe("adjustAccountBalance", () => {
 
       const [after] = await db.select().from(accounts).where(eq(accounts.id, accountId));
       expect(await derivedBalance(accountId)).toBe(BigInt(-1_800_000));
-      expect(after.metadata.availableCreditCents).toBe(3_200_000);
+      // #420: cupo is NOT snapshotted anymore — display derives from limit + ledger.
+      expect(after.metadata.availableCreditCents).toBeUndefined();
+      expect(after.metadata.creditLimitCents).toBe(5_000_000);
+    });
+
+    it("#420: strips a stale availableCreditCents snapshot on adjust", async () => {
+      // Legacy row written under the pre-#420 model. The stale value must be
+      // stripped so display stops reading it and starts deriving from ledger.
+      const accountId = await seedCreditCard({
+        creditLimit: 5_000_000,
+        availableCredit: 4_000_000, // stale — ledger says 0 debt → real available=5M
+      });
+
+      const result = await adjustAccountBalance({
+        accountId,
+        declared: { kind: "availableCredit", availableCreditCents: 3_200_000 },
+      });
+
+      expect(result.status).toBe("ok");
+      const [after] = await db.select().from(accounts).where(eq(accounts.id, accountId));
+      expect(after.metadata.availableCreditCents).toBeUndefined();
+      expect(after.metadata.creditLimitCents).toBe(5_000_000);
+    });
+
+    it("#420: strips stale availableCreditCents even on no-op (declared matches)", async () => {
+      // Ledger balance=0, stale snapshot=4M, limit=5M → declared=5M means
+      // debt=0, target balance matches current → diff=0 (noop). Strip still lands.
+      const accountId = await seedCreditCard({
+        creditLimit: 5_000_000,
+        availableCredit: 4_000_000,
+      });
+
+      const result = await adjustAccountBalance({
+        accountId,
+        declared: { kind: "availableCredit", availableCreditCents: 5_000_000 },
+      });
+
+      expect(result.status).toBe("noop");
+      const [after] = await db.select().from(accounts).where(eq(accounts.id, accountId));
+      expect(after.metadata.availableCreditCents).toBeUndefined();
       expect(after.metadata.creditLimitCents).toBe(5_000_000);
     });
 

--- a/src/app/(app)/settings/accounts/actions.ts
+++ b/src/app/(app)/settings/accounts/actions.ts
@@ -61,7 +61,6 @@ const metadataSchema = z
       .optional(),
     network: z.enum(["visa", "mastercard", "amex"]).optional(),
     creditLimitCents: z.number().int().nonnegative().optional(),
-    availableCreditCents: z.number().int().nonnegative().optional(),
     cutoffDay: z.number().int().min(1).max(31).optional(),
     interestRateMonthly: z.number().nonnegative().optional(),
     termMonths: z.number().int().positive().optional(),
@@ -432,8 +431,9 @@ export type AdjustBalanceResult =
  *   never shows debt directly, only the available limit, so the server
  *   reads `metadata.creditLimitCents` and derives
  *   `balance_cents = availableCreditCents - creditLimitCents` (negative, per
- *   the repo convention — see CreditMeter in /accounts). Also updates
- *   `metadata.availableCreditCents` so the card display stays consistent.
+ *   the repo convention — see CreditMeter in /accounts). #420: the cupo is
+ *   NOT snapshotted in metadata — display derives on read from limit +
+ *   SUM(ledger), so the only persisted state change is the adjustment tx.
  *
  * The adjustment tx is categorized as `adjustments` — spend/insights queries
  * filter these out via `is_adjustment = false`; balance/net-worth queries
@@ -511,7 +511,14 @@ export async function adjustAccountBalance(
       // debt is limit - available; balance_cents for credit_card is stored
       // negative (debt reduces net worth — see CreditMeter).
       targetBalanceCents = BigInt(available) - BigInt(limit);
-      nextMetadata = { ...account.metadata, availableCreditCents: available };
+      // #420: stop snapshotting availableCreditCents. Display always derives
+      // from limit + ledger; strip any stale value so old rows converge on
+      // the next adjust (same pattern as sharedAvailableCop below).
+      if (account.metadata.availableCreditCents !== undefined) {
+        const { availableCreditCents: _drop, ...rest } = account.metadata;
+        void _drop;
+        nextMetadata = rest;
+      }
     } else {
       // kind: "sharedAvailableCop" (#346). Back-solve the target sub-account's
       // balance from: the shared cupo, the declared-available-COP, the sibling
@@ -591,12 +598,11 @@ export async function adjustAccountBalance(
     const diff = targetBalanceCents - account.balanceCents;
 
     if (diff === BigInt(0)) {
-      // Metadata might still need to be persisted even when the balance
-      // didn't move (e.g. first time availableCreditCents is stored).
-      const metadataDrifted =
-        parsed.data.declared.kind === "availableCredit" &&
-        account.metadata.availableCreditCents !== parsed.data.declared.availableCreditCents;
-      if (metadataDrifted) {
+      // #420: on no-op, still persist metadata if we stripped a stale
+      // `availableCreditCents` snapshot. `nextMetadata !== account.metadata`
+      // is the strip signal — both kinds (availableCredit, sharedAvailableCop)
+      // rebind nextMetadata only when something needs cleaning up.
+      if (nextMetadata !== account.metadata) {
         await tx
           .update(accounts)
           .set({ metadata: nextMetadata, updatedAt: new Date() })
@@ -653,8 +659,8 @@ export async function adjustAccountBalance(
       .returning({ id: transactions.id });
 
     // Balance is derived from SUM(transactions.amount_cents) post #368 —
-    // the adjustment tx inserted above *is* the state change. Metadata
-    // still needs persisting (availableCreditCents, etc.).
+    // the adjustment tx inserted above *is* the state change. This update
+    // persists any `nextMetadata` rebind (currently only strip cleanups, #420).
     await tx
       .update(accounts)
       .set({ metadata: nextMetadata, updatedAt: today })

--- a/src/app/(app)/settings/accounts/balance-adjust-dialog.tsx
+++ b/src/app/(app)/settings/accounts/balance-adjust-dialog.tsx
@@ -220,7 +220,6 @@ function CreditCardFormInner({
   const currentDebt = currentBalance < BigInt(0) ? -currentBalance : BigInt(0);
   const limitBig = BigInt(creditLimitCents);
   const currentAvailableFromBalance = limitBig - currentDebt;
-  const priorAvailable = target.metadata.availableCreditCents;
   const placeholderAvailable = Number(currentAvailableFromBalance) / 100;
 
   const [declared, setDeclared] = useState("");
@@ -291,12 +290,7 @@ function CreditCardFormInner({
           autoFocus
         />
         <p className="text-muted-foreground text-xs">
-          El monto disponible que te muestra la app del banco — no la deuda.{" "}
-          {priorAvailable !== undefined ? (
-            <>
-              Último registro: <Money cents={BigInt(priorAvailable)} currency={target.currency} />.
-            </>
-          ) : null}
+          El monto disponible que te muestra la app del banco — no la deuda.
         </p>
         {exceedsLimit ? (
           <p className="text-destructive text-xs">

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -315,10 +315,9 @@ export async function getCreditCardsSummary(
       const md = primary.metadata;
       if (md.creditLimitCents && md.creditLimitCents > 0) {
         const limitNative = BigInt(md.creditLimitCents);
-        const availNative =
-          md.availableCreditCents !== undefined
-            ? BigInt(md.availableCreditCents)
-            : limitNative + primary.balanceCents;
+        // #420: always derive — stop reading `md.availableCreditCents`
+        // snapshot since it stays stale between balance-adjusts.
+        const availNative = limitNative + primary.balanceCents;
         limitCopCents += toCopCents(limitNative, primary.currency);
         availableCopCents += toCopCents(availNative, primary.currency);
       }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -229,6 +229,12 @@ export type AccountMetadata = {
   last4s?: string[];
   network?: "visa" | "mastercard" | "amex";
   creditLimitCents?: number;
+  /**
+   * @deprecated #420 — do NOT read. Display always derives cupo disponible
+   * from `creditLimitCents + derivedBalance(SUM(ledger))`. Field kept in the
+   * type for backwards-compat with legacy JSONB rows; `adjustAccountBalance`
+   * strips it on the next balance-adjust so it drains orgánicamente.
+   */
   availableCreditCents?: number;
   cutoffDay?: number;
   paymentDueDay?: number;


### PR DESCRIPTION
## Summary

TC single-currency cards en `/accounts` y en el widget Credit Cards del dashboard mostraban un cupo disponible desactualizado: el valor venía de `metadata.availableCreditCents`, un snapshot que no se invalidaba al entrar nuevas transacciones por SMS/manual (ledger sí se actualizaba).

**Evidencia prod (account 5 *2575):**
- `metadata.availableCreditCents` = 15.501.742 (stale, lo que mostraba Findash)
- `limit + derivedBalance(SUM ledger)` = 15.481.842 (matches Bancolombia app)
- Delta: 19.900 COP = exactamente la última compra SMS-ingerida

Shared-cupo (multi-moneda) ya derivaba siempre, así que no tenía el bug — el fix alinea el path single-currency con ese mismo modelo.

## Cambios

- **Read sites** (`accounts/page.tsx:281`, `dashboard/queries.ts:319`, `balance-adjust-dialog.tsx`): siempre derivan `available = limit + balance`. Borré la rama `metadata.availableCreditCents !== undefined`.
- **Write site** (`actions.ts` `adjustAccountBalance`): deja de snapshotear `availableCreditCents`. Tanto `kind: "availableCredit"` como `kind: "sharedAvailableCop"` ahora comparten el patrón de strip — si el valor existe en metadata, lo limpian (mismo patrón que ya tenía sharedAvailableCop desde #346). La rama no-op persiste el strip también.
- **Zod**: `metadataSchema` drops `availableCreditCents` (nunca fue input del editor).
- **Type**: `AccountMetadata.availableCreditCents` marcado `@deprecated` con referencia a este issue. Se mantiene en el type por compat con JSONB rows legacy.
- **Tests**: flip del assert en el test existente + 2 tests nuevos (strip-on-ok y strip-on-noop).

## Seguimiento

- [ ] Post-merge: correr `UPDATE accounts SET metadata = metadata - 'availableCreditCents' WHERE type='credit_card' AND metadata ? 'availableCreditCents' AND deleted_at IS NULL` en dev y prod para drenar los snapshots en bulk (opt-in, no requerido — el strip orgánico ya converge).
- [ ] Verificar post-deploy que account 5 muestra 15.481.842 en `/accounts` y el dashboard.

## Test plan

- [x] Unit tests: 898/898 pasando (incluyendo los 2 nuevos)
- [x] Lint + format + typecheck verdes
- [ ] Post-merge smoke en prod: abrir `/accounts`, verificar que TCs single-currency matchean el banco

Closes #420