### PR TITLE
feat(ingestion): multi-sheet Bancolombia extracto (PESOS + DOLARES) (#426)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-form.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-form.tsx
@@ -3,17 +3,16 @@
 import { useCallback, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { AlertTriangleIcon, CheckCircleIcon, PlusCircleIcon, UploadCloudIcon } from "lucide-react";
+import { UploadCloudIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import type { ConsolidationReport } from "@/lib/ingestion/bancolombia-statement/consolidate";
 
 import { commitStatementAction, previewStatementAction } from "../actions";
+import { isMultiReport, type ConsolidateActionResult } from "../consolidate-types";
+import { ReportSection } from "./consolidate-report-view";
 
 type Props = {
   accountId: number;
@@ -22,30 +21,18 @@ type Props = {
   institutionSlug: string;
 };
 
-function formatCents(str: string): string {
-  if (!str) return "—";
-  const big = BigInt(str);
-  const negative = big < BigInt(0);
-  const abs = negative ? -big : big;
-  const units = abs / BigInt(100);
-  const fractional = (abs % BigInt(100)).toString().padStart(2, "0");
-  const unitsStr = units.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-  return `${negative ? "-" : ""}$${unitsStr},${fractional}`;
+function toReportList(result: ConsolidateActionResult): ConsolidationReport[] {
+  return isMultiReport(result) ? result.reports : [result];
 }
 
-function formatRate(x10k: number | null): string {
-  if (x10k == null) return "—";
-  const whole = Math.floor(x10k / 10_000);
-  const frac = (x10k % 10_000).toString().padStart(4, "0");
-  return `${whole},${frac}%`;
+function sumMatched(reports: ConsolidationReport[]): number {
+  return reports.reduce((a, r) => a + r.matchStats.matched, 0);
 }
-
-function formatDate(iso: string): string {
-  return new Intl.DateTimeFormat("es-CO", {
-    day: "2-digit",
-    month: "short",
-    timeZone: "America/Bogota",
-  }).format(new Date(iso));
+function sumInserted(reports: ConsolidationReport[]): number {
+  return reports.reduce((a, r) => a + r.matchStats.insertedMissing, 0);
+}
+function sumUnmatched(reports: ConsolidationReport[]): number {
+  return reports.reduce((a, r) => a + r.matchStats.unmatchedInLedger, 0);
 }
 
 export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug }: Props) {
@@ -53,7 +40,7 @@ export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
   const [dragging, setDragging] = useState(false);
-  const [preview, setPreview] = useState<ConsolidationReport | null>(null);
+  const [preview, setPreview] = useState<ConsolidateActionResult | null>(null);
   const [parsing, startParsing] = useTransition();
   const [applying, startApplying] = useTransition();
 
@@ -87,16 +74,37 @@ export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug
     fd.set("cycle", cycle);
     startParsing(async () => {
       try {
-        const report = await previewStatementAction(fd);
-        setPreview(report);
+        const result = await previewStatementAction(fd);
+        setPreview(result);
+        const reports = toReportList(result);
+        const suffix =
+          reports.length > 1
+            ? ` · ${reports.length} hojas (${reports.map((r) => r.accountId).join(", ")})`
+            : "";
         toast.success(
-          `Preview listo · ${report.matchStats.matched} matched, ${report.matchStats.insertedMissing} nuevas, ${report.matchStats.unmatchedInLedger} sin match`,
+          `Preview listo · ${sumMatched(reports)} matched, ${sumInserted(reports)} nuevas, ${sumUnmatched(reports)} sin match${suffix}`,
         );
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Parse failed";
         if (msg.startsWith("last4_mismatch")) {
           toast.error(
             `El xlsx es de otra tarjeta. Subí el extracto correspondiente a ${accountName}.`,
+          );
+        } else if (msg.startsWith("currency_mismatch")) {
+          toast.error(
+            `La moneda del extracto no coincide con la cuenta (${accountName}). Subí el extracto correcto.`,
+          );
+        } else if (msg.startsWith("missing_usd_sibling")) {
+          toast.error(
+            "El xlsx incluye la hoja DOLARES pero esta tarjeta no tiene una sub-cuenta USD linkeada. Creala desde Cuentas → Tarjetas físicas.",
+          );
+        } else if (msg.startsWith("missing_cop_sibling")) {
+          toast.error(
+            "El xlsx incluye la hoja PESOS pero no hay una sub-cuenta COP linkeada a este plástico.",
+          );
+        } else if (msg === "multi_sheet_without_physical_card") {
+          toast.error(
+            "El xlsx es multi-moneda (PESOS + DOLARES) pero esta cuenta no está asociada a una tarjeta física. Asocíala primero.",
           );
         } else if (msg === "unsupported_file_type") {
           toast.error("Solo soportamos .xlsx por ahora (no PDF).");
@@ -119,12 +127,17 @@ export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug
     fd.set("cycle", cycle);
     startApplying(async () => {
       try {
-        const report = await commitStatementAction(fd);
-        if (report.status === "already-consolidated") {
+        const result = await commitStatementAction(fd);
+        const reports = toReportList(result);
+        const allAlreadyConsolidated = reports.every((r) => r.status === "already-consolidated");
+        if (allAlreadyConsolidated) {
           toast.info("Ya estaba consolidado — sin cambios.");
         } else {
+          const insertedTotal = reports.reduce((a, r) => a + r.insertedTxIds.length, 0);
+          const interesesSummary = reports.map((r) => r.intereses.status).join(" / ");
+          const suffix = reports.length > 1 ? ` (${reports.length} hojas)` : "";
           toast.success(
-            `Consolidado · ${report.matchStats.matched} matched, ${report.insertedTxIds.length} insertadas, intereses: ${report.intereses.status}`,
+            `Consolidado · ${sumMatched(reports)} matched, ${insertedTotal} insertadas, intereses: ${interesesSummary}${suffix}`,
           );
         }
         setPreview(null);
@@ -138,10 +151,13 @@ export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug
   }
 
   const busy = parsing || applying;
+  const previewReports = preview ? toReportList(preview) : [];
   const canConfirm =
-    preview !== null &&
-    preview.status === "dry-run" &&
-    (preview.matchStats.matched > 0 || preview.matchStats.insertedMissing > 0);
+    previewReports.length > 0 &&
+    previewReports.some(
+      (r) =>
+        r.status === "dry-run" && (r.matchStats.matched > 0 || r.matchStats.insertedMissing > 0),
+    );
 
   return (
     <div className="flex flex-col gap-6">
@@ -210,7 +226,7 @@ export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug
 
       {preview ? (
         <PreviewPanel
-          report={preview}
+          reports={previewReports}
           onConfirm={runCommit}
           canConfirm={canConfirm}
           applying={applying}
@@ -221,247 +237,37 @@ export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug
 }
 
 function PreviewPanel({
-  report,
+  reports,
   onConfirm,
   canConfirm,
   applying,
 }: {
-  report: ConsolidationReport;
+  reports: ConsolidationReport[];
   onConfirm: () => void;
   canConfirm: boolean;
   applying: boolean;
 }) {
-  const willChangeRows = report.matchedDiffs.filter((d) => d.willChange);
-  const noChangeMatches = report.matchedDiffs.length - willChangeRows.length;
-  const interesesLine =
-    report.intereses.status === "inserted"
-      ? `se insertará 1 tx sintética intereses-tc por ${formatCents(report.intereses.totalInterestCentsStr)}`
-      : report.intereses.status === "skipped"
-        ? `no se insertará tx sintética (${report.intereses.reason})`
-        : `intereses se corren al confirmar (dry-run lo omite)`;
-
+  const isMulti = reports.length > 1;
   return (
     <Card data-testid="consolidate-preview">
       <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <CardTitle>Preview — dry-run</CardTitle>
           <CardDescription>
-            Revisá los cambios antes de confirmar. Una vez aplicado, el ciclo queda marcado como
-            consolidado y cualquier re-subida se convierte en no-op.
+            {isMulti
+              ? "El extracto trae varias hojas. Al confirmar aplicamos la consolidación a cada cuenta asociada."
+              : "Revisá los cambios antes de confirmar. Una vez aplicado, el ciclo queda marcado como consolidado y cualquier re-subida se convierte en no-op."}
           </CardDescription>
         </div>
         <Button type="button" onClick={onConfirm} disabled={!canConfirm || applying}>
           {applying ? "Aplicando…" : "Confirmar consolidación"}
         </Button>
       </CardHeader>
-      <CardContent className="flex flex-col gap-4">
-        <SummaryGrid report={report} />
-        <Alert>
-          <AlertTitle>Proyección de intereses</AlertTitle>
-          <AlertDescription>
-            Al confirmar, {interesesLine}.{" "}
-            {report.intereses.status === "inserted"
-              ? `Compras multi-cuota sin tasa: ${report.intereses.purchasesNeedingRate}.`
-              : null}
-          </AlertDescription>
-        </Alert>
-
-        <MatchesSection rows={willChangeRows} noChangeCount={noChangeMatches} />
-        <MissingSection missing={report.missingInLedger} />
-        <UnmatchedSection ids={report.unmatchedInLedgerIds} />
+      <CardContent className="flex flex-col gap-6">
+        {reports.map((report, idx) => (
+          <ReportSection key={`${report.accountId}-${idx}`} report={report} showHeading={isMulti} />
+        ))}
       </CardContent>
     </Card>
-  );
-}
-
-function SummaryGrid({ report }: { report: ConsolidationReport }) {
-  return (
-    <dl className="grid grid-cols-2 gap-2 rounded-md border p-3 text-sm sm:grid-cols-5">
-      <Stat label="Matched" value={report.matchStats.matched} />
-      <Stat label="Updates" value={report.matchStats.matchedWillChange} />
-      <Stat label="Nuevas" value={report.matchStats.insertedMissing} />
-      <Stat label="Antes (skip)" value={report.matchStats.skippedMissingBefore} />
-      <Stat label="Sin match" value={report.matchStats.unmatchedInLedger} muted />
-    </dl>
-  );
-}
-
-function Stat({ label, value, muted = false }: { label: string; value: number; muted?: boolean }) {
-  return (
-    <div>
-      <dt className="text-muted-foreground text-xs">{label}</dt>
-      <dd className={cn("font-medium", muted && "text-muted-foreground")}>{value}</dd>
-    </div>
-  );
-}
-
-function MatchesSection({
-  rows,
-  noChangeCount,
-}: {
-  rows: ConsolidationReport["matchedDiffs"];
-  noChangeCount: number;
-}) {
-  return (
-    <Collapsible defaultOpen={rows.length > 0}>
-      <CollapsibleTrigger
-        data-testid="consolidate-matches-trigger"
-        className="hover:bg-muted flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm"
-      >
-        <span className="flex items-center gap-2 font-medium">
-          <CheckCircleIcon className="size-4 text-emerald-600 dark:text-emerald-400" />
-          Con updates ({rows.length})
-          {noChangeCount > 0 ? (
-            <span className="text-muted-foreground text-xs">+{noChangeCount} ya alineadas</span>
-          ) : null}
-        </span>
-        <Badge variant="secondary">{rows.length}</Badge>
-      </CollapsibleTrigger>
-      <CollapsibleContent className="mt-2">
-        {rows.length === 0 ? (
-          <p className="text-muted-foreground px-3 py-2 text-xs">
-            Ninguna fila matched requiere update — todas ya estaban alineadas con el extracto.
-          </p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-left text-sm">
-              <thead className="text-muted-foreground text-xs">
-                <tr>
-                  <th className="py-1 pr-3">Fecha</th>
-                  <th className="py-1 pr-3">Merchant</th>
-                  <th className="py-1 pr-3 text-right">Monto</th>
-                  <th className="py-1 pr-3">Cuotas</th>
-                  <th className="py-1 pr-3">Tasa EM</th>
-                  <th className="py-1 pr-3 text-right">Tx</th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((row) => (
-                  <tr key={row.txId} className="border-t">
-                    <td className="py-1 pr-3">{formatDate(row.occurredAt)}</td>
-                    <td className="truncate py-1 pr-3">{row.merchant}</td>
-                    <td className="py-1 pr-3 text-right tabular-nums">
-                      {formatCents(row.amountCentsStr)}
-                    </td>
-                    <td className="py-1 pr-3 tabular-nums">
-                      {row.installmentsTotalBefore} → {row.installmentsTotalAfter}
-                    </td>
-                    <td className="py-1 pr-3 tabular-nums">
-                      {formatRate(row.rateEmX10kBefore)} → {formatRate(row.rateEmX10kAfter)}
-                    </td>
-                    <td className="text-muted-foreground py-1 pr-3 text-right text-xs">
-                      #{row.txId}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </CollapsibleContent>
-    </Collapsible>
-  );
-}
-
-function MissingSection({ missing }: { missing: ConsolidationReport["missingInLedger"] }) {
-  const during = missing.filter((r) => r.kind === "during-period");
-  const before = missing.filter((r) => r.kind === "before-period");
-
-  return (
-    <Collapsible defaultOpen={during.length > 0}>
-      <CollapsibleTrigger
-        data-testid="consolidate-missing-trigger"
-        className="hover:bg-muted flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm"
-      >
-        <span className="flex items-center gap-2 font-medium">
-          <PlusCircleIcon className="size-4 text-sky-600 dark:text-sky-400" />
-          Nuevas ({during.length})
-          {before.length > 0 ? (
-            <span className="text-muted-foreground text-xs">+{before.length} antes del ciclo</span>
-          ) : null}
-        </span>
-        <Badge variant="secondary">{during.length}</Badge>
-      </CollapsibleTrigger>
-      <CollapsibleContent className="mt-2">
-        {missing.length === 0 ? (
-          <p className="text-muted-foreground px-3 py-2 text-xs">
-            No hay compras en el extracto que falten en Findash.
-          </p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-left text-sm">
-              <thead className="text-muted-foreground text-xs">
-                <tr>
-                  <th className="py-1 pr-3">Fecha</th>
-                  <th className="py-1 pr-3">Merchant</th>
-                  <th className="py-1 pr-3 text-right">Monto</th>
-                  <th className="py-1 pr-3">Auth</th>
-                  <th className="py-1 pr-3">Acción</th>
-                </tr>
-              </thead>
-              <tbody>
-                {missing.map((row) => (
-                  <tr key={`${row.authorizationNumber}-${row.occurredAt}`} className="border-t">
-                    <td className="py-1 pr-3">{formatDate(row.occurredAt)}</td>
-                    <td className="truncate py-1 pr-3">{row.merchant}</td>
-                    <td className="py-1 pr-3 text-right tabular-nums">
-                      {formatCents(row.amountCentsStr)}
-                    </td>
-                    <td className="py-1 pr-3 font-mono text-xs">
-                      {row.authorizationNumber ?? "—"}
-                    </td>
-                    <td className="py-1 pr-3">
-                      {row.kind === "during-period" ? (
-                        <Badge variant="secondary">insert</Badge>
-                      ) : (
-                        <Badge variant="outline">before — skip</Badge>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </CollapsibleContent>
-    </Collapsible>
-  );
-}
-
-function UnmatchedSection({ ids }: { ids: number[] }) {
-  return (
-    <Collapsible>
-      <CollapsibleTrigger
-        data-testid="consolidate-unmatched-trigger"
-        className="hover:bg-muted flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm"
-      >
-        <span className="flex items-center gap-2 font-medium">
-          <AlertTriangleIcon className="size-4 text-amber-600 dark:text-amber-400" />
-          Sin match en el extracto ({ids.length})
-        </span>
-        <Badge variant="secondary">{ids.length}</Badge>
-      </CollapsibleTrigger>
-      <CollapsibleContent className="mt-2">
-        {ids.length === 0 ? (
-          <p className="text-muted-foreground px-3 py-2 text-xs">
-            Todas las transacciones del período aparecen en el extracto.
-          </p>
-        ) : (
-          <p className="text-muted-foreground px-3 py-2 text-xs">
-            Estas transacciones están en Findash pero no en el extracto — probablemente son dupes de
-            SMS (retry), reversiones netted-out, o errores. Revisalas en{" "}
-            <a className="underline" href="/transactions">
-              /transactions
-            </a>
-            . No se tocan automáticamente.
-            <br />
-            <span className="font-mono text-xs">
-              IDs: {ids.slice(0, 20).join(", ")}
-              {ids.length > 20 ? ` … (+${ids.length - 20} más)` : null}
-            </span>
-          </p>
-        )}
-      </CollapsibleContent>
-    </Collapsible>
   );
 }

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-report-view.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-report-view.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { AlertTriangleIcon, CheckCircleIcon, PlusCircleIcon } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import type { ConsolidationReport } from "@/lib/ingestion/bancolombia-statement/consolidate";
+
+export function formatCents(str: string): string {
+  if (!str) return "—";
+  const big = BigInt(str);
+  const negative = big < BigInt(0);
+  const abs = negative ? -big : big;
+  const units = abs / BigInt(100);
+  const fractional = (abs % BigInt(100)).toString().padStart(2, "0");
+  const unitsStr = units.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  return `${negative ? "-" : ""}$${unitsStr},${fractional}`;
+}
+
+export function formatRate(x10k: number | null): string {
+  if (x10k == null) return "—";
+  const whole = Math.floor(x10k / 10_000);
+  const frac = (x10k % 10_000).toString().padStart(4, "0");
+  return `${whole},${frac}%`;
+}
+
+export function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat("es-CO", {
+    day: "2-digit",
+    month: "short",
+    timeZone: "America/Bogota",
+  }).format(new Date(iso));
+}
+
+export function sectionLabel(report: ConsolidationReport): string {
+  return `${report.currency} · cuenta #${report.accountId}`;
+}
+
+export function ReportSection({
+  report,
+  showHeading,
+}: {
+  report: ConsolidationReport;
+  showHeading: boolean;
+}) {
+  const willChangeRows = report.matchedDiffs.filter((d) => d.willChange);
+  const noChangeMatches = report.matchedDiffs.length - willChangeRows.length;
+  const interesesLine =
+    report.intereses.status === "inserted"
+      ? `se insertó 1 tx sintética intereses-tc por ${formatCents(report.intereses.totalInterestCentsStr)}`
+      : report.intereses.status === "skipped"
+        ? `no se insertó tx sintética (${report.intereses.reason})`
+        : report.dryRun
+          ? `intereses se corren al confirmar (dry-run lo omite)`
+          : `intereses: ${report.intereses.reason}`;
+  return (
+    <section
+      data-testid="consolidate-report-section"
+      className={cn("flex flex-col gap-4", showHeading && "rounded-md border border-dashed p-4")}
+    >
+      {showHeading ? (
+        <div className="flex flex-wrap items-baseline gap-2">
+          <h3 className="text-sm font-semibold">{sectionLabel(report)}</h3>
+          <Badge variant="outline">{report.status}</Badge>
+        </div>
+      ) : null}
+      <SummaryGrid report={report} />
+      <Alert>
+        <AlertTitle>Intereses-causados</AlertTitle>
+        <AlertDescription>
+          {interesesLine}.{" "}
+          {report.intereses.status === "inserted"
+            ? `Compras multi-cuota sin tasa: ${report.intereses.purchasesNeedingRate}.`
+            : null}
+        </AlertDescription>
+      </Alert>
+
+      <MatchesSection rows={willChangeRows} noChangeCount={noChangeMatches} />
+      <MissingSection missing={report.missingInLedger} />
+      <UnmatchedSection ids={report.unmatchedInLedgerIds} />
+    </section>
+  );
+}
+
+function SummaryGrid({ report }: { report: ConsolidationReport }) {
+  return (
+    <dl className="grid grid-cols-2 gap-2 rounded-md border p-3 text-sm sm:grid-cols-5">
+      <Stat label="Matched" value={report.matchStats.matched} />
+      <Stat label="Updates" value={report.matchStats.matchedWillChange} />
+      <Stat label="Nuevas" value={report.matchStats.insertedMissing} />
+      <Stat label="Antes (skip)" value={report.matchStats.skippedMissingBefore} />
+      <Stat label="Sin match" value={report.matchStats.unmatchedInLedger} muted />
+    </dl>
+  );
+}
+
+function Stat({ label, value, muted = false }: { label: string; value: number; muted?: boolean }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground text-xs">{label}</dt>
+      <dd className={cn("font-medium", muted && "text-muted-foreground")}>{value}</dd>
+    </div>
+  );
+}
+
+function MatchesSection({
+  rows,
+  noChangeCount,
+}: {
+  rows: ConsolidationReport["matchedDiffs"];
+  noChangeCount: number;
+}) {
+  return (
+    <Collapsible defaultOpen={rows.length > 0}>
+      <CollapsibleTrigger
+        data-testid="consolidate-matches-trigger"
+        className="hover:bg-muted flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm"
+      >
+        <span className="flex items-center gap-2 font-medium">
+          <CheckCircleIcon className="size-4 text-emerald-600 dark:text-emerald-400" />
+          Con updates ({rows.length})
+          {noChangeCount > 0 ? (
+            <span className="text-muted-foreground text-xs">+{noChangeCount} ya alineadas</span>
+          ) : null}
+        </span>
+        <Badge variant="secondary">{rows.length}</Badge>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2">
+        {rows.length === 0 ? (
+          <p className="text-muted-foreground px-3 py-2 text-xs">
+            Ninguna fila matched requiere update — todas ya estaban alineadas con el extracto.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="text-muted-foreground text-xs">
+                <tr>
+                  <th className="py-1 pr-3">Fecha</th>
+                  <th className="py-1 pr-3">Merchant</th>
+                  <th className="py-1 pr-3 text-right">Monto</th>
+                  <th className="py-1 pr-3">Cuotas</th>
+                  <th className="py-1 pr-3">Tasa EM</th>
+                  <th className="py-1 pr-3 text-right">Tx</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.txId} className="border-t">
+                    <td className="py-1 pr-3">{formatDate(row.occurredAt)}</td>
+                    <td className="truncate py-1 pr-3">{row.merchant}</td>
+                    <td className="py-1 pr-3 text-right tabular-nums">
+                      {formatCents(row.amountCentsStr)}
+                    </td>
+                    <td className="py-1 pr-3 tabular-nums">
+                      {row.installmentsTotalBefore} → {row.installmentsTotalAfter}
+                    </td>
+                    <td className="py-1 pr-3 tabular-nums">
+                      {formatRate(row.rateEmX10kBefore)} → {formatRate(row.rateEmX10kAfter)}
+                    </td>
+                    <td className="text-muted-foreground py-1 pr-3 text-right text-xs">
+                      #{row.txId}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function MissingSection({ missing }: { missing: ConsolidationReport["missingInLedger"] }) {
+  const during = missing.filter((r) => r.kind === "during-period");
+  const before = missing.filter((r) => r.kind === "before-period");
+
+  return (
+    <Collapsible defaultOpen={during.length > 0}>
+      <CollapsibleTrigger
+        data-testid="consolidate-missing-trigger"
+        className="hover:bg-muted flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm"
+      >
+        <span className="flex items-center gap-2 font-medium">
+          <PlusCircleIcon className="size-4 text-sky-600 dark:text-sky-400" />
+          Nuevas ({during.length})
+          {before.length > 0 ? (
+            <span className="text-muted-foreground text-xs">+{before.length} antes del ciclo</span>
+          ) : null}
+        </span>
+        <Badge variant="secondary">{during.length}</Badge>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2">
+        {missing.length === 0 ? (
+          <p className="text-muted-foreground px-3 py-2 text-xs">
+            No hay compras en el extracto que falten en Findash.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="text-muted-foreground text-xs">
+                <tr>
+                  <th className="py-1 pr-3">Fecha</th>
+                  <th className="py-1 pr-3">Merchant</th>
+                  <th className="py-1 pr-3 text-right">Monto</th>
+                  <th className="py-1 pr-3">Auth</th>
+                  <th className="py-1 pr-3">Acción</th>
+                </tr>
+              </thead>
+              <tbody>
+                {missing.map((row) => (
+                  <tr key={`${row.authorizationNumber}-${row.occurredAt}`} className="border-t">
+                    <td className="py-1 pr-3">{formatDate(row.occurredAt)}</td>
+                    <td className="truncate py-1 pr-3">{row.merchant}</td>
+                    <td className="py-1 pr-3 text-right tabular-nums">
+                      {formatCents(row.amountCentsStr)}
+                    </td>
+                    <td className="py-1 pr-3 font-mono text-xs">
+                      {row.authorizationNumber ?? "—"}
+                    </td>
+                    <td className="py-1 pr-3">
+                      {row.kind === "during-period" ? (
+                        <Badge variant="secondary">insert</Badge>
+                      ) : (
+                        <Badge variant="outline">before — skip</Badge>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function UnmatchedSection({ ids }: { ids: number[] }) {
+  return (
+    <Collapsible>
+      <CollapsibleTrigger
+        data-testid="consolidate-unmatched-trigger"
+        className="hover:bg-muted flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm"
+      >
+        <span className="flex items-center gap-2 font-medium">
+          <AlertTriangleIcon className="size-4 text-amber-600 dark:text-amber-400" />
+          Sin match en el extracto ({ids.length})
+        </span>
+        <Badge variant="secondary">{ids.length}</Badge>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2">
+        {ids.length === 0 ? (
+          <p className="text-muted-foreground px-3 py-2 text-xs">
+            Todas las transacciones del período aparecen en el extracto.
+          </p>
+        ) : (
+          <p className="text-muted-foreground px-3 py-2 text-xs">
+            Estas transacciones están en Findash pero no en el extracto — probablemente son dupes de
+            SMS (retry), reversiones netted-out, o errores. Revisalas en{" "}
+            <a className="underline" href="/transactions">
+              /transactions
+            </a>
+            . No se tocan automáticamente.
+            <br />
+            <span className="font-mono text-xs">
+              IDs: {ids.slice(0, 20).join(", ")}
+              {ids.length > 20 ? ` … (+${ids.length - 20} más)` : null}
+            </span>
+          </p>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/page.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/page.tsx
@@ -13,6 +13,7 @@ import { buttonVariants } from "@/components/ui/button";
 
 import type { ConsolidationReport } from "@/lib/ingestion/bancolombia-statement/consolidate";
 import { ConsolidateForm } from "./consolidate-form";
+import { ReportSection } from "./consolidate-report-view";
 
 export const dynamic = "force-dynamic";
 
@@ -26,10 +27,20 @@ function formatBogotaDate(d: Date): string {
 }
 
 type CycleRouteParams = Promise<{ accountId: string; cycle: string }>;
+type CycleRouteSearchParams = Promise<{ view?: string | string[] }>;
 
-export default async function ConsolidatePage({ params }: { params: CycleRouteParams }) {
+export default async function ConsolidatePage({
+  params,
+  searchParams,
+}: {
+  params: CycleRouteParams;
+  searchParams?: CycleRouteSearchParams;
+}) {
   const session = await getSessionUser();
   const { accountId: rawId, cycle } = await params;
+  const search = (await searchParams) ?? {};
+  const rawView = Array.isArray(search.view) ? search.view[0] : search.view;
+  const view = rawView === "run" ? "run" : "summary";
   const accountId = Number(rawId);
   if (!Number.isInteger(accountId) || accountId <= 0) notFound();
   if (!/^\d{4}-\d{2}$/.test(cycle)) notFound();
@@ -106,7 +117,11 @@ export default async function ConsolidatePage({ params }: { params: CycleRoutePa
       </div>
 
       {existing ? (
-        <ExistingConsolidationCard existing={existing} cycle={cycle} accountId={accountId} />
+        view === "run" ? (
+          <ExistingRunDetail existing={existing} cycle={cycle} accountId={accountId} />
+        ) : (
+          <ExistingConsolidationCard existing={existing} cycle={cycle} accountId={accountId} />
+        )
       ) : (
         <ConsolidateForm
           accountId={accountId}
@@ -116,6 +131,56 @@ export default async function ConsolidatePage({ params }: { params: CycleRoutePa
         />
       )}
     </main>
+  );
+}
+
+function ExistingRunDetail({
+  existing,
+  cycle,
+  accountId,
+}: {
+  existing: {
+    id: number;
+    importedAt: Date;
+    syntheticTxId: number | null;
+    report: unknown;
+    txnCount: number;
+  };
+  cycle: string;
+  accountId: number;
+}) {
+  const report = (existing.report ?? null) as ConsolidationReport | null;
+  return (
+    <Card data-testid="consolidate-run-detail">
+      <CardHeader className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <CardTitle className="flex items-center gap-2">
+            Run consolidado
+            <Badge variant="secondary">{cycle}</Badge>
+          </CardTitle>
+          <CardDescription>
+            Corrida el {formatBogotaDate(existing.importedAt)} · statement_import #{existing.id} ·{" "}
+            {existing.txnCount} tx tocadas
+          </CardDescription>
+        </div>
+        <Link
+          href={`/settings/accounts/${accountId}/consolidate/${cycle}`}
+          className={buttonVariants({ variant: "outline", size: "sm" })}
+        >
+          Volver al resumen
+        </Link>
+      </CardHeader>
+      <CardContent>
+        {report ? (
+          <ReportSection report={report} showHeading={false} />
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            Este run no tiene un reporte guardado (puede que se haya ejecutado antes de que lo
+            persistiéramos). Re-ejecutalo desde la consola si necesitás el detalle.
+          </p>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/page.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/page.tsx
@@ -83,7 +83,7 @@ export default async function ConsolidatePage({ params }: { params: CycleRoutePa
   });
 
   return (
-    <div className="flex flex-col gap-6">
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 sm:p-6">
       <div className="flex flex-col gap-1">
         <div className="text-muted-foreground flex items-center gap-2 text-xs">
           <Link href="/settings/accounts" className="hover:underline">
@@ -115,7 +115,7 @@ export default async function ConsolidatePage({ params }: { params: CycleRoutePa
           institutionSlug={account.institutionSlug}
         />
       )}
-    </div>
+    </main>
   );
 }
 

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.test.ts
@@ -3,10 +3,26 @@ import { eq, sql } from "drizzle-orm";
 import * as XLSX from "xlsx";
 
 import { db } from "@/lib/db";
-import { accounts, statementImports, transactions, users } from "@/lib/db/schema";
+import { accounts, physicalCards, statementImports, transactions, users } from "@/lib/db/schema";
 import { copyCategorySeedsToUser } from "@/lib/auth/signup";
 
+import type { ConsolidationReport } from "@/lib/ingestion/bancolombia-statement/consolidate";
+import { isMultiReport, type ConsolidateActionResult } from "./consolidate-types";
+
 const TAG = "CONSOL_ACT_TEST";
+
+// Narrowing helper — existing tests exercise the single-sheet path, so callers
+// want a plain ConsolidationReport and assert on legacy fields. Fails loudly if
+// the action unexpectedly returns the multi shape so we don't silently miss a
+// regression.
+function asSingle(result: ConsolidateActionResult): ConsolidationReport {
+  if (isMultiReport(result)) {
+    throw new Error(
+      `asSingle: expected single-report result, got multi with ${result.reports.length} sheets`,
+    );
+  }
+  return result;
+}
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 const sessionMock = { id: 0, email: "test@test.local", name: "Test" };
@@ -206,7 +222,7 @@ describe("previewStatementAction / commitStatementAction", () => {
 
   it("preview returns a dry-run report without writing to the DB", async () => {
     const buf = buildSyntheticXlsxBuffer("2575");
-    const report = await previewStatementAction(formDataFor(buf, tcId, "2026-03"));
+    const report = asSingle(await previewStatementAction(formDataFor(buf, tcId, "2026-03")));
     expect(report.dryRun).toBe(true);
     expect(report.status).toBe("dry-run");
     // 2 missing during-period rows in the synthetic fixture (no matching txs seeded).
@@ -226,7 +242,7 @@ describe("previewStatementAction / commitStatementAction", () => {
     revalidate.mockClear();
 
     const buf = buildSyntheticXlsxBuffer("2575");
-    const report = await commitStatementAction(formDataFor(buf, tcId, "2026-03"));
+    const report = asSingle(await commitStatementAction(formDataFor(buf, tcId, "2026-03")));
     expect(report.status).toBe("consolidated");
     expect(report.insertedTxIds.length).toBe(2);
     expect(report.statementImportId).not.toBeNull();
@@ -241,12 +257,255 @@ describe("previewStatementAction / commitStatementAction", () => {
     expect(imports[0].kind).toBe("extracto_detallado");
 
     // Second call: already-consolidated, no new imports.
-    const second = await commitStatementAction(formDataFor(buf, tcId, "2026-03"));
+    const second = asSingle(await commitStatementAction(formDataFor(buf, tcId, "2026-03")));
     expect(second.status).toBe("already-consolidated");
     const stillOne = await db
       .select()
       .from(statementImports)
       .where(eq(statementImports.userId, userId));
     expect(stillOne).toHaveLength(1);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Multi-sheet dispatch (#426): Mastercard internacional .xlsx con PESOS+DOLARES
+// en un solo upload debe consolidar ambas cuentas linkeadas por physicalCardId.
+// -----------------------------------------------------------------------------
+
+function buildMultiSheetXlsxBuffer(last4: string): Buffer {
+  const aoa = (moneda: "PESOS" | "DOLARES"): (string | number | null)[][] => {
+    const isUsd = moneda === "DOLARES";
+    const rateRows: (string | number | null)[][] = isUsd
+      ? [
+          ["Compra Internacional", "1.9110 %", "25.5026 %", "+ Saldo anterior", "0,00"],
+          ["Avance Internacional", "1.9110 %", "25.5026 %", "+ Compras del mes", "500,00"],
+          ["Mora", "1.9110 %", "25.5026 %", "+ Intereses de mora", "0,00"],
+          [null, null, null, "+ Intereses corrientes", "0,00"],
+          [null, null, null, "+ Avances", "0,00"],
+        ]
+      : [
+          ["Compra un mes", "0.0000 %", "0.0000 %", "+ Saldo anterior", "0,00"],
+          ["Compra 2 - 36 meses", "1.9110 %", "25.5026 %", "+ Compras del mes", "500.000,00"],
+          ["Impuestos", "1.9110 %", "25.5026 %", "+ Intereses de mora", "0,00"],
+          ["Avances", "1.9110 %", "25.5026 %", "+ Intereses corrientes", "0,00"],
+          ["Mora", "1.9110 %", "25.5026 %", "+ Avances", "0,00"],
+        ];
+    const rows = isUsd
+      ? [
+          [
+            "010003",
+            "20/03/2026",
+            "USD MERCHANT",
+            "500,00",
+            "1/1",
+            "500,00",
+            "0,0000",
+            "00,0000",
+            "0,00",
+          ],
+        ]
+      : [
+          [
+            "010001",
+            "20/03/2026",
+            "COP MERCHANT",
+            "500.000,00",
+            "1/1",
+            "500.000,00",
+            "0,0000",
+            "00,0000",
+            "0,00",
+          ],
+        ];
+    return [
+      ["Información Cliente:"],
+      ["Cliente", null, "Dirección"],
+      ["TEST", null, "CALLE 1"],
+      [],
+      ["Información de la Tarjeta", `************${last4}`],
+      ["Moneda: ", moneda],
+      [],
+      ["Periodo facturado: ", "01 mar", "30 mar. 2026"],
+      ["Pagar antes de: ", "abr. 16, 2026"],
+      ["Pago mínimo", "100.000,00"],
+      ["Pago total", "500.000,00"],
+      ["Cupo total: ", "1.000.000,00"],
+      ["Cupo disponible: ", "500.000,00"],
+      [],
+      [],
+      [
+        "Tasas de interés vigente",
+        "Tasa Mes Vencido",
+        "Tasa Efectivo Anual",
+        "Resumen Saldo Total",
+        "",
+        "Resumen Pago Mínimo",
+      ],
+      [],
+      ...rateRows,
+      [null, null, null, "+ Otros cargos", "0,00"],
+      [null, null, null, "Cargos", "500.000,00"],
+      [null, null, null, "(-) Pagos / abonos", "0,00"],
+      [null, null, null, "(-) Saldo a favor", "0,00"],
+      [null, null, null, "Abono", "0,00"],
+      [],
+      [],
+      ["Movimientos durante el periodo"],
+      [
+        "Número de autorización",
+        "Fecha",
+        "Movimientos",
+        "Valor Movimiento",
+        "Número de cuotas",
+        "Valor cuota/abono",
+        "Interés mensual (%)",
+        "Interés anual (%)",
+        "Saldo pendiente",
+      ],
+      ...rows,
+    ];
+  };
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(aoa("PESOS")), "PESOS");
+  XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(aoa("DOLARES")), "DOLARES");
+  return Buffer.from(XLSX.write(wb, { bookType: "xlsx", type: "buffer" }));
+}
+
+async function createPhysicalCard(userId: number, last4: string): Promise<string> {
+  const [row] = await db
+    .insert(physicalCards)
+    .values({
+      id: sql`gen_random_uuid()`,
+      userId,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      name: `${TAG} mastercard ${last4}`,
+      creditLimitCents: BigInt(10_000_000_00),
+      network: "mastercard",
+      last4,
+    })
+    .returning({ id: physicalCards.id });
+  return row.id;
+}
+
+async function createTcLinked(
+  userId: number,
+  last4: string,
+  currency: "COP" | "USD",
+  physicalCardId: string,
+): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} mc ${last4} ${currency}`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      type: "credit_card",
+      currency,
+      metadata: { last4s: [last4] },
+      physicalCardId,
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+describe("multi-sheet dispatch (#426)", () => {
+  let userId!: number;
+  let pcId!: string;
+  let copAccountId!: number;
+  let usdAccountId!: number;
+  let soloCopAccountId!: number; // no sibling → should reject multi-sheet
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.ms.${Date.now()}@test.local`);
+    sessionMock.id = userId;
+    pcId = await createPhysicalCard(userId, "7291");
+    copAccountId = await createTcLinked(userId, "7291", "COP", pcId);
+    usdAccountId = await createTcLinked(userId, "7291", "USD", pcId);
+    const soloPc = await createPhysicalCard(userId, "5555");
+    soloCopAccountId = await createTcLinked(userId, "5555", "COP", soloPc);
+  });
+
+  afterEach(async () => {
+    await db.execute(
+      sql`DELETE FROM transactions WHERE user_id = ${userId} AND external_id LIKE 'bancolombia-stmt:%'`,
+    );
+    await db.delete(statementImports).where(eq(statementImports.userId, userId));
+    await db.execute(
+      sql`DELETE FROM transactions WHERE user_id = ${userId} AND category_slug = 'intereses-tc'`,
+    );
+  });
+
+  afterAll(async () => {
+    await db.delete(accounts).where(eq(accounts.userId, userId));
+    await db.delete(physicalCards).where(eq(physicalCards.userId, userId));
+    await db.delete(users).where(eq(users.id, userId));
+  });
+
+  it("preview against a multi-sheet xlsx returns reports for BOTH sibling accounts", async () => {
+    const buf = buildMultiSheetXlsxBuffer("7291");
+    const result = await previewStatementAction(formDataFor(buf, copAccountId, "2026-03"));
+    if (!isMultiReport(result)) {
+      throw new Error("expected multi-sheet result");
+    }
+    expect(result.reports).toHaveLength(2);
+    const byCurrency = Object.fromEntries(result.reports.map((r) => [r.currency, r]));
+    expect(byCurrency.COP.accountId).toBe(copAccountId);
+    expect(byCurrency.USD.accountId).toBe(usdAccountId);
+    expect(byCurrency.COP.status).toBe("dry-run");
+    expect(byCurrency.USD.status).toBe("dry-run");
+    expect(byCurrency.COP.matchStats.insertedMissing).toBe(1);
+    expect(byCurrency.USD.matchStats.insertedMissing).toBe(1);
+    // Dry-run should not write.
+    const imports = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.userId, userId));
+    expect(imports).toHaveLength(0);
+  });
+
+  it("commit against a multi-sheet xlsx writes one statement_imports row per account", async () => {
+    const buf = buildMultiSheetXlsxBuffer("7291");
+    const result = await commitStatementAction(formDataFor(buf, copAccountId, "2026-03"));
+    if (!isMultiReport(result)) throw new Error("expected multi-sheet result");
+    expect(result.reports).toHaveLength(2);
+    expect(result.reports.every((r) => r.status === "consolidated")).toBe(true);
+
+    const imports = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.userId, userId));
+    expect(imports).toHaveLength(2);
+    const accountIds = new Set(imports.map((i) => i.accountId));
+    expect(accountIds.has(copAccountId)).toBe(true);
+    expect(accountIds.has(usdAccountId)).toBe(true);
+
+    // Re-commit is idempotent per account (both come back already-consolidated).
+    const second = await commitStatementAction(formDataFor(buf, copAccountId, "2026-03"));
+    if (!isMultiReport(second)) throw new Error("expected multi-sheet result");
+    expect(second.reports.every((r) => r.status === "already-consolidated")).toBe(true);
+    const stillTwo = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.userId, userId));
+    expect(stillTwo).toHaveLength(2);
+  });
+
+  it("multi-sheet xlsx on an account without a USD sibling throws missing_usd_sibling", async () => {
+    const buf = buildMultiSheetXlsxBuffer("5555");
+    await expect(
+      previewStatementAction(formDataFor(buf, soloCopAccountId, "2026-03")),
+    ).rejects.toThrow(/missing_usd_sibling/);
+  });
+
+  it("entering from the USD sibling also dispatches to both accounts", async () => {
+    const buf = buildMultiSheetXlsxBuffer("7291");
+    const result = await previewStatementAction(formDataFor(buf, usdAccountId, "2026-03"));
+    if (!isMultiReport(result)) throw new Error("expected multi-sheet result");
+    expect(result.reports).toHaveLength(2);
+    const byCurrency = Object.fromEntries(result.reports.map((r) => [r.currency, r]));
+    expect(byCurrency.COP.accountId).toBe(copAccountId);
+    expect(byCurrency.USD.accountId).toBe(usdAccountId);
   });
 });

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { z } from "zod";
 
 import { db } from "@/lib/db";
@@ -13,8 +13,14 @@ import {
   hashStatementBuffer,
   type ConsolidationReport,
 } from "@/lib/ingestion/bancolombia-statement/consolidate";
-import { parseBancolombiaStatement } from "@/lib/ingestion/bancolombia-statement/xlsx";
+import { parseBancolombiaStatementAllSheets } from "@/lib/ingestion/bancolombia-statement/xlsx";
+import type { ParsedStatement } from "@/lib/ingestion/bancolombia-statement/types";
 import { createLogger } from "@/lib/logger";
+
+// Only async exports are allowed from a "use server" file in Next.js 16; types
+// are elided at runtime and safe, but non-async helpers (e.g. type guards) must
+// live in a non-server module — see `./consolidate-types`.
+import type { ConsolidateActionResult } from "./consolidate-types";
 
 const log = createLogger({ module: "consolidate-actions" });
 
@@ -25,7 +31,17 @@ const inputSchema = z.object({
   cycle: z.string().regex(/^\d{4}-\d{2}$/, "cycle must be YYYY-MM"),
 });
 
-async function loadTcAccount(userId: number, accountId: number) {
+type TcAccount = {
+  id: number;
+  name: string;
+  currency: "COP" | "USD";
+  institutionSlug: string;
+  type: string;
+  metadata: typeof accounts.$inferSelect.metadata;
+  physicalCardId: string | null;
+};
+
+async function loadTcAccount(userId: number, accountId: number): Promise<TcAccount> {
   const [account] = await db
     .select({
       id: accounts.id,
@@ -34,6 +50,7 @@ async function loadTcAccount(userId: number, accountId: number) {
       institutionSlug: accounts.institutionSlug,
       type: accounts.type,
       metadata: accounts.metadata,
+      physicalCardId: accounts.physicalCardId,
     })
     .from(accounts)
     .where(
@@ -50,6 +67,108 @@ async function loadTcAccount(userId: number, accountId: number) {
   return account;
 }
 
+// For multi-sheet dispatch: given a credit_card account sharing a physical card
+// with another currency sub-account, return the sibling (opposite currency).
+// Returns null when no sibling exists — caller raises `missing_usd_sibling` or
+// equivalent based on the parsed sheet's expectations.
+async function loadSiblingAccount(
+  userId: number,
+  physicalCardId: string,
+  excludeAccountId: number,
+): Promise<TcAccount | null> {
+  const [sibling] = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      currency: accounts.currency,
+      institutionSlug: accounts.institutionSlug,
+      type: accounts.type,
+      metadata: accounts.metadata,
+      physicalCardId: accounts.physicalCardId,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, userId),
+        eq(accounts.physicalCardId, physicalCardId),
+        ne(accounts.id, excludeAccountId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .limit(1);
+  return sibling ?? null;
+}
+
+function last4sOf(account: TcAccount): string[] {
+  return Array.isArray(account.metadata?.last4s) ? account.metadata!.last4s : [];
+}
+
+function assertLast4Match(account: TcAccount, parsed: ParsedStatement) {
+  const last4s = last4sOf(account);
+  if (last4s.length > 0 && parsed.account.last4 && !last4s.includes(parsed.account.last4)) {
+    throw new Error(`last4_mismatch:file=${parsed.account.last4},account=${last4s.join(",")}`);
+  }
+}
+
+// Multi-sheet dispatch: resolves which ParsedStatement targets which account
+// based on currency. Raises `missing_usd_sibling` / `missing_cop_sibling` when
+// the xlsx carries a sheet whose currency has no linked account to consolidate
+// into. Raises `currency_mismatch` when a single-sheet upload's currency does
+// not match the account the user navigated to.
+async function resolveDispatch(
+  userId: number,
+  originAccount: TcAccount,
+  parsed: ParsedStatement[],
+): Promise<{ account: TcAccount; parsed: ParsedStatement }[]> {
+  if (parsed.length === 0) {
+    throw new Error("no_sheets_parsed");
+  }
+  if (parsed.length === 1) {
+    const only = parsed[0];
+    if (only.account.currency !== originAccount.currency) {
+      throw new Error(
+        `currency_mismatch:file=${only.account.currency},account=${originAccount.currency}`,
+      );
+    }
+    assertLast4Match(originAccount, only);
+    return [{ account: originAccount, parsed: only }];
+  }
+
+  // Multi-sheet: need a sibling to absorb the other currency.
+  if (!originAccount.physicalCardId) {
+    throw new Error("multi_sheet_without_physical_card");
+  }
+  const sibling = await loadSiblingAccount(userId, originAccount.physicalCardId, originAccount.id);
+  if (!sibling) {
+    // Name the error by the missing currency so the UI can tell the user
+    // exactly what's not linked.
+    const originCurrencies = new Set(parsed.map((p) => p.account.currency));
+    if (!originCurrencies.has(originAccount.currency)) {
+      throw new Error("currency_mismatch:file_missing_account_currency");
+    }
+    const missing = parsed.map((p) => p.account.currency).find((c) => c !== originAccount.currency);
+    throw new Error(`missing_${(missing ?? "usd").toLowerCase()}_sibling`);
+  }
+  if (sibling.institutionSlug !== "bancolombia") {
+    throw new Error(`unsupported_sibling_institution:${sibling.institutionSlug}`);
+  }
+
+  const dispatches: { account: TcAccount; parsed: ParsedStatement }[] = [];
+  for (const p of parsed) {
+    let target: TcAccount | null = null;
+    if (p.account.currency === originAccount.currency) target = originAccount;
+    else if (p.account.currency === sibling.currency) target = sibling;
+    if (!target) {
+      throw new Error(
+        `currency_mismatch:file=${p.account.currency},origin=${originAccount.currency},sibling=${sibling.currency}`,
+      );
+    }
+    assertLast4Match(target, p);
+    dispatches.push({ account: target, parsed: p });
+  }
+  return dispatches;
+}
+
 async function readUploadedBuffer(formData: FormData): Promise<Buffer> {
   const file = formData.get("file");
   if (!(file instanceof File)) throw new Error("no_file");
@@ -59,99 +178,113 @@ async function readUploadedBuffer(formData: FormData): Promise<Buffer> {
   return Buffer.from(await file.arrayBuffer());
 }
 
-// Dry-run: parses the xlsx, runs matching against the ledger, returns a
-// ConsolidationReport without writing to the DB. The report is already
-// JSON-serializable (bigints serialized as strings) — safe to return to
-// a client component.
-export async function previewStatementAction(formData: FormData): Promise<ConsolidationReport> {
+// Dry-run: parses the xlsx, runs matching against the ledger for each sheet,
+// returns either a single ConsolidationReport (single-sheet xlsx) or a
+// MultiConsolidationReport wrapping one report per sheet (multi-currency
+// Mastercard/Amex internacionales). Already JSON-serializable (bigints
+// serialized as strings) — safe to return to a client component.
+export async function previewStatementAction(formData: FormData): Promise<ConsolidateActionResult> {
   const session = await getSessionUser();
   const { accountId, cycle } = inputSchema.parse({
     accountId: formData.get("accountId"),
     cycle: formData.get("cycle"),
   });
 
-  const account = await loadTcAccount(session.id, accountId);
+  const origin = await loadTcAccount(session.id, accountId);
   const buffer = await readUploadedBuffer(formData);
-  const parsed = parseBancolombiaStatement(buffer);
-
-  if (parsed.account.last4) {
-    const last4s = Array.isArray(account.metadata?.last4s) ? account.metadata!.last4s : [];
-    if (last4s.length > 0 && !last4s.includes(parsed.account.last4)) {
-      throw new Error(`last4_mismatch:file=${parsed.account.last4},account=${last4s.join(",")}`);
-    }
-  }
-
+  const parsedSheets = parseBancolombiaStatementAllSheets(buffer);
+  const dispatch = await resolveDispatch(session.id, origin, parsedSheets);
   const fileHash = hashStatementBuffer(buffer);
-  const report = await consolidateCycleFromStatement({
-    userId: session.id,
-    accountId: account.id,
-    cycle,
-    parsed,
-    fileHash,
-    dryRun: true,
-  });
+
+  const reports: ConsolidationReport[] = [];
+  for (const { account, parsed } of dispatch) {
+    const r = await consolidateCycleFromStatement({
+      userId: session.id,
+      accountId: account.id,
+      cycle,
+      parsed,
+      fileHash,
+      dryRun: true,
+    });
+    reports.push(r);
+  }
 
   log.info(
     {
       event: "statement_preview",
       userId: session.id,
-      accountId: account.id,
+      originAccountId: origin.id,
       cycle,
-      matched: report.matchStats.matched,
-      willChange: report.matchStats.matchedWillChange,
-      inserted: report.matchStats.insertedMissing,
+      sheetCount: parsedSheets.length,
+      reports: reports.map((r) => ({
+        accountId: r.accountId,
+        matched: r.matchStats.matched,
+        willChange: r.matchStats.matchedWillChange,
+        inserted: r.matchStats.insertedMissing,
+      })),
     },
     "statement preview computed",
   );
 
-  return report;
+  return reports.length === 1 ? reports[0] : { kind: "multi", reports };
 }
 
 // Commit: re-parses the uploaded xlsx (we don't trust a client-side round-trip
-// of the report), runs the full consolidation, and revalidates the surfaces
-// that render cycle state so the user immediately sees the "consolidated"
-// badge without a manual refresh.
-export async function commitStatementAction(formData: FormData): Promise<ConsolidationReport> {
+// of the report), runs the full consolidation for each sheet sequentially, and
+// revalidates the surfaces that render cycle state so the user immediately
+// sees the "consolidated" badge without a manual refresh.
+export async function commitStatementAction(formData: FormData): Promise<ConsolidateActionResult> {
   const session = await getSessionUser();
   const { accountId, cycle } = inputSchema.parse({
     accountId: formData.get("accountId"),
     cycle: formData.get("cycle"),
   });
 
-  const account = await loadTcAccount(session.id, accountId);
+  const origin = await loadTcAccount(session.id, accountId);
   const buffer = await readUploadedBuffer(formData);
-  const parsed = parseBancolombiaStatement(buffer);
+  const parsedSheets = parseBancolombiaStatementAllSheets(buffer);
+  const dispatch = await resolveDispatch(session.id, origin, parsedSheets);
   const fileHash = hashStatementBuffer(buffer);
 
-  const report = await consolidateCycleFromStatement({
-    userId: session.id,
-    accountId: account.id,
-    cycle,
-    parsed,
-    fileHash,
-    dryRun: false,
-  });
+  const reports: ConsolidationReport[] = [];
+  for (const { account, parsed } of dispatch) {
+    const r = await consolidateCycleFromStatement({
+      userId: session.id,
+      accountId: account.id,
+      cycle,
+      parsed,
+      fileHash,
+      dryRun: false,
+    });
+    reports.push(r);
+  }
 
   log.info(
     {
       event: "statement_commit",
       userId: session.id,
-      accountId: account.id,
+      originAccountId: origin.id,
       cycle,
-      status: report.status,
-      matched: report.matchStats.matched,
-      willChange: report.matchStats.matchedWillChange,
-      inserted: report.insertedTxIds.length,
-      intereses: report.intereses.status,
-      statementImportId: report.statementImportId,
+      sheetCount: parsedSheets.length,
+      reports: reports.map((r) => ({
+        accountId: r.accountId,
+        status: r.status,
+        matched: r.matchStats.matched,
+        willChange: r.matchStats.matchedWillChange,
+        inserted: r.insertedTxIds.length,
+        intereses: r.intereses.status,
+        statementImportId: r.statementImportId,
+      })),
     },
-    `statement commit: ${report.status}`,
+    `statement commit done (${reports.length} sheet${reports.length === 1 ? "" : "s"})`,
   );
 
   revalidatePath("/");
   revalidatePath("/transactions");
   revalidatePath("/settings/accounts");
-  revalidatePath(`/settings/accounts/${account.id}/consolidate/${cycle}`);
+  for (const r of reports) {
+    revalidatePath(`/settings/accounts/${r.accountId}/consolidate/${cycle}`);
+  }
 
-  return report;
+  return reports.length === 1 ? reports[0] : { kind: "multi", reports };
 }

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/consolidate-types.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/consolidate-types.ts
@@ -1,0 +1,16 @@
+import type { ConsolidationReport } from "@/lib/ingestion/bancolombia-statement/consolidate";
+
+// Returned by preview / commit actions. Single-sheet uploads (Visa, Amex
+// nacional) yield a plain ConsolidationReport; multi-sheet uploads
+// (Mastercard/Amex internacional = PESOS + DOLARES in one xlsx) yield a
+// MultiConsolidationReport wrapping one report per sheet, keyed by account.
+export type ConsolidateActionResult = ConsolidationReport | MultiConsolidationReport;
+
+export type MultiConsolidationReport = {
+  kind: "multi";
+  reports: ConsolidationReport[];
+};
+
+export function isMultiReport(result: ConsolidateActionResult): result is MultiConsolidationReport {
+  return (result as MultiConsolidationReport).kind === "multi";
+}

--- a/src/lib/ingestion/bancolombia-statement/consolidate.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.ts
@@ -45,6 +45,9 @@ export type MatchStats = {
 export type ConsolidationReport = {
   userId: number;
   accountId: number;
+  // Account currency — useful to callers rendering multi-sheet previews so they
+  // can label each report section (COP vs USD) without re-querying the account.
+  currency: "COP" | "USD";
   cycle: string;
   dryRun: boolean;
   status: ConsolidationStatus;
@@ -202,6 +205,7 @@ function serializeMissing(match: MatchResult): ConsolidationReport["missingInLed
 
 function emptyReport(
   opts: ConsolidateOptions,
+  account: { id: number; currency: "COP" | "USD" },
   match: MatchResult,
   status: ConsolidationStatus,
   statementImportId: number | null,
@@ -210,6 +214,7 @@ function emptyReport(
   return {
     userId: opts.userId,
     accountId: opts.accountId,
+    currency: account.currency,
     cycle: opts.cycle,
     dryRun: opts.dryRun,
     status,
@@ -255,6 +260,9 @@ export async function consolidateCycleFromStatement(
     const persistedReport = (existing.report ?? {}) as Partial<ConsolidationReport>;
     return {
       ...(persistedReport as ConsolidationReport),
+      // Persisted reports written before the currency field was added may
+      // lack it — fill from the current account so the UI has what it needs.
+      currency: persistedReport.currency ?? account.currency,
       dryRun: opts.dryRun,
       status: "already-consolidated",
       statementImportId: existing.id,
@@ -272,7 +280,7 @@ export async function consolidateCycleFromStatement(
   const match = matchStatementAgainstLedger(opts.parsed, txs);
 
   if (opts.dryRun) {
-    return emptyReport(opts, match, "dry-run", null, {
+    return emptyReport(opts, account, match, "dry-run", null, {
       status: "not-run",
       reason: "dry-run",
     });
@@ -378,6 +386,7 @@ export async function consolidateCycleFromStatement(
   const finalReport: ConsolidationReport = {
     userId: opts.userId,
     accountId: opts.accountId,
+    currency: account.currency,
     cycle: opts.cycle,
     dryRun: false,
     status: "consolidated",

--- a/src/lib/ingestion/bancolombia-statement/xlsx.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/xlsx.test.ts
@@ -6,6 +6,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 import {
   parseBancolombiaStatement,
+  parseBancolombiaStatementAllSheets,
   parseCopAmount,
   parseCuotas,
   parsePeriod,
@@ -147,14 +148,93 @@ describe("parsePeriod", () => {
 // Runs in CI — the real fixture at .private/statements/ is gitignored.
 // -----------------------------------------------------------------------------
 
-function buildSyntheticSheet(): Buffer {
-  const aoa: (string | number | null)[][] = [
+type SyntheticOptions = {
+  last4?: string;
+  moneda?: string;
+};
+
+function buildSyntheticAoa(opts: SyntheticOptions = {}): (string | number | null)[][] {
+  const last4 = opts.last4 ?? "9999";
+  const moneda = opts.moneda ?? "PESOS";
+  const isUsd = /USD|DOLAR/i.test(moneda);
+  const rateRows: (string | number | null)[][] = isUsd
+    ? [
+        [
+          "Compra Internacional",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Saldo anterior",
+          "300.000,00",
+          "Cuota transacciones",
+          "50.000,00",
+        ],
+        [
+          "Avance Internacional",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Compras del mes",
+          "250.000,00",
+          "Cuota Transacciones anteriores",
+          "0,00",
+        ],
+        ["Mora", "1.9110 %", "25.5026 %", "+ Intereses de mora", "0,00", "Cuota avances", "0,00"],
+        [null, null, null, "+ Intereses corrientes", "5.000,00", "+ Intereses de mora", "0,00"],
+        [null, null, null, "+ Avances", "0,00", "+ Intereses corrientes", "5.000,00"],
+      ]
+    : [
+        [
+          "Compra un mes",
+          "0.0000 %",
+          "0.0000 %",
+          "+ Saldo anterior",
+          "300.000,00",
+          "Cuota transacciones",
+          "50.000,00",
+        ],
+        [
+          "Compra 2 - 36 meses",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Compras del mes",
+          "250.000,00",
+          "Cuota Transacciones anteriores",
+          "0,00",
+        ],
+        [
+          "Impuestos",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Intereses de mora",
+          "0,00",
+          "Cuota avances",
+          "0,00",
+        ],
+        [
+          "Avances",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Intereses corrientes",
+          "5.000,00",
+          "+ Intereses de mora",
+          "0,00",
+        ],
+        [
+          "Mora",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Avances",
+          "0,00",
+          "+ Intereses corrientes",
+          "5.000,00",
+        ],
+      ];
+  return [
     ["Información Cliente:"],
     ["Cliente", null, "Dirección", "Ciudad", "Departamento"],
     ["TEST USER", null, "CALLE 1", "MEDELLIN", "ANTIOQUIA"],
     [],
-    ["Información de la Tarjeta", "************9999"],
-    ["Moneda: ", "PESOS"],
+    ["Información de la Tarjeta", `************${last4}`],
+    ["Moneda: ", moneda],
     [],
     ["Periodo facturado: ", "01 ene", "31 ene. 2026"],
     ["Pagar antes de: ", "feb. 15, 2026"],
@@ -173,35 +253,7 @@ function buildSyntheticSheet(): Buffer {
       "Resumen Pago Mínimo",
     ],
     [],
-    [
-      "Compra un mes",
-      "0.0000 %",
-      "0.0000 %",
-      "+ Saldo anterior",
-      "300.000,00",
-      "Cuota transacciones",
-      "50.000,00",
-    ],
-    [
-      "Compra 2 - 36 meses",
-      "1.9110 %",
-      "25.5026 %",
-      "+ Compras del mes",
-      "250.000,00",
-      "Cuota Transacciones anteriores",
-      "0,00",
-    ],
-    ["Impuestos", "1.9110 %", "25.5026 %", "+ Intereses de mora", "0,00", "Cuota avances", "0,00"],
-    [
-      "Avances",
-      "1.9110 %",
-      "25.5026 %",
-      "+ Intereses corrientes",
-      "5.000,00",
-      "+ Intereses de mora",
-      "0,00",
-    ],
-    ["Mora", "1.9110 %", "25.5026 %", "+ Avances", "0,00", "+ Intereses corrientes", "5.000,00"],
+    ...rateRows,
     [null, null, null, "+ Otros cargos", "0,00"],
     [null, null, null, "Cargos", "555.000,00"],
     [null, null, null, "(-) Pagos / abonos", "100.000,00"],
@@ -270,10 +322,22 @@ function buildSyntheticSheet(): Buffer {
       "66.666,68",
     ],
   ];
+}
 
+function buildSyntheticSheet(): Buffer {
   const wb = XLSX.utils.book_new();
-  const sheet = XLSX.utils.aoa_to_sheet(aoa);
+  const sheet = XLSX.utils.aoa_to_sheet(buildSyntheticAoa());
   XLSX.utils.book_append_sheet(wb, sheet, "PESOS");
+  const buf = XLSX.write(wb, { bookType: "xlsx", type: "buffer" });
+  return Buffer.from(buf);
+}
+
+function buildMultiSheetSynthetic(): Buffer {
+  const wb = XLSX.utils.book_new();
+  const pesos = XLSX.utils.aoa_to_sheet(buildSyntheticAoa({ last4: "8888", moneda: "PESOS" }));
+  const dolares = XLSX.utils.aoa_to_sheet(buildSyntheticAoa({ last4: "8888", moneda: "USD" }));
+  XLSX.utils.book_append_sheet(wb, pesos, "PESOS");
+  XLSX.utils.book_append_sheet(wb, dolares, "DOLARES");
   const buf = XLSX.write(wb, { bookType: "xlsx", type: "buffer" });
   return Buffer.from(buf);
 }
@@ -334,6 +398,42 @@ describe("parseBancolombiaStatement (synthetic fixture)", () => {
     const beforeRow = before[0];
     expect(beforeRow.merchant).toBe("OLD MERCHANT");
     expect(beforeRow.rateEmX10k).toBe(18311);
+  });
+});
+
+describe("parseBancolombiaStatement (multi-sheet)", () => {
+  it("parseBancolombiaStatementAllSheets returns both COP + USD for PESOS+DOLARES workbook", () => {
+    const parsed = parseBancolombiaStatementAllSheets(buildMultiSheetSynthetic());
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].account).toEqual({ last4: "8888", currency: "COP" });
+    expect(parsed[1].account).toEqual({ last4: "8888", currency: "USD" });
+  });
+
+  it("parseBancolombiaStatementAllSheets returns a single ParsedStatement for PESOS-only workbook", () => {
+    const parsed = parseBancolombiaStatementAllSheets(buildSyntheticSheet());
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].account).toEqual({ last4: "9999", currency: "COP" });
+  });
+
+  it("parseBancolombiaStatement({ sheet: 'DOLARES' }) selects the USD sheet", () => {
+    const parsed = parseBancolombiaStatement(buildMultiSheetSynthetic(), { sheet: "DOLARES" });
+    expect(parsed.account.currency).toBe("USD");
+  });
+
+  it("parseBancolombiaStatement({ sheet: 'PESOS' }) selects the COP sheet", () => {
+    const parsed = parseBancolombiaStatement(buildMultiSheetSynthetic(), { sheet: "PESOS" });
+    expect(parsed.account.currency).toBe("COP");
+  });
+
+  it("throws when requested sheet name is not present", () => {
+    expect(() => parseBancolombiaStatement(buildSyntheticSheet(), { sheet: "DOLARES" })).toThrow(
+      /sheet "DOLARES" not found/,
+    );
+  });
+
+  it("remains backwards-compatible when called with no options (PESOS-only)", () => {
+    const parsed = parseBancolombiaStatement(buildSyntheticSheet());
+    expect(parsed.account.currency).toBe("COP");
   });
 });
 
@@ -436,4 +536,51 @@ describeIfFixture("parseBancolombiaStatement (real fixture 202603 Visa 2575)", (
     expect(row?.rateEmX10k).toBe(18895);
     expect(row?.amountCents).toBe(BigInt(24650000));
   });
+
+  it("parseBancolombiaStatementAllSheets returns a single ParsedStatement (Visa is PESOS-only)", () => {
+    const parsed = parseBancolombiaStatementAllSheets(readFileSync(FIXTURE_PATH));
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].account).toEqual({ last4: "2575", currency: "COP" });
+  });
 });
+
+const MASTERCARD_FIXTURE_PATH = resolve(
+  process.cwd(),
+  ".private/statements/Extracto_202603_Mastercard_Detallado_7291.xlsx",
+);
+
+const describeIfMastercardFixture = existsSync(MASTERCARD_FIXTURE_PATH) ? describe : describe.skip;
+
+describeIfMastercardFixture(
+  "parseBancolombiaStatementAllSheets (real fixture 202603 Mastercard 7291)",
+  () => {
+    let parsed: ReturnType<typeof parseBancolombiaStatementAllSheets>;
+    beforeAll(() => {
+      parsed = parseBancolombiaStatementAllSheets(readFileSync(MASTERCARD_FIXTURE_PATH));
+    });
+
+    it("returns two ParsedStatement — PESOS first, DOLARES second", () => {
+      expect(parsed).toHaveLength(2);
+    });
+
+    it("first element is the COP statement for card 7291", () => {
+      expect(parsed[0].account).toEqual({ last4: "7291", currency: "COP" });
+    });
+
+    it("second element is the USD statement for card 7291", () => {
+      expect(parsed[1].account).toEqual({ last4: "7291", currency: "USD" });
+    });
+
+    it("COP sheet has at least one parsed row", () => {
+      expect(parsed[0].rows.length).toBeGreaterThan(0);
+    });
+
+    it("USD sheet has at least one parsed row", () => {
+      expect(parsed[1].rows.length).toBeGreaterThan(0);
+    });
+
+    it("both sheets share the same statement period (same physical card, same cycle)", () => {
+      expect(parsed[0].period.endDate.toISOString()).toBe(parsed[1].period.endDate.toISOString());
+    });
+  },
+);

--- a/src/lib/ingestion/bancolombia-statement/xlsx.ts
+++ b/src/lib/ingestion/bancolombia-statement/xlsx.ts
@@ -199,28 +199,56 @@ export function parsePeriod(
 
 type SheetRows = (string | null)[][];
 
-function loadSheet(buffer: Buffer): { name: string; rows: SheetRows } {
-  let wb: XLSX.WorkBook;
+export type StatementSheetName = "PESOS" | "DOLARES";
+
+const SUPPORTED_SHEETS: readonly StatementSheetName[] = ["PESOS", "DOLARES"] as const;
+
+function readWorkbook(buffer: Buffer): XLSX.WorkBook {
   try {
-    wb = XLSX.read(buffer, { type: "buffer", raw: false, cellDates: false });
+    return XLSX.read(buffer, { type: "buffer", raw: false, cellDates: false });
   } catch (err) {
     throw new Error(`parseBancolombiaStatement: not a valid xlsx file (${(err as Error).message})`);
   }
-  const sheetName = wb.SheetNames.find((n) => n.toUpperCase() === "PESOS") ?? wb.SheetNames[0];
-  if (!sheetName) {
-    throw new Error("parseBancolombiaStatement: workbook has no sheets");
+}
+
+function pickSheetName(wb: XLSX.WorkBook, preferred: StatementSheetName | null): string {
+  if (preferred !== null) {
+    const match = wb.SheetNames.find((n) => n.toUpperCase() === preferred);
+    if (!match) {
+      throw new Error(
+        `parseBancolombiaStatement: sheet "${preferred}" not found (available: ${wb.SheetNames.join(", ") || "<none>"})`,
+      );
+    }
+    return match;
   }
+  // Legacy default: PESOS if present, else the first sheet — matches the
+  // pre-#426 behavior so single-sheet callers keep working unchanged.
+  return wb.SheetNames.find((n) => n.toUpperCase() === "PESOS") ?? wb.SheetNames[0];
+}
+
+function loadSheetRows(wb: XLSX.WorkBook, sheetName: string): SheetRows {
   const sheet = wb.Sheets[sheetName];
   if (!sheet) {
     throw new Error(`parseBancolombiaStatement: sheet "${sheetName}" missing`);
   }
-  const rows = XLSX.utils.sheet_to_json<(string | null)[]>(sheet, {
+  return XLSX.utils.sheet_to_json<(string | null)[]>(sheet, {
     header: 1,
     raw: false,
     defval: null,
     blankrows: true,
   });
-  return { name: sheetName, rows };
+}
+
+function loadSheet(
+  buffer: Buffer,
+  preferred: StatementSheetName | null,
+): { name: string; rows: SheetRows } {
+  const wb = readWorkbook(buffer);
+  if (!wb.SheetNames.length) {
+    throw new Error("parseBancolombiaStatement: workbook has no sheets");
+  }
+  const name = pickSheetName(wb, preferred);
+  return { name, rows: loadSheetRows(wb, name) };
 }
 
 function cellText(rows: SheetRows, rowIdx: number, colIdx: number): string {
@@ -326,24 +354,40 @@ function extractSummary(rows: SheetRows): StatementSummary {
   };
 }
 
-function extractRates(rows: SheetRows): StatementRates {
-  const rateFor = (label: string): number => {
-    const needle = label.toLowerCase();
-    for (let i = 0; i < rows.length; i++) {
-      if (cellText(rows, i, 0).toLowerCase().includes(needle)) {
-        const parsed = parseRateEmX10k(cellText(rows, i, 1));
-        if (parsed == null) {
-          throw new Error(`parseBancolombiaStatement: rate for "${label}" is empty`);
+function extractRates(rows: SheetRows, currency: StatementCurrency): StatementRates {
+  const rateForAny = (labels: string[]): number => {
+    for (const label of labels) {
+      const needle = label.toLowerCase();
+      for (let i = 0; i < rows.length; i++) {
+        if (cellText(rows, i, 0).toLowerCase().includes(needle)) {
+          const parsed = parseRateEmX10k(cellText(rows, i, 1));
+          if (parsed == null) {
+            throw new Error(`parseBancolombiaStatement: rate for "${label}" is empty`);
+          }
+          return parsed;
         }
-        return parsed;
       }
     }
-    throw new Error(`parseBancolombiaStatement: missing rate row "${label}"`);
+    throw new Error(`parseBancolombiaStatement: missing rate row "${labels[0]}"`);
   };
+  // USD (international) extractos use a simpler rate table: one row for
+  // "Compra Internacional" covering all installment horizons and "Avance
+  // Internacional" for cash advances. COP extractos split compras into 1-mes
+  // vs 2-36 meses. Fall back to the international labels when the COP ones
+  // aren't present so the parser handles both sheet layouts.
+  if (currency === "USD") {
+    const compra = rateForAny(["compra internacional", "compras internacionales"]);
+    const advances = rateForAny(["avance internacional", "avances internacionales", "avances"]);
+    return {
+      oneMonth: compra,
+      months2to36: compra,
+      advances,
+    };
+  }
   return {
-    oneMonth: rateFor("compra un mes"),
-    months2to36: rateFor("compra 2 - 36 meses"),
-    advances: rateFor("avances"),
+    oneMonth: rateForAny(["compra un mes"]),
+    months2to36: rateForAny(["compra 2 - 36 meses"]),
+    advances: rateForAny(["avances"]),
   };
 }
 
@@ -423,12 +467,58 @@ function extractStatementRows(rows: SheetRows): StatementRow[] {
   return out;
 }
 
-export function parseBancolombiaStatement(buffer: Buffer): ParsedStatement {
-  const { rows } = loadSheet(buffer);
+export type ParseStatementOptions = {
+  // Pick a specific sheet. Defaults to the legacy "PESOS-first, else first
+  // sheet" discovery so single-sheet callers keep working.
+  sheet?: StatementSheetName;
+};
+
+function parseSheetRows(rows: SheetRows): ParsedStatement {
   const account = extractAccount(rows);
   const period = extractPeriod(rows);
   const summary = extractSummary(rows);
-  const currentRates = extractRates(rows);
+  const currentRates = extractRates(rows, account.currency);
   const statementRows = extractStatementRows(rows);
   return { account, period, summary, currentRates, rows: statementRows };
+}
+
+export function parseBancolombiaStatement(
+  buffer: Buffer,
+  opts?: ParseStatementOptions,
+): ParsedStatement {
+  const { rows } = loadSheet(buffer, opts?.sheet ?? null);
+  return parseSheetRows(rows);
+}
+
+// Multi-sheet helper: one ParsedStatement per PESOS/DOLARES sheet present in
+// the workbook, in the order they appear. Returns length 1 for a single-sheet
+// xlsx (the Visa case) and length 2 for Mastercard/Amex internacionales.
+// Sheet discovery is case-insensitive. If a sheet is present but empty/invalid
+// (can't parse), we surface the underlying parse error with the sheet name
+// prefixed so callers can tell which sheet failed.
+export function parseBancolombiaStatementAllSheets(buffer: Buffer): ParsedStatement[] {
+  const wb = readWorkbook(buffer);
+  if (!wb.SheetNames.length) {
+    throw new Error("parseBancolombiaStatement: workbook has no sheets");
+  }
+  const present: { canonical: StatementSheetName; raw: string }[] = [];
+  for (const target of SUPPORTED_SHEETS) {
+    const raw = wb.SheetNames.find((n) => n.toUpperCase() === target);
+    if (raw) present.push({ canonical: target, raw });
+  }
+  if (present.length === 0) {
+    // Fall back to the legacy discovery (first sheet) for backwards compat
+    // with workbooks that didn't follow the PESOS/DOLARES naming.
+    return [parseSheetRows(loadSheetRows(wb, wb.SheetNames[0]))];
+  }
+  const out: ParsedStatement[] = [];
+  for (const { canonical, raw } of present) {
+    try {
+      out.push(parseSheetRows(loadSheetRows(wb, raw)));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`parseBancolombiaStatement[${canonical}]: ${msg}`);
+    }
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary

- **#426**: Mastercard internacional .xlsx con PESOS + DOLARES en un solo upload consolida ambas sub-accounts (COP + USD linkeadas por `physical_card_id`) en una sola acción.
- **#427**: la página de consolidación ahora respeta el `max-w-5xl` container como el resto de `/settings`.
- **#428**: el link "Ver run" muestra el detalle completo del `ConsolidationReport` persistido (matched diffs, inserted, missing, unmatched, intereses) en vez de volver a renderizar el mismo summary.

## Cambios principales

- `parseBancolombiaStatementAllSheets(buffer)` devuelve un `ParsedStatement` por cada sheet PESOS/DOLARES presente. Single-sheet (Visa) → length 1; Mastercard internacional → length 2.
- `parseBancolombiaStatement(buffer, { sheet })` deja elegir sheet explícitamente. Sin opts, mantiene el default legacy (PESOS-first) — backwards-compatible con los CLI scripts y callers existentes.
- `extractRates` ahora es currency-aware: DOLARES usa labels `Compra Internacional` / `Avance Internacional` (no 1-mes split). COP mantiene labels existentes.
- `consolidateCycleFromStatement` action dispatcher: detecta multi-sheet, busca sibling account por `physicalCardId`, retorna `ConsolidationReport | MultiConsolidationReport`. Errores explícitos: `missing_usd_sibling`, `missing_cop_sibling`, `currency_mismatch`, `multi_sheet_without_physical_card`.
- `ConsolidationReport` gana campo `currency` para que la UI etiquete cada sección sin re-query del account.
- Types y type guards en nuevo `consolidate-types.ts` (no-server module) — cumple la restricción de Next.js 16 de solo async exports en `use server` files.
- `ReportSection` extraído a `consolidate-report-view.tsx` para reuse entre el preview (multi-sheet) y el nuevo `ExistingRunDetail` (`?view=run`).

## Test plan

- [x] `bun run lint` — verde
- [x] `tsc --noEmit` — verde
- [x] `bun test src/lib/ingestion/bancolombia-statement/ src/app/(app)/settings/accounts/[accountId]/consolidate/` — 82 pass / 1 pre-existing fail (`vi.mocked` no soportado en bun; ya era rojo en main antes de este PR).
- [x] Tests nuevos de parser (6): sheets option, parseAllSheets multi, parseAllSheets single, currency mismatch error, backwards-compat.
- [x] Tests nuevos de action (4): preview multi-sheet, commit multi-sheet + idempotencia, missing_usd_sibling, entrada desde USD sibling.
- [x] Integration tests contra fixtures reales (.private, skipped en CI): Mastercard 7291 parsea 2 ParsedStatement con currencies COP + USD; Visa 2575 parsea 1.
- [ ] Smoke manual en ia-server con el extracto real de Mastercard 7291 (cycle 2026-03).
- [ ] Verificar que `?view=run` renderiza el detalle sobre la Visa 2575 feb+mar (ya consolidadas en prod).

## Out of scope

- PDF parsing (sigue siendo xlsx-only)
- Otros bancos (solo Bancolombia)
- UI de rollback (runs se deletean via psql)
- Banner / `recentCycles` filtrar ciclos sin transacciones — pendiente de conversar antes de implementar.

Closes #426
Closes #427
Closes #428