### PR TITLE
feat(ui): group TC cycles by physical_card in status list + banner (#431)

### DIFF
--- a/src/app/(app)/settings/accounts/tc-consolidation-status.tsx
+++ b/src/app/(app)/settings/accounts/tc-consolidation-status.tsx
@@ -2,18 +2,30 @@
 // manager. Shows the last 3 cycles per credit-card account with status badges
 // and a "Consolidar" shortcut on pending ones — the dashboard banner flags
 // users, this is where they complete the work.
+//
+// #431: linked multi-currency plastics (Mastercard COP + USD share one
+// physicalCardId) collapse into ONE block with one row per cycle. The
+// backend still writes one statement_imports row per account; the UI just
+// reflects that the extract is plastic-level.
 
 import Link from "next/link";
 import { and, asc, eq } from "drizzle-orm";
 
 import { db } from "@/lib/db";
-import { accounts } from "@/lib/db/schema";
+import { accounts, type AccountMetadata } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { formatAccountLabel } from "@/lib/accounts/format";
 import { recentCycles, type CycleStatus } from "@/lib/accounts/cycles";
+import {
+  groupAccountsForConsolidation,
+  type CycleGroup,
+  type GroupAccount,
+} from "@/lib/accounts/cycle-groups";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+type TcAccount = GroupAccount & { metadata: AccountMetadata | null };
 
 function formatBogotaDate(d: Date): string {
   return new Intl.DateTimeFormat("es-CO", {
@@ -37,6 +49,27 @@ function statusLabel(status: CycleStatus): string {
   }
 }
 
+function groupDisplayLabel(group: CycleGroup<TcAccount>): string {
+  const first = group.accounts[0];
+  if (group.isMultiCurrency) {
+    // Drop the currency suffix — `first.name` already embeds the plastic's
+    // *last4 (e.g. "Bancolombia Mastercard *7291"), which is plastic-level.
+    return first.name;
+  }
+  return formatAccountLabel({
+    name: first.name,
+    currency: first.currency,
+    institution: first.institution ?? undefined,
+    metadata: first.metadata,
+  });
+}
+
+function multiCurrencySubtitle(currencies: readonly string[]): string {
+  // Matches the copy from the issue body: "COP + USD · 1 extracto, 2 hojas".
+  const currencyPart = currencies.join(" + ");
+  return `${currencyPart} · 1 extracto, ${currencies.length} hoja${currencies.length === 1 ? "" : "s"}`;
+}
+
 export async function TcConsolidationStatus({ userId }: { userId: number }) {
   const tcAccounts = await db
     .select({
@@ -46,6 +79,7 @@ export async function TcConsolidationStatus({ userId }: { userId: number }) {
       institution: accounts.institution,
       institutionSlug: accounts.institutionSlug,
       metadata: accounts.metadata,
+      physicalCardId: accounts.physicalCardId,
     })
     .from(accounts)
     .where(
@@ -72,7 +106,8 @@ export async function TcConsolidationStatus({ userId }: { userId: number }) {
     })),
   );
 
-  const hasPending = perAccount.some((p) => p.cycles.some((c) => c.status === "pending"));
+  const groups = groupAccountsForConsolidation(perAccount);
+  const hasPending = groups.some((g) => g.cycles.some((c) => c.status === "pending"));
 
   return (
     <Card>
@@ -88,64 +123,68 @@ export async function TcConsolidationStatus({ userId }: { userId: number }) {
       </CardHeader>
       <CardContent>
         <ul className="flex flex-col gap-4">
-          {perAccount.map(({ account, cycles }) => {
-            const label = formatAccountLabel({
-              name: account.name,
-              currency: account.currency,
-              institution: account.institution,
-              metadata: account.metadata,
-            });
+          {groups.map((group) => {
+            const label = groupDisplayLabel(group);
             return (
-              <li key={account.id} className="flex flex-col gap-2">
+              <li key={group.key} className="flex flex-col gap-2">
                 <div className="text-sm font-medium">{label}</div>
                 <div className="flex flex-wrap gap-2">
-                  {cycles.map((cycle) => (
+                  {group.cycles.map((cycle) => (
                     <div
                       key={cycle.cycle}
                       className={
                         cycle.status === "no-activity"
-                          ? "flex items-center gap-2 rounded-md border px-3 py-2 text-sm opacity-70"
-                          : "flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                          ? "flex flex-col gap-1 rounded-md border px-3 py-2 text-sm opacity-70"
+                          : "flex flex-col gap-1 rounded-md border px-3 py-2 text-sm"
                       }
                     >
-                      <span className="font-mono text-xs">{cycle.cycle}</span>
-                      <Badge
-                        variant={
-                          cycle.status === "consolidated"
-                            ? "default"
-                            : cycle.status === "pending"
-                              ? "secondary"
-                              : "outline"
-                        }
-                        className={
-                          cycle.status === "no-activity" ? "text-muted-foreground" : undefined
-                        }
-                      >
-                        {statusLabel(cycle.status)}
-                      </Badge>
-                      {cycle.status === "consolidated" && cycle.consolidatedAt ? (
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono text-xs">{cycle.cycle}</span>
+                        <Badge
+                          variant={
+                            cycle.status === "consolidated"
+                              ? "default"
+                              : cycle.status === "pending"
+                                ? "secondary"
+                                : "outline"
+                          }
+                          className={
+                            cycle.status === "no-activity" ? "text-muted-foreground" : undefined
+                          }
+                        >
+                          {statusLabel(cycle.status)}
+                        </Badge>
+                        {cycle.status === "consolidated" && cycle.consolidatedAt ? (
+                          <span className="text-muted-foreground text-xs">
+                            {formatBogotaDate(cycle.consolidatedAt)}
+                          </span>
+                        ) : null}
+                        {cycle.status === "pending" && cycle.daysOverdue > 0 ? (
+                          <span className="text-muted-foreground text-xs">
+                            +{cycle.daysOverdue}d
+                          </span>
+                        ) : null}
+                        {cycle.status === "pending" ? (
+                          <Link
+                            href={`/settings/accounts/${group.primaryAccountId}/consolidate/${cycle.cycle}`}
+                            className={buttonVariants({ variant: "outline", size: "sm" })}
+                          >
+                            Consolidar
+                          </Link>
+                        ) : null}
+                        {cycle.status === "consolidated" ? (
+                          <Link
+                            href={`/settings/accounts/${group.primaryAccountId}/consolidate/${cycle.cycle}`}
+                            className="text-muted-foreground text-xs underline"
+                          >
+                            Ver run
+                          </Link>
+                        ) : null}
+                      </div>
+                      {group.isMultiCurrency ? (
                         <span className="text-muted-foreground text-xs">
-                          {formatBogotaDate(cycle.consolidatedAt)}
+                          {multiCurrencySubtitle(cycle.currencies)}
                         </span>
-                      ) : null}
-                      {cycle.status === "pending" && cycle.daysOverdue > 0 ? (
-                        <span className="text-muted-foreground text-xs">+{cycle.daysOverdue}d</span>
-                      ) : null}
-                      {cycle.status === "pending" ? (
-                        <Link
-                          href={`/settings/accounts/${account.id}/consolidate/${cycle.cycle}`}
-                          className={buttonVariants({ variant: "outline", size: "sm" })}
-                        >
-                          Consolidar
-                        </Link>
-                      ) : null}
-                      {cycle.status === "consolidated" ? (
-                        <Link
-                          href={`/settings/accounts/${account.id}/consolidate/${cycle.cycle}`}
-                          className="text-muted-foreground text-xs underline"
-                        >
-                          Ver run
-                        </Link>
                       ) : null}
                     </div>
                   ))}

--- a/src/components/dashboard/pending-consolidation-banner.tsx
+++ b/src/components/dashboard/pending-consolidation-banner.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { AlertTriangleIcon } from "lucide-react";
 
 import { overdueCyclesForUser } from "@/lib/accounts/cycles";
+import { dedupeOverdueByPhysicalCard } from "@/lib/accounts/cycle-groups";
 import { db } from "@/lib/db";
 import { accounts } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
@@ -11,6 +12,13 @@ import { and, eq } from "drizzle-orm";
 // or more cycles are past their cut day by more than the threshold. Intended
 // to live at the top of the dashboard — shows nothing when the user is caught
 // up, so it's zero UI cost on the happy path.
+//
+// #431: plastic-dedup. Mastercard Internacional (COP + USD) shares one
+// physicalCardId; consolidating uses a single extract that covers both
+// sheets, so the banner must count ONE pending cycle per (plastic, cycle),
+// not one per account+cycle. The label also drops the currency suffix
+// because the extract is plastic-level ("Bancolombia Mastercard *7291"
+// instead of "Bancolombia Mastercard *7291 (COP)").
 export async function PendingConsolidationBanner({
   userId,
   thresholdDays = 7,
@@ -22,7 +30,9 @@ export async function PendingConsolidationBanner({
     .select({
       id: accounts.id,
       name: accounts.name,
+      currency: accounts.currency,
       metadata: accounts.metadata,
+      physicalCardId: accounts.physicalCardId,
     })
     .from(accounts)
     .where(
@@ -38,13 +48,39 @@ export async function PendingConsolidationBanner({
   const overdue = await overdueCyclesForUser(userId, tcAccounts, { thresholdDays });
   if (overdue.length === 0) return null;
 
-  const mostOverdue = overdue[0];
-  const message =
-    overdue.length === 1
-      ? `Ciclo ${mostOverdue.cycle} de ${mostOverdue.accountName} está pendiente hace ${mostOverdue.daysOverdue} días.`
-      : `Tenés ${overdue.length} ciclos TC sin consolidar — el más atrasado es ${mostOverdue.cycle} de ${mostOverdue.accountName} (+${mostOverdue.daysOverdue}d).`;
+  // Build the plastic → COP account map from the full tcAccounts list so the
+  // banner links to the COP sibling even when the COP side isn't in the
+  // overdue feed (e.g. only USD is pending for that cycle). Keeps the banner
+  // link in lockstep with `TcConsolidationStatus`'s "Consolidar" button.
+  const copAccountByPcId = new Map<string, number>();
+  const copNameByPcId = new Map<string, string>();
+  for (const a of tcAccounts) {
+    if (a.physicalCardId && a.currency === "COP" && !copAccountByPcId.has(a.physicalCardId)) {
+      copAccountByPcId.set(a.physicalCardId, a.id);
+      copNameByPcId.set(a.physicalCardId, a.name);
+    }
+  }
 
-  const linkHref = `/settings/accounts/${mostOverdue.accountId}/consolidate/${mostOverdue.cycle}`;
+  const deduped = dedupeOverdueByPhysicalCard(
+    overdue.map((o) => ({
+      cycle: o.cycle,
+      accountId: o.accountId,
+      accountName: o.accountName,
+      daysOverdue: o.daysOverdue,
+      physicalCardId: o.physicalCardId,
+      currency: o.currency,
+    })),
+    { copAccountByPcId, copNameByPcId },
+  );
+  if (deduped.length === 0) return null;
+
+  const mostOverdue = deduped[0];
+  const message =
+    deduped.length === 1
+      ? `Ciclo ${mostOverdue.cycle} de ${mostOverdue.label} está pendiente hace ${mostOverdue.daysOverdue} días.`
+      : `Tenés ${deduped.length} ciclos TC sin consolidar — el más atrasado es ${mostOverdue.cycle} de ${mostOverdue.label} (+${mostOverdue.daysOverdue}d).`;
+
+  const linkHref = `/settings/accounts/${mostOverdue.primaryAccountId}/consolidate/${mostOverdue.cycle}`;
 
   return (
     <aside

--- a/src/lib/accounts/cycle-groups.test.ts
+++ b/src/lib/accounts/cycle-groups.test.ts
@@ -1,0 +1,324 @@
+// #431: Unit tests for the plastic-grouping helpers. Pure functions, no DB.
+
+import { describe, expect, it } from "vitest";
+
+import type { CycleStatus, CycleSummary } from "@/lib/accounts/cycles";
+import {
+  coalesceStatus,
+  dedupeOverdueByPhysicalCard,
+  groupAccountsForConsolidation,
+  type AccountWithCycles,
+  type GroupAccount,
+  type OverdueWithCard,
+} from "@/lib/accounts/cycle-groups";
+
+function utcDate(y: number, m: number, d: number): Date {
+  return new Date(Date.UTC(y, m - 1, d, 23, 0, 0, 0));
+}
+
+function cycle(label: string, status: CycleStatus, daysOverdue = 0): CycleSummary {
+  const [y, m] = label.split("-").map(Number);
+  return {
+    cycle: label,
+    status,
+    anchor: utcDate(y, m, 30),
+    daysOverdue,
+    consolidatedAt: status === "consolidated" ? utcDate(y, m, 30) : null,
+    statementImportId: status === "consolidated" ? 100 : null,
+  };
+}
+
+function account(
+  id: number,
+  name: string,
+  currency: string,
+  physicalCardId: string | null,
+): GroupAccount {
+  return {
+    id,
+    name,
+    currency,
+    institution: "Bancolombia",
+    institutionSlug: "bancolombia",
+    metadata: null,
+    physicalCardId,
+  };
+}
+
+describe("coalesceStatus (#431)", () => {
+  it("picks pending when any sibling is pending", () => {
+    expect(coalesceStatus(["pending", "consolidated"])).toBe("pending");
+    expect(coalesceStatus(["consolidated", "pending"])).toBe("pending");
+    expect(coalesceStatus(["pending", "no-activity"])).toBe("pending");
+  });
+
+  it("falls through the precedence when no pending", () => {
+    expect(coalesceStatus(["in-progress", "consolidated"])).toBe("in-progress");
+    expect(coalesceStatus(["consolidated", "no-activity"])).toBe("consolidated");
+  });
+
+  it("returns the single value when siblings agree", () => {
+    expect(coalesceStatus(["consolidated", "consolidated"])).toBe("consolidated");
+    expect(coalesceStatus(["no-activity", "no-activity"])).toBe("no-activity");
+  });
+});
+
+describe("groupAccountsForConsolidation (#431)", () => {
+  it("groups accounts sharing a physicalCardId into one CycleGroup", () => {
+    const a: AccountWithCycles = {
+      account: account(10, "Bancolombia Mastercard *7291", "COP", "pc-1"),
+      cycles: [cycle("2026-04", "in-progress"), cycle("2026-03", "pending", 21)],
+    };
+    const b: AccountWithCycles = {
+      account: account(11, "Bancolombia Mastercard *7291", "USD", "pc-1"),
+      cycles: [cycle("2026-04", "in-progress"), cycle("2026-03", "pending", 21)],
+    };
+    const groups = groupAccountsForConsolidation([a, b]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("pc-1");
+    expect(groups[0].isMultiCurrency).toBe(true);
+    expect(groups[0].accounts.map((x) => x.currency)).toEqual(["COP", "USD"]);
+    expect(groups[0].primaryAccountId).toBe(10); // COP wins.
+    expect(groups[0].cycles[1].cycle).toBe("2026-03");
+    expect(groups[0].cycles[1].status).toBe("pending");
+    expect(groups[0].cycles[1].currencies).toEqual(["COP", "USD"]);
+    expect(groups[0].cycles[1].daysOverdue).toBe(21);
+  });
+
+  it("keeps single-currency accounts as single-member groups", () => {
+    const a: AccountWithCycles = {
+      account: account(5, "Bancolombia Visa *2575", "COP", null),
+      cycles: [cycle("2026-04", "in-progress"), cycle("2026-03", "consolidated")],
+    };
+    const groups = groupAccountsForConsolidation([a]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("single:5");
+    expect(groups[0].isMultiCurrency).toBe(false);
+    expect(groups[0].accounts).toHaveLength(1);
+    expect(groups[0].primaryAccountId).toBe(5);
+    expect(groups[0].cycles[0].currencies).toEqual(["COP"]);
+  });
+
+  it("coalesces mismatched sibling statuses to the worst case", () => {
+    const a: AccountWithCycles = {
+      account: account(10, "MC", "COP", "pc-1"),
+      cycles: [cycle("2026-03", "consolidated")],
+    };
+    const b: AccountWithCycles = {
+      account: account(11, "MC", "USD", "pc-1"),
+      cycles: [cycle("2026-03", "pending", 52)],
+    };
+    const group = groupAccountsForConsolidation([a, b])[0];
+    expect(group.cycles[0].status).toBe("pending");
+    expect(group.cycles[0].daysOverdue).toBe(52);
+  });
+
+  it("prefers COP sibling as primaryAccountId regardless of input order", () => {
+    const usd: AccountWithCycles = {
+      account: account(20, "Amex", "USD", "pc-x"),
+      cycles: [cycle("2026-03", "pending", 30)],
+    };
+    const cop: AccountWithCycles = {
+      account: account(21, "Amex", "COP", "pc-x"),
+      cycles: [cycle("2026-03", "pending", 30)],
+    };
+    const group = groupAccountsForConsolidation([usd, cop])[0];
+    expect(group.primaryAccountId).toBe(21); // COP wins.
+    expect(group.accounts[0].currency).toBe("COP");
+  });
+
+  it("falls back to first sibling when no COP is present", () => {
+    const a: AccountWithCycles = {
+      account: account(30, "Exotic", "USD", "pc-y"),
+      cycles: [cycle("2026-03", "pending", 10)],
+    };
+    const b: AccountWithCycles = {
+      account: account(31, "Exotic", "EUR", "pc-y"),
+      cycles: [cycle("2026-03", "pending", 10)],
+    };
+    const group = groupAccountsForConsolidation([a, b])[0];
+    expect(group.primaryAccountId).toBe(30);
+  });
+
+  it("preserves group order by first appearance of each plastic", () => {
+    const mcCop: AccountWithCycles = {
+      account: account(10, "MC", "COP", "pc-mc"),
+      cycles: [cycle("2026-03", "pending", 5)],
+    };
+    const visa: AccountWithCycles = {
+      account: account(5, "Visa", "COP", null),
+      cycles: [cycle("2026-03", "consolidated")],
+    };
+    const mcUsd: AccountWithCycles = {
+      account: account(11, "MC", "USD", "pc-mc"),
+      cycles: [cycle("2026-03", "pending", 5)],
+    };
+    const groups = groupAccountsForConsolidation([mcCop, visa, mcUsd]);
+    // MC plastic appears before Visa in the input; its group must come first.
+    expect(groups.map((g) => g.key)).toEqual(["pc-mc", "single:5"]);
+  });
+});
+
+describe("dedupeOverdueByPhysicalCard (#431)", () => {
+  it("collapses (plastic, cycle) duplicates into one row", () => {
+    const rows: OverdueWithCard[] = [
+      {
+        cycle: "2026-03",
+        accountId: 10,
+        accountName: "Bancolombia Mastercard *7291",
+        daysOverdue: 21,
+        physicalCardId: "pc-1",
+        currency: "COP",
+      },
+      {
+        cycle: "2026-03",
+        accountId: 11,
+        accountName: "Bancolombia Mastercard *7291",
+        daysOverdue: 21,
+        physicalCardId: "pc-1",
+        currency: "USD",
+      },
+    ];
+    const out = dedupeOverdueByPhysicalCard(rows);
+    expect(out).toHaveLength(1);
+    expect(out[0].primaryAccountId).toBe(10); // COP wins.
+    expect(out[0].label).toBe("Bancolombia Mastercard *7291");
+    expect(out[0].cycle).toBe("2026-03");
+  });
+
+  it("keeps separate rows for different cycles on the same plastic", () => {
+    const rows: OverdueWithCard[] = [
+      {
+        cycle: "2026-03",
+        accountId: 10,
+        accountName: "MC",
+        daysOverdue: 21,
+        physicalCardId: "pc-1",
+        currency: "COP",
+      },
+      {
+        cycle: "2026-02",
+        accountId: 10,
+        accountName: "MC",
+        daysOverdue: 52,
+        physicalCardId: "pc-1",
+        currency: "COP",
+      },
+    ];
+    const out = dedupeOverdueByPhysicalCard(rows);
+    expect(out).toHaveLength(2);
+    expect(out[0].cycle).toBe("2026-02"); // most-overdue first
+    expect(out[1].cycle).toBe("2026-03");
+  });
+
+  it("keeps standalone accounts (no physicalCardId) as their own buckets", () => {
+    const rows: OverdueWithCard[] = [
+      {
+        cycle: "2026-03",
+        accountId: 5,
+        accountName: "Visa *2575",
+        daysOverdue: 10,
+        physicalCardId: null,
+        currency: "COP",
+      },
+      {
+        cycle: "2026-03",
+        accountId: 6,
+        accountName: "Other",
+        daysOverdue: 8,
+        physicalCardId: null,
+        currency: "COP",
+      },
+    ];
+    const out = dedupeOverdueByPhysicalCard(rows);
+    expect(out).toHaveLength(2);
+    expect(out.map((r) => r.primaryAccountId).sort()).toEqual([5, 6]);
+  });
+
+  it("takes max daysOverdue across siblings", () => {
+    const rows: OverdueWithCard[] = [
+      {
+        cycle: "2026-03",
+        accountId: 10,
+        accountName: "MC",
+        daysOverdue: 10,
+        physicalCardId: "pc-1",
+        currency: "COP",
+      },
+      {
+        cycle: "2026-03",
+        accountId: 11,
+        accountName: "MC",
+        daysOverdue: 30,
+        physicalCardId: "pc-1",
+        currency: "USD",
+      },
+    ];
+    const out = dedupeOverdueByPhysicalCard(rows);
+    expect(out[0].daysOverdue).toBe(30);
+  });
+
+  it("uses the COP map fallback when the COP sibling isn't in the overdue feed", () => {
+    // Scenario: Mastercard COP is `no-activity` for 2026-02 (not in overdue
+    // feed) but USD is `pending`. The banner link should still resolve to
+    // the COP account so it matches the Status widget.
+    const rows: OverdueWithCard[] = [
+      {
+        cycle: "2026-02",
+        accountId: 11,
+        accountName: "Bancolombia Mastercard *7291",
+        daysOverdue: 52,
+        physicalCardId: "pc-1",
+        currency: "USD",
+      },
+    ];
+    const out = dedupeOverdueByPhysicalCard(rows, {
+      copAccountByPcId: new Map([["pc-1", 10]]),
+      copNameByPcId: new Map([["pc-1", "Bancolombia Mastercard *7291"]]),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].primaryAccountId).toBe(10);
+    expect(out[0].label).toBe("Bancolombia Mastercard *7291");
+  });
+
+  it("counts the banner message correctly (plásticos, not accounts)", () => {
+    // The regression from #431: Mastercard with 2 pending cycles (COP+USD)
+    // had the banner saying "4 ciclos pendientes". After dedup it says "2".
+    const rows: OverdueWithCard[] = [
+      {
+        cycle: "2026-03",
+        accountId: 10,
+        accountName: "MC",
+        daysOverdue: 21,
+        physicalCardId: "pc-1",
+        currency: "COP",
+      },
+      {
+        cycle: "2026-03",
+        accountId: 11,
+        accountName: "MC",
+        daysOverdue: 21,
+        physicalCardId: "pc-1",
+        currency: "USD",
+      },
+      {
+        cycle: "2026-02",
+        accountId: 10,
+        accountName: "MC",
+        daysOverdue: 52,
+        physicalCardId: "pc-1",
+        currency: "COP",
+      },
+      {
+        cycle: "2026-02",
+        accountId: 11,
+        accountName: "MC",
+        daysOverdue: 52,
+        physicalCardId: "pc-1",
+        currency: "USD",
+      },
+    ];
+    const out = dedupeOverdueByPhysicalCard(rows);
+    expect(out).toHaveLength(2);
+  });
+});

--- a/src/lib/accounts/cycle-groups.ts
+++ b/src/lib/accounts/cycle-groups.ts
@@ -1,0 +1,252 @@
+// #431: Collapse linked multi-currency TC accounts (e.g. Mastercard
+// Internacional COP + USD) into a single UI block so the user sees one row
+// per (plástico, cycle) instead of duplicated pending nags.
+//
+// The backend still writes one `statement_imports` row per account — that's
+// correct, the extract has one sheet per currency. The UI just needs to
+// know that a single extract satisfies the whole plastic's cycle, and the
+// dashboard banner must not double-count. Both consumers share this helper
+// so the semantics stay in one place.
+
+import type { CycleStatus, CycleSummary } from "@/lib/accounts/cycles";
+
+// Ordered from "needs most attention" to "needs none". When two siblings of
+// the same plastic disagree on a cycle (e.g. one currency was consolidated
+// and the other wasn't), the group inherits the more urgent status. Kept as
+// a module-level array so the precedence is readable in one line.
+const STATUS_PRECEDENCE: readonly CycleStatus[] = [
+  "pending",
+  "in-progress",
+  "consolidated",
+  "no-activity",
+] as const;
+
+function rank(status: CycleStatus): number {
+  return STATUS_PRECEDENCE.indexOf(status);
+}
+
+// `coalesceStatus` picks the worst-case status from a list of siblings for
+// the same cycle label. Public for testability.
+export function coalesceStatus(statuses: readonly CycleStatus[]): CycleStatus {
+  if (statuses.length === 0) return "consolidated"; // defensive; coalesce([]) never called in practice
+  let best = statuses[0];
+  for (let i = 1; i < statuses.length; i++) {
+    if (rank(statuses[i]) < rank(best)) best = statuses[i];
+  }
+  return best;
+}
+
+export type GroupAccount = {
+  id: number;
+  name: string;
+  currency: string;
+  institution: string | null;
+  institutionSlug: string | null;
+  metadata: unknown;
+  physicalCardId: string | null;
+};
+
+export type AccountWithCycles<A extends GroupAccount = GroupAccount> = {
+  account: A;
+  cycles: CycleSummary[];
+};
+
+export type CoalescedCycle = {
+  cycle: string;
+  status: CycleStatus;
+  anchor: Date;
+  daysOverdue: number;
+  consolidatedAt: Date | null;
+  statementImportId: number | null;
+  // Currencies present in this cycle's siblings, in the order they appeared.
+  // Used to render the "COP + USD · 1 extracto, 2 hojas" subtitle.
+  currencies: string[];
+};
+
+export type CycleGroup<A extends GroupAccount = GroupAccount> = {
+  // The plastic key — `physicalCardId` for linked groups, or `single:<id>`
+  // for standalone accounts. Stable id for React keys.
+  key: string;
+  // All accounts linked to the same plastic. Single-currency accounts get a
+  // one-element array. Ordered with COP first when present.
+  accounts: A[];
+  // Account whose id is used in `/consolidate/<id>/<cycle>` links. Convention
+  // from the issue: COP account wins; otherwise the first sibling.
+  primaryAccountId: number;
+  // Cycles coalesced across siblings (same label dedup'd into one row).
+  cycles: CoalescedCycle[];
+  // `true` when there are 2+ linked accounts sharing the plastic — UI uses
+  // this to show the multi-sheet subtitle.
+  isMultiCurrency: boolean;
+};
+
+// Sort helper: COP before USD before other currencies. Deterministic so the
+// "primary" pick and the currencies list in the subtitle are stable.
+function currencyRank(c: string): number {
+  if (c === "COP") return 0;
+  if (c === "USD") return 1;
+  return 2;
+}
+
+export function groupAccountsForConsolidation<A extends GroupAccount>(
+  perAccount: AccountWithCycles<A>[],
+): CycleGroup<A>[] {
+  // Group by physicalCardId. Accounts without one are their own group.
+  const byPcId = new Map<string, AccountWithCycles<A>[]>();
+  const singletons: AccountWithCycles<A>[] = [];
+  for (const item of perAccount) {
+    if (item.account.physicalCardId) {
+      const existing = byPcId.get(item.account.physicalCardId);
+      if (existing) existing.push(item);
+      else byPcId.set(item.account.physicalCardId, [item]);
+    } else {
+      singletons.push(item);
+    }
+  }
+
+  const groups: CycleGroup<A>[] = [];
+
+  // Keep input order: groups ordered by the FIRST appearance of each plastic.
+  const seen = new Set<string>();
+  for (const item of perAccount) {
+    if (item.account.physicalCardId) {
+      if (seen.has(item.account.physicalCardId)) continue;
+      seen.add(item.account.physicalCardId);
+      const siblings = byPcId.get(item.account.physicalCardId)!;
+      // Sort siblings: COP first, then USD, then others (stable by currency rank).
+      const sorted = [...siblings].sort(
+        (a, b) => currencyRank(a.account.currency) - currencyRank(b.account.currency),
+      );
+      groups.push(buildGroup(item.account.physicalCardId, sorted));
+    } else {
+      groups.push(buildGroup(`single:${item.account.id}`, [item]));
+    }
+  }
+  // Consume singletons iteration already covered them above; avoid double-push.
+  // (Left in loop-form defensively — any account with physicalCardId=null is
+  // not in byPcId, so the `else` branch handles it inline.)
+  void singletons;
+
+  return groups;
+}
+
+function buildGroup<A extends GroupAccount>(
+  key: string,
+  siblings: AccountWithCycles<A>[],
+): CycleGroup<A> {
+  const accounts = siblings.map((s) => s.account);
+  const primary = accounts.find((a) => a.currency === "COP") ?? accounts[0];
+  const isMultiCurrency = siblings.length > 1;
+
+  // Walk every cycle label the siblings emit (in order from the first sibling
+  // — they all share the same cutoff day by definition, so their cycle labels
+  // match). Coalesce status across siblings at the same label.
+  const [first, ...rest] = siblings;
+  const cycles: CoalescedCycle[] = first.cycles.map((c) => {
+    const peers = rest.map((s) => s.cycles.find((pc) => pc.cycle === c.cycle) ?? c);
+    const statuses = [c.status, ...peers.map((p) => p.status)];
+    const status = coalesceStatus(statuses);
+    // `daysOverdue` is driven by the coalesced status: if the group is
+    // pending, use the max daysOverdue among the pending siblings. If
+    // consolidated, 0. If no-activity or in-progress, 0.
+    let daysOverdue = 0;
+    if (status === "pending") {
+      const allCycles = [c, ...peers];
+      daysOverdue = allCycles.reduce((max, x) => (x.daysOverdue > max ? x.daysOverdue : max), 0);
+    }
+    // `consolidatedAt` / `statementImportId` — pick from any sibling that's
+    // consolidated (prefer primary). Useful when the group is consolidated
+    // as a whole or when viewing a specific account's run.
+    const consolidatedSiblings = [c, ...peers].filter((x) => x.consolidatedAt !== null);
+    const consolidatedAt = consolidatedSiblings[0]?.consolidatedAt ?? null;
+    const statementImportId = consolidatedSiblings[0]?.statementImportId ?? null;
+
+    const currencies: string[] = [];
+    for (const s of siblings) {
+      if (!currencies.includes(s.account.currency)) currencies.push(s.account.currency);
+    }
+
+    return {
+      cycle: c.cycle,
+      status,
+      anchor: c.anchor,
+      daysOverdue,
+      consolidatedAt,
+      statementImportId,
+      currencies,
+    };
+  });
+
+  return {
+    key,
+    accounts,
+    primaryAccountId: primary.id,
+    cycles,
+    isMultiCurrency,
+  };
+}
+
+export type OverdueWithCard = {
+  cycle: string;
+  accountId: number;
+  accountName: string;
+  daysOverdue: number;
+  physicalCardId: string | null;
+  currency: string;
+};
+
+export type DedupedOverdue = {
+  cycle: string;
+  // Label to show ("Bancolombia Mastercard *7291"); for standalone accounts
+  // this is the regular account name.
+  label: string;
+  // Account id used for the "Consolidar ahora" link (COP preferred).
+  primaryAccountId: number;
+  // Max daysOverdue across siblings of the same plastic on this cycle.
+  daysOverdue: number;
+};
+
+// Dedupe an overdue feed by `(physicalCardId, cycle)`. Accounts without a
+// physicalCardId stay one-row-per-account (their key is `single:<id>`).
+// `label` is the account name of the chosen primary sibling — the caller
+// already has the name string, so this helper doesn't re-query.
+//
+// `opts.copAccountByPcId` lets the caller pass a `physicalCardId → COP
+// accountId` map so the primary link resolves to the plastic's COP account
+// EVEN WHEN the COP account isn't in the overdue feed (e.g. COP side is
+// `no-activity`, only USD is pending). Without the map the helper falls
+// back to the first sibling present in the feed. This keeps the Status
+// widget and the dashboard banner pointing to the same destination.
+export function dedupeOverdueByPhysicalCard(
+  rows: OverdueWithCard[],
+  opts: { copAccountByPcId?: Map<string, number>; copNameByPcId?: Map<string, string> } = {},
+): DedupedOverdue[] {
+  type Bucket = { rows: OverdueWithCard[]; key: string };
+  const buckets = new Map<string, Bucket>();
+  for (const r of rows) {
+    const key = `${r.physicalCardId ?? `single:${r.accountId}`}::${r.cycle}`;
+    const existing = buckets.get(key);
+    if (existing) existing.rows.push(r);
+    else buckets.set(key, { rows: [r], key });
+  }
+  const out: DedupedOverdue[] = [];
+  for (const b of buckets.values()) {
+    const copRowInFeed = b.rows.find((r) => r.currency === "COP");
+    const fallback = b.rows[0];
+    const pcId = fallback.physicalCardId;
+    const copIdFromMap = pcId ? opts.copAccountByPcId?.get(pcId) : undefined;
+    const copNameFromMap = pcId ? opts.copNameByPcId?.get(pcId) : undefined;
+    const primaryAccountId = copRowInFeed?.accountId ?? copIdFromMap ?? fallback.accountId;
+    const label = copRowInFeed?.accountName ?? copNameFromMap ?? fallback.accountName;
+    const daysOverdue = b.rows.reduce((max, r) => (r.daysOverdue > max ? r.daysOverdue : max), 0);
+    out.push({
+      cycle: fallback.cycle,
+      label,
+      primaryAccountId,
+      daysOverdue,
+    });
+  }
+  // Preserve the input's "most overdue first" ordering — sort by daysOverdue desc.
+  out.sort((a, b) => b.daysOverdue - a.daysOverdue);
+  return out;
+}

--- a/src/lib/accounts/cycles.ts
+++ b/src/lib/accounts/cycles.ts
@@ -230,13 +230,24 @@ export async function recentCycles(ctx: CyclesContext): Promise<CycleSummary[]> 
 export type OverdueCycleSummary = CycleSummary & {
   accountId: number;
   accountName: string;
+  // #431: surfaced so the dashboard banner can dedupe by plastic (Mastercard
+  // Internacional COP + USD share one physicalCardId and should count as
+  // one pending cycle, not two). Null for standalone accounts.
+  physicalCardId: string | null;
+  currency: string;
 };
 
 // Dashboard banner helper: across all of a user's TC accounts, return every
 // cycle that's pending AND more than `thresholdDays` past its cut.
 export async function overdueCyclesForUser(
   userId: number,
-  accounts: Array<{ id: number; name: string; metadata: AccountMetadata | null | undefined }>,
+  accounts: Array<{
+    id: number;
+    name: string;
+    metadata: AccountMetadata | null | undefined;
+    physicalCardId?: string | null;
+    currency?: string;
+  }>,
   opts: { thresholdDays?: number; now?: Date; count?: number; database?: DB } = {},
 ): Promise<OverdueCycleSummary[]> {
   const threshold = opts.thresholdDays ?? 7;
@@ -252,7 +263,13 @@ export async function overdueCyclesForUser(
     });
     for (const c of cycles) {
       if (c.status === "pending" && c.daysOverdue >= threshold) {
-        out.push({ ...c, accountId: account.id, accountName: account.name });
+        out.push({
+          ...c,
+          accountId: account.id,
+          accountName: account.name,
+          physicalCardId: account.physicalCardId ?? null,
+          currency: account.currency ?? "COP",
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary

Closes #431. Stacked on #437 (merged).

Multi-currency TCs (Mastercard Internacional COP + USD sharing a `physicalCardId`) collapse into ONE block in `TcConsolidationStatus` with one row per cycle. The dashboard banner dedupes its pending count by `(plastic, cycle)` so 2 pending cycles × 2 currencies = 2 (not 4). Single-currency accounts render exactly as before.

Backend stays unchanged — `#426`'s multi-sheet dispatch already applies one extract to both siblings. This PR is UI-only.

## Changes

- **New** `src/lib/accounts/cycle-groups.ts` (pure helpers, no DB):
  - `groupAccountsForConsolidation` clusters siblings by `physicalCardId`, sorts COP → USD → others, and coalesces cycle statuses per label with precedence `pending > in-progress > consolidated > no-activity`. Single-currency accounts become one-member groups (key `single:<id>`).
  - `dedupeOverdueByPhysicalCard` collapses `(plastic, cycle)` pairs for the banner. Takes an optional `copAccountByPcId` map so the banner link resolves to the COP sibling even when only USD is in the overdue feed (e.g. COP side is `no-activity` per #430, only USD is `pending`). This keeps the banner and the Status widget pointing at the same destination.

- `src/lib/accounts/cycles.ts`
  - `OverdueCycleSummary` now carries `physicalCardId` and `currency` so the banner can dedupe.
  - `overdueCyclesForUser` accepts those fields in its `accounts` input (back-compat via `?? null` / `?? \"COP\"`).

- `src/app/(app)/settings/accounts/tc-consolidation-status.tsx`
  - Uses `groupAccountsForConsolidation`. Multi-currency blocks show one title + one row per cycle with subtitle \"COP + USD · 1 extracto, 2 hojas\". \"Consolidar\" and \"Ver run\" links point at `group.primaryAccountId` (the COP sibling).

- `src/components/dashboard/pending-consolidation-banner.tsx`
  - Selects `physicalCardId` and passes it to `overdueCyclesForUser`.
  - Builds a `physicalCardId → COP accountId` map from the fetched TC accounts and passes it to `dedupeOverdueByPhysicalCard`.
  - Message and link point at the plastic's COP account.

## Acceptance (from #431)

- [x] Mastercard *7291 con 2 ciclos pendientes aparece como UN bloque con 2 filas (en vez de 2 bloques con 2 filas c/u). Verified on dev DB.
- [x] Visa *2575 (single-currency) sigue mostrándose igual que hoy (single bloque, sin cambios). Verified.
- [x] Banner dice \"2 ciclos pendientes\" cuando hay 2 plásticos pending × 1 cycle cada uno. Verified on dev: \"Tenés 2 ciclos TC sin consolidar\" post-#431 (era 3 post-#430, era 4 pre-#430).
- [x] El link Consolidar funciona — apunta al COP (/settings/accounts/6/consolidate/2026-02). Multi-sheet dispatch de #426 se encarga del resto.
- [x] Tests existentes siguen verdes + 15 nuevos unit tests del helper.

## Out of scope (per issue)

- `/consolidate/<id>/<cycle>?view=run` multi-currency side-by-side — sigue mostrando solo el account actual; follow-up opcional.
- El backend sigue escribiendo un `statement_imports` row por account. Correcto — es la UI la que sumaba mal.

## Test plan

- [x] `bun run test src/lib/accounts/cycle-groups.test.ts` — 15/15 pass
- [x] `bun run test` — 1018/1018 pass
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run format:check` — clean
- [x] Manual smoke on dev DB via `/api/dev/login`:
  - `/settings/accounts`: Mastercard *7291 renders as one block titled \"Bancolombia Mastercard *7291\" (no currency suffix), 2026-04 `en curso`, 2026-03 `pendiente +21d` → /accounts/6/..., 2026-02 `pendiente +52d` (USD was pending, COP was no-activity — coalesced to pending) → /accounts/6/.... Each cycle has subtitle \"COP + USD · 1 extracto, 2 hojas\".
  - Visa *2575 stays single-block \"Bancolombia Visa *2575 (COP)\" with no subtitle — zero visual drift.
  - Dashboard banner: \"Tenés 2 ciclos TC sin consolidar — el más atrasado es 2026-02 de Bancolombia Mastercard *7291 (+52d).\" Link → /settings/accounts/6/consolidate/2026-02 (COP). Matches the Status widget link.