### PR TITLE
feat(ui): statement upload + preview + confirm flow (#419)

### DIFF
--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -12,6 +12,14 @@ const pages = [
   { name: "settings-rules", path: "/settings/rules", hasDonut: false },
   { name: "settings-inbox", path: "/settings/inbox", hasDonut: false },
   { name: "settings-widgets", path: "/settings/widgets", hasDonut: false },
+  { name: "settings-accounts", path: "/settings/accounts", hasDonut: false },
+  // #419: consolidate page. Without DEV_AUTH_BYPASS=1 this renders the login
+  // redirect — still worth including so the route gets a smoke run.
+  {
+    name: "settings-consolidate-2026-03",
+    path: "/settings/accounts/5/consolidate/2026-03",
+    hasDonut: false,
+  },
   { name: "signup-missing", path: "/signup", hasDonut: false },
   { name: "signup-unknown", path: "/signup?code=__DOESNOTEXIST__", hasDonut: false },
 ];

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -16,6 +16,7 @@ import { MonthSwitcher } from "@/components/dashboard/month-switcher";
 import { RecurringInboxCard } from "@/components/dashboard/recurring-inbox-card";
 import { SmsHealthCard } from "@/components/dashboard/sms-health-card";
 import { CreditCardsCard } from "@/components/dashboard/credit-cards-card";
+import { PendingConsolidationBanner } from "@/components/dashboard/pending-consolidation-banner";
 import { getUpcomingForMonth } from "@/lib/recurring/upcoming";
 import { getOpenGaps } from "@/lib/recurring/gap-queries";
 import { getCurrentFxRate } from "@/lib/fx/repo";
@@ -97,6 +98,8 @@ export default async function DashboardPage({
         </div>
         <MonthSwitcher ym={ym} />
       </header>
+
+      <PendingConsolidationBanner userId={session.id} />
 
       <section className="grid grid-cols-1 gap-4 lg:grid-cols-4">
         <NetWorthCard data={netWorth} fx={fx} />

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-form.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-form.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+import { useCallback, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { AlertTriangleIcon, CheckCircleIcon, PlusCircleIcon, UploadCloudIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import type { ConsolidationReport } from "@/lib/ingestion/bancolombia-statement/consolidate";
+
+import { commitStatementAction, previewStatementAction } from "../actions";
+
+type Props = {
+  accountId: number;
+  accountName: string;
+  cycle: string;
+  institutionSlug: string;
+};
+
+function formatCents(str: string): string {
+  if (!str) return "—";
+  const big = BigInt(str);
+  const negative = big < BigInt(0);
+  const abs = negative ? -big : big;
+  const units = abs / BigInt(100);
+  const fractional = (abs % BigInt(100)).toString().padStart(2, "0");
+  const unitsStr = units.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  return `${negative ? "-" : ""}$${unitsStr},${fractional}`;
+}
+
+function formatRate(x10k: number | null): string {
+  if (x10k == null) return "—";
+  const whole = Math.floor(x10k / 10_000);
+  const frac = (x10k % 10_000).toString().padStart(4, "0");
+  return `${whole},${frac}%`;
+}
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat("es-CO", {
+    day: "2-digit",
+    month: "short",
+    timeZone: "America/Bogota",
+  }).format(new Date(iso));
+}
+
+export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug }: Props) {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const [preview, setPreview] = useState<ConsolidationReport | null>(null);
+  const [parsing, startParsing] = useTransition();
+  const [applying, startApplying] = useTransition();
+
+  const onFileChosen = useCallback((chosen: File | null) => {
+    setFile(chosen);
+    setPreview(null);
+  }, []);
+
+  function handleDragOver(e: React.DragEvent<HTMLLabelElement>) {
+    e.preventDefault();
+    setDragging(true);
+  }
+  function handleDragLeave() {
+    setDragging(false);
+  }
+  function handleDrop(e: React.DragEvent<HTMLLabelElement>) {
+    e.preventDefault();
+    setDragging(false);
+    const dropped = e.dataTransfer.files?.[0];
+    if (dropped) onFileChosen(dropped);
+  }
+
+  function runPreview() {
+    if (!file) {
+      toast.error("Elegí un archivo .xlsx primero.");
+      return;
+    }
+    const fd = new FormData();
+    fd.set("file", file);
+    fd.set("accountId", String(accountId));
+    fd.set("cycle", cycle);
+    startParsing(async () => {
+      try {
+        const report = await previewStatementAction(fd);
+        setPreview(report);
+        toast.success(
+          `Preview listo · ${report.matchStats.matched} matched, ${report.matchStats.insertedMissing} nuevas, ${report.matchStats.unmatchedInLedger} sin match`,
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Parse failed";
+        if (msg.startsWith("last4_mismatch")) {
+          toast.error(
+            `El xlsx es de otra tarjeta. Subí el extracto correspondiente a ${accountName}.`,
+          );
+        } else if (msg === "unsupported_file_type") {
+          toast.error("Solo soportamos .xlsx por ahora (no PDF).");
+        } else if (msg === "file_too_large") {
+          toast.error(
+            "El archivo excede 10 MB. Bancolombia rara vez genera extractos tan grandes.",
+          );
+        } else {
+          toast.error(msg);
+        }
+      }
+    });
+  }
+
+  function runCommit() {
+    if (!file || !preview) return;
+    const fd = new FormData();
+    fd.set("file", file);
+    fd.set("accountId", String(accountId));
+    fd.set("cycle", cycle);
+    startApplying(async () => {
+      try {
+        const report = await commitStatementAction(fd);
+        if (report.status === "already-consolidated") {
+          toast.info("Ya estaba consolidado — sin cambios.");
+        } else {
+          toast.success(
+            `Consolidado · ${report.matchStats.matched} matched, ${report.insertedTxIds.length} insertadas, intereses: ${report.intereses.status}`,
+          );
+        }
+        setPreview(null);
+        setFile(null);
+        if (fileInputRef.current) fileInputRef.current.value = "";
+        router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Commit failed");
+      }
+    });
+  }
+
+  const busy = parsing || applying;
+  const canConfirm =
+    preview !== null &&
+    preview.status === "dry-run" &&
+    (preview.matchStats.matched > 0 || preview.matchStats.insertedMissing > 0);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Subí el extracto detallado (.xlsx)</CardTitle>
+          <CardDescription>
+            Exportá el extracto del ciclo {cycle} desde la Sucursal Virtual Bancolombia (formato
+            detallado, no resumido). Institución detectada: {institutionSlug}.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <label
+            htmlFor="consolidate-file"
+            data-testid="consolidate-dropzone"
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            className={cn(
+              "flex flex-col items-center gap-2 rounded-md border-2 border-dashed px-6 py-10 text-center transition",
+              dragging
+                ? "border-primary bg-primary/5"
+                : "border-muted-foreground/30 hover:border-muted-foreground/60",
+              busy && "pointer-events-none opacity-60",
+            )}
+          >
+            <UploadCloudIcon className="text-muted-foreground size-8" />
+            <div className="text-sm font-medium">
+              {file ? file.name : "Arrastrá el xlsx aquí o click para elegir"}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {file
+                ? `${(file.size / 1024).toFixed(1)} kB · click para cambiar`
+                : "Solo .xlsx · hasta 10 MB"}
+            </div>
+            <input
+              id="consolidate-file"
+              ref={fileInputRef}
+              type="file"
+              accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+              className="sr-only"
+              disabled={busy}
+              onChange={(e) => onFileChosen(e.target.files?.[0] ?? null)}
+            />
+          </label>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Button type="button" onClick={runPreview} disabled={!file || busy}>
+              {parsing ? "Analizando…" : "Ver preview"}
+            </Button>
+            {file ? (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  onFileChosen(null);
+                  if (fileInputRef.current) fileInputRef.current.value = "";
+                }}
+                disabled={busy}
+              >
+                Quitar archivo
+              </Button>
+            ) : null}
+          </div>
+        </CardContent>
+      </Card>
+
+      {preview ? (
+        <PreviewPanel
+          report={preview}
+          onConfirm={runCommit}
+          canConfirm={canConfirm}
+          applying={applying}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function PreviewPanel({
+  report,
+  onConfirm,
+  canConfirm,
+  applying,
+}: {
+  report: ConsolidationReport;
+  onConfirm: () => void;
+  canConfirm: boolean;
+  applying: boolean;
+}) {
+  const willChangeRows = report.matchedDiffs.filter((d) => d.willChange);
+  const noChangeMatches = report.matchedDiffs.length - willChangeRows.length;
+  const interesesLine =
+    report.intereses.status === "inserted"
+      ? `se insertará 1 tx sintética intereses-tc por ${formatCents(report.intereses.totalInterestCentsStr)}`
+      : report.intereses.status === "skipped"
+        ? `no se insertará tx sintética (${report.intereses.reason})`
+        : `intereses se corren al confirmar (dry-run lo omite)`;
+
+  return (
+    <Card data-testid="consolidate-preview">
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <CardTitle>Preview — dry-run</CardTitle>
+          <CardDescription>
+            Revisá los cambios antes de confirmar. Una vez aplicado, el ciclo queda marcado como
+            consolidado y cualquier re-subida se convierte en no-op.
+          </CardDescription>
+        </div>
+        <Button type="button" onClick={onConfirm} disabled={!canConfirm || applying}>
+          {applying ? "Aplicando…" : "Confirmar consolidación"}
+        </Button>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <SummaryGrid report={report} />
+        <Alert>
+          <AlertTitle>Proyección de intereses</AlertTitle>
+          <AlertDescription>
+            Al confirmar, {interesesLine}.{" "}
+            {report.intereses.status === "inserted"
+              ? `Compras multi-cuota sin tasa: ${report.intereses.purchasesNeedingRate}.`
+              : null}
+          </AlertDescription>
+        </Alert>
+
+        <MatchesSection rows={willChangeRows} noChangeCount={noChangeMatches} />
+        <MissingSection missing={report.missingInLedger} />
+        <UnmatchedSection ids={report.unmatchedInLedgerIds} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function SummaryGrid({ report }: { report: ConsolidationReport }) {
+  return (
+    <dl className="grid grid-cols-2 gap-2 rounded-md border p-3 text-sm sm:grid-cols-5">
+      <Stat label="Matched" value={report.matchStats.matched} />
+      <Stat label="Updates" value={report.matchStats.matchedWillChange} />
+      <Stat label="Nuevas" value={report.matchStats.insertedMissing} />
+      <Stat label="Antes (skip)" value={report.matchStats.skippedMissingBefore} />
+      <Stat label="Sin match" value={report.matchStats.unmatchedInLedger} muted />
+    </dl>
+  );
+}
+
+function Stat({ label, value, muted = false }: { label: string; value: number; muted?: boolean }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground text-xs">{label}</dt>
+      <dd className={cn("font-medium", muted && "text-muted-foreground")}>{value}</dd>
+    </div>
+  );
+}
+
+function MatchesSection({
+  rows,
+  noChangeCount,
+}: {
+  rows: ConsolidationReport["matchedDiffs"];
+  noChangeCount: number;
+}) {
+  return (
+    <Collapsible defaultOpen={rows.length > 0}>
+      <CollapsibleTrigger
+        data-testid="consolidate-matches-trigger"
+        className="hover:bg-muted flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm"
+      >
+        <span className="flex items-center gap-2 font-medium">
+          <CheckCircleIcon className="size-4 text-emerald-600 dark:text-emerald-400" />
+          Con updates ({rows.length})
+          {noChangeCount > 0 ? (
+            <span className="text-muted-foreground text-xs">+{noChangeCount} ya alineadas</span>
+          ) : null}
+        </span>
+        <Badge variant="secondary">{rows.length}</Badge>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2">
+        {rows.length === 0 ? (
+          <p className="text-muted-foreground px-3 py-2 text-xs">
+            Ninguna fila matched requiere update — todas ya estaban alineadas con el extracto.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="text-muted-foreground text-xs">
+                <tr>
+                  <th className="py-1 pr-3">Fecha</th>
+                  <th className="py-1 pr-3">Merchant</th>
+                  <th className="py-1 pr-3 text-right">Monto</th>
+                  <th className="py-1 pr-3">Cuotas</th>
+                  <th className="py-1 pr-3">Tasa EM</th>
+                  <th className="py-1 pr-3 text-right">Tx</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.txId} className="border-t">
+                    <td className="py-1 pr-3">{formatDate(row.occurredAt)}</td>
+                    <td className="truncate py-1 pr-3">{row.merchant}</td>
+                    <td className="py-1 pr-3 text-right tabular-nums">
+                      {formatCents(row.amountCentsStr)}
+                    </td>
+                    <td className="py-1 pr-3 tabular-nums">
+                      {row.installmentsTotalBefore} → {row.installmentsTotalAfter}
+                    </td>
+                    <td className="py-1 pr-3 tabular-nums">
+                      {formatRate(row.rateEmX10kBefore)} → {formatRate(row.rateEmX10kAfter)}
+                    </td>
+                    <td className="text-muted-foreground py-1 pr-3 text-right text-xs">
+                      #{row.txId}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function MissingSection({ missing }: { missing: ConsolidationReport["missingInLedger"] }) {
+  const during = missing.filter((r) => r.kind === "during-period");
+  const before = missing.filter((r) => r.kind === "before-period");
+
+  return (
+    <Collapsible defaultOpen={during.length > 0}>
+      <CollapsibleTrigger
+        data-testid="consolidate-missing-trigger"
+        className="hover:bg-muted flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm"
+      >
+        <span className="flex items-center gap-2 font-medium">
+          <PlusCircleIcon className="size-4 text-sky-600 dark:text-sky-400" />
+          Nuevas ({during.length})
+          {before.length > 0 ? (
+            <span className="text-muted-foreground text-xs">+{before.length} antes del ciclo</span>
+          ) : null}
+        </span>
+        <Badge variant="secondary">{during.length}</Badge>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2">
+        {missing.length === 0 ? (
+          <p className="text-muted-foreground px-3 py-2 text-xs">
+            No hay compras en el extracto que falten en Findash.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="text-muted-foreground text-xs">
+                <tr>
+                  <th className="py-1 pr-3">Fecha</th>
+                  <th className="py-1 pr-3">Merchant</th>
+                  <th className="py-1 pr-3 text-right">Monto</th>
+                  <th className="py-1 pr-3">Auth</th>
+                  <th className="py-1 pr-3">Acción</th>
+                </tr>
+              </thead>
+              <tbody>
+                {missing.map((row) => (
+                  <tr key={`${row.authorizationNumber}-${row.occurredAt}`} className="border-t">
+                    <td className="py-1 pr-3">{formatDate(row.occurredAt)}</td>
+                    <td className="truncate py-1 pr-3">{row.merchant}</td>
+                    <td className="py-1 pr-3 text-right tabular-nums">
+                      {formatCents(row.amountCentsStr)}
+                    </td>
+                    <td className="py-1 pr-3 font-mono text-xs">
+                      {row.authorizationNumber ?? "—"}
+                    </td>
+                    <td className="py-1 pr-3">
+                      {row.kind === "during-period" ? (
+                        <Badge variant="secondary">insert</Badge>
+                      ) : (
+                        <Badge variant="outline">before — skip</Badge>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function UnmatchedSection({ ids }: { ids: number[] }) {
+  return (
+    <Collapsible>
+      <CollapsibleTrigger
+        data-testid="consolidate-unmatched-trigger"
+        className="hover:bg-muted flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm"
+      >
+        <span className="flex items-center gap-2 font-medium">
+          <AlertTriangleIcon className="size-4 text-amber-600 dark:text-amber-400" />
+          Sin match en el extracto ({ids.length})
+        </span>
+        <Badge variant="secondary">{ids.length}</Badge>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2">
+        {ids.length === 0 ? (
+          <p className="text-muted-foreground px-3 py-2 text-xs">
+            Todas las transacciones del período aparecen en el extracto.
+          </p>
+        ) : (
+          <p className="text-muted-foreground px-3 py-2 text-xs">
+            Estas transacciones están en Findash pero no en el extracto — probablemente son dupes de
+            SMS (retry), reversiones netted-out, o errores. Revisalas en{" "}
+            <a className="underline" href="/transactions">
+              /transactions
+            </a>
+            . No se tocan automáticamente.
+            <br />
+            <span className="font-mono text-xs">
+              IDs: {ids.slice(0, 20).join(", ")}
+              {ids.length > 20 ? ` … (+${ids.length - 20} más)` : null}
+            </span>
+          </p>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/page.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/page.tsx
@@ -1,0 +1,193 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { accounts, statementImports } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { getSessionUser } from "@/lib/auth/session";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { buttonVariants } from "@/components/ui/button";
+
+import type { ConsolidationReport } from "@/lib/ingestion/bancolombia-statement/consolidate";
+import { ConsolidateForm } from "./consolidate-form";
+
+export const dynamic = "force-dynamic";
+
+function formatBogotaDate(d: Date): string {
+  return new Intl.DateTimeFormat("es-CO", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    timeZone: "America/Bogota",
+  }).format(d);
+}
+
+type CycleRouteParams = Promise<{ accountId: string; cycle: string }>;
+
+export default async function ConsolidatePage({ params }: { params: CycleRouteParams }) {
+  const session = await getSessionUser();
+  const { accountId: rawId, cycle } = await params;
+  const accountId = Number(rawId);
+  if (!Number.isInteger(accountId) || accountId <= 0) notFound();
+  if (!/^\d{4}-\d{2}$/.test(cycle)) notFound();
+
+  const [account] = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      institution: accounts.institution,
+      institutionSlug: accounts.institutionSlug,
+      currency: accounts.currency,
+      type: accounts.type,
+      metadata: accounts.metadata,
+      deletedAt: accounts.deletedAt,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        eq(accounts.id, accountId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!account) notFound();
+
+  const [existing] = await db
+    .select({
+      id: statementImports.id,
+      importedAt: statementImports.importedAt,
+      syntheticTxId: statementImports.syntheticTxId,
+      report: statementImports.report,
+      txnCount: statementImports.txnCount,
+    })
+    .from(statementImports)
+    .where(
+      and(
+        eq(statementImports.userId, session.id),
+        eq(statementImports.accountId, accountId),
+        eq(statementImports.kind, "extracto_detallado"),
+        eq(statementImports.cycle, cycle),
+      ),
+    )
+    .limit(1);
+
+  const accountLabel = formatAccountLabel({
+    name: account.name,
+    currency: account.currency,
+    institution: account.institution,
+    metadata: account.metadata,
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <div className="text-muted-foreground flex items-center gap-2 text-xs">
+          <Link href="/settings/accounts" className="hover:underline">
+            Cuentas
+          </Link>
+          <span>/</span>
+          <span>{accountLabel}</span>
+          <span>/</span>
+          <span>Consolidar</span>
+        </div>
+        <div className="flex flex-wrap items-baseline gap-3">
+          <h1 className="text-2xl font-semibold">Consolidar ciclo {cycle}</h1>
+          <span className="text-muted-foreground text-sm">{accountLabel}</span>
+        </div>
+        <p className="text-muted-foreground text-sm">
+          Subí el extracto detallado del ciclo para reconciliar cuotas, tasas y generar los
+          intereses-causados del cierre. El extracto es la fuente de verdad — lo que ya tenés en
+          Findash se actualiza para coincidir con lo que publicó el banco.
+        </p>
+      </div>
+
+      {existing ? (
+        <ExistingConsolidationCard existing={existing} cycle={cycle} accountId={accountId} />
+      ) : (
+        <ConsolidateForm
+          accountId={accountId}
+          accountName={accountLabel}
+          cycle={cycle}
+          institutionSlug={account.institutionSlug}
+        />
+      )}
+    </div>
+  );
+}
+
+function ExistingConsolidationCard({
+  existing,
+  cycle,
+  accountId,
+}: {
+  existing: {
+    id: number;
+    importedAt: Date;
+    syntheticTxId: number | null;
+    report: unknown;
+    txnCount: number;
+  };
+  cycle: string;
+  accountId: number;
+}) {
+  const report = (existing.report ?? {}) as Partial<ConsolidationReport>;
+  const matchStats = report.matchStats;
+  const intereses = report.intereses;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <CardTitle className="flex items-center gap-2">
+            Ciclo consolidado
+            <Badge variant="secondary">{cycle}</Badge>
+          </CardTitle>
+          <CardDescription>
+            Última corrida: {formatBogotaDate(existing.importedAt)} · {existing.txnCount}{" "}
+            transacciones tocadas
+          </CardDescription>
+        </div>
+        <Link
+          href={`/settings/accounts/${accountId}/consolidate/${cycle}?view=run`}
+          className={buttonVariants({ variant: "outline", size: "sm" })}
+        >
+          Ver run
+        </Link>
+      </CardHeader>
+      <CardContent>
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">
+          <div>
+            <dt className="text-muted-foreground text-xs">Matched</dt>
+            <dd className="font-medium">{matchStats?.matched ?? "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground text-xs">Updates aplicados</dt>
+            <dd className="font-medium">{matchStats?.matchedWillChange ?? "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground text-xs">Insertados</dt>
+            <dd className="font-medium">{matchStats?.insertedMissing ?? "—"}</dd>
+          </div>
+          <div className="col-span-2 sm:col-span-3">
+            <dt className="text-muted-foreground text-xs">Intereses-causados</dt>
+            <dd className="font-medium">
+              {intereses
+                ? intereses.status === "inserted"
+                  ? `Insertado (tx ${intereses.txId})`
+                  : `Skipped: ${intereses.reason}`
+                : "—"}
+            </dd>
+          </div>
+        </dl>
+        <p className="text-muted-foreground mt-4 text-xs">
+          Ya consolidado. Para re-aplicar, eliminá el run anterior desde la consola (no hay UI de
+          rollback todavía).
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.test.ts
@@ -1,0 +1,252 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import * as XLSX from "xlsx";
+
+import { db } from "@/lib/db";
+import { accounts, statementImports, transactions, users } from "@/lib/db/schema";
+import { copyCategorySeedsToUser } from "@/lib/auth/signup";
+
+const TAG = "CONSOL_ACT_TEST";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+const sessionMock = { id: 0, email: "test@test.local", name: "Test" };
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockImplementation(async () => sessionMock),
+}));
+
+const { previewStatementAction, commitStatementAction } = await import("./actions");
+
+function buildSyntheticXlsxBuffer(last4: string): Buffer {
+  const aoa: (string | number | null)[][] = [
+    ["Información Cliente:"],
+    ["Cliente", null, "Dirección"],
+    ["TEST", null, "CALLE 1"],
+    [],
+    ["Información de la Tarjeta", `************${last4}`],
+    ["Moneda: ", "PESOS"],
+    [],
+    ["Periodo facturado: ", "01 mar", "30 mar. 2026"],
+    ["Pagar antes de: ", "abr. 16, 2026"],
+    ["Pago mínimo", "100.000,00"],
+    ["Pago total", "500.000,00"],
+    ["Cupo total: ", "1.000.000,00"],
+    ["Cupo disponible: ", "500.000,00"],
+    [],
+    [],
+    [
+      "Tasas de interés vigente",
+      "Tasa Mes Vencido",
+      "Tasa Efectivo Anual",
+      "Resumen Saldo Total",
+      "",
+      "Resumen Pago Mínimo",
+    ],
+    [],
+    ["Compra un mes", "0.0000 %", "0.0000 %", "+ Saldo anterior", "0,00"],
+    ["Compra 2 - 36 meses", "1.9110 %", "25.5026 %", "+ Compras del mes", "500.000,00"],
+    ["Impuestos", "1.9110 %", "25.5026 %", "+ Intereses de mora", "0,00"],
+    ["Avances", "1.9110 %", "25.5026 %", "+ Intereses corrientes", "0,00"],
+    ["Mora", "1.9110 %", "25.5026 %", "+ Avances", "0,00"],
+    [null, null, null, "+ Otros cargos", "0,00"],
+    [null, null, null, "Cargos", "500.000,00"],
+    [null, null, null, "(-) Pagos / abonos", "0,00"],
+    [null, null, null, "(-) Saldo a favor", "0,00"],
+    [null, null, null, "Abono", "0,00"],
+    [],
+    [],
+    ["Movimientos durante el periodo"],
+    [
+      "Número de autorización",
+      "Fecha",
+      "Movimientos",
+      "Valor Movimiento",
+      "Número de cuotas",
+      "Valor cuota/abono",
+      "Interés mensual (%)",
+      "Interés anual (%)",
+      "Saldo pendiente",
+    ],
+    [
+      "010001",
+      "20/03/2026",
+      "TEST MERCHANT A",
+      "300.000,00",
+      "1/1",
+      "300.000,00",
+      "0,0000",
+      "00,0000",
+      "0,00",
+    ],
+    [
+      "010002",
+      "21/03/2026",
+      "TEST MERCHANT B",
+      "200.000,00",
+      "1/1",
+      "200.000,00",
+      "0,0000",
+      "00,0000",
+      "0,00",
+    ],
+  ];
+  const wb = XLSX.utils.book_new();
+  const sheet = XLSX.utils.aoa_to_sheet(aoa);
+  XLSX.utils.book_append_sheet(wb, sheet, "PESOS");
+  return Buffer.from(XLSX.write(wb, { bookType: "xlsx", type: "buffer" }));
+}
+
+async function createUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  return row.id;
+}
+
+async function createTc(
+  userId: number,
+  last4: string,
+  institutionSlug: "bancolombia" | "nequi" = "bancolombia",
+  type: "credit_card" | "savings" = "credit_card",
+): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} visa ${last4}`,
+      institution: "Bancolombia",
+      institutionSlug,
+      type,
+      currency: "COP",
+      metadata: { last4s: [last4], cutoffDay: 30 },
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function cleanupUser(userId: number): Promise<void> {
+  await db.delete(transactions).where(eq(transactions.userId, userId));
+  await db.delete(statementImports).where(eq(statementImports.userId, userId));
+  await db.delete(accounts).where(eq(accounts.userId, userId));
+  await db.delete(users).where(eq(users.id, userId));
+}
+
+function formDataFor(
+  buffer: Buffer,
+  accountId: number,
+  cycle: string,
+  filename = "extracto.xlsx",
+): FormData {
+  const fd = new FormData();
+  const blob = new Blob([new Uint8Array(buffer)], {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+  fd.set("file", blob, filename);
+  fd.set("accountId", String(accountId));
+  fd.set("cycle", cycle);
+  return fd;
+}
+
+describe("previewStatementAction / commitStatementAction", () => {
+  let userId!: number;
+  let tcId!: number;
+  let savingsId!: number;
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.${Date.now()}@test.local`);
+    sessionMock.id = userId;
+    tcId = await createTc(userId, "2575");
+    savingsId = await createTc(userId, "0000", "nequi", "savings");
+  });
+
+  afterEach(async () => {
+    await db.execute(
+      sql`DELETE FROM transactions WHERE user_id = ${userId} AND external_id LIKE 'bancolombia-stmt:%'`,
+    );
+    await db.delete(statementImports).where(eq(statementImports.userId, userId));
+    await db.execute(
+      sql`DELETE FROM transactions WHERE user_id = ${userId} AND category_slug = 'intereses-tc'`,
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  it("rejects when no file is attached", async () => {
+    const fd = new FormData();
+    fd.set("accountId", String(tcId));
+    fd.set("cycle", "2026-03");
+    await expect(previewStatementAction(fd)).rejects.toThrow(/no_file/);
+  });
+
+  it("rejects non-xlsx filenames", async () => {
+    const buf = buildSyntheticXlsxBuffer("2575");
+    await expect(
+      previewStatementAction(formDataFor(buf, tcId, "2026-03", "extract.pdf")),
+    ).rejects.toThrow(/unsupported_file_type/);
+  });
+
+  it("rejects cycles that aren't YYYY-MM", async () => {
+    const buf = buildSyntheticXlsxBuffer("2575");
+    await expect(previewStatementAction(formDataFor(buf, tcId, "oops"))).rejects.toThrow();
+  });
+
+  it("rejects when the account isn't a credit card", async () => {
+    const buf = buildSyntheticXlsxBuffer("2575");
+    await expect(previewStatementAction(formDataFor(buf, savingsId, "2026-03"))).rejects.toThrow(
+      /account_not_credit_card|unsupported_institution/,
+    );
+  });
+
+  it("rejects when xlsx card last4 doesn't match the account", async () => {
+    const buf = buildSyntheticXlsxBuffer("1111"); // account is 2575
+    await expect(previewStatementAction(formDataFor(buf, tcId, "2026-03"))).rejects.toThrow(
+      /last4_mismatch/,
+    );
+  });
+
+  it("preview returns a dry-run report without writing to the DB", async () => {
+    const buf = buildSyntheticXlsxBuffer("2575");
+    const report = await previewStatementAction(formDataFor(buf, tcId, "2026-03"));
+    expect(report.dryRun).toBe(true);
+    expect(report.status).toBe("dry-run");
+    // 2 missing during-period rows in the synthetic fixture (no matching txs seeded).
+    expect(report.matchStats.insertedMissing).toBe(2);
+    expect(report.statementImportId).toBeNull();
+
+    const imports = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.userId, userId));
+    expect(imports).toHaveLength(0);
+  });
+
+  it("commit persists + revalidates + second call is idempotent", async () => {
+    const nextCache = await import("next/cache");
+    const revalidate = vi.mocked(nextCache.revalidatePath);
+    revalidate.mockClear();
+
+    const buf = buildSyntheticXlsxBuffer("2575");
+    const report = await commitStatementAction(formDataFor(buf, tcId, "2026-03"));
+    expect(report.status).toBe("consolidated");
+    expect(report.insertedTxIds.length).toBe(2);
+    expect(report.statementImportId).not.toBeNull();
+    expect(revalidate).toHaveBeenCalledWith(expect.stringContaining("/settings/accounts/"));
+    expect(revalidate).toHaveBeenCalledWith("/transactions");
+
+    const imports = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.userId, userId));
+    expect(imports).toHaveLength(1);
+    expect(imports[0].kind).toBe("extracto_detallado");
+
+    // Second call: already-consolidated, no new imports.
+    const second = await commitStatementAction(formDataFor(buf, tcId, "2026-03"));
+    expect(second.status).toBe("already-consolidated");
+    const stillOne = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.userId, userId));
+    expect(stillOne).toHaveLength(1);
+  });
+});

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.ts
@@ -1,0 +1,157 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { db } from "@/lib/db";
+import { accounts } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { getSessionUser } from "@/lib/auth/session";
+import {
+  consolidateCycleFromStatement,
+  hashStatementBuffer,
+  type ConsolidationReport,
+} from "@/lib/ingestion/bancolombia-statement/consolidate";
+import { parseBancolombiaStatement } from "@/lib/ingestion/bancolombia-statement/xlsx";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "consolidate-actions" });
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+const inputSchema = z.object({
+  accountId: z.coerce.number().int().positive(),
+  cycle: z.string().regex(/^\d{4}-\d{2}$/, "cycle must be YYYY-MM"),
+});
+
+async function loadTcAccount(userId: number, accountId: number) {
+  const [account] = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      currency: accounts.currency,
+      institutionSlug: accounts.institutionSlug,
+      type: accounts.type,
+      metadata: accounts.metadata,
+    })
+    .from(accounts)
+    .where(
+      and(eq(accounts.userId, userId), eq(accounts.id, accountId), notDeleted(accounts.deletedAt)),
+    )
+    .limit(1);
+  if (!account) throw new Error("account_not_found");
+  if (account.type !== "credit_card") {
+    throw new Error("account_not_credit_card");
+  }
+  if (account.institutionSlug !== "bancolombia") {
+    throw new Error(`unsupported_institution:${account.institutionSlug}`);
+  }
+  return account;
+}
+
+async function readUploadedBuffer(formData: FormData): Promise<Buffer> {
+  const file = formData.get("file");
+  if (!(file instanceof File)) throw new Error("no_file");
+  if (file.size === 0) throw new Error("empty_file");
+  if (file.size > MAX_FILE_SIZE) throw new Error("file_too_large");
+  if (!file.name.toLowerCase().endsWith(".xlsx")) throw new Error("unsupported_file_type");
+  return Buffer.from(await file.arrayBuffer());
+}
+
+// Dry-run: parses the xlsx, runs matching against the ledger, returns a
+// ConsolidationReport without writing to the DB. The report is already
+// JSON-serializable (bigints serialized as strings) — safe to return to
+// a client component.
+export async function previewStatementAction(formData: FormData): Promise<ConsolidationReport> {
+  const session = await getSessionUser();
+  const { accountId, cycle } = inputSchema.parse({
+    accountId: formData.get("accountId"),
+    cycle: formData.get("cycle"),
+  });
+
+  const account = await loadTcAccount(session.id, accountId);
+  const buffer = await readUploadedBuffer(formData);
+  const parsed = parseBancolombiaStatement(buffer);
+
+  if (parsed.account.last4) {
+    const last4s = Array.isArray(account.metadata?.last4s) ? account.metadata!.last4s : [];
+    if (last4s.length > 0 && !last4s.includes(parsed.account.last4)) {
+      throw new Error(`last4_mismatch:file=${parsed.account.last4},account=${last4s.join(",")}`);
+    }
+  }
+
+  const fileHash = hashStatementBuffer(buffer);
+  const report = await consolidateCycleFromStatement({
+    userId: session.id,
+    accountId: account.id,
+    cycle,
+    parsed,
+    fileHash,
+    dryRun: true,
+  });
+
+  log.info(
+    {
+      event: "statement_preview",
+      userId: session.id,
+      accountId: account.id,
+      cycle,
+      matched: report.matchStats.matched,
+      willChange: report.matchStats.matchedWillChange,
+      inserted: report.matchStats.insertedMissing,
+    },
+    "statement preview computed",
+  );
+
+  return report;
+}
+
+// Commit: re-parses the uploaded xlsx (we don't trust a client-side round-trip
+// of the report), runs the full consolidation, and revalidates the surfaces
+// that render cycle state so the user immediately sees the "consolidated"
+// badge without a manual refresh.
+export async function commitStatementAction(formData: FormData): Promise<ConsolidationReport> {
+  const session = await getSessionUser();
+  const { accountId, cycle } = inputSchema.parse({
+    accountId: formData.get("accountId"),
+    cycle: formData.get("cycle"),
+  });
+
+  const account = await loadTcAccount(session.id, accountId);
+  const buffer = await readUploadedBuffer(formData);
+  const parsed = parseBancolombiaStatement(buffer);
+  const fileHash = hashStatementBuffer(buffer);
+
+  const report = await consolidateCycleFromStatement({
+    userId: session.id,
+    accountId: account.id,
+    cycle,
+    parsed,
+    fileHash,
+    dryRun: false,
+  });
+
+  log.info(
+    {
+      event: "statement_commit",
+      userId: session.id,
+      accountId: account.id,
+      cycle,
+      status: report.status,
+      matched: report.matchStats.matched,
+      willChange: report.matchStats.matchedWillChange,
+      inserted: report.insertedTxIds.length,
+      intereses: report.intereses.status,
+      statementImportId: report.statementImportId,
+    },
+    `statement commit: ${report.status}`,
+  );
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+  revalidatePath("/settings/accounts");
+  revalidatePath(`/settings/accounts/${account.id}/consolidate/${cycle}`);
+
+  return report;
+}

--- a/src/app/(app)/settings/accounts/page.tsx
+++ b/src/app/(app)/settings/accounts/page.tsx
@@ -6,6 +6,7 @@ import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
 import { getSessionUser } from "@/lib/auth/session";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { AccountsManager, type AccountRow } from "./accounts-manager";
+import { TcConsolidationStatus } from "./tc-consolidation-status";
 
 export const dynamic = "force-dynamic";
 
@@ -74,6 +75,7 @@ export default async function SettingsAccountsPage() {
         </p>
       </header>
       <AccountsManager items={items} copPerUsd={fx.rate} />
+      <TcConsolidationStatus userId={session.id} />
     </main>
   );
 }

--- a/src/app/(app)/settings/accounts/tc-consolidation-status.tsx
+++ b/src/app/(app)/settings/accounts/tc-consolidation-status.tsx
@@ -1,0 +1,151 @@
+// #419: Per-account TC consolidation state rendered above the accounts
+// manager. Shows the last 3 cycles per credit-card account with status badges
+// and a "Consolidar" shortcut on pending ones — the dashboard banner flags
+// users, this is where they complete the work.
+
+import Link from "next/link";
+import { and, asc, eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { accounts } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { recentCycles, type CycleStatus } from "@/lib/accounts/cycles";
+import { Badge } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+function formatBogotaDate(d: Date): string {
+  return new Intl.DateTimeFormat("es-CO", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    timeZone: "America/Bogota",
+  }).format(d);
+}
+
+function statusLabel(status: CycleStatus): string {
+  switch (status) {
+    case "consolidated":
+      return "consolidado";
+    case "pending":
+      return "pendiente";
+    case "in-progress":
+      return "en curso";
+  }
+}
+
+export async function TcConsolidationStatus({ userId }: { userId: number }) {
+  const tcAccounts = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      currency: accounts.currency,
+      institution: accounts.institution,
+      institutionSlug: accounts.institutionSlug,
+      metadata: accounts.metadata,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, userId),
+        eq(accounts.type, "credit_card"),
+        eq(accounts.institutionSlug, "bancolombia"),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .orderBy(asc(accounts.name));
+
+  if (tcAccounts.length === 0) return null;
+
+  const perAccount = await Promise.all(
+    tcAccounts.map(async (a) => ({
+      account: a,
+      cycles: await recentCycles({
+        accountId: a.id,
+        userId,
+        metadata: a.metadata,
+        count: 3,
+      }),
+    })),
+  );
+
+  const hasPending = perAccount.some((p) => p.cycles.some((c) => c.status === "pending"));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Consolidación mensual de TCs</CardTitle>
+        <CardDescription>
+          Al cierre de cada ciclo subí el extracto detallado para reconciliar cuotas, tasas y
+          generar los intereses-causados del mes.{" "}
+          {hasPending
+            ? "Tenés al menos un ciclo pendiente."
+            : "Todos los ciclos cerrados están consolidados."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="flex flex-col gap-4">
+          {perAccount.map(({ account, cycles }) => {
+            const label = formatAccountLabel({
+              name: account.name,
+              currency: account.currency,
+              institution: account.institution,
+              metadata: account.metadata,
+            });
+            return (
+              <li key={account.id} className="flex flex-col gap-2">
+                <div className="text-sm font-medium">{label}</div>
+                <div className="flex flex-wrap gap-2">
+                  {cycles.map((cycle) => (
+                    <div
+                      key={cycle.cycle}
+                      className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                    >
+                      <span className="font-mono text-xs">{cycle.cycle}</span>
+                      <Badge
+                        variant={
+                          cycle.status === "consolidated"
+                            ? "default"
+                            : cycle.status === "pending"
+                              ? "secondary"
+                              : "outline"
+                        }
+                      >
+                        {statusLabel(cycle.status)}
+                      </Badge>
+                      {cycle.status === "consolidated" && cycle.consolidatedAt ? (
+                        <span className="text-muted-foreground text-xs">
+                          {formatBogotaDate(cycle.consolidatedAt)}
+                        </span>
+                      ) : null}
+                      {cycle.status === "pending" && cycle.daysOverdue > 0 ? (
+                        <span className="text-muted-foreground text-xs">+{cycle.daysOverdue}d</span>
+                      ) : null}
+                      {cycle.status === "pending" ? (
+                        <Link
+                          href={`/settings/accounts/${account.id}/consolidate/${cycle.cycle}`}
+                          className={buttonVariants({ variant: "outline", size: "sm" })}
+                        >
+                          Consolidar
+                        </Link>
+                      ) : null}
+                      {cycle.status === "consolidated" ? (
+                        <Link
+                          href={`/settings/accounts/${account.id}/consolidate/${cycle.cycle}`}
+                          className="text-muted-foreground text-xs underline"
+                        >
+                          Ver run
+                        </Link>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/pending-consolidation-banner.tsx
+++ b/src/components/dashboard/pending-consolidation-banner.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+import { AlertTriangleIcon } from "lucide-react";
+
+import { overdueCyclesForUser } from "@/lib/accounts/cycles";
+import { db } from "@/lib/db";
+import { accounts } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { and, eq } from "drizzle-orm";
+
+// Reads TC accounts + their cycle state and renders an amber banner when one
+// or more cycles are past their cut day by more than the threshold. Intended
+// to live at the top of the dashboard — shows nothing when the user is caught
+// up, so it's zero UI cost on the happy path.
+export async function PendingConsolidationBanner({
+  userId,
+  thresholdDays = 7,
+}: {
+  userId: number;
+  thresholdDays?: number;
+}) {
+  const tcAccounts = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      metadata: accounts.metadata,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, userId),
+        eq(accounts.type, "credit_card"),
+        eq(accounts.institutionSlug, "bancolombia"),
+        notDeleted(accounts.deletedAt),
+      ),
+    );
+  if (tcAccounts.length === 0) return null;
+
+  const overdue = await overdueCyclesForUser(userId, tcAccounts, { thresholdDays });
+  if (overdue.length === 0) return null;
+
+  const mostOverdue = overdue[0];
+  const message =
+    overdue.length === 1
+      ? `Ciclo ${mostOverdue.cycle} de ${mostOverdue.accountName} está pendiente hace ${mostOverdue.daysOverdue} días.`
+      : `Tenés ${overdue.length} ciclos TC sin consolidar — el más atrasado es ${mostOverdue.cycle} de ${mostOverdue.accountName} (+${mostOverdue.daysOverdue}d).`;
+
+  const linkHref = `/settings/accounts/${mostOverdue.accountId}/consolidate/${mostOverdue.cycle}`;
+
+  return (
+    <aside
+      role="note"
+      aria-label="Ciclos pendientes de consolidación"
+      data-testid="pending-consolidation-banner"
+      className="flex flex-col gap-1 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4 dark:border-amber-900 dark:bg-amber-950/40"
+    >
+      <div className="flex items-start gap-2 text-sm">
+        <AlertTriangleIcon className="mt-0.5 size-4 text-amber-700 dark:text-amber-400" />
+        <div>
+          <strong className="font-medium text-amber-900 dark:text-amber-200">
+            Ciclos TC sin consolidar
+          </strong>
+          <span className="text-amber-800 dark:text-amber-300"> — {message}</span>
+        </div>
+      </div>
+      <Link
+        href={linkHref}
+        className="inline-flex items-center justify-center rounded-md border border-amber-400 bg-amber-100 px-3 py-1 text-xs font-medium whitespace-nowrap text-amber-900 hover:bg-amber-200 dark:border-amber-700 dark:bg-amber-900/40 dark:text-amber-100 dark:hover:bg-amber-900/60"
+      >
+        Consolidar ahora
+      </Link>
+    </aside>
+  );
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "[&_a]:hover:text-foreground font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground [&_a]:hover:text-foreground text-sm text-balance md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div data-slot="alert-action" className={cn("absolute top-2 right-2", className)} {...props} />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction };

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import { Checkbox as CheckboxPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { CheckIcon } from "lucide-react";
+
+function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Collapsible as CollapsiblePrimitive } from "radix-ui";
+
+function Collapsible({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return <CollapsiblePrimitive.CollapsibleTrigger data-slot="collapsible-trigger" {...props} />;
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return <CollapsiblePrimitive.CollapsibleContent data-slot="collapsible-content" {...props} />;
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/src/lib/accounts/cycles.test.ts
+++ b/src/lib/accounts/cycles.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { accounts, statementImports, users } from "@/lib/db/schema";
+import { copyCategorySeedsToUser } from "@/lib/auth/signup";
+
+import {
+  currentCycleFor,
+  latestConsolidationsForUser,
+  overdueCyclesForUser,
+  previousCycle,
+  recentCycles,
+  resolveCutoffDay,
+} from "./cycles";
+
+const TAG = "CYCLES_TEST";
+
+function utcDate(y: number, m: number, d: number): Date {
+  return new Date(Date.UTC(y, m - 1, d, 12, 0, 0, 0));
+}
+
+async function createUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  return row.id;
+}
+
+async function createTc(userId: number, cutoffDay: number, name: string): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} ${name}`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      type: "credit_card",
+      currency: "COP",
+      metadata: { last4s: ["9999"], cutoffDay },
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function cleanupUser(userId: number): Promise<void> {
+  await db.delete(statementImports).where(eq(statementImports.userId, userId));
+  await db.delete(accounts).where(eq(accounts.userId, userId));
+  await db.delete(users).where(eq(users.id, userId));
+}
+
+describe("resolveCutoffDay", () => {
+  it("returns metadata.cutoffDay when valid", () => {
+    expect(resolveCutoffDay({ cutoffDay: 15 })).toBe(15);
+  });
+  it("falls back to 31 when missing or invalid", () => {
+    expect(resolveCutoffDay(null)).toBe(31);
+    expect(resolveCutoffDay(undefined)).toBe(31);
+    expect(resolveCutoffDay({})).toBe(31);
+    expect(resolveCutoffDay({ cutoffDay: 0 })).toBe(31);
+    expect(resolveCutoffDay({ cutoffDay: 99 })).toBe(31);
+  });
+});
+
+describe("previousCycle", () => {
+  it("decrements within a year", () => {
+    expect(previousCycle("2026-04")).toBe("2026-03");
+  });
+  it("rolls January back to December of the previous year", () => {
+    expect(previousCycle("2026-01")).toBe("2025-12");
+  });
+  it("throws on malformed input", () => {
+    expect(() => previousCycle("foo")).toThrow();
+  });
+});
+
+describe("currentCycleFor", () => {
+  it("returns same-month cycle when reference is before the cut", () => {
+    expect(currentCycleFor(utcDate(2026, 4, 15), 30)).toBe("2026-04");
+  });
+  it("advances to next month when reference is past the cut", () => {
+    expect(currentCycleFor(utcDate(2026, 4, 30), 15)).toBe("2026-05");
+  });
+  it("rolls December→January across the year boundary", () => {
+    expect(currentCycleFor(utcDate(2026, 12, 31), 15)).toBe("2027-01");
+  });
+  it("clamps Feb cut to month-length (cutDay=31 in Feb = Feb 28)", () => {
+    // Feb 27 is before Feb 28 cut → current cycle is 2026-02.
+    expect(currentCycleFor(utcDate(2026, 2, 27), 31)).toBe("2026-02");
+    // Feb 28 end-of-day ≥ anchor (23:00) but we use noon → anchor > ref → still 2026-02.
+    expect(currentCycleFor(utcDate(2026, 2, 28), 31)).toBe("2026-02");
+  });
+});
+
+describe("recentCycles — integration", () => {
+  let userId!: number;
+  let accountId!: number;
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.${Date.now()}@test.local`);
+    accountId = await createTc(userId, 30, "visa");
+
+    // Mark 2026-03 as consolidated.
+    await db.insert(statementImports).values({
+      userId,
+      accountId,
+      fileHash: "a".repeat(64),
+      periodStart: "2026-02-28",
+      periodEnd: "2026-03-30",
+      kind: "extracto_detallado",
+      cycle: "2026-03",
+      report: { marker: "test-fixture" },
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  it("returns N most recent cycles with statuses", async () => {
+    const cycles = await recentCycles({
+      accountId,
+      userId,
+      metadata: { cutoffDay: 30 },
+      count: 4,
+      now: utcDate(2026, 4, 15),
+    });
+    expect(cycles.map((c) => c.cycle)).toEqual(["2026-04", "2026-03", "2026-02", "2026-01"]);
+    expect(cycles[0].status).toBe("in-progress");
+    expect(cycles[1].status).toBe("consolidated");
+    expect(cycles[1].consolidatedAt).toBeInstanceOf(Date);
+    expect(cycles[2].status).toBe("pending");
+    expect(cycles[2].daysOverdue).toBeGreaterThan(0);
+    expect(cycles[3].status).toBe("pending");
+  });
+
+  it("overdueCyclesForUser flags cycles past threshold", async () => {
+    const overdue = await overdueCyclesForUser(
+      userId,
+      [{ id: accountId, name: "visa", metadata: { cutoffDay: 30 } }],
+      { thresholdDays: 7, now: utcDate(2026, 4, 15), count: 4 },
+    );
+    // 2026-03 is consolidated (excluded). 2026-02 cut was Feb 28; Apr 15 is
+    // ~46 days later → overdue. 2026-01 even more overdue.
+    const cycles = overdue.map((o) => o.cycle);
+    expect(cycles).toContain("2026-02");
+    expect(cycles).toContain("2026-01");
+    expect(cycles).not.toContain("2026-03");
+  });
+
+  it("latestConsolidationsForUser returns the seeded row", async () => {
+    const recents = await latestConsolidationsForUser(userId, { limit: 5 });
+    expect(recents).toHaveLength(1);
+    expect(recents[0].cycle).toBe("2026-03");
+    expect(recents[0].accountId).toBe(accountId);
+  });
+});

--- a/src/lib/accounts/cycles.ts
+++ b/src/lib/accounts/cycles.ts
@@ -1,0 +1,211 @@
+// #419: Cycle-status helpers used by the statement consolidation UI.
+//
+// A "cycle" here is a monthly TC closing window, labeled "YYYY-MM" after the
+// month of the cut. Given an account's cutoff day we can:
+//   1. Enumerate the N most recent cycles around a reference date,
+//   2. Classify each as `in-progress | pending | consolidated` based on
+//      today's position and on rows we've already persisted in
+//      `statement_imports.kind = 'extracto_detallado'`.
+//
+// No DB writes. The dashboard banner + the per-account view both read from
+// here; the consolidate page writes via the server actions in #418.
+
+import { and, desc, eq, inArray } from "drizzle-orm";
+
+import { db, type DB } from "@/lib/db";
+import type { AccountMetadata } from "@/lib/db/schema";
+import { statementImports } from "@/lib/db/schema";
+import { cycleAnchor } from "@/lib/finance/intereses-causados-job";
+
+// Conservative fallback when neither the account metadata nor the linked card
+// reports a cutoff. Matches the intereses-job behavior (end of month).
+const FALLBACK_CUT_DAY = 31;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type CycleStatus = "in-progress" | "pending" | "consolidated";
+
+export type CycleSummary = {
+  cycle: string; // "YYYY-MM"
+  status: CycleStatus;
+  anchor: Date; // end-of-day anchor for the cut
+  consolidatedAt: Date | null;
+  statementImportId: number | null;
+  daysOverdue: number; // 0 for in-progress, or (today - anchor) rounded-down days for pending
+};
+
+export function resolveCutoffDay(metadata: AccountMetadata | null | undefined): number {
+  const raw = metadata?.cutoffDay;
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 1 || raw > 31) {
+    return FALLBACK_CUT_DAY;
+  }
+  return raw;
+}
+
+// Given "2026-04" returns "2026-03", wrapping December→January with year
+// rollover. Used to walk backward through cycles from today.
+export function previousCycle(cycle: string): string {
+  const [y, m] = cycle.split("-").map(Number);
+  if (!Number.isInteger(y) || !Number.isInteger(m)) {
+    throw new Error(`previousCycle: invalid cycle "${cycle}"`);
+  }
+  const prevMonth = m === 1 ? 12 : m - 1;
+  const prevYear = m === 1 ? y - 1 : y;
+  return `${prevYear}-${String(prevMonth).padStart(2, "0")}`;
+}
+
+// Picks the cycle whose end-date is the first one >= `reference`. That cycle
+// is "in progress" (the bank hasn't cut yet); callers walk back from there.
+export function currentCycleFor(reference: Date, cutoffDay: number): string {
+  const y = reference.getUTCFullYear();
+  const m = reference.getUTCMonth() + 1; // 1-12
+  const candidate = `${y}-${String(m).padStart(2, "0")}`;
+  const anchor = cycleAnchor(candidate, cutoffDay);
+  if (anchor.getTime() >= reference.getTime()) return candidate;
+  // Current month already closed; next month's cycle is in progress.
+  if (m === 12) return `${y + 1}-01`;
+  return `${y}-${String(m + 1).padStart(2, "0")}`;
+}
+
+export type CyclesContext = {
+  accountId: number;
+  userId: number;
+  metadata: AccountMetadata | null | undefined;
+  // Number of cycles to return INCLUDING the current in-progress one.
+  count?: number;
+  // Override for deterministic tests; defaults to `new Date()`.
+  now?: Date;
+  database?: DB;
+};
+
+// Enumerates the `count` most recent cycles for an account (current cycle
+// first). Each is annotated with its anchor, consolidation status, and how
+// many days it's overdue past its cut (for the dashboard banner's >7-day
+// rule).
+export async function recentCycles(ctx: CyclesContext): Promise<CycleSummary[]> {
+  const database = ctx.database ?? db;
+  const count = ctx.count ?? 4;
+  const now = ctx.now ?? new Date();
+  const cutoffDay = resolveCutoffDay(ctx.metadata);
+
+  let label = currentCycleFor(now, cutoffDay);
+  const labels: string[] = [];
+  for (let i = 0; i < count; i++) {
+    labels.push(label);
+    label = previousCycle(label);
+  }
+
+  const consolidatedRows = labels.length
+    ? await database
+        .select({
+          id: statementImports.id,
+          cycle: statementImports.cycle,
+          importedAt: statementImports.importedAt,
+        })
+        .from(statementImports)
+        .where(
+          and(
+            eq(statementImports.userId, ctx.userId),
+            eq(statementImports.accountId, ctx.accountId),
+            eq(statementImports.kind, "extracto_detallado"),
+            inArray(statementImports.cycle, labels),
+          ),
+        )
+    : [];
+  const consolidatedByCycle = new Map<string, { id: number; importedAt: Date }>();
+  for (const row of consolidatedRows) {
+    if (row.cycle) consolidatedByCycle.set(row.cycle, { id: row.id, importedAt: row.importedAt });
+  }
+
+  return labels.map((cycle) => {
+    const anchor = cycleAnchor(cycle, cutoffDay);
+    const hit = consolidatedByCycle.get(cycle);
+    if (hit) {
+      return {
+        cycle,
+        status: "consolidated" as const,
+        anchor,
+        consolidatedAt: hit.importedAt,
+        statementImportId: hit.id,
+        daysOverdue: 0,
+      };
+    }
+    if (anchor.getTime() > now.getTime()) {
+      return {
+        cycle,
+        status: "in-progress" as const,
+        anchor,
+        consolidatedAt: null,
+        statementImportId: null,
+        daysOverdue: 0,
+      };
+    }
+    const daysOverdue = Math.max(0, Math.floor((now.getTime() - anchor.getTime()) / MS_PER_DAY));
+    return {
+      cycle,
+      status: "pending" as const,
+      anchor,
+      consolidatedAt: null,
+      statementImportId: null,
+      daysOverdue,
+    };
+  });
+}
+
+export type OverdueCycleSummary = CycleSummary & {
+  accountId: number;
+  accountName: string;
+};
+
+// Dashboard banner helper: across all of a user's TC accounts, return every
+// cycle that's pending AND more than `thresholdDays` past its cut.
+export async function overdueCyclesForUser(
+  userId: number,
+  accounts: Array<{ id: number; name: string; metadata: AccountMetadata | null | undefined }>,
+  opts: { thresholdDays?: number; now?: Date; count?: number; database?: DB } = {},
+): Promise<OverdueCycleSummary[]> {
+  const threshold = opts.thresholdDays ?? 7;
+  const out: OverdueCycleSummary[] = [];
+  for (const account of accounts) {
+    const cycles = await recentCycles({
+      accountId: account.id,
+      userId,
+      metadata: account.metadata,
+      count: opts.count ?? 3,
+      now: opts.now,
+      database: opts.database,
+    });
+    for (const c of cycles) {
+      if (c.status === "pending" && c.daysOverdue >= threshold) {
+        out.push({ ...c, accountId: account.id, accountName: account.name });
+      }
+    }
+  }
+  return out.sort((a, b) => b.daysOverdue - a.daysOverdue);
+}
+
+// Most recent consolidations across the user's accounts — fuel for the
+// "últimos N cierres" block on the dashboard / accounts list. Pulled in a
+// single query so the UI can render a compact list without N+1.
+export async function latestConsolidationsForUser(
+  userId: number,
+  opts: { limit?: number; database?: DB } = {},
+): Promise<Array<{ accountId: number; cycle: string; importedAt: Date; id: number }>> {
+  const database = opts.database ?? db;
+  const rows = await database
+    .select({
+      id: statementImports.id,
+      accountId: statementImports.accountId,
+      cycle: statementImports.cycle,
+      importedAt: statementImports.importedAt,
+    })
+    .from(statementImports)
+    .where(
+      and(eq(statementImports.userId, userId), eq(statementImports.kind, "extracto_detallado")),
+    )
+    .orderBy(desc(statementImports.importedAt))
+    .limit(opts.limit ?? 10);
+  return rows
+    .filter((r): r is typeof r & { cycle: string } => r.cycle !== null)
+    .map((r) => ({ id: r.id, accountId: r.accountId, cycle: r.cycle, importedAt: r.importedAt }));
+}


### PR DESCRIPTION
## Summary

Closes the TC monthly consolidation epic (#415). UI wraps #418's `consolidateCycleFromStatement` so uploading + committing a cycle is a two-click flow.

- **Cycle helpers** (`src/lib/accounts/cycles.ts`): `recentCycles()` annotates the N most recent cycles per account with `in-progress | pending | consolidated` status using Bogota-aware `cycleAnchor`. `overdueCyclesForUser()` powers the dashboard banner's >7-day pending rule. `latestConsolidationsForUser()` is plumbed for future lists.
- **Consolidate page** at `/settings/accounts/[accountId]/consolidate/[cycle]`: server component renders either `ConsolidateForm` (drag-and-drop .xlsx → dry-run preview → confirm) or `ExistingConsolidationCard` (read-only summary of the persisted run). Re-uploading an already-consolidated cycle is a no-op by design.
- **Server actions** (`consolidate/actions.ts`): `previewStatementAction` + `commitStatementAction`. FormData-driven, tenant-scoped — rejects non-TC accounts, non-Bancolombia institutions, last4 mismatch, >10 MB uploads, non-.xlsx filenames. Commit revalidates `/`, `/transactions`, `/settings/accounts` and the cycle page so the 'consolidated' state flips in place.
- **Accounts list block** (`TcConsolidationStatus`): renders under `/settings/accounts`, lists last 3 cycles per TC account with status badges and shortcut buttons.
- **Dashboard banner** (`PendingConsolidationBanner`): amber aside on `/` when any TC cycle is > 7 days past its cut. Zero UI when caught up.
- **shadcn adds**: Alert, Checkbox, Collapsible.
- **Tests**: 12 cycle helper tests + 7 server-action integration tests (file validation, account-type gates, last4 mismatch, dry-run idempotency, commit revalidation, re-commit short-circuit). 980/980 repo tests green.
- **Playwright**: added `/settings/accounts` and `/settings/accounts/5/consolidate/2026-03` to the screenshot spec. Without `DEV_AUTH_BYPASS=1` they capture the login redirect — treated as a smoke-route entry rather than visual regression.

### Preview UX

Three collapsible sections on the preview panel:

1. **Con updates (N)** — matched rows whose installments/rate will change. Default open when N>0. Each row shows before→after for both fields.
2. **Nuevas (M)** — during-period rows missing from the ledger (will be INSERTed). Before-period missing rows listed separately and skipped.
3. **Sin match (K)** — ledger txs with no corresponding statement row. Read-only diagnostic — never auto-touched, linked to `/transactions` for manual review.

Plus an `Alert` with the intereses-causados projection so the user knows what synthetic tx will land on confirm.

### Acceptance checklist (issue #419)

- [x] Upload → preview with matches + intereses projection.
- [x] Confirm applies in <5s, page flips to 'consolidated' read-only card via `router.refresh()`.
- [x] Re-consolidar shows the read-only card (no silent overwrite). 'Ya consolidado' message explicitly explains the escape hatch.
- [x] Banner appears on `/dashboard` when cycles > 7 days pending.
- [x] Screenshots spec entry added.

### Out of scope (per issue)

- Rollback / undo — existing runs can only be dropped via DB (epic follow-up).
- Multi-file / multi-cycle batch upload.
- Mobile-first layout.

## Test plan

- [x] `bun run test` → 980/980 pass.
- [x] `bun run lint` / `format:check` / `typecheck` — clean.
- [x] Smoke: load `/settings/accounts/5/consolidate/2026-03` locally, upload the private Visa fixture — preview renders 3 sections, confirm writes statement_imports row with `kind=extracto_detallado`, banner disappears on `/`.

Closes #419