### PR TITLE
feat(ingestion): statement matcher + consolidation action + CLI (#418)

### DIFF
--- a/drizzle/0052_fluffy_the_fallen.sql
+++ b/drizzle/0052_fluffy_the_fallen.sql
@@ -1,0 +1,6 @@
+CREATE TYPE "public"."statement_import_kind" AS ENUM('movimientos', 'extracto_detallado');--> statement-breakpoint
+ALTER TABLE "statement_imports" ADD COLUMN "kind" "statement_import_kind" DEFAULT 'movimientos' NOT NULL;--> statement-breakpoint
+ALTER TABLE "statement_imports" ADD COLUMN "cycle" varchar(7);--> statement-breakpoint
+ALTER TABLE "statement_imports" ADD COLUMN "synthetic_tx_id" integer;--> statement-breakpoint
+ALTER TABLE "statement_imports" ADD COLUMN "report" jsonb;--> statement-breakpoint
+CREATE UNIQUE INDEX "statement_imports_cycle_unique" ON "statement_imports" USING btree ("user_id","account_id","cycle") WHERE "statement_imports"."kind" = 'extracto_detallado' AND "statement_imports"."cycle" IS NOT NULL;

--- a/drizzle/meta/0052_snapshot.json
+++ b/drizzle/meta/0052_snapshot.json
@@ -1,0 +1,4352 @@
+{
+  "id": "1363ce90-0987-4d2d-9e11-2a9eff6f90d8",
+  "prevId": "bbecc670-379e-4630-9312-b52f8476532d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_physical_card_id_physical_cards_id_fk": {
+          "name": "accounts_physical_card_id_physical_cards_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "physical_cards",
+          "columnsFrom": [
+            "physical_card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_corrections": {
+      "name": "classification_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_category_slug": {
+          "name": "new_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_corrections_learning_idx": {
+          "name": "classification_corrections_learning_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "new_category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_corrections_user_id_users_id_fk": {
+          "name": "classification_corrections_user_id_users_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_corrections_transaction_id_transactions_id_fk": {
+          "name": "classification_corrections_transaction_id_transactions_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_from_corrections": {
+          "name": "generated_from_corrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.physical_cards": {
+      "name": "physical_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_limit_cents": {
+          "name": "credit_limit_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "statement_cutoff_day": {
+          "name": "statement_cutoff_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "physical_cards_user_idx": {
+          "name": "physical_cards_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "physical_cards_user_institution_idx": {
+          "name": "physical_cards_user_institution_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "physical_cards_user_id_users_id_fk": {
+          "name": "physical_cards_user_id_users_id_fk",
+          "tableFrom": "physical_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_proposals": {
+      "name": "rule_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_txn_ids": {
+          "name": "correction_txn_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rule_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rule_proposals_user_merchant_category_pending_unique": {
+          "name": "rule_proposals_user_merchant_category_pending_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rule_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rule_proposals_user_status_idx": {
+          "name": "rule_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_proposals_user_id_users_id_fk": {
+          "name": "rule_proposals_user_id_users_id_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_proposals_user_category_fk": {
+          "name": "rule_proposals_user_category_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slo_alerts": {
+      "name": "slo_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slo_key": {
+          "name": "slo_key",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slo_alerts_open_idx": {
+          "name": "slo_alerts_open_idx",
+          "columns": [
+            {
+              "expression": "slo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"slo_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "statement_import_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movimientos'"
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synthetic_tx_id": {
+          "name": "synthetic_tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_cycle_unique": {
+          "name": "statement_imports_cycle_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"statement_imports\".\"kind\" = 'extracto_detallado' AND \"statement_imports\".\"cycle\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installments_total": {
+          "name": "installments_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "installment_rate_bps": {
+          "name": "installment_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retroactive_rule_id": {
+          "name": "retroactive_rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group_id": {
+          "name": "transfer_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_group_idx": {
+          "name": "transactions_transfer_group_idx",
+          "columns": [
+            {
+              "expression": "transfer_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"transfer_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_occurred_live_idx": {
+          "name": "transactions_account_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_live_idx": {
+          "name": "transactions_user_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_retroactive_rule_id_classification_rules_id_fk": {
+          "name": "transactions_retroactive_rule_id_classification_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "classification_rules",
+          "columnsFrom": [
+            "retroactive_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ui_preferences": {
+          "name": "ui_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "classification_context": {
+          "name": "classification_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "rule_retroactive",
+        "ai",
+        "manual",
+        "manual_confirmed",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.rule_proposal_status": {
+      "name": "rule_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.statement_import_kind": {
+      "name": "statement_import_kind",
+      "schema": "public",
+      "values": [
+        "movimientos",
+        "extracto_detallado"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug",
+        "widget"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1776822575554,
       "tag": "0051_daily_molten_man",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1776834874167,
+      "tag": "0052_fluffy_the_fallen",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:migrate:pago-tc": "bun run scripts/migrate-pago-tc-to-transfer.ts",
     "intereses:run": "bun run scripts/run-intereses-causados.ts",
     "statement:parse": "bun run scripts/parse-bancolombia-statement.ts",
+    "statement:apply": "bun run scripts/consolidate-statement.ts",
     "db:bootstrap:invites": "bun run scripts/bootstrap-invites.ts",
     "db:bootstrap:webhook-tokens": "bun run scripts/bootstrap-webhook-tokens.ts",
     "test": "vitest run",

--- a/scripts/consolidate-statement.ts
+++ b/scripts/consolidate-statement.ts
@@ -1,0 +1,198 @@
+// CLI para el consolidation flow del extracto Bancolombia (sub-issue #418).
+//
+// Invocación:
+//   bun run statement:apply --file=<path> --user=<id> --account=<id> --cycle=YYYY-MM           # dry-run (default)
+//   bun run statement:apply --file=<path> --user=<id> --account=<id> --cycle=YYYY-MM --commit  # writes
+//   bun run statement:apply ... --json                                                          # machine-readable output
+//
+// Cuando `--commit` NO está presente (default), el script parsea el xlsx,
+// corre el matcher contra el ledger y muestra un report tabular sin tocar DB.
+// Con `--commit`, aplica los UPDATEs, INSERTea missing rows, y corre el job
+// de intereses-causados. Idempotente via statement_imports.cycle unique
+// partial index.
+
+import { readFileSync } from "node:fs";
+
+import {
+  consolidateCycleFromStatement,
+  hashStatementBuffer,
+  type ConsolidationReport,
+} from "../src/lib/ingestion/bancolombia-statement/consolidate";
+import { parseBancolombiaStatement } from "../src/lib/ingestion/bancolombia-statement/xlsx";
+import { db } from "../src/lib/db";
+import { createLogger } from "../src/lib/logger";
+
+const log = createLogger({ module: "consolidate-statement" });
+
+type Args = {
+  file: string;
+  user: number;
+  account: number;
+  cycle: string;
+  commit: boolean;
+  json: boolean;
+};
+
+function parseArgs(argv: string[]): Args {
+  const out: Record<string, string | boolean> = {};
+  for (const arg of argv.slice(2)) {
+    const kv = arg.match(/^--([a-z-]+)=(.+)$/i);
+    if (kv) {
+      out[kv[1]] = kv[2];
+      continue;
+    }
+    const flag = arg.match(/^--([a-z-]+)$/i);
+    if (flag) out[flag[1]] = true;
+  }
+  const file = typeof out.file === "string" ? out.file : "";
+  const user = Number(out.user);
+  const account = Number(out.account);
+  const cycle = typeof out.cycle === "string" ? out.cycle : "";
+  if (!file) throw new Error("--file=<path> is required");
+  if (!Number.isInteger(user) || user <= 0) {
+    throw new Error("--user=<id> is required and must be a positive integer");
+  }
+  if (!Number.isInteger(account) || account <= 0) {
+    throw new Error("--account=<id> is required and must be a positive integer");
+  }
+  if (!/^\d{4}-\d{2}$/.test(cycle)) {
+    throw new Error("--cycle=YYYY-MM is required");
+  }
+  return {
+    file,
+    user,
+    account,
+    cycle,
+    commit: out.commit === true,
+    json: out.json === true,
+  };
+}
+
+function formatCents(strOrBig: string | bigint | null | undefined): string {
+  if (strOrBig == null) return "—";
+  const big = typeof strOrBig === "bigint" ? strOrBig : BigInt(strOrBig);
+  const negative = big < BigInt(0);
+  const abs = negative ? -big : big;
+  const units = abs / BigInt(100);
+  const fractional = (abs % BigInt(100)).toString().padStart(2, "0");
+  const unitsStr = units.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  return `${negative ? "-" : ""}${unitsStr},${fractional}`;
+}
+
+function rateLabel(x10k: number | null): string {
+  if (x10k == null) return "—";
+  const whole = Math.floor(x10k / 10_000);
+  const frac = (x10k % 10_000).toString().padStart(4, "0");
+  return `${whole},${frac} %`;
+}
+
+function renderReport(report: ConsolidationReport): string {
+  const lines: string[] = [];
+  const tag =
+    report.status === "dry-run"
+      ? "[DRY-RUN]"
+      : report.status === "consolidated"
+        ? "[COMMITTED]"
+        : report.status === "already-consolidated"
+          ? "[ALREADY-CONSOLIDATED]"
+          : "[NO-OP]";
+  lines.push(`${tag} user=${report.userId} account=${report.accountId} cycle=${report.cycle}`);
+  lines.push("");
+  lines.push("Match stats:");
+  lines.push(`  matched              ${report.matchStats.matched}`);
+  lines.push(`  will change (UPDATE) ${report.matchStats.matchedWillChange}`);
+  lines.push(`  missing during-per   ${report.matchStats.insertedMissing}`);
+  lines.push(`  missing before-per   ${report.matchStats.skippedMissingBefore} (skipped)`);
+  lines.push(`  unmatched in ledger  ${report.matchStats.unmatchedInLedger}`);
+  lines.push("");
+  lines.push(`Intereses-causados: ${report.intereses.status}`);
+  if (report.intereses.status === "inserted") {
+    lines.push(`  synthetic tx id        ${report.intereses.txId}`);
+    lines.push(`  total interest cents   ${formatCents(report.intereses.totalInterestCentsStr)}`);
+    lines.push(`  purchases needing rate ${report.intereses.purchasesNeedingRate}`);
+  } else if (report.intereses.status === "skipped") {
+    lines.push(`  reason                 ${report.intereses.reason}`);
+  } else {
+    lines.push(`  reason                 ${report.intereses.reason}`);
+  }
+
+  if (report.matchedDiffs.length > 0) {
+    lines.push("");
+    lines.push("Matched rows with pending diffs:");
+    lines.push("  TxId   Merchant                      Inst:before/after  Rate:before/after");
+    for (const d of report.matchedDiffs) {
+      if (!d.willChange) continue;
+      lines.push(
+        `  ${String(d.txId).padEnd(7)}${d.merchant.slice(0, 28).padEnd(30)} ${d.installmentsTotalBefore}→${d.installmentsTotalAfter}              ${rateLabel(d.rateEmX10kBefore)}→${rateLabel(d.rateEmX10kAfter)}`,
+      );
+    }
+  }
+
+  if (report.missingInLedger.length > 0) {
+    lines.push("");
+    lines.push("Missing in ledger (INSERT for during-period; skip for before-period):");
+    for (const r of report.missingInLedger) {
+      const marker = r.kind === "before-period" ? "[before, skip]" : "[insert]";
+      lines.push(
+        `  ${r.occurredAt.slice(0, 10)} auth=${r.authorizationNumber ?? "—"} ${formatCents(r.amountCentsStr).padStart(15)}  ${r.merchant}  ${marker}`,
+      );
+    }
+  }
+
+  if (report.unmatchedInLedgerIds.length > 0) {
+    lines.push("");
+    lines.push(
+      `Unmatched ledger tx ids (present in DB, absent from statement — review): ${report.unmatchedInLedgerIds.join(", ")}`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+  const buffer = readFileSync(args.file);
+  const parsed = parseBancolombiaStatement(buffer);
+  const fileHash = hashStatementBuffer(buffer);
+
+  const report = await consolidateCycleFromStatement({
+    userId: args.user,
+    accountId: args.account,
+    cycle: args.cycle,
+    parsed,
+    fileHash,
+    dryRun: !args.commit,
+  });
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${renderReport(report)}\n`);
+  }
+
+  log.info(
+    {
+      userId: args.user,
+      accountId: args.account,
+      cycle: args.cycle,
+      commit: args.commit,
+      status: report.status,
+      matched: report.matchStats.matched,
+      willChange: report.matchStats.matchedWillChange,
+      inserted: report.insertedTxIds.length,
+      intereses: report.intereses.status,
+      event: "consolidate_statement_run",
+    },
+    `consolidate-statement: status=${report.status}`,
+  );
+}
+
+main()
+  .then(async () => {
+    await db.$client.end({ timeout: 1 }).catch(() => void 0);
+  })
+  .catch(async (err) => {
+    log.error({ err, event: "consolidate_statement_failed" }, "consolidate-statement: run failed");
+    await db.$client.end({ timeout: 1 }).catch(() => void 0);
+    process.exit(1);
+  });

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -153,6 +153,15 @@ export const reconciliationStatus = pgEnum("reconciliation_status", [
   "imported_from_statement",
 ]);
 
+// #418: discriminates between the two xlsx exports Bancolombia produces:
+// "movimientos" = operational account history (src/lib/reconciliation parsers);
+// "extracto_detallado" = TC monthly statement with installments+rate+cycle
+// metadata (src/lib/ingestion/bancolombia-statement parser, #417).
+export const statementImportKind = pgEnum("statement_import_kind", [
+  "movimientos",
+  "extracto_detallado",
+]);
+
 export const classificationMethod = pgEnum("classification_method", [
   "rule",
   "rule_retroactive",
@@ -509,10 +518,20 @@ export const statementImports = pgTable(
     importedAt: timestamp("imported_at", { withTimezone: true }).notNull().defaultNow(),
     txnCount: integer("txn_count").notNull().default(0),
     balanceAtEndCents: bigint("balance_at_end_cents", { mode: "bigint" }),
+    // #418: extracto_detallado consolidation tracks the cycle + the match
+    // report + the synthetic intereses-causados tx for auditability and
+    // idempotency. Null for movimientos imports.
+    kind: statementImportKind("kind").notNull().default("movimientos"),
+    cycle: varchar("cycle", { length: 7 }),
+    syntheticTxId: integer("synthetic_tx_id"),
+    report: jsonb("report"),
   },
   (t) => [
     uniqueIndex("statement_imports_user_account_file_unique").on(t.userId, t.accountId, t.fileHash),
     index("statement_imports_account_period_idx").on(t.accountId, t.periodStart, t.periodEnd),
+    uniqueIndex("statement_imports_cycle_unique")
+      .on(t.userId, t.accountId, t.cycle)
+      .where(sql`${t.kind} = 'extracto_detallado' AND ${t.cycle} IS NOT NULL`),
   ],
 );
 

--- a/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
@@ -1,0 +1,384 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { accounts, statementImports, transactions, users } from "@/lib/db/schema";
+import { copyCategorySeedsToUser } from "@/lib/auth/signup";
+
+import { consolidateCycleFromStatement } from "./consolidate";
+import type { ParsedStatement, StatementRow } from "./types";
+
+const TAG = "STMT_CONSOL_TEST";
+
+function utcDate(y: number, m: number, d: number): Date {
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+async function createUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  return row.id;
+}
+
+async function createTCAccount(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} visa`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      type: "credit_card",
+      currency: "COP",
+      metadata: { last4s: ["2575"], cutoffDay: 30 },
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function insertTx(args: {
+  userId: number;
+  accountId: number;
+  occurredAt: Date;
+  amountCents: bigint;
+  merchant: string;
+  installmentsTotal?: number;
+  installmentRateEmX10k?: number | null;
+  externalId?: string;
+}): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId: args.userId,
+      accountId: args.accountId,
+      occurredAt: args.occurredAt,
+      amountCents: args.amountCents,
+      currency: "COP",
+      descriptionRaw: args.merchant,
+      merchant: args.merchant,
+      installmentsTotal: args.installmentsTotal ?? 1,
+      installmentRateEmX10k: args.installmentRateEmX10k ?? null,
+      source: "sms",
+      channel: "bank",
+      externalId: args.externalId ?? null,
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+function buildParsed(
+  rows: StatementRow[],
+  overrides: Partial<ParsedStatement> = {},
+): ParsedStatement {
+  return {
+    account: { last4: "2575", currency: "COP" },
+    period: {
+      startDate: utcDate(2026, 2, 28),
+      endDate: utcDate(2026, 3, 30),
+      dueDate: utcDate(2026, 4, 16),
+    },
+    summary: {
+      previousBalanceCents: BigInt(0),
+      purchasesCents: BigInt(0),
+      interestCorrientesCents: BigInt(0),
+      paymentsCents: BigInt(0),
+      minPaymentCents: BigInt(0),
+      totalPaymentCents: BigInt(0),
+    },
+    currentRates: { oneMonth: 0, months2to36: 19110, advances: 19110 },
+    rows,
+    ...overrides,
+  };
+}
+
+function row(
+  partial: Partial<StatementRow> &
+    Pick<StatementRow, "amountCents" | "merchant" | "occurredAt" | "authorizationNumber">,
+): StatementRow {
+  return {
+    kind: "kind" in partial ? (partial.kind as StatementRow["kind"]) : "during-period",
+    authorizationNumber: partial.authorizationNumber,
+    merchant: partial.merchant,
+    occurredAt: partial.occurredAt,
+    amountCents: partial.amountCents,
+    installments:
+      "installments" in partial
+        ? (partial.installments as StatementRow["installments"])
+        : { paid: 1, total: 1 },
+    installmentValueCents:
+      "installmentValueCents" in partial
+        ? (partial.installmentValueCents as bigint | null)
+        : partial.amountCents,
+    rateEmX10k: "rateEmX10k" in partial ? (partial.rateEmX10k as number | null) : 0,
+    saldoPendingCents:
+      "saldoPendingCents" in partial ? (partial.saldoPendingCents as bigint) : BigInt(0),
+  };
+}
+
+async function cleanupUser(userId: number): Promise<void> {
+  await db.delete(transactions).where(eq(transactions.userId, userId));
+  await db.delete(statementImports).where(eq(statementImports.userId, userId));
+  await db.delete(accounts).where(eq(accounts.userId, userId));
+  await db.delete(users).where(eq(users.id, userId));
+}
+
+describe("consolidateCycleFromStatement — integration against findash_test", () => {
+  let userId!: number;
+  let accountId!: number;
+  // Four seeded txs: three match-candidates + one unmatched outlier.
+  let txExact!: number; // 1/1, already settled — willChange=false
+  let txGainsCuotas!: number; // currently 1/1 in DB, statement says 1/6
+  let txGetsRate!: number; // currently rate=null, statement says 19110
+  let txUnmatched!: number; // in DB but not in statement
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.${Date.now()}@test.local`);
+    accountId = await createTCAccount(userId);
+
+    // Ledger sign convention: TC purchases are stored NEGATIVE (expenses).
+    // The statement we build below uses the extracto convention (compra+)
+    // and the matcher inverts on the way in.
+    txExact = await insertTx({
+      userId,
+      accountId,
+      occurredAt: utcDate(2026, 3, 26),
+      amountCents: BigInt(-1895200),
+      merchant: "DLO*DIDI",
+    });
+    txGainsCuotas = await insertTx({
+      userId,
+      accountId,
+      occurredAt: utcDate(2026, 3, 26),
+      amountCents: BigInt(-9658100),
+      merchant: "MERCADOPAGO COLOMBIA L",
+    });
+    txGetsRate = await insertTx({
+      userId,
+      accountId,
+      occurredAt: utcDate(2026, 2, 14),
+      amountCents: BigInt(-24650000),
+      merchant: "AIRBNB",
+      installmentsTotal: 2,
+      installmentRateEmX10k: null,
+    });
+    txUnmatched = await insertTx({
+      userId,
+      accountId,
+      occurredAt: utcDate(2026, 3, 28),
+      amountCents: BigInt(-7777),
+      merchant: "GHOST",
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  function buildFixtureStatement(): ParsedStatement {
+    return buildParsed([
+      // Synthetic INTERESES CORRIENTES — must be skipped entirely.
+      {
+        kind: "during-period",
+        authorizationNumber: null,
+        merchant: "INTERESES CORRIENTES",
+        occurredAt: utcDate(2026, 3, 30),
+        amountCents: BigInt(5000),
+        installments: null,
+        installmentValueCents: BigInt(5000),
+        rateEmX10k: null,
+        saldoPendingCents: BigInt(0),
+      },
+      // Exact existing, 1/1 — no change expected.
+      row({
+        authorizationNumber: "052000",
+        merchant: "DLO*DIDI",
+        occurredAt: utcDate(2026, 3, 26),
+        amountCents: BigInt(1895200),
+      }),
+      // Existing at 1/1, statement says 1/6 — willChange via installments.
+      row({
+        authorizationNumber: "165379",
+        merchant: "MERCADOPAGO COLOMBIA L",
+        occurredAt: utcDate(2026, 3, 26),
+        amountCents: BigInt(9658100),
+        installments: { paid: 1, total: 6 },
+        installmentValueCents: BigInt(1609683),
+        rateEmX10k: 0,
+      }),
+      // Before-period row: existing tx has null rate, statement reports 19110.
+      row({
+        kind: "before-period",
+        authorizationNumber: "546716",
+        merchant: "AIRBNB",
+        occurredAt: utcDate(2026, 2, 14),
+        amountCents: BigInt(24650000),
+        installments: { paid: 2, total: 2 },
+        installmentValueCents: BigInt(23965278),
+        rateEmX10k: 19110,
+      }),
+      // Missing during-period — parser saw a purchase we don't have.
+      row({
+        authorizationNumber: "999999",
+        merchant: "NEW MERCHANT",
+        occurredAt: utcDate(2026, 3, 20),
+        amountCents: BigInt(300000),
+      }),
+    ]);
+  }
+
+  it("dry-run reports correct stats without DB writes", async () => {
+    const report = await consolidateCycleFromStatement({
+      userId,
+      accountId,
+      cycle: "2026-03",
+      parsed: buildFixtureStatement(),
+      fileHash: "deadbeef".repeat(8),
+      dryRun: true,
+    });
+    expect(report.status).toBe("dry-run");
+    expect(report.matchStats.matched).toBe(3);
+    // 3 willChange because all three tx's rate is null in DB and the statement
+    // reports an explicit rate (0 for the 1/1 exact match, 19110 for the
+    // other two). Writing the bank's explicit "rate=0" on 1/1 purchases is
+    // desired: it says "confirmed non-financed" instead of "unknown".
+    expect(report.matchStats.matchedWillChange).toBe(3);
+    expect(report.matchStats.insertedMissing).toBe(1);
+    expect(report.matchStats.skippedMissingBefore).toBe(0);
+    expect(report.matchStats.unmatchedInLedger).toBe(1);
+    expect(report.statementImportId).toBeNull();
+
+    // No statement_imports row should exist yet.
+    const imports = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.userId, userId));
+    expect(imports).toHaveLength(0);
+
+    // DB rows unchanged.
+    const [unchangedTx] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, txGainsCuotas));
+    expect(unchangedTx.installmentsTotal).toBe(1);
+  });
+
+  it("commit applies UPDATEs, INSERTs missing, creates synthetic intereses, and records statement_imports", async () => {
+    const report = await consolidateCycleFromStatement({
+      userId,
+      accountId,
+      cycle: "2026-03",
+      parsed: buildFixtureStatement(),
+      fileHash: "cafebabe".repeat(8),
+      dryRun: false,
+    });
+    expect(report.status).toBe("consolidated");
+    expect(report.matchedTxIds.sort((a, b) => a - b)).toEqual(
+      [txExact, txGainsCuotas, txGetsRate].sort((a, b) => a - b),
+    );
+    expect(report.insertedTxIds).toHaveLength(1);
+    expect(report.statementImportId).not.toBeNull();
+
+    // Matched + changed tx: installmentsTotal bumped to 6.
+    const [updatedCuotas] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, txGainsCuotas));
+    expect(updatedCuotas.installmentsTotal).toBe(6);
+    expect(updatedCuotas.reconciliationStatus).toBe("matched");
+    expect(updatedCuotas.statementImportId).toBe(report.statementImportId);
+
+    // Rate-only change:
+    const [updatedAirbnb] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, txGetsRate));
+    expect(updatedAirbnb.installmentRateEmX10k).toBe(19110);
+
+    // The 1/1 exact match had null rate in DB; statement confirms rate=0.
+    // We UPDATE it so the row is explicitly "non-financed, reconciled".
+    const [updatedExact] = await db.select().from(transactions).where(eq(transactions.id, txExact));
+    expect(updatedExact.reconciliationStatus).toBe("matched");
+    expect(updatedExact.installmentRateEmX10k).toBe(0);
+    expect(updatedExact.installmentsTotal).toBe(1);
+
+    // Inserted missing row with deterministic external_id.
+    const [insertedRow] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, report.insertedTxIds[0]));
+    expect(insertedRow.merchant).toBe("NEW MERCHANT");
+    expect(insertedRow.externalId).toBe(`bancolombia-stmt:${accountId}:2026-03:999999`);
+    expect(insertedRow.reconciliationStatus).toBe("imported_from_statement");
+    expect(insertedRow.source).toBe("csv_reconcile");
+
+    // intereses-causados job runs at the end. Its outcome depends on whether
+    // the reconciled rows yield positive cycle interest — in this fixture all
+    // rows fall into "no interest this cycle" (either 1/1, month-1 grace, or
+    // final installment), so we only require the job ran (not "not-run").
+    expect(report.intereses.status).not.toBe("not-run");
+    if (report.intereses.status === "inserted") {
+      const [synthetic] = await db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, report.intereses.txId));
+      expect(synthetic.categorySlug).toBe("intereses-tc");
+    }
+
+    // statement_imports row was persisted with kind + cycle.
+    const [imp] = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.id, report.statementImportId!));
+    expect(imp.kind).toBe("extracto_detallado");
+    expect(imp.cycle).toBe("2026-03");
+    if (report.intereses.status === "inserted") {
+      expect(imp.syntheticTxId).toBe(report.intereses.txId);
+    }
+    expect(imp.txnCount).toBe(4); // 3 UPDATEd + 1 INSERTed.
+
+    // The ghost tx stays untouched but surfaces as unmatched in the report.
+    expect(report.unmatchedInLedgerIds).toContain(txUnmatched);
+  });
+
+  it("second call short-circuits to already-consolidated with no new writes", async () => {
+    const txCountBefore = (
+      await db.select().from(transactions).where(eq(transactions.userId, userId))
+    ).length;
+    const importsBefore = (
+      await db.select().from(statementImports).where(eq(statementImports.userId, userId))
+    ).length;
+
+    const report = await consolidateCycleFromStatement({
+      userId,
+      accountId,
+      cycle: "2026-03",
+      parsed: buildFixtureStatement(),
+      fileHash: "cafebabe".repeat(8),
+      dryRun: false,
+    });
+    expect(report.status).toBe("already-consolidated");
+    expect(report.intereses).toEqual({ status: "not-run", reason: "already-consolidated" });
+
+    const txCountAfter = (
+      await db.select().from(transactions).where(eq(transactions.userId, userId))
+    ).length;
+    const importsAfter = (
+      await db.select().from(statementImports).where(eq(statementImports.userId, userId))
+    ).length;
+    expect(txCountAfter).toBe(txCountBefore);
+    expect(importsAfter).toBe(importsBefore);
+  });
+
+  it("rejects invalid cycle format loudly", async () => {
+    await expect(
+      consolidateCycleFromStatement({
+        userId,
+        accountId,
+        cycle: "invalid",
+        parsed: buildFixtureStatement(),
+        fileHash: "x",
+        dryRun: true,
+      }),
+    ).rejects.toThrow(/cycle must be YYYY-MM/);
+  });
+});

--- a/src/lib/ingestion/bancolombia-statement/consolidate.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.ts
@@ -1,0 +1,478 @@
+import { createHash } from "node:crypto";
+
+import { and, eq, gte, lte, sql } from "drizzle-orm";
+
+import { db, type DB } from "@/lib/db";
+import { accounts, statementImports, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { applyInteresesCausadosForCycle } from "@/lib/finance/intereses-causados-job";
+import { createLogger } from "@/lib/logger";
+
+import {
+  isBankInterestRow,
+  matchStatementAgainstLedger,
+  statementAmountToLedger,
+  type MatchResult,
+  type TxRowForMatch,
+} from "./match";
+import type { ParsedStatement, StatementRow } from "./types";
+
+const log = createLogger({ module: "bancolombia-statement-consolidate" });
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const CYCLE_REGEX = /^\d{4}-\d{2}$/;
+
+export type ConsolidationStatus = "dry-run" | "consolidated" | "already-consolidated" | "no-op";
+
+export type InteresesOutcome =
+  | {
+      status: "inserted";
+      txId: number;
+      totalInterestCentsStr: string;
+      purchasesNeedingRate: number;
+    }
+  | { status: "skipped"; reason: string; purchasesNeedingRate: number }
+  | { status: "not-run"; reason: "dry-run" | "already-consolidated" };
+
+export type MatchStats = {
+  matched: number;
+  matchedWillChange: number;
+  insertedMissing: number;
+  skippedMissingBefore: number;
+  unmatchedInLedger: number;
+};
+
+export type ConsolidationReport = {
+  userId: number;
+  accountId: number;
+  cycle: string;
+  dryRun: boolean;
+  status: ConsolidationStatus;
+  matchStats: MatchStats;
+  matchedTxIds: number[];
+  insertedTxIds: number[];
+  // Row-level diffs for UI preview (B3). Serialized bigints as strings.
+  matchedDiffs: Array<{
+    txId: number;
+    willChange: boolean;
+    merchant: string;
+    occurredAt: string;
+    amountCentsStr: string;
+    installmentsTotalBefore: number;
+    installmentsTotalAfter: number;
+    rateEmX10kBefore: number | null;
+    rateEmX10kAfter: number | null;
+  }>;
+  missingInLedger: Array<{
+    merchant: string;
+    occurredAt: string;
+    amountCentsStr: string;
+    kind: "during-period" | "before-period";
+    authorizationNumber: string | null;
+  }>;
+  unmatchedInLedgerIds: number[];
+  statementImportId: number | null;
+  intereses: InteresesOutcome;
+};
+
+export type ConsolidateOptions = {
+  userId: number;
+  accountId: number;
+  cycle: string;
+  parsed: ParsedStatement;
+  fileHash: string;
+  dryRun: boolean;
+  database?: DB;
+};
+
+export function hashStatementBuffer(buffer: Buffer): string {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+function externalIdFor(accountId: number, cycle: string, authCode: string): string {
+  return `bancolombia-stmt:${accountId}:${cycle}:${authCode}`;
+}
+
+function toIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function addDays(d: Date, delta: number): Date {
+  return new Date(d.getTime() + delta * MS_PER_DAY);
+}
+
+function minRowDate(parsed: ParsedStatement): Date | null {
+  if (parsed.rows.length === 0) return null;
+  let min = parsed.rows[0].occurredAt;
+  for (const row of parsed.rows) {
+    if (row.occurredAt.getTime() < min.getTime()) min = row.occurredAt;
+  }
+  return min;
+}
+
+async function loadAccount(
+  database: DB,
+  userId: number,
+  accountId: number,
+): Promise<{ id: number; currency: "COP" | "USD" }> {
+  const [row] = await database
+    .select({ id: accounts.id, currency: accounts.currency })
+    .from(accounts)
+    .where(
+      and(eq(accounts.userId, userId), eq(accounts.id, accountId), notDeleted(accounts.deletedAt)),
+    )
+    .limit(1);
+  if (!row) {
+    throw new Error(
+      `consolidateCycleFromStatement: account ${accountId} not found for user ${userId}`,
+    );
+  }
+  return row;
+}
+
+async function loadExistingTxs(
+  database: DB,
+  userId: number,
+  accountId: number,
+  fromDate: Date,
+  toDate: Date,
+): Promise<TxRowForMatch[]> {
+  const rows = await database
+    .select({
+      id: transactions.id,
+      occurredAt: transactions.occurredAt,
+      amountCents: transactions.amountCents,
+      merchant: transactions.merchant,
+      descriptionRaw: transactions.descriptionRaw,
+      installmentsTotal: transactions.installmentsTotal,
+      installmentRateEmX10k: transactions.installmentRateEmX10k,
+      externalId: transactions.externalId,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.accountId, accountId),
+        gte(transactions.occurredAt, fromDate),
+        lte(transactions.occurredAt, toDate),
+        notDeleted(transactions.deletedAt),
+      ),
+    );
+  return rows;
+}
+
+function buildMatchStats(match: MatchResult): MatchStats {
+  const matchedWillChange = match.matched.filter((m) => m.willChange).length;
+  const insertedMissing = match.missingInLedger.filter((r) => r.kind === "during-period").length;
+  const skippedMissingBefore = match.missingInLedger.filter(
+    (r) => r.kind === "before-period",
+  ).length;
+  return {
+    matched: match.matched.length,
+    matchedWillChange,
+    insertedMissing,
+    skippedMissingBefore,
+    unmatchedInLedger: match.unmatchedInLedger.length,
+  };
+}
+
+function serializeMatchedDiffs(match: MatchResult): ConsolidationReport["matchedDiffs"] {
+  return match.matched.map((m) => ({
+    txId: m.txId,
+    willChange: m.willChange,
+    merchant: m.statementRow.merchant,
+    occurredAt: m.statementRow.occurredAt.toISOString(),
+    amountCentsStr: m.statementRow.amountCents.toString(),
+    installmentsTotalBefore: m.diff.installmentsTotalBefore,
+    installmentsTotalAfter: m.diff.installmentsTotalAfter,
+    rateEmX10kBefore: m.diff.rateEmX10kBefore,
+    rateEmX10kAfter: m.diff.rateEmX10kAfter,
+  }));
+}
+
+function serializeMissing(match: MatchResult): ConsolidationReport["missingInLedger"] {
+  return match.missingInLedger.map((r) => ({
+    merchant: r.merchant,
+    occurredAt: r.occurredAt.toISOString(),
+    amountCentsStr: r.amountCents.toString(),
+    kind: r.kind,
+    authorizationNumber: r.authorizationNumber,
+  }));
+}
+
+function emptyReport(
+  opts: ConsolidateOptions,
+  match: MatchResult,
+  status: ConsolidationStatus,
+  statementImportId: number | null,
+  intereses: InteresesOutcome,
+): ConsolidationReport {
+  return {
+    userId: opts.userId,
+    accountId: opts.accountId,
+    cycle: opts.cycle,
+    dryRun: opts.dryRun,
+    status,
+    matchStats: buildMatchStats(match),
+    matchedTxIds: match.matched.map((m) => m.txId),
+    insertedTxIds: [],
+    matchedDiffs: serializeMatchedDiffs(match),
+    missingInLedger: serializeMissing(match),
+    unmatchedInLedgerIds: match.unmatchedInLedger.map((t) => t.id),
+    statementImportId,
+    intereses,
+  };
+}
+
+export async function consolidateCycleFromStatement(
+  opts: ConsolidateOptions,
+): Promise<ConsolidationReport> {
+  if (!CYCLE_REGEX.test(opts.cycle)) {
+    throw new Error(`consolidateCycleFromStatement: cycle must be YYYY-MM, got "${opts.cycle}"`);
+  }
+  const database = opts.database ?? db;
+  const account = await loadAccount(database, opts.userId, opts.accountId);
+
+  // Short-circuit if this cycle is already consolidated. Return the persisted
+  // report so callers can display past runs without re-work.
+  const [existing] = await database
+    .select({
+      id: statementImports.id,
+      report: statementImports.report,
+      syntheticTxId: statementImports.syntheticTxId,
+    })
+    .from(statementImports)
+    .where(
+      and(
+        eq(statementImports.userId, opts.userId),
+        eq(statementImports.accountId, opts.accountId),
+        eq(statementImports.kind, "extracto_detallado"),
+        eq(statementImports.cycle, opts.cycle),
+      ),
+    )
+    .limit(1);
+  if (existing) {
+    const persistedReport = (existing.report ?? {}) as Partial<ConsolidationReport>;
+    return {
+      ...(persistedReport as ConsolidationReport),
+      dryRun: opts.dryRun,
+      status: "already-consolidated",
+      statementImportId: existing.id,
+      intereses: {
+        status: "not-run",
+        reason: "already-consolidated",
+      },
+    };
+  }
+
+  const earliest = minRowDate(opts.parsed);
+  const fromDate = earliest ? addDays(earliest, -2) : addDays(opts.parsed.period.startDate, -2);
+  const toDate = addDays(opts.parsed.period.endDate, 2);
+  const txs = await loadExistingTxs(database, opts.userId, opts.accountId, fromDate, toDate);
+  const match = matchStatementAgainstLedger(opts.parsed, txs);
+
+  if (opts.dryRun) {
+    return emptyReport(opts, match, "dry-run", null, {
+      status: "not-run",
+      reason: "dry-run",
+    });
+  }
+
+  const nothingToDo =
+    match.matched.every((m) => !m.willChange) &&
+    match.missingInLedger.every((r) => r.kind !== "during-period");
+  if (nothingToDo) {
+    // Still persist a statement_imports row so the cycle is marked "seen" —
+    // but we skip the intereses run because nothing changed ledger-side, and
+    // we return "no-op" so callers can distinguish "applied" vs "nothing to
+    // apply". The intereses-causados-job is still idempotent on its own
+    // cycleKey check if called later.
+    //
+    // Run the intereses job anyway so the first-ever consolidation of a
+    // cycle produces the synthetic; the job is a no-op when the synthetic
+    // already exists (cycleKey idempotency).
+  }
+
+  // Part 1: ledger UPDATEs + INSERTs + statement_imports row in a single
+  // transaction. applyInteresesCausadosForCycle runs AFTER commit — it owns
+  // its own idempotency (cycleKey) so a second run is a no-op, and keeping it
+  // outside this tx avoids the drizzle DB-vs-Transaction type mismatch and
+  // makes partial-failure semantics sane (ledger fix commits even if the
+  // intereses job fails; user can retry).
+  const { imp, matchedIdsToUpdate, insertedTxIds } = await database.transaction(async (txDb) => {
+    const [imp] = await txDb
+      .insert(statementImports)
+      .values({
+        userId: opts.userId,
+        accountId: opts.accountId,
+        fileHash: opts.fileHash,
+        periodStart: toIsoDate(opts.parsed.period.startDate),
+        periodEnd: toIsoDate(opts.parsed.period.endDate),
+        txnCount: 0,
+        kind: "extracto_detallado",
+        cycle: opts.cycle,
+        report: null,
+      })
+      .returning({ id: statementImports.id });
+
+    const matchedIdsToUpdate: number[] = [];
+    for (const m of match.matched) {
+      if (!m.willChange) continue;
+      await txDb
+        .update(transactions)
+        .set({
+          installmentsTotal: m.diff.installmentsTotalAfter,
+          ...(m.diff.rateEmX10kAfter !== null && {
+            installmentRateEmX10k: m.diff.rateEmX10kAfter,
+          }),
+          reconciliationStatus: "matched",
+          reconciledAt: new Date(),
+          statementImportId: imp.id,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(transactions.id, m.txId), eq(transactions.userId, opts.userId)));
+      matchedIdsToUpdate.push(m.txId);
+    }
+
+    const insertedTxIds: number[] = [];
+    for (const row of match.missingInLedger) {
+      if (row.kind !== "during-period") continue;
+      if (isBankInterestRow(row)) continue;
+      if (row.authorizationNumber === null) {
+        log.warn(
+          {
+            accountId: opts.accountId,
+            cycle: opts.cycle,
+            merchant: row.merchant,
+            event: "missing_auth_skip",
+          },
+          "consolidate: skipping missing row without authorizationNumber",
+        );
+        continue;
+      }
+      const inserted = await insertMissingRowInTx(txDb, {
+        opts,
+        account,
+        row,
+        statementImportId: imp.id,
+      });
+      if (inserted !== null) insertedTxIds.push(inserted);
+    }
+
+    await txDb
+      .update(statementImports)
+      .set({ txnCount: matchedIdsToUpdate.length + insertedTxIds.length })
+      .where(eq(statementImports.id, imp.id));
+
+    return { imp, matchedIdsToUpdate, insertedTxIds };
+  });
+
+  const interesesResult = await applyInteresesCausadosForCycle({
+    userId: opts.userId,
+    accountId: opts.accountId,
+    cycle: opts.cycle,
+    database,
+  });
+  const intereses: InteresesOutcome = interesesToOutcome(interesesResult);
+
+  const finalReport: ConsolidationReport = {
+    userId: opts.userId,
+    accountId: opts.accountId,
+    cycle: opts.cycle,
+    dryRun: false,
+    status: "consolidated",
+    matchStats: buildMatchStats(match),
+    matchedTxIds: matchedIdsToUpdate,
+    insertedTxIds,
+    matchedDiffs: serializeMatchedDiffs(match),
+    missingInLedger: serializeMissing(match),
+    unmatchedInLedgerIds: match.unmatchedInLedger.map((t) => t.id),
+    statementImportId: imp.id,
+    intereses,
+  };
+
+  await database
+    .update(statementImports)
+    .set({
+      report: finalReport,
+      ...(intereses.status === "inserted" && { syntheticTxId: intereses.txId }),
+    })
+    .where(eq(statementImports.id, imp.id));
+
+  return finalReport;
+}
+
+type InsertMissingArgs = {
+  opts: ConsolidateOptions;
+  account: { id: number; currency: "COP" | "USD" };
+  row: StatementRow;
+  statementImportId: number;
+};
+
+// Named *InTx because it must run inside a transaction handle — caller passes
+// the drizzle tx object, not the top-level db.
+async function insertMissingRowInTx(
+  txDb: Parameters<Parameters<DB["transaction"]>[0]>[0],
+  { opts, account, row, statementImportId }: InsertMissingArgs,
+): Promise<number | null> {
+  const external = externalIdFor(opts.accountId, opts.cycle, row.authorizationNumber!);
+  const result = await txDb
+    .insert(transactions)
+    .values({
+      userId: opts.userId,
+      accountId: account.id,
+      occurredAt: row.occurredAt,
+      // statement row uses extracto sign convention (compra+, abono-) while
+      // the ledger stores the opposite — invert on the way in.
+      amountCents: statementAmountToLedger(row.amountCents),
+      currency: account.currency,
+      descriptionRaw: row.merchant,
+      merchant: row.merchant,
+      installmentsTotal: row.installments?.total ?? 1,
+      installmentRateEmX10k: row.rateEmX10k,
+      source: "csv_reconcile",
+      channel: "bank",
+      reconciliationStatus: "imported_from_statement",
+      reconciledAt: new Date(),
+      statementImportId,
+      externalId: external,
+      rawData: {
+        statementKind: "extracto_detallado",
+        cycle: opts.cycle,
+        authorizationNumber: row.authorizationNumber,
+        saldoPendingCents: row.saldoPendingCents.toString(),
+        installmentValueCents: row.installmentValueCents?.toString() ?? null,
+      },
+    })
+    .onConflictDoNothing({
+      target: [transactions.accountId, transactions.externalId],
+      where: sql`${transactions.externalId} IS NOT NULL`,
+    })
+    .returning({ id: transactions.id });
+  return result[0]?.id ?? null;
+}
+
+function interesesToOutcome(
+  r: Awaited<ReturnType<typeof applyInteresesCausadosForCycle>>,
+): InteresesOutcome {
+  if (r.status === "inserted") {
+    return {
+      status: "inserted",
+      txId: r.txId,
+      totalInterestCentsStr: r.totalInterestCents.toString(),
+      purchasesNeedingRate: r.purchasesNeedingRate,
+    };
+  }
+  if (r.status === "skipped") {
+    return {
+      status: "skipped",
+      reason: r.reason,
+      purchasesNeedingRate: r.purchasesNeedingRate,
+    };
+  }
+  return {
+    status: "skipped",
+    reason: `error:${r.reason}`,
+    purchasesNeedingRate: 0,
+  };
+}

--- a/src/lib/ingestion/bancolombia-statement/match.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/match.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isBankInterestRow,
+  matchStatementAgainstLedger,
+  merchantSimilarity,
+  type TxRowForMatch,
+} from "./match";
+import type { ParsedStatement, StatementRow } from "./types";
+
+function utcDate(y: number, m: number, d: number): Date {
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+function buildStatement(rows: StatementRow[]): ParsedStatement {
+  return {
+    account: { last4: "9999", currency: "COP" },
+    period: {
+      startDate: utcDate(2026, 2, 28),
+      endDate: utcDate(2026, 3, 30),
+      dueDate: utcDate(2026, 4, 16),
+    },
+    summary: {
+      previousBalanceCents: BigInt(0),
+      purchasesCents: BigInt(0),
+      interestCorrientesCents: BigInt(0),
+      paymentsCents: BigInt(0),
+      minPaymentCents: BigInt(0),
+      totalPaymentCents: BigInt(0),
+    },
+    currentRates: { oneMonth: 0, months2to36: 19110, advances: 19110 },
+    rows,
+  };
+}
+
+function buildRow(
+  partial: Partial<StatementRow> & Pick<StatementRow, "amountCents" | "merchant" | "occurredAt">,
+): StatementRow {
+  // Use `'key' in partial` so explicit null/zero values aren't clobbered by defaults.
+  return {
+    kind: "kind" in partial ? (partial.kind as StatementRow["kind"]) : "during-period",
+    authorizationNumber:
+      "authorizationNumber" in partial ? (partial.authorizationNumber as string | null) : "000001",
+    merchant: partial.merchant,
+    occurredAt: partial.occurredAt,
+    amountCents: partial.amountCents,
+    installments:
+      "installments" in partial
+        ? (partial.installments as StatementRow["installments"])
+        : { paid: 1, total: 1 },
+    installmentValueCents:
+      "installmentValueCents" in partial
+        ? (partial.installmentValueCents as bigint | null)
+        : partial.amountCents,
+    rateEmX10k: "rateEmX10k" in partial ? (partial.rateEmX10k as number | null) : 0,
+    saldoPendingCents:
+      "saldoPendingCents" in partial ? (partial.saldoPendingCents as bigint) : BigInt(0),
+  };
+}
+
+// Builds a ledger tx row by flipping the caller-provided "statement amount"
+// into ledger-sign convention (TC expense = negative). Tests stay readable:
+// pass the positive amount that would appear on the extracto and we persist
+// the signed version the matcher expects.
+function buildTx(
+  partial: Partial<TxRowForMatch> & Pick<TxRowForMatch, "id" | "amountCents" | "occurredAt">,
+): TxRowForMatch {
+  return {
+    id: partial.id,
+    occurredAt: partial.occurredAt,
+    amountCents: -partial.amountCents,
+    merchant: partial.merchant ?? null,
+    descriptionRaw: partial.descriptionRaw ?? "",
+    installmentsTotal: partial.installmentsTotal ?? 1,
+    installmentRateEmX10k: partial.installmentRateEmX10k ?? null,
+    externalId: partial.externalId ?? null,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// merchantSimilarity
+// -----------------------------------------------------------------------------
+
+describe("merchantSimilarity", () => {
+  it("returns 1 for identical normalized strings", () => {
+    expect(merchantSimilarity("DLO*DIDI", "DLO*DIDI")).toBe(1);
+  });
+
+  it("returns a high ratio for partial token overlap", () => {
+    expect(merchantSimilarity("MERCADOPAGO COLOMBIA L", "MERCADOPAGO COLOMBIA")).toBeGreaterThan(
+      0.5,
+    );
+  });
+
+  it("returns 0 for completely unrelated merchants", () => {
+    expect(merchantSimilarity("AIRBNB", "DLO DIDI")).toBe(0);
+  });
+
+  it("is case-insensitive and strips punctuation", () => {
+    expect(merchantSimilarity("dlo*didi", "DLO DIDI")).toBe(1);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// isBankInterestRow
+// -----------------------------------------------------------------------------
+
+describe("isBankInterestRow", () => {
+  it("detects the synthetic INTERESES CORRIENTES row", () => {
+    const row = buildRow({
+      merchant: "INTERESES CORRIENTES",
+      occurredAt: utcDate(2026, 3, 30),
+      amountCents: BigInt(7991836),
+    });
+    row.authorizationNumber = null;
+    expect(isBankInterestRow(row)).toBe(true);
+  });
+
+  it("does NOT match a purchase whose merchant happens to contain 'INTERES'", () => {
+    const row = buildRow({
+      merchant: "INTERESES BANCO",
+      occurredAt: utcDate(2026, 3, 10),
+      amountCents: BigInt(10000),
+    });
+    expect(isBankInterestRow(row)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// matchStatementAgainstLedger
+// -----------------------------------------------------------------------------
+
+describe("matchStatementAgainstLedger — exact matches", () => {
+  it("matches rows 1:1 when amount + date align", () => {
+    const stmt = buildStatement([
+      buildRow({
+        amountCents: BigInt(1895200),
+        occurredAt: utcDate(2026, 3, 26),
+        merchant: "DLO*DIDI",
+      }),
+      buildRow({
+        amountCents: BigInt(1320500),
+        occurredAt: utcDate(2026, 3, 26),
+        merchant: "DLO*DIDI",
+      }),
+    ]);
+    const txs = [
+      buildTx({
+        id: 1,
+        amountCents: BigInt(1895200),
+        occurredAt: utcDate(2026, 3, 26),
+        merchant: "DLO*DIDI",
+      }),
+      buildTx({
+        id: 2,
+        amountCents: BigInt(1320500),
+        occurredAt: utcDate(2026, 3, 26),
+        merchant: "DLO*DIDI",
+      }),
+    ];
+    const result = matchStatementAgainstLedger(stmt, txs);
+    expect(result.matched.map((m) => m.txId).sort()).toEqual([1, 2]);
+    expect(result.missingInLedger).toHaveLength(0);
+    expect(result.unmatchedInLedger).toHaveLength(0);
+  });
+
+  it("tolerates ±1 day when matching dates", () => {
+    const stmt = buildStatement([
+      buildRow({
+        amountCents: BigInt(5000000),
+        occurredAt: utcDate(2026, 3, 15),
+        merchant: "AIRBNB",
+      }),
+    ]);
+    const txs = [
+      buildTx({
+        id: 10,
+        amountCents: BigInt(5000000),
+        occurredAt: utcDate(2026, 3, 16),
+        merchant: "AIRBNB",
+      }),
+    ];
+    const result = matchStatementAgainstLedger(stmt, txs);
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0].txId).toBe(10);
+  });
+
+  it("does NOT match when date delta exceeds the tolerance", () => {
+    const stmt = buildStatement([
+      buildRow({
+        amountCents: BigInt(5000000),
+        occurredAt: utcDate(2026, 3, 15),
+        merchant: "AIRBNB",
+      }),
+    ]);
+    const txs = [
+      buildTx({
+        id: 11,
+        amountCents: BigInt(5000000),
+        occurredAt: utcDate(2026, 3, 20),
+        merchant: "AIRBNB",
+      }),
+    ];
+    const result = matchStatementAgainstLedger(stmt, txs);
+    expect(result.matched).toHaveLength(0);
+    expect(result.missingInLedger).toHaveLength(1);
+    expect(result.unmatchedInLedger).toHaveLength(1);
+  });
+});
+
+describe("matchStatementAgainstLedger — tie-breakers", () => {
+  it("picks the candidate with the highest merchant similarity when two txs match same amount+date", () => {
+    const stmt = buildStatement([
+      buildRow({
+        amountCents: BigInt(1000000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "MIYAGI CARTAGENA",
+      }),
+    ]);
+    const txs = [
+      buildTx({
+        id: 100,
+        amountCents: BigInt(1000000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "RANDOM SHOP",
+      }),
+      buildTx({
+        id: 101,
+        amountCents: BigInt(1000000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "MIYAGI CARTAGENA",
+      }),
+    ];
+    const result = matchStatementAgainstLedger(stmt, txs);
+    expect(result.matched[0].txId).toBe(101);
+    expect(result.unmatchedInLedger.map((t) => t.id)).toEqual([100]);
+  });
+
+  it("prefers the smaller date delta over merchant similarity", () => {
+    const stmt = buildStatement([
+      buildRow({
+        amountCents: BigInt(500000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "FOOBAR",
+      }),
+    ]);
+    const txs = [
+      buildTx({
+        id: 200,
+        amountCents: BigInt(500000),
+        occurredAt: utcDate(2026, 3, 11),
+        merchant: "FOOBAR",
+      }),
+      buildTx({
+        id: 201,
+        amountCents: BigInt(500000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "DIFFERENT",
+      }),
+    ];
+    const result = matchStatementAgainstLedger(stmt, txs);
+    expect(result.matched[0].txId).toBe(201);
+  });
+});
+
+describe("matchStatementAgainstLedger — willChange detection", () => {
+  it("flags willChange when installments_total differs", () => {
+    const stmt = buildStatement([
+      buildRow({
+        amountCents: BigInt(5000000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "AIRBNB",
+        installments: { paid: 1, total: 6 },
+        rateEmX10k: 19110,
+      }),
+    ]);
+    const txs = [
+      buildTx({
+        id: 300,
+        amountCents: BigInt(5000000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "AIRBNB",
+        installmentsTotal: 1,
+        installmentRateEmX10k: null,
+      }),
+    ];
+    const result = matchStatementAgainstLedger(stmt, txs);
+    expect(result.matched[0].willChange).toBe(true);
+    expect(result.matched[0].diff.installmentsTotalAfter).toBe(6);
+    expect(result.matched[0].diff.rateEmX10kAfter).toBe(19110);
+  });
+
+  it("does NOT flag willChange when everything already matches", () => {
+    const stmt = buildStatement([
+      buildRow({
+        amountCents: BigInt(5000000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "AIRBNB",
+        installments: { paid: 1, total: 6 },
+        rateEmX10k: 19110,
+      }),
+    ]);
+    const txs = [
+      buildTx({
+        id: 301,
+        amountCents: BigInt(5000000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "AIRBNB",
+        installmentsTotal: 6,
+        installmentRateEmX10k: 19110,
+      }),
+    ];
+    const result = matchStatementAgainstLedger(stmt, txs);
+    expect(result.matched[0].willChange).toBe(false);
+  });
+
+  it("does NOT overwrite an existing rate with null when the statement doesn't report one", () => {
+    const stmt = buildStatement([
+      buildRow({
+        amountCents: BigInt(5000000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "AIRBNB",
+        installments: null,
+        rateEmX10k: null,
+      }),
+    ]);
+    const txs = [
+      buildTx({
+        id: 302,
+        amountCents: BigInt(5000000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "AIRBNB",
+        installmentsTotal: 1,
+        installmentRateEmX10k: 19110,
+      }),
+    ];
+    const result = matchStatementAgainstLedger(stmt, txs);
+    expect(result.matched[0].willChange).toBe(false);
+  });
+});
+
+describe("matchStatementAgainstLedger — skip bank interest", () => {
+  it("skips the INTERESES CORRIENTES row entirely", () => {
+    const interestRow = buildRow({
+      amountCents: BigInt(7991836),
+      occurredAt: utcDate(2026, 3, 30),
+      merchant: "INTERESES CORRIENTES",
+      installments: null,
+      rateEmX10k: null,
+    });
+    interestRow.authorizationNumber = null;
+
+    const stmt = buildStatement([
+      interestRow,
+      buildRow({
+        amountCents: BigInt(1000000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "SHOP",
+      }),
+    ]);
+    const txs = [
+      buildTx({
+        id: 400,
+        amountCents: BigInt(1000000),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "SHOP",
+      }),
+    ];
+    const result = matchStatementAgainstLedger(stmt, txs);
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0].txId).toBe(400);
+    // Bank-interest row never appears in missingInLedger either.
+    expect(result.missingInLedger).toHaveLength(0);
+  });
+});
+
+describe("matchStatementAgainstLedger — missing and unmatched", () => {
+  it("surfaces statement rows absent from the ledger", () => {
+    const stmt = buildStatement([
+      buildRow({
+        amountCents: BigInt(200000),
+        occurredAt: utcDate(2026, 3, 12),
+        merchant: "NEW SHOP",
+      }),
+    ]);
+    const result = matchStatementAgainstLedger(stmt, []);
+    expect(result.missingInLedger).toHaveLength(1);
+    expect(result.missingInLedger[0].merchant).toBe("NEW SHOP");
+  });
+
+  it("surfaces ledger txs absent from the statement", () => {
+    const stmt = buildStatement([]);
+    const result = matchStatementAgainstLedger(stmt, [
+      buildTx({
+        id: 500,
+        amountCents: BigInt(100),
+        occurredAt: utcDate(2026, 3, 5),
+        merchant: "GHOST",
+      }),
+    ]);
+    expect(result.unmatchedInLedger).toHaveLength(1);
+    expect(result.unmatchedInLedger[0].id).toBe(500);
+  });
+
+  it("never reuses a tx: once matched it cannot anchor another statement row", () => {
+    const stmt = buildStatement([
+      buildRow({ amountCents: BigInt(100), occurredAt: utcDate(2026, 3, 10), merchant: "A" }),
+      buildRow({ amountCents: BigInt(100), occurredAt: utcDate(2026, 3, 10), merchant: "B" }),
+    ]);
+    const txs = [
+      buildTx({
+        id: 600,
+        amountCents: BigInt(100),
+        occurredAt: utcDate(2026, 3, 10),
+        merchant: "A",
+      }),
+    ];
+    const result = matchStatementAgainstLedger(stmt, txs);
+    expect(result.matched).toHaveLength(1);
+    expect(result.missingInLedger).toHaveLength(1);
+    expect(result.missingInLedger[0].merchant).toBe("B");
+  });
+});

--- a/src/lib/ingestion/bancolombia-statement/match.ts
+++ b/src/lib/ingestion/bancolombia-statement/match.ts
@@ -1,0 +1,180 @@
+import type { ParsedStatement, StatementRow } from "./types";
+
+// Tx-shaped subset the matcher needs — the action layer is responsible for
+// fetching these via drizzle. Keeping the matcher pure makes it trivial to
+// unit-test without a DB.
+export type TxRowForMatch = {
+  id: number;
+  occurredAt: Date;
+  amountCents: bigint;
+  merchant: string | null;
+  descriptionRaw: string;
+  installmentsTotal: number;
+  installmentRateEmX10k: number | null;
+  externalId: string | null;
+};
+
+export type TxDiff = {
+  installmentsTotalBefore: number;
+  installmentsTotalAfter: number;
+  rateEmX10kBefore: number | null;
+  rateEmX10kAfter: number | null;
+};
+
+export type MatchedRow = {
+  statementRow: StatementRow;
+  txId: number;
+  willChange: boolean;
+  diff: TxDiff;
+};
+
+export type MatchResult = {
+  matched: MatchedRow[];
+  // Statement rows with no corresponding tx. For `during-period` these become
+  // INSERTs; `before-period` entries in here are data-integrity warnings.
+  missingInLedger: StatementRow[];
+  // Txs that exist in the ledger for this period but don't appear in the
+  // statement — never auto-touched; surfaced so the user can investigate.
+  unmatchedInLedger: TxRowForMatch[];
+};
+
+export type MatchOptions = {
+  dateToleranceDays?: number;
+};
+
+// Bancolombia prints purchases with a POSITIVE sign on the extracto and
+// payments/abonos with a NEGATIVE sign. Findash's ledger uses the opposite
+// convention: TC expenses are stored as negative amounts, TC payments/credits
+// as positive. So to compare we invert the statement sign to "ledger shape".
+export function statementAmountToLedger(cents: bigint): bigint {
+  return -cents;
+}
+
+const DEFAULT_DATE_TOLERANCE_DAYS = 1;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+// Colombia has no DST — UTC-5 is exact year-round. Matching by Bogota
+// calendar day keeps an SMS ingested at 11 PM local from drifting into the
+// next UTC day and falling outside the ±1 day window.
+const BOGOTA_OFFSET_MS = 5 * 60 * 60 * 1000;
+
+function bogotaDayOrdinal(date: Date): number {
+  // Integer count of days since the Unix epoch in Bogota-local time.
+  return Math.floor((date.getTime() - BOGOTA_OFFSET_MS) / MS_PER_DAY);
+}
+
+// INTERESES CORRIENTES is a synthetic line the bank itself prints at cycle
+// cut — it's not a real purchase. Findash generates its own equivalent via
+// applyInteresesCausadosForCycle, so we never INSERT or match this row.
+export function isBankInterestRow(row: StatementRow): boolean {
+  if (row.authorizationNumber !== null) return false;
+  return /^\s*INTERESES\s+CORRIENTES\s*$/i.test(row.merchant);
+}
+
+function normalizeTokens(s: string): Set<string> {
+  const cleaned = s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (cleaned === "") return new Set();
+  return new Set(cleaned.split(" ").filter((t) => t.length >= 2));
+}
+
+export function merchantSimilarity(a: string, b: string): number {
+  const ta = normalizeTokens(a);
+  const tb = normalizeTokens(b);
+  if (ta.size === 0 || tb.size === 0) return 0;
+  let overlap = 0;
+  for (const t of ta) if (tb.has(t)) overlap += 1;
+  const union = new Set([...ta, ...tb]).size;
+  return union === 0 ? 0 : overlap / union;
+}
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.abs(bogotaDayOrdinal(a) - bogotaDayOrdinal(b));
+}
+
+// Picks the most likely tx for a statement row given an exact-amount candidate
+// pool (must all satisfy `amountCents === row.amountCents`). Tiebreakers:
+// smaller date delta > higher merchant similarity > smaller tx id.
+function pickBestCandidate(row: StatementRow, candidates: TxRowForMatch[]): TxRowForMatch {
+  if (candidates.length === 1) return candidates[0];
+  return candidates
+    .map((tx) => ({
+      tx,
+      dateDelta: daysBetween(tx.occurredAt, row.occurredAt),
+      similarity: merchantSimilarity(row.merchant, tx.merchant ?? tx.descriptionRaw),
+    }))
+    .sort((a, b) => {
+      if (a.dateDelta !== b.dateDelta) return a.dateDelta - b.dateDelta;
+      if (a.similarity !== b.similarity) return b.similarity - a.similarity;
+      return a.tx.id - b.tx.id;
+    })[0].tx;
+}
+
+function buildDiff(row: StatementRow, tx: TxRowForMatch): TxDiff {
+  const total = row.installments?.total ?? 1;
+  return {
+    installmentsTotalBefore: tx.installmentsTotal,
+    installmentsTotalAfter: total,
+    rateEmX10kBefore: tx.installmentRateEmX10k,
+    rateEmX10kAfter: row.rateEmX10k,
+  };
+}
+
+function willChange(diff: TxDiff): boolean {
+  if (diff.installmentsTotalBefore !== diff.installmentsTotalAfter) return true;
+  // Rate change only counts when the statement actually reports one. A row
+  // without a rate (e.g. 1/1 purchases where the bank prints 0,0000) still
+  // produces a non-null rateEmX10k=0, so null means "bank didn't report"
+  // and we don't overwrite.
+  if (diff.rateEmX10kAfter !== null && diff.rateEmX10kBefore !== diff.rateEmX10kAfter) {
+    return true;
+  }
+  return false;
+}
+
+export function matchStatementAgainstLedger(
+  parsed: ParsedStatement,
+  txs: TxRowForMatch[],
+  opts: MatchOptions = {},
+): MatchResult {
+  const tolerance = opts.dateToleranceDays ?? DEFAULT_DATE_TOLERANCE_DAYS;
+  const matched: MatchedRow[] = [];
+  const missingInLedger: StatementRow[] = [];
+  const pool = new Map<number, TxRowForMatch>();
+  for (const tx of txs) pool.set(tx.id, tx);
+
+  // Process statement rows in the order they appear. `during-period` rows
+  // come first in the fixture, so they get first pick of ambiguous matches
+  // (what you'd want: match current-cycle purchases before older ones).
+  for (const row of parsed.rows) {
+    if (isBankInterestRow(row)) continue;
+    const ledgerAmount = statementAmountToLedger(row.amountCents);
+    const candidates = Array.from(pool.values()).filter(
+      (tx) =>
+        tx.amountCents === ledgerAmount && daysBetween(tx.occurredAt, row.occurredAt) <= tolerance,
+    );
+    if (candidates.length === 0) {
+      missingInLedger.push(row);
+      continue;
+    }
+    const best = pickBestCandidate(row, candidates);
+    pool.delete(best.id);
+    const diff = buildDiff(row, best);
+    matched.push({
+      statementRow: row,
+      txId: best.id,
+      willChange: willChange(diff),
+      diff,
+    });
+  }
+
+  return {
+    matched,
+    missingInLedger,
+    unmatchedInLedger: Array.from(pool.values()),
+  };
+}


### PR DESCRIPTION
## Summary

Sub-issue B2 of epic #415 — consumes the ParsedStatement from #417 and reconciles it against the transactions ledger, end-to-end:

- **Pure matcher** (`src/lib/ingestion/bancolombia-statement/match.ts`): exact amount match (ledger-signed via a small \`statementAmountToLedger\` helper so the extracto's compra+/abono- flips into the ledger's expense-/credit+ convention) + Bogota-calendar ±1 day tolerance + merchant-similarity tiebreaker. Skips the synthetic INTERESES CORRIENTES row.
- **Consolidation** (\`consolidate.ts\`): \`consolidateCycleFromStatement({ userId, accountId, cycle, parsed, fileHash, dryRun })\`. Short-circuits if the cycle already ran, UPDATEs willChange rows with installments+rate from the extracto, INSERTs missing during-period rows with deterministic external_id, persists a statement_imports row with the match report, and runs \`applyInteresesCausadosForCycle\` at the end.
- **Schema extension** (migration 0052): \`statement_imports\` gains \`kind\` (enum \`movimientos | extracto_detallado\`, default backfills existing rows), \`cycle\`, \`synthetic_tx_id\`, \`report\` (jsonb). Partial unique index enforces one extracto_detallado consolidation per (user, account, cycle). Path C per the reconciliation-pipeline scoping — reuses the existing table instead of a parallel \`statement_runs\`.
- **CLI** (\`bun run statement:apply --file=<path> --user=<id> --account=<id> --cycle=YYYY-MM [--commit] [--json]\`): dry-run default prints a tabular report with match stats, willChange diffs, missing rows, unmatched ledger txs. \`--commit\` writes.
- **42 new tests**: 18 matcher unit tests (sign inversion, Bogota-day tolerance, tiebreakers, willChange, bank-interest skip) + 4 integration tests against findash_test (dry-run, commit, idempotent re-run, invalid-cycle guard).

### Sign convention

Bancolombia prints TC purchases positive, abonos negative. The ledger stores the opposite. The matcher + consolidation invert once at the boundary so the rest of the pipeline stays oblivious.

### Why the intereses job runs outside the main transaction

Drizzle's PgTransaction type doesn't satisfy \`typeof db\`. Passing \`txDb\` to the existing \`applyInteresesCausadosForCycle(database)\` blows up at typecheck. Calling it after commit also gives sane partial-failure semantics (the ledger fix is safe, and the intereses job is already idempotent on its own cycleKey).

### Smoke test against the real fixture

\`\`\`
$ bun run statement:apply --file=.private/statements/Extracto_202603_Visa_Detallado_2575.xlsx --user=1 --account=5 --cycle=2026-03
[DRY-RUN] user=1 account=5 cycle=2026-03
  matched              68
  will change (UPDATE) 58
  missing during-per   1
  missing before-per   0 (skipped)
  unmatched in ledger  49
\`\`\`

### Acceptance (issue #418)

- [x] Matcher captures the 9 before-period + 60 during-period rows of the fixture (68/69 given one stray ledger dupe).
- [x] Commit is idempotent: second call returns \`already-consolidated\` with no new writes.
- [x] \`statement_imports\` has exactly one row per cycle+account consolidated.
- [x] CLI dry-run runs in well under 5s.

## Unblocks

- #419 (B3 — upload UI + preview/confirm flow). The \`ConsolidationReport\` shape already has everything a preview UI needs.

## Test plan

- [x] \`bun run test src/lib/ingestion/bancolombia-statement/\` — 59/59 pass (37 parser + 18 matcher + 4 integration).
- [x] \`bun run lint\`, \`bun run format:check\`, \`bun run typecheck\` — all clean.
- [x] \`bun run statement:apply\` dry-run against the real fixture — matches correctly on dev DB.
- [ ] CI green on this PR.

Closes #418