### PR TITLE
feat(consolidation): skip empty cycles in banner + status list (#430)

### DIFF
--- a/src/app/(app)/settings/accounts/tc-consolidation-status.tsx
+++ b/src/app/(app)/settings/accounts/tc-consolidation-status.tsx
@@ -32,6 +32,8 @@ function statusLabel(status: CycleStatus): string {
       return "pendiente";
     case "in-progress":
       return "en curso";
+    case "no-activity":
+      return "sin actividad";
   }
 }
 
@@ -100,7 +102,11 @@ export async function TcConsolidationStatus({ userId }: { userId: number }) {
                   {cycles.map((cycle) => (
                     <div
                       key={cycle.cycle}
-                      className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                      className={
+                        cycle.status === "no-activity"
+                          ? "flex items-center gap-2 rounded-md border px-3 py-2 text-sm opacity-70"
+                          : "flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                      }
                     >
                       <span className="font-mono text-xs">{cycle.cycle}</span>
                       <Badge
@@ -110,6 +116,9 @@ export async function TcConsolidationStatus({ userId }: { userId: number }) {
                             : cycle.status === "pending"
                               ? "secondary"
                               : "outline"
+                        }
+                        className={
+                          cycle.status === "no-activity" ? "text-muted-foreground" : undefined
                         }
                       >
                         {statusLabel(cycle.status)}

--- a/src/lib/accounts/cycles.test.ts
+++ b/src/lib/accounts/cycles.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { eq } from "drizzle-orm";
 
 import { db } from "@/lib/db";
-import { accounts, statementImports, users } from "@/lib/db/schema";
+import { accounts, statementImports, transactions, users } from "@/lib/db/schema";
 import { copyCategorySeedsToUser } from "@/lib/auth/signup";
 
 import {
@@ -43,6 +43,7 @@ async function createTc(userId: number, cutoffDay: number, name: string): Promis
 }
 
 async function cleanupUser(userId: number): Promise<void> {
+  await db.delete(transactions).where(eq(transactions.userId, userId));
   await db.delete(statementImports).where(eq(statementImports.userId, userId));
   await db.delete(accounts).where(eq(accounts.userId, userId));
   await db.delete(users).where(eq(users.id, userId));
@@ -110,6 +111,37 @@ describe("recentCycles — integration", () => {
       cycle: "2026-03",
       report: { marker: "test-fixture" },
     });
+
+    // #430: cycles without txs are demoted to `no-activity`. Seed one
+    // purchase in each past window so these pre-existing tests (which
+    // predate the demotion) still exercise the `pending` classification.
+    // Windows (cutoff=30): 2026-01 = (Dec 30, Jan 30], 2026-02 = (Jan 30, Feb 28].
+    await db.insert(transactions).values([
+      {
+        userId,
+        accountId,
+        occurredAt: utcDate(2026, 1, 15),
+        amountCents: BigInt(-1000),
+        currency: "COP",
+        descriptionRaw: `${TAG} pending-jan-window`,
+        categorySlug: "adjustments",
+        classificationMethod: "manual",
+        source: "manual",
+        channel: "manual",
+      },
+      {
+        userId,
+        accountId,
+        occurredAt: utcDate(2026, 2, 15),
+        amountCents: BigInt(-2000),
+        currency: "COP",
+        descriptionRaw: `${TAG} pending-feb-window`,
+        categorySlug: "adjustments",
+        classificationMethod: "manual",
+        source: "manual",
+        channel: "manual",
+      },
+    ]);
   });
 
   afterAll(async () => {
@@ -152,5 +184,170 @@ describe("recentCycles — integration", () => {
     expect(recents).toHaveLength(1);
     expect(recents[0].cycle).toBe("2026-03");
     expect(recents[0].accountId).toBe(accountId);
+  });
+});
+
+describe("recentCycles — no-activity (#430)", () => {
+  let userId!: number;
+  let accountId!: number;
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.noact.${Date.now()}@test.local`);
+    accountId = await createTc(userId, 30, "noact-visa");
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  async function clearTxs(): Promise<void> {
+    await db.delete(transactions).where(eq(transactions.userId, userId));
+  }
+
+  it("demotes pending cycles to no-activity when the window has zero live txs", async () => {
+    await clearTxs();
+    const cycles = await recentCycles({
+      accountId,
+      userId,
+      metadata: { cutoffDay: 30 },
+      count: 4,
+      now: utcDate(2026, 4, 15),
+    });
+    // 2026-04 = in-progress, 2026-03, 2026-02, 2026-01 = all past cuts.
+    expect(cycles[0].status).toBe("in-progress");
+    for (let i = 1; i < cycles.length; i++) {
+      expect(cycles[i].status).toBe("no-activity");
+      expect(cycles[i].daysOverdue).toBe(0);
+    }
+  });
+
+  it("keeps a cycle pending when the window has at least one live tx", async () => {
+    await clearTxs();
+    // One purchase on 2026-03-15, inside (2026-02-28, 2026-03-30] → pending.
+    await db.insert(transactions).values({
+      userId,
+      accountId,
+      occurredAt: utcDate(2026, 3, 15),
+      amountCents: BigInt(-50000),
+      currency: "COP",
+      descriptionRaw: `${TAG} noact tx march`,
+      categorySlug: "adjustments",
+      classificationMethod: "manual",
+      source: "manual",
+      channel: "manual",
+    });
+    const cycles = await recentCycles({
+      accountId,
+      userId,
+      metadata: { cutoffDay: 30 },
+      count: 4,
+      now: utcDate(2026, 4, 15),
+    });
+    const byCycle = new Map(cycles.map((c) => [c.cycle, c]));
+    expect(byCycle.get("2026-03")?.status).toBe("pending");
+    expect(byCycle.get("2026-03")?.daysOverdue).toBeGreaterThan(0);
+    expect(byCycle.get("2026-02")?.status).toBe("no-activity");
+    expect(byCycle.get("2026-01")?.status).toBe("no-activity");
+  });
+
+  it("ignores synthetic intereses-causados txs when counting activity", async () => {
+    await clearTxs();
+    // Synthetic tx from intereses-causados-job — rawData.synthetic = true.
+    // Anchor is end-of-day on cut day, which IS within (prev_anchor, anchor].
+    await db.insert(transactions).values({
+      userId,
+      accountId,
+      occurredAt: utcDate(2026, 3, 30),
+      amountCents: BigInt(-10000),
+      currency: "COP",
+      descriptionRaw: `${TAG} synthetic intereses`,
+      categorySlug: "intereses-tc",
+      classificationMethod: "manual",
+      source: "manual",
+      channel: "manual",
+      rawData: { synthetic: true, job: "intereses-causados-job" },
+    });
+    const cycles = await recentCycles({
+      accountId,
+      userId,
+      metadata: { cutoffDay: 30 },
+      count: 4,
+      now: utcDate(2026, 4, 15),
+    });
+    const march = cycles.find((c) => c.cycle === "2026-03");
+    expect(march?.status).toBe("no-activity");
+  });
+
+  it("ignores soft-deleted txs when counting activity", async () => {
+    await clearTxs();
+    await db.insert(transactions).values({
+      userId,
+      accountId,
+      occurredAt: utcDate(2026, 3, 15),
+      amountCents: BigInt(-1234),
+      currency: "COP",
+      descriptionRaw: `${TAG} deleted tx`,
+      categorySlug: "adjustments",
+      classificationMethod: "manual",
+      source: "manual",
+      channel: "manual",
+      deletedAt: new Date(),
+    });
+    const cycles = await recentCycles({
+      accountId,
+      userId,
+      metadata: { cutoffDay: 30 },
+      count: 4,
+      now: utcDate(2026, 4, 15),
+    });
+    const march = cycles.find((c) => c.cycle === "2026-03");
+    expect(march?.status).toBe("no-activity");
+  });
+
+  it("flips no-activity back to pending when a backfill tx lands in the window", async () => {
+    await clearTxs();
+    let cycles = await recentCycles({
+      accountId,
+      userId,
+      metadata: { cutoffDay: 30 },
+      count: 4,
+      now: utcDate(2026, 4, 15),
+    });
+    expect(cycles.find((c) => c.cycle === "2026-02")?.status).toBe("no-activity");
+
+    // Simulate a historical import (SMS dump, CSV, extracto) into Feb window.
+    await db.insert(transactions).values({
+      userId,
+      accountId,
+      occurredAt: utcDate(2026, 2, 10),
+      amountCents: BigInt(-999),
+      currency: "COP",
+      descriptionRaw: `${TAG} backfill`,
+      categorySlug: "adjustments",
+      classificationMethod: "manual",
+      source: "manual",
+      channel: "manual",
+    });
+
+    cycles = await recentCycles({
+      accountId,
+      userId,
+      metadata: { cutoffDay: 30 },
+      count: 4,
+      now: utcDate(2026, 4, 15),
+    });
+    const feb = cycles.find((c) => c.cycle === "2026-02");
+    expect(feb?.status).toBe("pending");
+    expect(feb?.daysOverdue).toBeGreaterThan(0);
+  });
+
+  it("overdueCyclesForUser excludes no-activity cycles from the banner feed", async () => {
+    await clearTxs();
+    const overdue = await overdueCyclesForUser(
+      userId,
+      [{ id: accountId, name: "noact", metadata: { cutoffDay: 30 } }],
+      { thresholdDays: 7, now: utcDate(2026, 4, 15), count: 4 },
+    );
+    expect(overdue).toHaveLength(0);
   });
 });

--- a/src/lib/accounts/cycles.ts
+++ b/src/lib/accounts/cycles.ts
@@ -10,11 +10,12 @@
 // No DB writes. The dashboard banner + the per-account view both read from
 // here; the consolidate page writes via the server actions in #418.
 
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 
 import { db, type DB } from "@/lib/db";
 import type { AccountMetadata } from "@/lib/db/schema";
-import { statementImports } from "@/lib/db/schema";
+import { statementImports, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
 import { cycleAnchor } from "@/lib/finance/intereses-causados-job";
 
 // Conservative fallback when neither the account metadata nor the linked card
@@ -23,7 +24,13 @@ const FALLBACK_CUT_DAY = 31;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-export type CycleStatus = "in-progress" | "pending" | "consolidated";
+// `no-activity` = anchor has passed, not consolidated, and the window
+// `(prev_anchor, this_anchor]` contains zero user-visible transactions.
+// Introduced in #430 to kill the "consolidate an empty cycle" nag for new
+// users, fresh accounts, and dormant cards. Importing old txs (CSV/SMS
+// backfill/extracto) flips it back to `pending` on the next read — the
+// rule is current ledger state, not a frozen snapshot.
+export type CycleStatus = "in-progress" | "pending" | "no-activity" | "consolidated";
 
 export type CycleSummary = {
   cycle: string; // "YYYY-MM"
@@ -117,14 +124,26 @@ export async function recentCycles(ctx: CyclesContext): Promise<CycleSummary[]> 
     if (row.cycle) consolidatedByCycle.set(row.cycle, { id: row.id, importedAt: row.importedAt });
   }
 
-  return labels.map((cycle) => {
+  // First-pass classification without activity check.
+  type Prelim = {
+    cycle: string;
+    anchor: Date;
+    prevAnchor: Date;
+    status: CycleStatus;
+    consolidatedAt: Date | null;
+    statementImportId: number | null;
+    daysOverdue: number;
+  };
+  const prelim: Prelim[] = labels.map((cycle) => {
     const anchor = cycleAnchor(cycle, cutoffDay);
+    const prevAnchor = cycleAnchor(previousCycle(cycle), cutoffDay);
     const hit = consolidatedByCycle.get(cycle);
     if (hit) {
       return {
         cycle,
-        status: "consolidated" as const,
         anchor,
+        prevAnchor,
+        status: "consolidated",
         consolidatedAt: hit.importedAt,
         statementImportId: hit.id,
         daysOverdue: 0,
@@ -133,8 +152,9 @@ export async function recentCycles(ctx: CyclesContext): Promise<CycleSummary[]> 
     if (anchor.getTime() > now.getTime()) {
       return {
         cycle,
-        status: "in-progress" as const,
         anchor,
+        prevAnchor,
+        status: "in-progress",
         consolidatedAt: null,
         statementImportId: null,
         daysOverdue: 0,
@@ -143,13 +163,68 @@ export async function recentCycles(ctx: CyclesContext): Promise<CycleSummary[]> 
     const daysOverdue = Math.max(0, Math.floor((now.getTime() - anchor.getTime()) / MS_PER_DAY));
     return {
       cycle,
-      status: "pending" as const,
       anchor,
+      prevAnchor,
+      status: "pending",
       consolidatedAt: null,
       statementImportId: null,
       daysOverdue,
     };
   });
+
+  // #430: only candidates for activity-demotion are `pending` rows. If none
+  // are pending we skip the tx-count query entirely (zero cost on the happy
+  // path where every past cycle is already consolidated).
+  const pendingRows = prelim.filter((p) => p.status === "pending");
+  if (pendingRows.length > 0) {
+    const windowStart = pendingRows.reduce(
+      (min, p) => (p.prevAnchor < min ? p.prevAnchor : min),
+      pendingRows[0].prevAnchor,
+    );
+    const windowEnd = pendingRows.reduce(
+      (max, p) => (p.anchor > max ? p.anchor : max),
+      pendingRows[0].anchor,
+    );
+
+    // Pull only `occurred_at` for the minimum superset window. Syntheticos de
+    // `intereses-causados-job` (rawData.synthetic === true) se excluyen —
+    // contarlas haría que un ciclo sin compras reales pero con intereses
+    // computados salga como "pending", contradiciendo la semántica del issue.
+    const liveRows = await database
+      .select({ occurredAt: transactions.occurredAt })
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.userId, ctx.userId),
+          eq(transactions.accountId, ctx.accountId),
+          notDeleted(transactions.deletedAt),
+          sql`${transactions.occurredAt} > ${windowStart.toISOString()}`,
+          sql`${transactions.occurredAt} <= ${windowEnd.toISOString()}`,
+          sql`COALESCE(${transactions.rawData} ->> 'synthetic', 'false') <> 'true'`,
+        ),
+      );
+
+    for (const p of pendingRows) {
+      const hasActivity = liveRows.some(
+        (r) =>
+          r.occurredAt.getTime() > p.prevAnchor.getTime() &&
+          r.occurredAt.getTime() <= p.anchor.getTime(),
+      );
+      if (!hasActivity) {
+        p.status = "no-activity";
+        p.daysOverdue = 0; // no-activity cycles are not overdue — nothing to do.
+      }
+    }
+  }
+
+  return prelim.map((p) => ({
+    cycle: p.cycle,
+    status: p.status,
+    anchor: p.anchor,
+    consolidatedAt: p.consolidatedAt,
+    statementImportId: p.statementImportId,
+    daysOverdue: p.daysOverdue,
+  }));
 }
 
 export type OverdueCycleSummary = CycleSummary & {


### PR DESCRIPTION
## Summary

Closes #430.

Cycles whose anchor has passed but whose window `(prev_anchor, this_anchor]` contains zero user-visible transactions are now classified as `no-activity` instead of `pending`. Kills the "consolidate an empty cycle" nag for new accounts, fresh users, and dormant cards.

The rule evaluates current ledger state each read — a CSV/SMS/extracto backfill that lands a tx inside a previously empty window flips the status back to `pending` on the next read. No stored flag to keep in sync.

## Changes

- `src/lib/accounts/cycles.ts`
  - New `no-activity` variant in `CycleStatus`.
  - `recentCycles`: when at least one cycle came out `pending`, runs a single query that pulls `occurred_at` of live non-synthetic txs in the minimum superset window, then buckets per cycle in-memory. Pending cycles with zero hits are demoted to `no-activity` with `daysOverdue = 0`.
  - Excludes `rawData->>'synthetic' = 'true'` (the marker `intereses-causados-job` stamps — counting it would be self-referential).
  - Excludes soft-deleted rows via `notDeleted`.
  - Zero extra cost on the all-consolidated happy path.

- `src/app/(app)/settings/accounts/tc-consolidation-status.tsx`
  - Renders `no-activity` with muted outline + `opacity-70`, no Consolidar link. Still visible so the user sees the cycle existed.

- `src/lib/accounts/cycles.test.ts`
  - 6 new integration tests: empty window, 1 tx, synthetic-only, soft-deleted-only, backfill-flips-back, overdue feed excludes no-activity.
  - Existing pre-430 tests that relied on empty windows being `pending` now seed explicit txs in those windows.

## Acceptance (from #430)

- [x] Cuenta nueva sin txs históricas: zero ciclos pendientes en banner y status list.
- [x] Cuenta con txs solo en marzo: marzo aparece pendiente; feb aparece con badge "sin actividad" (no con link Consolidar). Verified on dev DB — `Bancolombia Mastercard *7291 (COP)` 2026-02 renders `sin actividad`, 2026-03 stays `pendiente`.
- [x] Backfill-friendly: importar una tx vieja en feb → el status flipea a pendiente sin intervención.
- [x] Todos los tests existentes siguen verdes. 1003/1003 pass.

## Test plan

- [x] `bun run test src/lib/accounts/cycles.test.ts` — 18/18 pass (6 new)
- [x] `bun run test` — 1003/1003 pass
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run format:check` — clean
- [x] Manual smoke on dev DB via `/api/dev/login`: Mastercard *7291 (COP) 2026-02 renders muted `sin actividad`, 2026-03 stays actionable `pendiente`, Visa *2575 2026-03 stays `consolidado`. Banner count dropped from 4 → 3 because Mastercard *7291 (COP) 2026-02 is no longer counted.

## Out of scope

- Grouping Mastercard COP/USD siblings as one block → #431, stacked next.
- `CardDescription` copy — current "Tenés al menos un ciclo pendiente" stays coherent because `no-activity` cycles don't need action.