### PR TITLE
feat(ingestion): Bancolombia xlsx statement parser + CLI dry-run (#417)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:backfill:users": "bun run scripts/backfill-users-reference.ts",
     "db:migrate:pago-tc": "bun run scripts/migrate-pago-tc-to-transfer.ts",
     "intereses:run": "bun run scripts/run-intereses-causados.ts",
+    "statement:parse": "bun run scripts/parse-bancolombia-statement.ts",
     "db:bootstrap:invites": "bun run scripts/bootstrap-invites.ts",
     "db:bootstrap:webhook-tokens": "bun run scripts/bootstrap-webhook-tokens.ts",
     "test": "vitest run",

--- a/scripts/parse-bancolombia-statement.ts
+++ b/scripts/parse-bancolombia-statement.ts
@@ -1,0 +1,133 @@
+// CLI dry-run para el parser de extractos Bancolombia (sub-issue #417).
+//
+// Invocación:
+//   bun run statement:parse --file=<path>           # tabla humana
+//   bun run statement:parse --file=<path> --json    # ParsedStatement serializado
+//
+// No escribe a DB. Útil para smoke-testing manual del parser antes de
+// conectarlo al matcher + consolidateCycle (sub-issue #415 B2).
+
+import { readFileSync } from "node:fs";
+
+import { parseBancolombiaStatement } from "../src/lib/ingestion/bancolombia-statement/xlsx";
+import type {
+  ParsedStatement,
+  StatementRow,
+} from "../src/lib/ingestion/bancolombia-statement/types";
+
+function parseArgs(argv: string[]): { file: string; json: boolean } {
+  const out: Record<string, string | boolean> = {};
+  for (const arg of argv.slice(2)) {
+    const kv = arg.match(/^--([a-z-]+)=(.+)$/i);
+    if (kv) {
+      out[kv[1]] = kv[2];
+      continue;
+    }
+    const flag = arg.match(/^--([a-z-]+)$/i);
+    if (flag) out[flag[1]] = true;
+  }
+  const file = typeof out.file === "string" ? out.file : "";
+  if (!file) {
+    throw new Error("--file=<path> is required");
+  }
+  return { file, json: out.json === true };
+}
+
+function formatCents(cents: bigint): string {
+  const negative = cents < BigInt(0);
+  const abs = negative ? -cents : cents;
+  const units = abs / BigInt(100);
+  const fractional = (abs % BigInt(100)).toString().padStart(2, "0");
+  const unitsStr = units.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  return `${negative ? "-" : ""}${unitsStr},${fractional}`;
+}
+
+function formatDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function rateLabel(x10k: number | null): string {
+  if (x10k == null) return "—";
+  const whole = Math.floor(x10k / 10_000);
+  const frac = (x10k % 10_000).toString().padStart(4, "0");
+  return `${whole},${frac} %`;
+}
+
+function renderHuman(out: ParsedStatement): string {
+  const lines: string[] = [];
+  lines.push(`Account: ****${out.account.last4}  currency=${out.account.currency}`);
+  lines.push(
+    `Period: ${formatDate(out.period.startDate)} → ${formatDate(out.period.endDate)} (due ${formatDate(out.period.dueDate)})`,
+  );
+  lines.push("");
+  lines.push("Summary:");
+  lines.push(
+    `  Saldo anterior       ${formatCents(out.summary.previousBalanceCents).padStart(18)}`,
+  );
+  lines.push(`  Compras del mes      ${formatCents(out.summary.purchasesCents).padStart(18)}`);
+  lines.push(
+    `  Intereses corrientes ${formatCents(out.summary.interestCorrientesCents).padStart(18)}`,
+  );
+  lines.push(`  Pagos / abonos       ${formatCents(out.summary.paymentsCents).padStart(18)}`);
+  lines.push(`  Pago mínimo          ${formatCents(out.summary.minPaymentCents).padStart(18)}`);
+  lines.push(`  Pago total           ${formatCents(out.summary.totalPaymentCents).padStart(18)}`);
+  lines.push("");
+  lines.push(
+    `Rates EM: 1-mes=${rateLabel(out.currentRates.oneMonth)}  2-36m=${rateLabel(out.currentRates.months2to36)}  avances=${rateLabel(out.currentRates.advances)}`,
+  );
+  lines.push("");
+  lines.push(
+    `Rows: ${out.rows.length} total (${out.rows.filter((r) => r.kind === "during-period").length} durante, ${out.rows.filter((r) => r.kind === "before-period").length} antes)`,
+  );
+  lines.push("");
+  lines.push("Date       Auth    Cuot     Rate EM  Amount            Merchant");
+  for (const row of out.rows) {
+    lines.push(formatRow(row));
+  }
+  return lines.join("\n");
+}
+
+function formatRow(row: StatementRow): string {
+  const date = formatDate(row.occurredAt);
+  const auth = (row.authorizationNumber ?? "—").padEnd(7);
+  const cuotas = row.installments
+    ? `${row.installments.paid}/${row.installments.total}`.padEnd(8)
+    : "—".padEnd(8);
+  const rate = rateLabel(row.rateEmX10k).padEnd(8);
+  const amount = formatCents(row.amountCents).padStart(16);
+  const marker = row.kind === "before-period" ? "[antes] " : "";
+  return `${date} ${auth} ${cuotas} ${rate} ${amount}  ${marker}${row.merchant}`;
+}
+
+// JSON.stringify chokes on bigint. Normalize to strings.
+function toSerializable(out: ParsedStatement): unknown {
+  return {
+    ...out,
+    period: {
+      startDate: out.period.startDate.toISOString(),
+      endDate: out.period.endDate.toISOString(),
+      dueDate: out.period.dueDate.toISOString(),
+    },
+    summary: Object.fromEntries(Object.entries(out.summary).map(([k, v]) => [k, v.toString()])),
+    rows: out.rows.map((r) => ({
+      ...r,
+      occurredAt: r.occurredAt.toISOString(),
+      amountCents: r.amountCents.toString(),
+      installmentValueCents: r.installmentValueCents?.toString() ?? null,
+      saldoPendingCents: r.saldoPendingCents.toString(),
+    })),
+  };
+}
+
+function main(): void {
+  const { file, json } = parseArgs(process.argv);
+  const buffer = readFileSync(file);
+  const parsed = parseBancolombiaStatement(buffer);
+  if (json) {
+    process.stdout.write(`${JSON.stringify(toSerializable(parsed), null, 2)}\n`);
+  } else {
+    process.stdout.write(`${renderHuman(parsed)}\n`);
+  }
+}
+
+main();

--- a/src/lib/ingestion/bancolombia-statement/types.ts
+++ b/src/lib/ingestion/bancolombia-statement/types.ts
@@ -1,0 +1,69 @@
+// Bancolombia .xlsx credit-card statement parser — shared types.
+//
+// The parser output is deliberately DB-agnostic: it just represents what the
+// extracto file says. Matching against `transactions` rows and persistence is
+// a separate concern (see sub-issue #415 B2).
+
+export type StatementCurrency = "COP" | "USD";
+
+// Statements split movements into two tables:
+//   - "Movimientos durante el periodo": compras + pagos del ciclo actual.
+//   - "Movimientos antes del periodo": compras viejas aún pagándose a cuotas.
+export type StatementKind = "during-period" | "before-period";
+
+export type StatementAccount = {
+  last4: string;
+  currency: StatementCurrency;
+};
+
+export type StatementPeriod = {
+  startDate: Date;
+  endDate: Date;
+  dueDate: Date;
+};
+
+export type StatementSummary = {
+  previousBalanceCents: bigint;
+  purchasesCents: bigint;
+  interestCorrientesCents: bigint;
+  paymentsCents: bigint;
+  minPaymentCents: bigint;
+  totalPaymentCents: bigint;
+};
+
+// Rates are stored as EM (mes vencido) × 10_000 per project convention
+// (see memory `tc-installments-interest-model.md` — rate 19110 = 1.9110% EM).
+export type StatementRates = {
+  oneMonth: number;
+  months2to36: number;
+  advances: number;
+};
+
+export type StatementInstallments = {
+  paid: number;
+  total: number;
+};
+
+export type StatementRow = {
+  kind: StatementKind;
+  // null for rows without auth number (e.g. the synthetic INTERESES CORRIENTES
+  // line the bank itself inserts at cycle cut).
+  authorizationNumber: string | null;
+  occurredAt: Date;
+  merchant: string;
+  // Sign convention: purchase/charge positive, payment/credit negative — this
+  // matches what the extracto prints in column "Valor Movimiento".
+  amountCents: bigint;
+  installments: StatementInstallments | null;
+  installmentValueCents: bigint | null;
+  rateEmX10k: number | null;
+  saldoPendingCents: bigint;
+};
+
+export type ParsedStatement = {
+  account: StatementAccount;
+  period: StatementPeriod;
+  summary: StatementSummary;
+  currentRates: StatementRates;
+  rows: StatementRow[];
+};

--- a/src/lib/ingestion/bancolombia-statement/xlsx.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/xlsx.test.ts
@@ -1,0 +1,434 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import * as XLSX from "xlsx";
+import { describe, expect, it } from "vitest";
+
+import {
+  parseBancolombiaStatement,
+  parseCopAmount,
+  parseCuotas,
+  parsePeriod,
+  parseRateEmX10k,
+  parseSpanishDate,
+  parseStatementDate,
+} from "./xlsx";
+
+// -----------------------------------------------------------------------------
+// Scalar parsers
+// -----------------------------------------------------------------------------
+
+describe("parseCopAmount", () => {
+  it("parses COP locale (dot thousands, comma decimal)", () => {
+    expect(parseCopAmount("7.744.665,00")).toBe(BigInt(774466500));
+    expect(parseCopAmount("79.918,36")).toBe(BigInt(7991836));
+    expect(parseCopAmount("4.176.921,00")).toBe(BigInt(417692100));
+    expect(parseCopAmount("135.317,35")).toBe(BigInt(13531735));
+  });
+
+  it("parses US locale (comma thousands, dot decimal)", () => {
+    expect(parseCopAmount("4,351,431.00")).toBe(BigInt(435143100));
+    expect(parseCopAmount("1,000.00")).toBe(BigInt(100000));
+  });
+
+  it("parses values with single separator acting as decimal", () => {
+    expect(parseCopAmount("0,00")).toBe(BigInt(0));
+    expect(parseCopAmount("0.00")).toBe(BigInt(0));
+    expect(parseCopAmount("12,5")).toBe(BigInt(1250)); // 12.5 → 1250 cents
+  });
+
+  it("handles negative values for pagos / abonos", () => {
+    expect(parseCopAmount("-4.176.921,00")).toBe(-BigInt(417692100));
+  });
+
+  it("strips leading currency tokens", () => {
+    expect(parseCopAmount("COP1.000,00")).toBe(BigInt(100000));
+    expect(parseCopAmount("$1.000,00")).toBe(BigInt(100000));
+  });
+
+  it("accepts plain numeric input", () => {
+    expect(parseCopAmount(1234)).toBe(BigInt(123400));
+  });
+
+  it("throws on empty / non-numeric input", () => {
+    expect(() => parseCopAmount("")).toThrow();
+    expect(() => parseCopAmount("abc")).toThrow();
+  });
+});
+
+describe("parseRateEmX10k", () => {
+  it("parses comma decimal rate (row table format)", () => {
+    expect(parseRateEmX10k("1,8895")).toBe(18895);
+    expect(parseRateEmX10k("1,8311")).toBe(18311);
+    expect(parseRateEmX10k("0,0000")).toBe(0);
+  });
+
+  it("parses dot decimal rate with percent suffix (summary format)", () => {
+    expect(parseRateEmX10k("1.9110 %")).toBe(19110);
+    expect(parseRateEmX10k("0.0000 %")).toBe(0);
+    expect(parseRateEmX10k("25.5026 %")).toBe(255026);
+  });
+
+  it("returns null for empty / nullish input", () => {
+    expect(parseRateEmX10k("")).toBeNull();
+    expect(parseRateEmX10k(null)).toBeNull();
+    expect(parseRateEmX10k(undefined)).toBeNull();
+  });
+});
+
+describe("parseCuotas", () => {
+  it("parses N/total", () => {
+    expect(parseCuotas("1/1")).toEqual({ paid: 1, total: 1 });
+    expect(parseCuotas("2/6")).toEqual({ paid: 2, total: 6 });
+    expect(parseCuotas("3/12")).toEqual({ paid: 3, total: 12 });
+  });
+
+  it("returns null for empty / nullish input", () => {
+    expect(parseCuotas("")).toBeNull();
+    expect(parseCuotas(null)).toBeNull();
+  });
+
+  it("throws on malformed values", () => {
+    expect(() => parseCuotas("abc")).toThrow();
+    expect(() => parseCuotas("1/0")).toThrow();
+    expect(() => parseCuotas("5/2")).toThrow(); // paid > total
+  });
+});
+
+describe("parseStatementDate", () => {
+  it("parses DD/MM/YYYY", () => {
+    const d = parseStatementDate("30/03/2026");
+    expect(d.toISOString()).toBe("2026-03-30T00:00:00.000Z");
+  });
+
+  it("throws on invalid formats", () => {
+    expect(() => parseStatementDate("2026-03-30")).toThrow();
+    expect(() => parseStatementDate("30/13/2026")).toThrow();
+  });
+});
+
+describe("parseSpanishDate", () => {
+  it("parses 'mmm D, YYYY'", () => {
+    const d = parseSpanishDate("abr. 16, 2026");
+    expect(d.toISOString()).toBe("2026-04-16T00:00:00.000Z");
+  });
+
+  it("parses 'D mmm YYYY'", () => {
+    const d = parseSpanishDate("30 mar. 2026");
+    expect(d.toISOString()).toBe("2026-03-30T00:00:00.000Z");
+  });
+
+  it("throws on unknown month abbreviations", () => {
+    expect(() => parseSpanishDate("xxx 16 2026")).toThrow();
+  });
+});
+
+describe("parsePeriod", () => {
+  it("infers start year from end year when start has no year", () => {
+    const { startDate, endDate } = parsePeriod("28 feb", "30 mar. 2026");
+    expect(startDate.toISOString()).toBe("2026-02-28T00:00:00.000Z");
+    expect(endDate.toISOString()).toBe("2026-03-30T00:00:00.000Z");
+  });
+
+  it("rolls start year back when period crosses calendar boundary", () => {
+    const { startDate, endDate } = parsePeriod("28 dic", "27 ene. 2026");
+    expect(startDate.toISOString()).toBe("2025-12-28T00:00:00.000Z");
+    expect(endDate.toISOString()).toBe("2026-01-27T00:00:00.000Z");
+  });
+
+  it("honors explicit year when present on start", () => {
+    const { startDate } = parsePeriod("28 feb. 2025", "30 mar. 2026");
+    expect(startDate.toISOString()).toBe("2025-02-28T00:00:00.000Z");
+  });
+});
+
+// -----------------------------------------------------------------------------
+// End-to-end: synthetic xlsx fixture we build in-memory.
+// Runs in CI — the real fixture at .private/statements/ is gitignored.
+// -----------------------------------------------------------------------------
+
+function buildSyntheticSheet(): Buffer {
+  const aoa: (string | number | null)[][] = [
+    ["Información Cliente:"],
+    ["Cliente", null, "Dirección", "Ciudad", "Departamento"],
+    ["TEST USER", null, "CALLE 1", "MEDELLIN", "ANTIOQUIA"],
+    [],
+    ["Información de la Tarjeta", "************9999"],
+    ["Moneda: ", "PESOS"],
+    [],
+    ["Periodo facturado: ", "01 ene", "31 ene. 2026"],
+    ["Pagar antes de: ", "feb. 15, 2026"],
+    ["Pago mínimo", "100.000,00"],
+    ["Pago total", "500.000,00"],
+    ["Cupo total: ", "1.000.000,00"],
+    ["Cupo disponible: ", "500.000,00"],
+    [],
+    [],
+    [
+      "Tasas de interés vigente",
+      "Tasa Mes Vencido",
+      "Tasa Efectivo Anual",
+      "Resumen Saldo Total",
+      "",
+      "Resumen Pago Mínimo",
+    ],
+    [],
+    [
+      "Compra un mes",
+      "0.0000 %",
+      "0.0000 %",
+      "+ Saldo anterior",
+      "300.000,00",
+      "Cuota transacciones",
+      "50.000,00",
+    ],
+    [
+      "Compra 2 - 36 meses",
+      "1.9110 %",
+      "25.5026 %",
+      "+ Compras del mes",
+      "250.000,00",
+      "Cuota Transacciones anteriores",
+      "0,00",
+    ],
+    ["Impuestos", "1.9110 %", "25.5026 %", "+ Intereses de mora", "0,00", "Cuota avances", "0,00"],
+    [
+      "Avances",
+      "1.9110 %",
+      "25.5026 %",
+      "+ Intereses corrientes",
+      "5.000,00",
+      "+ Intereses de mora",
+      "0,00",
+    ],
+    ["Mora", "1.9110 %", "25.5026 %", "+ Avances", "0,00", "+ Intereses corrientes", "5.000,00"],
+    [null, null, null, "+ Otros cargos", "0,00"],
+    [null, null, null, "Cargos", "555.000,00"],
+    [null, null, null, "(-) Pagos / abonos", "100.000,00"],
+    [null, null, null, "(-) Saldo a favor", "0,00"],
+    [null, null, null, "Abono", "100.000,00"],
+    [],
+    [],
+    ["Movimientos durante el periodo"],
+    [
+      "Número de autorización",
+      "Fecha",
+      "Movimientos",
+      "Valor Movimiento",
+      "Número de cuotas",
+      "Valor cuota/abono",
+      "Interés mensual (%)",
+      "Interés anual (%)",
+      "Saldo pendiente",
+    ],
+    ["", "31/01/2026", "INTERESES CORRIENTES", "5.000,00", "", "5.000,00", "", "", "0,00"],
+    [
+      "111111",
+      "20/01/2026",
+      "TEST MERCHANT A",
+      "50.000,00",
+      "1/1",
+      "50.000,00",
+      "0,0000",
+      "00,0000",
+      "0,00",
+    ],
+    [
+      "222222",
+      "15/01/2026",
+      "TEST MERCHANT B",
+      "200.000,00",
+      "1/4",
+      "50.000,00",
+      "1,9110",
+      "25,5026",
+      "150.000,00",
+    ],
+    ["333333", "10/01/2026", "ABONO PAGO", "-100.000,00", "", "-100.000,00", "", "", "0,00"],
+    [],
+    ["Movimientos antes del periodo"],
+    [
+      "Número de autorización",
+      "Fecha",
+      "Movimientos",
+      "Valor Movimiento",
+      "Número de cuotas",
+      "Valor cuota/abono",
+      "Interés mensual (%)",
+      "Interés anual (%)",
+      "Saldo pendiente",
+    ],
+    [
+      "444444",
+      "15/12/2025",
+      "OLD MERCHANT",
+      "100.000,00",
+      "2/6",
+      "16.666,67",
+      "1,8311",
+      "24,3269",
+      "66.666,68",
+    ],
+  ];
+
+  const wb = XLSX.utils.book_new();
+  const sheet = XLSX.utils.aoa_to_sheet(aoa);
+  XLSX.utils.book_append_sheet(wb, sheet, "PESOS");
+  const buf = XLSX.write(wb, { bookType: "xlsx", type: "buffer" });
+  return Buffer.from(buf);
+}
+
+describe("parseBancolombiaStatement (synthetic fixture)", () => {
+  const parsed = parseBancolombiaStatement(buildSyntheticSheet());
+
+  it("extracts account metadata", () => {
+    expect(parsed.account).toEqual({ last4: "9999", currency: "COP" });
+  });
+
+  it("extracts period with inferred start year", () => {
+    expect(parsed.period.startDate.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+    expect(parsed.period.endDate.toISOString()).toBe("2026-01-31T00:00:00.000Z");
+    expect(parsed.period.dueDate.toISOString()).toBe("2026-02-15T00:00:00.000Z");
+  });
+
+  it("extracts summary values", () => {
+    expect(parsed.summary.previousBalanceCents).toBe(BigInt(30000000));
+    expect(parsed.summary.purchasesCents).toBe(BigInt(25000000));
+    expect(parsed.summary.interestCorrientesCents).toBe(BigInt(500000));
+    expect(parsed.summary.paymentsCents).toBe(BigInt(10000000));
+    expect(parsed.summary.minPaymentCents).toBe(BigInt(10000000));
+    expect(parsed.summary.totalPaymentCents).toBe(BigInt(50000000));
+  });
+
+  it("extracts current rates", () => {
+    expect(parsed.currentRates).toEqual({
+      oneMonth: 0,
+      months2to36: 19110,
+      advances: 19110,
+    });
+  });
+
+  it("extracts rows with correct kinds and sign conventions", () => {
+    expect(parsed.rows).toHaveLength(5);
+    const during = parsed.rows.filter((r) => r.kind === "during-period");
+    const before = parsed.rows.filter((r) => r.kind === "before-period");
+    expect(during).toHaveLength(4);
+    expect(before).toHaveLength(1);
+
+    const interestRow = during[0];
+    expect(interestRow.merchant).toBe("INTERESES CORRIENTES");
+    expect(interestRow.authorizationNumber).toBeNull();
+    expect(interestRow.amountCents).toBe(BigInt(500000));
+    expect(interestRow.installments).toBeNull();
+    expect(interestRow.rateEmX10k).toBeNull();
+
+    const abonoRow = during.find((r) => r.merchant === "ABONO PAGO");
+    expect(abonoRow?.amountCents).toBe(-BigInt(10000000));
+    expect(abonoRow?.authorizationNumber).toBe("333333");
+
+    const multiCuotaRow = during.find((r) => r.merchant === "TEST MERCHANT B");
+    expect(multiCuotaRow?.installments).toEqual({ paid: 1, total: 4 });
+    expect(multiCuotaRow?.rateEmX10k).toBe(19110);
+    expect(multiCuotaRow?.saldoPendingCents).toBe(BigInt(15000000));
+
+    const beforeRow = before[0];
+    expect(beforeRow.merchant).toBe("OLD MERCHANT");
+    expect(beforeRow.rateEmX10k).toBe(18311);
+  });
+});
+
+describe("parseBancolombiaStatement (malformed input)", () => {
+  it("rejects non-xlsx / empty buffer with explicit error", () => {
+    // SheetJS is tolerant and may treat random bytes as an empty workbook, so
+    // the parser bails at the "no extracto metadata" step instead of at load
+    // time. Either way the error is explicit and prefixed.
+    expect(() => parseBancolombiaStatement(Buffer.from("not an xlsx"))).toThrow(
+      /parseBancolombiaStatement/,
+    );
+  });
+
+  it("rejects xlsx missing the 'Información de la Tarjeta' row", () => {
+    const wb = XLSX.utils.book_new();
+    const sheet = XLSX.utils.aoa_to_sheet([["Nothing useful here"]]);
+    XLSX.utils.book_append_sheet(wb, sheet, "PESOS");
+    const buf = Buffer.from(XLSX.write(wb, { bookType: "xlsx", type: "buffer" }));
+    expect(() => parseBancolombiaStatement(buf)).toThrow(/información de la tarjeta/i);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Integration test against the real extracto fixture — opt-in because the
+// file lives in .private/ (gitignored) and is absent in CI.
+// -----------------------------------------------------------------------------
+
+const FIXTURE_PATH = resolve(
+  process.cwd(),
+  ".private/statements/Extracto_202603_Visa_Detallado_2575.xlsx",
+);
+
+const describeIfFixture = existsSync(FIXTURE_PATH) ? describe : describe.skip;
+
+describeIfFixture("parseBancolombiaStatement (real fixture 202603 Visa 2575)", () => {
+  const parsed = parseBancolombiaStatement(readFileSync(FIXTURE_PATH));
+
+  it("extracts account last4 + currency", () => {
+    expect(parsed.account).toEqual({ last4: "2575", currency: "COP" });
+  });
+
+  it("extracts period 2026-02-28 → 2026-03-30 due 2026-04-16", () => {
+    expect(parsed.period.startDate.toISOString()).toBe("2026-02-28T00:00:00.000Z");
+    expect(parsed.period.endDate.toISOString()).toBe("2026-03-30T00:00:00.000Z");
+    expect(parsed.period.dueDate.toISOString()).toBe("2026-04-16T00:00:00.000Z");
+  });
+
+  it("matches acceptance summary values (issue #417)", () => {
+    expect(parsed.summary.interestCorrientesCents).toBe(BigInt(7991836));
+    expect(parsed.summary.paymentsCents).toBe(BigInt(417692100));
+    expect(parsed.summary.previousBalanceCents).toBe(BigInt(824037652));
+    expect(parsed.summary.purchasesCents).toBe(BigInt(360129100));
+    expect(parsed.summary.minPaymentCents).toBe(BigInt(435143100));
+    expect(parsed.summary.totalPaymentCents).toBe(BigInt(774466500));
+  });
+
+  it("matches acceptance rate (2-36 meses === 19110)", () => {
+    expect(parsed.currentRates.months2to36).toBe(19110);
+    expect(parsed.currentRates.advances).toBe(19110);
+    expect(parsed.currentRates.oneMonth).toBe(0);
+  });
+
+  it("extracts 55+ rows (acceptance minimum)", () => {
+    expect(parsed.rows.length).toBeGreaterThanOrEqual(55);
+  });
+
+  it("captures the synthetic INTERESES CORRIENTES row (no auth, null rate)", () => {
+    const row = parsed.rows.find((r) => r.merchant === "INTERESES CORRIENTES");
+    expect(row).toBeDefined();
+    expect(row?.authorizationNumber).toBeNull();
+    expect(row?.amountCents).toBe(BigInt(7991836));
+    expect(row?.rateEmX10k).toBeNull();
+  });
+
+  it("captures the ABONO SUCURSAL VIRTUAL with negative amount", () => {
+    const row = parsed.rows.find((r) => r.merchant === "ABONO SUCURSAL VIRTUAL");
+    expect(row).toBeDefined();
+    expect(row?.amountCents).toBe(-BigInt(417692100));
+    expect(row?.authorizationNumber).toBe("202676");
+  });
+
+  it("splits rows between during-period and before-period", () => {
+    const during = parsed.rows.filter((r) => r.kind === "during-period");
+    const before = parsed.rows.filter((r) => r.kind === "before-period");
+    expect(during.length).toBeGreaterThan(0);
+    expect(before.length).toBeGreaterThan(0);
+    expect(during.length + before.length).toBe(parsed.rows.length);
+  });
+
+  it("preserves multi-cuota installment metadata on before-period rows", () => {
+    const row = parsed.rows.find((r) => r.merchant === "AIRBNB * HMRPPHENMF");
+    expect(row).toBeDefined();
+    expect(row?.kind).toBe("before-period");
+    expect(row?.installments).toEqual({ paid: 2, total: 2 });
+    expect(row?.rateEmX10k).toBe(18895);
+    expect(row?.amountCents).toBe(BigInt(24650000));
+  });
+});

--- a/src/lib/ingestion/bancolombia-statement/xlsx.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/xlsx.test.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import * as XLSX from "xlsx";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import {
   parseBancolombiaStatement,
@@ -369,7 +369,12 @@ const FIXTURE_PATH = resolve(
 const describeIfFixture = existsSync(FIXTURE_PATH) ? describe : describe.skip;
 
 describeIfFixture("parseBancolombiaStatement (real fixture 202603 Visa 2575)", () => {
-  const parsed = parseBancolombiaStatement(readFileSync(FIXTURE_PATH));
+  // Lazy read — `describe.skip` still evaluates the body; top-level readFileSync
+  // would explode in CI where the fixture is gitignored.
+  let parsed: ReturnType<typeof parseBancolombiaStatement>;
+  beforeAll(() => {
+    parsed = parseBancolombiaStatement(readFileSync(FIXTURE_PATH));
+  });
 
   it("extracts account last4 + currency", () => {
     expect(parsed.account).toEqual({ last4: "2575", currency: "COP" });

--- a/src/lib/ingestion/bancolombia-statement/xlsx.ts
+++ b/src/lib/ingestion/bancolombia-statement/xlsx.ts
@@ -1,0 +1,434 @@
+import * as XLSX from "xlsx";
+
+import type {
+  ParsedStatement,
+  StatementAccount,
+  StatementCurrency,
+  StatementInstallments,
+  StatementKind,
+  StatementPeriod,
+  StatementRates,
+  StatementRow,
+  StatementSummary,
+} from "./types";
+
+// -----------------------------------------------------------------------------
+// Scalar parsers (exported for unit tests)
+// -----------------------------------------------------------------------------
+
+// Colombian amounts appear in two formats mixed inside the same file:
+//   - "7.744.665,00"   → dot thousands, comma decimal (standard COP)
+//   - "4,351,431.00"   → comma thousands, dot decimal (US, used in some rows)
+// Rule: the LAST `.` or `,` followed by 1-2 digits is the decimal separator;
+// all earlier separators are thousands. Numbers with NO decimals keep every
+// separator as thousands (never observed in the fixture but defensive).
+export function parseCopAmount(raw: string | number): bigint {
+  if (raw == null) throw new Error("parseCopAmount: value is null/undefined");
+  const str = typeof raw === "number" ? String(raw) : raw;
+  const trimmed = str.trim();
+  if (trimmed === "") throw new Error("parseCopAmount: value is empty");
+
+  let body = trimmed.replace(/\s/g, "");
+
+  let negative = false;
+  if (body.startsWith("-")) {
+    negative = true;
+    body = body.slice(1);
+  } else if (body.startsWith("(") && body.endsWith(")")) {
+    negative = true;
+    body = body.slice(1, -1);
+  }
+  body = body.replace(/^(COP|USD|\$)/i, "");
+
+  if (!/^[\d.,]+$/.test(body)) {
+    throw new Error(`parseCopAmount: invalid characters in "${raw}"`);
+  }
+
+  const lastDot = body.lastIndexOf(".");
+  const lastComma = body.lastIndexOf(",");
+  const lastSep = Math.max(lastDot, lastComma);
+
+  let integerPart = body;
+  let decimalPart = "";
+  if (lastSep !== -1) {
+    const after = body.slice(lastSep + 1);
+    if (/^\d{1,2}$/.test(after)) {
+      integerPart = body.slice(0, lastSep);
+      decimalPart = after;
+    }
+  }
+
+  const intDigits = integerPart.replace(/[.,]/g, "");
+  if (!/^\d*$/.test(intDigits)) {
+    throw new Error(`parseCopAmount: invalid integer part in "${raw}"`);
+  }
+
+  const intVal = intDigits === "" ? BigInt(0) : BigInt(intDigits);
+  const centsFromDec = decimalPart === "" ? BigInt(0) : BigInt(decimalPart.padEnd(2, "0"));
+  const cents = intVal * BigInt(100) + centsFromDec;
+  return negative ? -cents : cents;
+}
+
+// Rates in the Bancolombia extracto can be either "1.9110 %" (dot decimal,
+// summary section) or "1,8895" (comma decimal, row table). Same rule as above
+// applies. Output is EM (mes vencido) × 10_000.
+export function parseRateEmX10k(raw: string | number | null | undefined): number | null {
+  if (raw == null) return null;
+  const str = typeof raw === "number" ? String(raw) : raw;
+  const body = str.trim().replace(/\s*%\s*$/, "");
+  if (body === "") return null;
+
+  if (!/^[\d.,]+$/.test(body)) {
+    throw new Error(`parseRateEmX10k: invalid characters in "${raw}"`);
+  }
+
+  const lastDot = body.lastIndexOf(".");
+  const lastComma = body.lastIndexOf(",");
+  const lastSep = Math.max(lastDot, lastComma);
+
+  let integerPart = body;
+  let decimalPart = "";
+  if (lastSep !== -1) {
+    integerPart = body.slice(0, lastSep);
+    decimalPart = body.slice(lastSep + 1);
+  }
+
+  const intDigits = integerPart.replace(/[.,]/g, "");
+  const intVal = intDigits === "" ? 0 : Number(intDigits);
+  const dec4 = decimalPart.slice(0, 4).padEnd(4, "0");
+  const decVal = Number(dec4);
+  if (!Number.isFinite(intVal) || !Number.isFinite(decVal)) {
+    throw new Error(`parseRateEmX10k: invalid number "${raw}"`);
+  }
+  return intVal * 10_000 + decVal;
+}
+
+export function parseCuotas(raw: string | number | null | undefined): StatementInstallments | null {
+  if (raw == null) return null;
+  const str = typeof raw === "number" ? String(raw) : raw;
+  const trimmed = str.trim();
+  if (trimmed === "") return null;
+  const m = trimmed.match(/^(\d+)\s*\/\s*(\d+)$/);
+  if (!m) throw new Error(`parseCuotas: expected "N/M", got "${raw}"`);
+  const paid = Number(m[1]);
+  const total = Number(m[2]);
+  if (paid <= 0 || total <= 0 || paid > total) {
+    throw new Error(`parseCuotas: invalid values in "${raw}"`);
+  }
+  return { paid, total };
+}
+
+export function parseStatementDate(raw: string): Date {
+  const m = raw.trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (!m) throw new Error(`parseStatementDate: expected DD/MM/YYYY, got "${raw}"`);
+  const day = Number(m[1]);
+  const month = Number(m[2]);
+  const year = Number(m[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) {
+    throw new Error(`parseStatementDate: out-of-range components in "${raw}"`);
+  }
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+const ES_MONTH_INDEX: Record<string, number> = {
+  ene: 0,
+  feb: 1,
+  mar: 2,
+  abr: 3,
+  may: 4,
+  jun: 5,
+  jul: 6,
+  ago: 7,
+  sep: 8,
+  set: 8, // rare variant
+  oct: 9,
+  nov: 10,
+  dic: 11,
+};
+
+export function parseSpanishDate(raw: string): Date {
+  const s = raw.trim().toLowerCase();
+  // "abr. 16, 2026" / "abr 16 2026"
+  let m = s.match(/^([a-zñ]{3})\.?\s+(\d{1,2}),?\s+(\d{4})$/);
+  if (m) {
+    const month = ES_MONTH_INDEX[m[1]];
+    if (month === undefined) throw new Error(`parseSpanishDate: unknown month in "${raw}"`);
+    return new Date(Date.UTC(Number(m[3]), month, Number(m[2])));
+  }
+  // "30 mar. 2026" / "30 mar 2026"
+  m = s.match(/^(\d{1,2})\s+([a-zñ]{3})\.?\s+(\d{4})$/);
+  if (m) {
+    const month = ES_MONTH_INDEX[m[2]];
+    if (month === undefined) throw new Error(`parseSpanishDate: unknown month in "${raw}"`);
+    return new Date(Date.UTC(Number(m[3]), month, Number(m[1])));
+  }
+  throw new Error(`parseSpanishDate: unrecognized format "${raw}"`);
+}
+
+// Start of the period may be yearless ("28 feb"); end always has a year. If
+// start month > end month, we assume the period crossed the calendar boundary.
+export function parsePeriod(
+  startRaw: string,
+  endRaw: string,
+): {
+  startDate: Date;
+  endDate: Date;
+} {
+  const endDate = parseSpanishDate(endRaw);
+  const endYear = endDate.getUTCFullYear();
+  const endMonth = endDate.getUTCMonth();
+
+  const s = startRaw.trim().toLowerCase();
+  // Try yearful start first.
+  const withYear = s.match(/^(\d{1,2})\s+([a-zñ]{3})\.?\s+(\d{4})$/);
+  if (withYear) {
+    return { startDate: parseSpanishDate(startRaw), endDate };
+  }
+  const m = s.match(/^(\d{1,2})\s+([a-zñ]{3})\.?$/);
+  if (!m) throw new Error(`parsePeriod: invalid start "${startRaw}"`);
+  const month = ES_MONTH_INDEX[m[2]];
+  if (month === undefined) throw new Error(`parsePeriod: unknown month in "${startRaw}"`);
+  const year = month > endMonth ? endYear - 1 : endYear;
+  const startDate = new Date(Date.UTC(year, month, Number(m[1])));
+  return { startDate, endDate };
+}
+
+// -----------------------------------------------------------------------------
+// Main parser
+// -----------------------------------------------------------------------------
+
+type SheetRows = (string | null)[][];
+
+function loadSheet(buffer: Buffer): { name: string; rows: SheetRows } {
+  let wb: XLSX.WorkBook;
+  try {
+    wb = XLSX.read(buffer, { type: "buffer", raw: false, cellDates: false });
+  } catch (err) {
+    throw new Error(`parseBancolombiaStatement: not a valid xlsx file (${(err as Error).message})`);
+  }
+  const sheetName = wb.SheetNames.find((n) => n.toUpperCase() === "PESOS") ?? wb.SheetNames[0];
+  if (!sheetName) {
+    throw new Error("parseBancolombiaStatement: workbook has no sheets");
+  }
+  const sheet = wb.Sheets[sheetName];
+  if (!sheet) {
+    throw new Error(`parseBancolombiaStatement: sheet "${sheetName}" missing`);
+  }
+  const rows = XLSX.utils.sheet_to_json<(string | null)[]>(sheet, {
+    header: 1,
+    raw: false,
+    defval: null,
+    blankrows: true,
+  });
+  return { name: sheetName, rows };
+}
+
+function cellText(rows: SheetRows, rowIdx: number, colIdx: number): string {
+  const row = rows[rowIdx];
+  if (!row) return "";
+  const v = row[colIdx];
+  if (v == null) return "";
+  return String(v).trim();
+}
+
+function findRowContaining(rows: SheetRows, substring: string, colIdx: number): number {
+  const needle = substring.toLowerCase();
+  for (let i = 0; i < rows.length; i++) {
+    if (cellText(rows, i, colIdx).toLowerCase().includes(needle)) return i;
+  }
+  return -1;
+}
+
+function extractAccount(rows: SheetRows): StatementAccount {
+  const cardRow = findRowContaining(rows, "información de la tarjeta", 0);
+  if (cardRow === -1) {
+    throw new Error('parseBancolombiaStatement: missing "Información de la Tarjeta" row');
+  }
+  const cardRaw = cellText(rows, cardRow, 1);
+  const last4Match = cardRaw.match(/(\d{4})\s*$/);
+  if (!last4Match) {
+    throw new Error(`parseBancolombiaStatement: cannot extract card last4 from "${cardRaw}"`);
+  }
+
+  const monedaRow = findRowContaining(rows, "moneda", 0);
+  if (monedaRow === -1) {
+    throw new Error('parseBancolombiaStatement: missing "Moneda" row');
+  }
+  const monedaRaw = cellText(rows, monedaRow, 1).toUpperCase();
+  let currency: StatementCurrency;
+  if (monedaRaw.includes("PESOS") || monedaRaw === "COP") currency = "COP";
+  else if (monedaRaw.includes("USD") || monedaRaw.includes("DOLAR")) currency = "USD";
+  else throw new Error(`parseBancolombiaStatement: unknown currency "${monedaRaw}"`);
+
+  return { last4: last4Match[1], currency };
+}
+
+function extractPeriod(rows: SheetRows): StatementPeriod {
+  const periodoRow = findRowContaining(rows, "periodo facturado", 0);
+  if (periodoRow === -1) {
+    throw new Error('parseBancolombiaStatement: missing "Periodo facturado" row');
+  }
+  const startRaw = cellText(rows, periodoRow, 1);
+  const endRaw = cellText(rows, periodoRow, 2);
+  if (!startRaw || !endRaw) {
+    throw new Error('parseBancolombiaStatement: "Periodo facturado" missing start or end');
+  }
+  const { startDate, endDate } = parsePeriod(startRaw, endRaw);
+
+  const dueRow = findRowContaining(rows, "pagar antes de", 0);
+  if (dueRow === -1) {
+    throw new Error('parseBancolombiaStatement: missing "Pagar antes de" row');
+  }
+  const dueRaw = cellText(rows, dueRow, 1);
+  if (!dueRaw) {
+    throw new Error('parseBancolombiaStatement: "Pagar antes de" has no value');
+  }
+  const dueDate = parseSpanishDate(dueRaw);
+
+  return { startDate, endDate, dueDate };
+}
+
+function findSummaryValueByLabel(
+  rows: SheetRows,
+  label: string,
+  labelCol: number,
+  valueCol: number,
+): string {
+  const needle = label.toLowerCase();
+  for (let i = 0; i < rows.length; i++) {
+    if (cellText(rows, i, labelCol).toLowerCase().includes(needle)) {
+      return cellText(rows, i, valueCol);
+    }
+  }
+  throw new Error(`parseBancolombiaStatement: missing summary row "${label}"`);
+}
+
+function extractSummary(rows: SheetRows): StatementSummary {
+  // Summary lives in two groups:
+  //   - Header key/value (rows 10-11): Pago mínimo, Pago total — col A / col B.
+  //   - Summary table (rows 18-27): + Saldo anterior / + Compras del mes / etc
+  //     labels in col D, values in col E.
+  const minPayRaw = findSummaryValueByLabel(rows, "pago mínimo", 0, 1);
+  const totalPayRaw = findSummaryValueByLabel(rows, "pago total", 0, 1);
+
+  const previousRaw = findSummaryValueByLabel(rows, "saldo anterior", 3, 4);
+  const purchasesRaw = findSummaryValueByLabel(rows, "compras del mes", 3, 4);
+  const interestRaw = findSummaryValueByLabel(rows, "intereses corrientes", 3, 4);
+  const paymentsRaw = findSummaryValueByLabel(rows, "pagos / abonos", 3, 4);
+
+  return {
+    previousBalanceCents: parseCopAmount(previousRaw),
+    purchasesCents: parseCopAmount(purchasesRaw),
+    interestCorrientesCents: parseCopAmount(interestRaw),
+    paymentsCents: parseCopAmount(paymentsRaw),
+    minPaymentCents: parseCopAmount(minPayRaw),
+    totalPaymentCents: parseCopAmount(totalPayRaw),
+  };
+}
+
+function extractRates(rows: SheetRows): StatementRates {
+  const rateFor = (label: string): number => {
+    const needle = label.toLowerCase();
+    for (let i = 0; i < rows.length; i++) {
+      if (cellText(rows, i, 0).toLowerCase().includes(needle)) {
+        const parsed = parseRateEmX10k(cellText(rows, i, 1));
+        if (parsed == null) {
+          throw new Error(`parseBancolombiaStatement: rate for "${label}" is empty`);
+        }
+        return parsed;
+      }
+    }
+    throw new Error(`parseBancolombiaStatement: missing rate row "${label}"`);
+  };
+  return {
+    oneMonth: rateFor("compra un mes"),
+    months2to36: rateFor("compra 2 - 36 meses"),
+    advances: rateFor("avances"),
+  };
+}
+
+// Data rows use these column indexes under the "Número de autorización | Fecha
+// | Movimientos | Valor Movimiento | Número de cuotas | Valor cuota/abono |
+// Interés mensual (%) | Interés anual (%) | Saldo pendiente" header.
+const COL_AUTH = 0;
+const COL_DATE = 1;
+const COL_MERCHANT = 2;
+const COL_AMOUNT = 3;
+const COL_CUOTAS = 4;
+const COL_CUOTA_VALUE = 5;
+const COL_RATE_EM = 6;
+const COL_SALDO_PENDING = 8;
+
+function isRowDataRow(rows: SheetRows, rowIdx: number): boolean {
+  const dateCell = cellText(rows, rowIdx, COL_DATE);
+  if (!/^\d{1,2}\/\d{1,2}\/\d{4}$/.test(dateCell)) return false;
+  const merchant = cellText(rows, rowIdx, COL_MERCHANT);
+  if (merchant === "") return false;
+  const amount = cellText(rows, rowIdx, COL_AMOUNT);
+  if (amount === "") return false;
+  return true;
+}
+
+function parseRow(rows: SheetRows, rowIdx: number, kind: StatementKind): StatementRow {
+  const authRaw = cellText(rows, rowIdx, COL_AUTH);
+  const dateRaw = cellText(rows, rowIdx, COL_DATE);
+  const merchantRaw = cellText(rows, rowIdx, COL_MERCHANT);
+  const amountRaw = cellText(rows, rowIdx, COL_AMOUNT);
+  const cuotasRaw = cellText(rows, rowIdx, COL_CUOTAS);
+  const cuotaValueRaw = cellText(rows, rowIdx, COL_CUOTA_VALUE);
+  const rateRaw = cellText(rows, rowIdx, COL_RATE_EM);
+  const saldoRaw = cellText(rows, rowIdx, COL_SALDO_PENDING);
+
+  const occurredAt = parseStatementDate(dateRaw);
+  const amountCents = parseCopAmount(amountRaw);
+  const installments = parseCuotas(cuotasRaw);
+  const installmentValueCents = cuotaValueRaw === "" ? null : parseCopAmount(cuotaValueRaw);
+  const rateEmX10k = parseRateEmX10k(rateRaw);
+  const saldoPendingCents = saldoRaw === "" ? BigInt(0) : parseCopAmount(saldoRaw);
+
+  return {
+    kind,
+    authorizationNumber: authRaw === "" ? null : authRaw,
+    occurredAt,
+    merchant: merchantRaw,
+    amountCents,
+    installments,
+    installmentValueCents,
+    rateEmX10k,
+    saldoPendingCents,
+  };
+}
+
+function extractStatementRows(rows: SheetRows): StatementRow[] {
+  const out: StatementRow[] = [];
+  let kind: StatementKind = "during-period";
+  for (let i = 0; i < rows.length; i++) {
+    const firstCol = cellText(rows, i, 0).toLowerCase();
+    if (firstCol.startsWith("movimientos antes del periodo")) {
+      kind = "before-period";
+      continue;
+    }
+    if (firstCol.startsWith("movimientos durante el periodo")) {
+      kind = "during-period";
+      continue;
+    }
+    // Skip repeated table header rows.
+    if (firstCol === "número de autorización") continue;
+    if (!isRowDataRow(rows, i)) continue;
+    out.push(parseRow(rows, i, kind));
+  }
+  if (out.length === 0) {
+    throw new Error("parseBancolombiaStatement: no movimientos rows found");
+  }
+  return out;
+}
+
+export function parseBancolombiaStatement(buffer: Buffer): ParsedStatement {
+  const { rows } = loadSheet(buffer);
+  const account = extractAccount(rows);
+  const period = extractPeriod(rows);
+  const summary = extractSummary(rows);
+  const currentRates = extractRates(rows);
+  const statementRows = extractStatementRows(rows);
+  return { account, period, summary, currentRates, rows: statementRows };
+}


### PR DESCRIPTION
## Summary

- Standalone `parseBancolombiaStatement(buffer)` for `.xlsx` extractos Bancolombia (PESOS sheet): account, period, summary, current rates, and movimientos rows — typed output, no DB writes.
- CLI `bun run statement:parse --file=<path> [--json]` for manual dry-runs; 0.13s on the reference fixture.
- 42 new tests — scalar helpers (dual-locale numeric, rate, cuotas, dates), in-memory synthetic xlsx end-to-end (runs in CI), and integration suite against the real `.private/` fixture (auto-skipped when absent).

### Acceptance criteria (issue #417)

Verified against `.private/statements/Extracto_202603_Visa_Detallado_2575.xlsx`:

- [x] `summary.interestCorrientesCents === 7991836n` (79.918,36 COP)
- [x] `summary.paymentsCents === 417692100n` (4.176.921,00)
- [x] `currentRates.months2to36 === 19110`
- [x] 70 rows (61 `during-period` + 9 `before-period`) — beats the 55+ floor
- [x] Parser rejects malformed xlsx with explicit error
- [x] CLI reproduces the fixture in <2s

### Design notes

- **Dual-locale numeric parsing**. Bancolombia mixes `7.744.665,00` (COP) and `4,351,431.00` (US) inside the same file. The parser uses \"last separator followed by 1-2 digits is the decimal\" so both formats round-trip correctly.
- **Rate scale**. Rates normalize to EM × 10 000 (e.g. `1,9110 %` → `19110`) consistent with `tc-installments-interest-model.md` and the `installment_rate_bps` field.
- **Section marker**. `StatementKind` flips from `during-period` to `before-period` when the row matches \"Movimientos antes del periodo\"; section switches are idempotent (headers repeat every ~24 rows for pagination).
- **SheetJS tolerance**. `XLSX.read` accepts almost any byte blob as an empty workbook, so the parser also validates that required labels (\"Información de la Tarjeta\", \"Periodo facturado\", \"Pagos / abonos\", etc.) are present — malformed input always throws with a `parseBancolombiaStatement:` prefix.

Unblocks sub-issue B2 (statement matcher + `consolidateCycle`).

## Test plan

- [x] `bun run test` — 939/939 pass
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run statement:parse --file=.private/statements/Extracto_202603_Visa_Detallado_2575.xlsx` — matches expected totals
- [x] `bun run statement:parse --file=.private/statements/Extracto_202603_Mastercard_Detallado_7291.xlsx` — parses second real fixture

Closes #417