### PR TITLE
feat(finance): rate explícita por tx + quitar fallback silencioso a 0 (#416)

### DIFF
--- a/src/app/(app)/transactions/actions.test.ts
+++ b/src/app/(app)/transactions/actions.test.ts
@@ -1642,11 +1642,11 @@ describe("updateTransactionInstallments (#406)", () => {
     expect(row.installment_rate_bps).toBe(19110);
   });
 
-  it("accepts a null rate (inherit from account bucket at compute time)", async () => {
-    const txId = await seedTcTx(`${EXT_PREFIX}:inherit`);
+  it("accepts a null rate for 1 cuota (no interest — diferido sin intereses)", async () => {
+    const txId = await seedTcTx(`${EXT_PREFIX}:one-cuota-null`);
     const result = await updateTransactionInstallments({
       txId,
-      installmentsTotal: 3,
+      installmentsTotal: 1,
       installmentRateEmX10k: null,
     });
     expect(result.status).toBe("ok");
@@ -1657,8 +1657,21 @@ describe("updateTransactionInstallments (#406)", () => {
     }>(sql`
       SELECT installments_total, installment_rate_bps FROM transactions WHERE id = ${txId}
     `);
-    expect(row.installments_total).toBe(3);
+    expect(row.installments_total).toBe(1);
     expect(row.installment_rate_bps).toBeNull();
+  });
+
+  it("rejects null rate when cuotas > 1 (#416 — no silent bucket fallback)", async () => {
+    const txId = await seedTcTx(`${EXT_PREFIX}:multi-null-rejected`);
+    const result = await updateTransactionInstallments({
+      txId,
+      installmentsTotal: 6,
+      installmentRateEmX10k: null,
+    });
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.message).toMatch(/obligatoria/i);
+    }
   });
 
   it("rejects suspiciously low EM values (likely EA mislabeled as EM)", async () => {

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -1130,12 +1130,20 @@ export async function createManualTransferGroup(
   return { status: "ok", transferGroupId: insertResult.transferGroupId, txIds: insertResult.txIds };
 }
 
-// #406: update the installment plan on an existing TC transaction. Only the
-// cuota count and the optional rate override are mutable — the account, the
-// amount, and the occurred date are intentionally locked, because any true
-// re-financing should be modeled as the modo-B split (ver #345 regla 6)
-// and that's a separate, explicit flow. Leaving `installmentRateEmX10k` as
-// `null` means "inherit from the account's bucket at compute time".
+// #406/#416: update the installment plan on an existing TC transaction. Only
+// the cuota count and the optional rate override are mutable — the account,
+// the amount, and the occurred date are intentionally locked, because any
+// true re-financing should be modeled as the modo-B split (ver #345 regla 6)
+// and that's a separate, explicit flow.
+//
+// Rate rules (post #416):
+//   - cuotas === 1: `installmentRateEmX10k` stays null (diferido sin
+//     intereses; rate would be ignored anyway).
+//   - cuotas > 1: `installmentRateEmX10k` is REQUIRED. No silent fallback to
+//     the account bucket because Bancolombia's bucket rate changes monthly
+//     and the per-tx value is the source of truth (regla 3). The UI dialog
+//     blocks empty submits; this server-side check is the second line of
+//     defense.
 const updateInstallmentsSchema = z
   .object({
     txId: z.coerce.number().int().positive(),
@@ -1148,6 +1156,15 @@ const updateInstallmentsSchema = z
       .transform((v) => (v === "" ? null : v)),
   })
   .superRefine((v, ctx) => {
+    if (v.installmentsTotal > 1 && v.installmentRateEmX10k === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "La tasa EM es obligatoria para compras a cuotas (> 1). Consultá el extracto del mes.",
+        path: ["installmentRateEmX10k"],
+      });
+      return;
+    }
     if (v.installmentRateEmX10k === null) return;
     const res = validateInstallmentRate(v.installmentRateEmX10k);
     if (!res.ok) {

--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { AlertTriangleIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AiClassifyButton } from "@/components/transactions/ai-classify-button";
 import { Filters } from "@/components/transactions/filters";
@@ -6,6 +7,7 @@ import { TransactionTable } from "@/components/transactions/transaction-table";
 import { TransferGroupDialog } from "@/components/transactions/transfer-group-dialog";
 import { getSessionUser } from "@/lib/auth/session";
 import {
+  countNeedingRate,
   countTotal,
   countUnclassified,
   listAccounts,
@@ -27,6 +29,7 @@ type SearchParams = Promise<{
   highlight?: string;
   showAdjustments?: string;
   showArchived?: string;
+  needsRate?: string;
 }>;
 
 function buildHref(base: Record<string, string | undefined>, cursor: string | null) {
@@ -48,6 +51,7 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
   const highlightId = Number.isFinite(highlightRaw) ? highlightRaw : undefined;
   const hideAdjustments = !sp.showAdjustments;
   const includeArchived = Boolean(sp.showArchived);
+  const needsRateActive = Boolean(sp.needsRate);
   const filters = {
     from: sp.from,
     to: sp.to,
@@ -57,24 +61,34 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
     cursor: sp.cursor,
     hideAdjustments,
     includeArchived,
+    needsRate: needsRateActive,
   };
 
-  const [{ rows, nextCursor }, accounts, categories, total, unclassified, allCounterparties] =
-    await Promise.all([
-      listTransactions(session.id, filters),
-      listAccounts(session.id),
-      listCategories(session.id),
-      countTotal(session.id, {
-        from: filters.from,
-        to: filters.to,
-        accountId: filters.accountId,
-        categorySlug: filters.categorySlug,
-        q: filters.q,
-        includeArchived,
-      }),
-      countUnclassified(session.id),
-      listCounterparties(session.id),
-    ]);
+  const [
+    { rows, nextCursor },
+    accounts,
+    categories,
+    total,
+    unclassified,
+    allCounterparties,
+    needingRate,
+  ] = await Promise.all([
+    listTransactions(session.id, filters),
+    listAccounts(session.id),
+    listCategories(session.id),
+    countTotal(session.id, {
+      from: filters.from,
+      to: filters.to,
+      accountId: filters.accountId,
+      categorySlug: filters.categorySlug,
+      q: filters.q,
+      includeArchived,
+      needsRate: needsRateActive,
+    }),
+    countUnclassified(session.id),
+    listCounterparties(session.id),
+    countNeedingRate(session.id),
+  ]);
 
   const baseQuery = {
     from: sp.from,
@@ -84,6 +98,7 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
     q: sp.q,
     showAdjustments: sp.showAdjustments,
     showArchived: sp.showArchived,
+    needsRate: sp.needsRate,
   };
 
   return (
@@ -105,6 +120,28 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
       </header>
 
       <Filters accounts={accounts} categories={categories} />
+
+      {needingRate > 0 && !needsRateActive ? (
+        <div className="flex flex-col gap-1 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4 dark:border-amber-900 dark:bg-amber-950/40">
+          <div className="flex items-start gap-2 text-sm">
+            <AlertTriangleIcon className="mt-0.5 size-4 text-amber-700 dark:text-amber-400" />
+            <div>
+              <strong className="font-medium text-amber-900 dark:text-amber-200">
+                {needingRate.toLocaleString()} {needingRate === 1 ? "compra" : "compras"} a cuotas
+                sin tasa EM
+              </strong>
+              <span className="text-amber-800 dark:text-amber-300">
+                {" "}
+                — los intereses causados del ciclo no se van a calcular hasta que las completes.
+                Mirá el extracto del mes.
+              </span>
+            </div>
+          </div>
+          <Button asChild variant="outline" size="sm" className="shrink-0">
+            <Link href="/transactions?needsRate=on">Ver y completar</Link>
+          </Button>
+        </div>
+      ) : null}
 
       <TransactionTable
         rows={rows}

--- a/src/components/transactions/filters.tsx
+++ b/src/components/transactions/filters.tsx
@@ -28,6 +28,7 @@ export function Filters({ accounts, categories }: FiltersProps) {
   const currentCategorySlug = searchParams.get("categorySlug") ?? "";
   const showAdjustmentsActive = Boolean(searchParams.get("showAdjustments"));
   const showArchivedActive = Boolean(searchParams.get("showArchived"));
+  const needsRateActive = Boolean(searchParams.get("needsRate"));
 
   // Local mirror for the text search so every keystroke stays snappy; we push
   // the URL (and therefore the DB query) only after SEARCH_DEBOUNCE_MS of idle.
@@ -75,7 +76,11 @@ export function Filters({ accounts, categories }: FiltersProps) {
     currentCategorySlug,
     currentQ,
   ].filter((v) => v.length > 0).length;
-  const activeCount = stringActive + (showAdjustmentsActive ? 1 : 0) + (showArchivedActive ? 1 : 0);
+  const activeCount =
+    stringActive +
+    (showAdjustmentsActive ? 1 : 0) +
+    (showArchivedActive ? 1 : 0) +
+    (needsRateActive ? 1 : 0);
   const hasAny = activeCount > 0;
 
   return (
@@ -204,6 +209,23 @@ export function Filters({ accounts, categories }: FiltersProps) {
           <span>Show archived</span>
           <span className="text-muted-foreground text-xs">
             (hidden by default — archived transactions are excluded from balance and reports)
+          </span>
+        </label>
+
+        <label
+          htmlFor="needsRate"
+          className="flex cursor-pointer items-center gap-2 text-sm sm:col-span-2 lg:col-span-6"
+        >
+          <input
+            id="needsRate"
+            type="checkbox"
+            checked={needsRateActive}
+            onChange={(e) => applyChange("needsRate", e.target.checked ? "on" : "")}
+            className="border-input size-4 rounded border"
+          />
+          <span>Only TC purchases needing rate</span>
+          <span className="text-muted-foreground text-xs">
+            (multi-cuota without an explicit EM — fill from the month&apos;s extract)
           </span>
         </label>
       </div>

--- a/src/components/transactions/tc-installments-dialog.tsx
+++ b/src/components/transactions/tc-installments-dialog.tsx
@@ -18,10 +18,16 @@ import { EM_X10K_SCALE, formatEmX10kAsEaPercent, parsePercentToEmX10k } from "@/
 import { updateTransactionInstallments } from "@/app/(app)/transactions/actions";
 import type { Currency } from "@/lib/types";
 
-// #406: edit installments + rate on a TC tx. Only these two fields are
+// #406/#416: edit installments + rate on a TC tx. Only these two fields are
 // editable; amount and account stay locked (re-financing = new transfer group,
-// not a mutation — see #345 regla 6). An empty rate input means "inherit from
-// the account's bucket on compute" (null in DB).
+// not a mutation — see #345 regla 6).
+//
+// Rate semantics (post #416):
+//   - cuotas = 1: rate is ignored (diferido sin intereses). Empty is fine.
+//   - cuotas > 1: rate is REQUIRED. No silent fallback to the account bucket
+//     because bucket rates change monthly at Bancolombia (regla 3) and the
+//     user is the source of truth for "what the bank snapshoted for this
+//     tx". Empty submit is rejected client-side + server-side.
 export type TcInstallmentsDialogProps = {
   open: boolean;
   onOpenChange: (v: boolean) => void;
@@ -63,11 +69,19 @@ export function TcInstallmentsDialog({
   const rateEmX10k = rate.trim() === "" ? null : parsePercentToEmX10k(rate);
   const eaPreview =
     rateEmX10k != null && rateEmX10k > 0 ? formatEmX10kAsEaPercent(rateEmX10k) : null;
+  // #416: when cuotas > 1, rate is mandatory. Disable submit + show inline
+  // message; we also double-check server-side in the zod schema.
+  const rateRequired = Number.isInteger(installmentsNum) && installmentsNum > 1;
+  const rateMissing = rateRequired && rate.trim() === "";
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!Number.isInteger(installmentsNum) || installmentsNum < 1 || installmentsNum > 120) {
       toast.error("Cuotas debe ser un entero entre 1 y 120");
+      return;
+    }
+    if (rateMissing) {
+      toast.error("Ingresá la tasa EM del extracto para compras a cuotas.");
       return;
     }
     startTransition(async () => {
@@ -91,8 +105,8 @@ export function TcInstallmentsDialog({
         <DialogHeader>
           <DialogTitle>Editar cuotas</DialogTitle>
           <DialogDescription>
-            La tasa se usa para calcular intereses causados. Dejá vacío para heredar del bucket de
-            la cuenta.
+            La tasa se usa para calcular intereses causados. Para compras a cuotas (&gt; 1) es
+            obligatoria — la sacás del extracto mensual. Para 1 cuota, dejala vacía.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={onSubmit} className="flex flex-col gap-4">
@@ -111,7 +125,9 @@ export function TcInstallmentsDialog({
               />
             </div>
             <div className="flex flex-col gap-1.5">
-              <Label htmlFor="tc-rate">Tasa EM</Label>
+              <Label htmlFor="tc-rate">
+                Tasa EM {rateRequired ? <span className="text-destructive">*</span> : null}
+              </Label>
               <div className="relative">
                 <Input
                   id="tc-rate"
@@ -119,16 +135,23 @@ export function TcInstallmentsDialog({
                   inputMode="decimal"
                   value={rate}
                   onChange={(e) => setRate(e.target.value)}
-                  placeholder="Heredar bucket"
+                  placeholder={rateRequired ? "Ej: 1.9110" : "Sin interés"}
+                  aria-invalid={rateMissing || undefined}
                   className="pr-10 tabular-nums"
                 />
                 <span className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-xs">
                   %
                 </span>
               </div>
-              <p className="text-muted-foreground text-xs tabular-nums">
-                {eaPreview ? `≈ ${eaPreview} EA` : "—"}
-              </p>
+              {rateMissing ? (
+                <p className="text-destructive text-xs">
+                  Obligatoria para compras a cuotas. Mirá el extracto del mes.
+                </p>
+              ) : (
+                <p className="text-muted-foreground text-xs tabular-nums">
+                  {eaPreview ? `≈ ${eaPreview} EA` : "—"}
+                </p>
+              )}
             </div>
           </div>
 
@@ -151,7 +174,7 @@ export function TcInstallmentsDialog({
             >
               Cancelar
             </Button>
-            <Button type="submit" disabled={pending}>
+            <Button type="submit" disabled={pending || rateMissing}>
               {pending ? "Guardando…" : "Guardar"}
             </Button>
           </DialogFooter>

--- a/src/lib/finance/intereses-causados-job.test.ts
+++ b/src/lib/finance/intereses-causados-job.test.ts
@@ -239,6 +239,110 @@ describe("computeInterestForCycle", () => {
     expect(run.anchor.getUTCDate()).toBe(30);
   });
 
+  it("flags multi-cuota without explicit rate AND without matching bucket as needsRate (#416)", async () => {
+    const visa = await getVisaId();
+    // Clear any buckets so months2to36 lookup returns null → needsRate path.
+    await db.execute(sql`
+      UPDATE accounts SET metadata = metadata - 'creditRateBuckets', updated_at = now()
+      WHERE id = ${visa}
+    `);
+
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}needs-rate`,
+      amountCentsMagnitude: BigInt(1_000_000),
+      occurredAt: "2026-03-10",
+      installmentsTotal: 6,
+      installmentRateEmX10k: null, // no explicit rate
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+
+    expect(run.intereses.length).toBe(1);
+    expect(run.intereses[0].needsRate).toBe(true);
+    expect(run.intereses[0].interestCents).toBe(BigInt(0));
+    expect(run.purchasesNeedingRate).toBe(1);
+    // No priced purchases → total stays at zero (NOT silently booked).
+    expect(run.totalInterestCents).toBe(BigInt(0));
+  });
+
+  it("does NOT flag 1-cuota purchases as needsRate even without bucket (#416)", async () => {
+    const visa = await getVisaId();
+    await db.execute(sql`
+      UPDATE accounts SET metadata = metadata - 'creditRateBuckets', updated_at = now()
+      WHERE id = ${visa}
+    `);
+
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}one-cuota-no-bucket`,
+      amountCentsMagnitude: BigInt(500_000),
+      occurredAt: "2026-03-10",
+      installmentsTotal: 1,
+      installmentRateEmX10k: null,
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+
+    // 1-cuota diferido sin intereses — no flag, no row surfaced.
+    expect(run.intereses.length).toBe(0);
+    expect(run.purchasesNeedingRate).toBe(0);
+    expect(run.totalInterestCents).toBe(BigInt(0));
+  });
+
+  it("mixes priced and needsRate purchases correctly: total only counts priced (#416)", async () => {
+    const visa = await getVisaId();
+    // No bucket → unpriced multi-cuota falls to needsRate.
+    await db.execute(sql`
+      UPDATE accounts SET metadata = metadata - 'creditRateBuckets', updated_at = now()
+      WHERE id = ${visa}
+    `);
+
+    // Priced (has explicit rate).
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}mix-priced`,
+      amountCentsMagnitude: BigInt(10_000_000),
+      occurredAt: "2026-03-10",
+      installmentsTotal: 12,
+      installmentRateEmX10k: 19110,
+    });
+    // Unpriced — multi-cuota without bucket or rate.
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}mix-needsrate`,
+      amountCentsMagnitude: BigInt(5_000_000),
+      occurredAt: "2026-03-10",
+      installmentsTotal: 6,
+      installmentRateEmX10k: null,
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+
+    expect(run.intereses.length).toBe(2);
+    expect(run.purchasesNeedingRate).toBe(1);
+    const priced = run.intereses.find((i) => !i.needsRate);
+    const unpriced = run.intereses.find((i) => i.needsRate);
+    expect(priced?.rateEmX10k).toBe(19110);
+    expect(unpriced?.rateEmX10k).toBe(0);
+    // The total reflects ONLY the priced row — the unpriced 0n must not mask
+    // the fact that we don't know its interest.
+    expect(run.totalInterestCents).toBe(priced!.interestCents);
+    expect(run.totalInterestCents).toBeGreaterThan(BigInt(0));
+  });
+
   it("skips purchases with 1 cuota + 0% oneMonth bucket (diferido nominal)", async () => {
     const visa = await getVisaId();
     await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });

--- a/src/lib/finance/intereses-causados-job.ts
+++ b/src/lib/finance/intereses-causados-job.ts
@@ -48,13 +48,35 @@ export type InterestRun = {
     installmentsPaid: number;
     outstandingBeforeCents: bigint;
     interestCents: bigint;
+    // #416: true when the tx is multi-cuota but neither an explicit rate nor
+    // a matching bucket was found. Interest can't be computed; the row is
+    // surfaced so the UI can prompt for a rate. `interestCents` is 0n.
+    needsRate: boolean;
   }>;
   totalInterestCents: bigint;
+  // #416: convenience count of rows with `needsRate: true`. Callers (CLI,
+  // future UI) use it to decide whether to warn the user that the run is
+  // incomplete.
+  purchasesNeedingRate: number;
 };
 
 export type ApplyResult =
-  | { status: "inserted"; txId: number; totalInterestCents: bigint }
-  | { status: "skipped"; reason: "zero-interest" | "already-run" }
+  | {
+      status: "inserted";
+      txId: number;
+      totalInterestCents: bigint;
+      // #416: non-zero when some purchases couldn't be priced. The synthetic
+      // tx still ships with the partial total; callers surface the gap.
+      purchasesNeedingRate: number;
+    }
+  | {
+      status: "skipped";
+      reason: "zero-interest" | "already-run";
+      // #416: surfaced even on zero-interest skips — a cycle may have only
+      // needs-rate purchases and no priced ones; the user still needs to see
+      // the gap.
+      purchasesNeedingRate: number;
+    }
   | { status: "error"; reason: string };
 
 function cycleKeyFor(accountId: number, cycle: string): string {
@@ -161,12 +183,30 @@ export async function computeInterestForCycle(opts: {
 
   const intereses: InterestRun["intereses"] = [];
   let totalInterestCents = BigInt(0);
+  let purchasesNeedingRate = 0;
 
   for (const p of purchases) {
-    const rateEmX10k =
-      p.installmentRateEmX10k != null
-        ? p.installmentRateEmX10k
-        : (resolveBucketRateX10k(buckets, p.installmentsTotal) ?? 0);
+    // #416: resolve rate without a silent `?? 0`. Precedence:
+    //   1. per-tx explicit rate (regla 3 — tasa inmutable por tx)
+    //   2. account bucket that matches installments_total
+    //   3. no fuente → needsRate flag; rate stays 0 so the schedule helper
+    //      returns zero interest (correct math: interés indefinido ≠ 0; we
+    //      surface the gap instead of booking a wrong number).
+    // 1-cuota sin fuente se marca NO como needsRate porque cuota única
+    // nunca genera interés (Bancolombia "diferido sin intereses").
+    let rateEmX10k: number;
+    let needsRate = false;
+    if (p.installmentRateEmX10k != null) {
+      rateEmX10k = p.installmentRateEmX10k;
+    } else {
+      const bucketRate = resolveBucketRateX10k(buckets, p.installmentsTotal);
+      if (bucketRate != null) {
+        rateEmX10k = bucketRate;
+      } else {
+        rateEmX10k = 0;
+        if (p.installmentsTotal > 1) needsRate = true;
+      }
+    }
 
     const schedule = installmentSchedule({
       amountCents: -p.amountCents, // stored negative, helper expects positive magnitude
@@ -182,7 +222,10 @@ export async function computeInterestForCycle(opts: {
     if (schedule.paidCount >= schedule.rows.length) continue;
     const nextRow = schedule.rows[schedule.paidCount];
     const interestCents = nextRow.interestCents + nextRow.deferredInterestCents;
-    if (interestCents === BigInt(0)) continue;
+    // #416: drop zero-interest priced rows (unchanged behavior), but KEEP
+    // `needsRate` rows even though their interestCents is 0 — the UI uses
+    // them to prompt for a rate.
+    if (interestCents === BigInt(0) && !needsRate) continue;
 
     const outstandingBefore =
       schedule.paidCount === 0
@@ -197,11 +240,13 @@ export async function computeInterestForCycle(opts: {
       installmentsPaid: schedule.paidCount,
       outstandingBeforeCents: outstandingBefore,
       interestCents,
+      needsRate,
     });
-    totalInterestCents += interestCents;
+    if (needsRate) purchasesNeedingRate += 1;
+    else totalInterestCents += interestCents;
   }
 
-  return { accountId, cycle, anchor, intereses, totalInterestCents };
+  return { accountId, cycle, anchor, intereses, totalInterestCents, purchasesNeedingRate };
 }
 
 // Persist the cycle's interest as a synthetic tx. Idempotent — second call
@@ -226,12 +271,23 @@ export async function applyInteresesCausadosForCycle(opts: {
     LIMIT 1
   `);
   if (existing.length > 0) {
-    return { status: "skipped", reason: "already-run" };
+    // Already-run skips still need a purchasesNeedingRate count — even if the
+    // synthetic already exists, new purchases added since then may need rate.
+    const run = await computeInterestForCycle({ userId, accountId, cycle, database });
+    return {
+      status: "skipped",
+      reason: "already-run",
+      purchasesNeedingRate: run.purchasesNeedingRate,
+    };
   }
 
   const run = await computeInterestForCycle({ userId, accountId, cycle, database });
   if (run.totalInterestCents === BigInt(0)) {
-    return { status: "skipped", reason: "zero-interest" };
+    return {
+      status: "skipped",
+      reason: "zero-interest",
+      purchasesNeedingRate: run.purchasesNeedingRate,
+    };
   }
 
   try {
@@ -274,7 +330,9 @@ export async function applyInteresesCausadosForCycle(opts: {
             installmentsPaid: i.installmentsPaid,
             outstandingBeforeCents: i.outstandingBeforeCents.toString(),
             interestCents: i.interestCents.toString(),
+            needsRate: i.needsRate,
           })),
+          purchasesNeedingRate: run.purchasesNeedingRate,
         },
       })
       .returning({ id: transactions.id });
@@ -283,6 +341,7 @@ export async function applyInteresesCausadosForCycle(opts: {
       status: "inserted",
       txId: inserted.id,
       totalInterestCents: run.totalInterestCents,
+      purchasesNeedingRate: run.purchasesNeedingRate,
     };
   } catch (err) {
     return { status: "error", reason: err instanceof Error ? err.message : String(err) };

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, ilike, lt, lte, gte, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, ilike, isNull, lt, lte, gte, ne, or, sql } from "drizzle-orm";
 import { notDeleted } from "@/lib/db/helpers";
 import { db } from "@/lib/db";
 import {
@@ -23,6 +23,11 @@ export type TxFilters = {
   cursor?: string;
   hideAdjustments?: boolean;
   includeArchived?: boolean;
+  // #416: when true, limits the list to multi-cuota TC purchases missing an
+  // explicit rate — the UI filters to "compras a cuotas sin tasa" so the
+  // user can supply the EM from the extract. Translates to
+  // `installments_total > 1 AND installment_rate_bps IS NULL`.
+  needsRate?: boolean;
 };
 
 export type TxListResult = {
@@ -70,6 +75,10 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
     );
   }
   if (filters.hideAdjustments) conditions.push(eq(transactions.isAdjustment, false));
+  if (filters.needsRate) {
+    conditions.push(gt(transactions.installmentsTotal, 1));
+    conditions.push(isNull(transactions.installmentRateEmX10k));
+  }
   if (filters.cursor) {
     const c = decodeCursor(filters.cursor);
     if (c) {
@@ -254,9 +263,33 @@ export async function countTotal(
     );
   }
   if (filters.hideAdjustments) conditions.push(eq(transactions.isAdjustment, false));
+  if (filters.needsRate) {
+    conditions.push(gt(transactions.installmentsTotal, 1));
+    conditions.push(isNull(transactions.installmentRateEmX10k));
+  }
   const [row] = await db
     .select({ n: sql<number>`count(*)::int` })
     .from(transactions)
     .where(and(...conditions));
+  return row?.n ?? 0;
+}
+
+/**
+ * #416: count live multi-cuota TC purchases missing an explicit rate. Drives
+ * the sticky banner on `/transactions` that prompts the user to supply the
+ * rate from the month's extract. Soft-deleted rows excluded.
+ */
+export async function countNeedingRate(userId: number): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        gt(transactions.installmentsTotal, 1),
+        isNull(transactions.installmentRateEmX10k),
+        notDeleted(transactions.deletedAt),
+      ),
+    );
   return row?.n ?? 0;
 }


### PR DESCRIPTION
Closes #416. Part of epic #415.

## Summary

Antes: una compra multi-cuota con `installmentRateEmX10k = null` y sin bucket resolvable caía a `rate = 0` via `?? 0` en el job → interés 0 sin señal. El ledger reportaba `zero-interest, skipped` como si fuera intencional.

Ahora: esa combinación se flagea como **`needsRate: true`** en el `InterestRun`. El total del ciclo NO incluye los unresolved; el UI los hace visibles con un banner sticky en `/transactions` + un filtro "Only TC purchases needing rate". El dialog `TcInstallmentsDialog` rechaza submit de compras a cuotas sin tasa — client-side (disabled button + inline error) y server-side (zod refine).

## Scope cambios

### Backend
- `intereses-causados-job.ts`: resolver de rate sin `?? 0` silencioso. Agrega `needsRate: boolean` por row + `purchasesNeedingRate: number` top-level en `InterestRun`. `ApplyResult` propaga el count tanto en `inserted` como `skipped`. El synthetic tx guarda `needsRate` + `purchasesNeedingRate` en su `raw_data.breakdown`.
- `queries.ts`: nuevo `TxFilters.needsRate?: boolean` → `installments_total > 1 AND installment_rate_bps IS NULL`. Nueva query `countNeedingRate(userId)` para el banner.

### UI
- `tc-installments-dialog.tsx`: rate requerido cuando cuotas > 1. `*` visible, `aria-invalid`, mensaje "Obligatoria para compras a cuotas — mirá el extracto del mes", botón deshabilitado hasta que se complete. Para 1 cuota queda opcional (diferido sin intereses).
- `transactions/page.tsx`: banner amarillo cuando hay compras needsRate y NO se está ya filtrando por ellas. CTA "Ver y completar" → `?needsRate=on`.
- `components/transactions/filters.tsx`: checkbox "Only TC purchases needing rate" integrado con el resto del filter panel (live filter, URL como source of truth).

### Validación server-side
- `updateInstallmentsSchema` en `transactions/actions.ts`: si cuotas > 1 y rate es null, rechaza con mensaje útil. Doble defensa: el dialog bloquea client-side, el server rechaza como segunda barrera.

## Test plan

- [x] Typecheck + lint verdes
- [x] `bun run test` — **902 / 902** pasan
- [x] 3 tests nuevos en `intereses-causados-job.test.ts`: needsRate flag, 1-cuota-sin-rate NO flageada, mix de priced+unpriced calcula total solo sobre priced
- [x] 2 tests nuevos en `actions.test.ts`: 1-cuota-null ok, multi-cuota-null rechazada
- [ ] Manual post-merge: ir a `/transactions`, crear / marcar una compra con cuotas=6 rate=null via dialog → validar que el submit se bloquea con mensaje

## Out of scope (defer)

- Bulk-edit wizard para pegar tasas en batch — tiene issue follow-up dentro del epic padre (#415 roadmap).
- Auto-populate desde extracto — esa es la sub-issue B (#417/#418/#419) del mismo epic.

## Risk notes

- Compras a cuotas YA EXISTENTES con rate null **siguen sin moverse** en DB — el fix es forward-compatible. El banner las hace visibles, el usuario las completa cuando quiere.
- No hay migraciones. Cambio puramente de código + Zod schema.