### PR TITLE
feat(consolidation): preview delta + breakdown (#432)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-report-view.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-report-view.tsx
@@ -6,7 +6,10 @@ import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
-import type { ConsolidationReport } from "@/lib/ingestion/bancolombia-statement/consolidate";
+import type {
+  BalanceProjection,
+  ConsolidationReport,
+} from "@/lib/ingestion/bancolombia-statement/consolidate";
 
 export function formatCents(str: string): string {
   if (!str) return "—";
@@ -65,6 +68,9 @@ export function ReportSection({
           <h3 className="text-sm font-semibold">{sectionLabel(report)}</h3>
           <Badge variant="outline">{report.status}</Badge>
         </div>
+      ) : null}
+      {report.projection ? (
+        <BalanceProjectionSection projection={report.projection} dryRun={report.dryRun} />
       ) : null}
       <SummaryGrid report={report} />
       <Alert>
@@ -235,6 +241,115 @@ function MissingSection({ missing }: { missing: ConsolidationReport["missingInLe
         )}
       </CollapsibleContent>
     </Collapsible>
+  );
+}
+
+function formatSignedCents(str: string): string {
+  if (!str) return "—";
+  const big = BigInt(str);
+  const formatted = formatCents(str);
+  if (big > BigInt(0) && !formatted.startsWith("+")) return `+${formatted}`;
+  return formatted;
+}
+
+function BalanceProjectionSection({
+  projection,
+  dryRun,
+}: {
+  projection: BalanceProjection;
+  dryRun: boolean;
+}) {
+  const deltaCents = BigInt(projection.deltaCentsStr);
+  const isZeroDelta = deltaCents === BigInt(0);
+  const plugsCents = BigInt(projection.breakdown.plugsObsoletosCentsStr);
+
+  return (
+    <section
+      data-testid="consolidate-projection"
+      className="flex flex-col gap-3 rounded-md border p-3 text-sm"
+    >
+      <div className="flex items-baseline gap-2">
+        <h4 className="font-semibold">Proyección de saldo</h4>
+        {dryRun ? (
+          <span className="text-muted-foreground text-xs">(preview)</span>
+        ) : (
+          <span className="text-muted-foreground text-xs">(aplicado)</span>
+        )}
+      </div>
+
+      {isZeroDelta ? (
+        <p className="text-muted-foreground text-xs" data-testid="consolidate-projection-zero">
+          Sin cambios en saldo — este ciclo no aporta compras nuevas ni intereses.
+        </p>
+      ) : (
+        <>
+          <p className="text-sm">
+            Saldo disponible cambiará de{" "}
+            <span className="font-medium tabular-nums">
+              {formatCents(projection.saldoActualCentsStr)}
+            </span>{" "}
+            →{" "}
+            <span className="font-medium tabular-nums">
+              {formatCents(projection.saldoProyectadoCentsStr)}
+            </span>{" "}
+            (delta:{" "}
+            <span
+              data-testid="consolidate-projection-delta"
+              className={cn(
+                "font-semibold tabular-nums",
+                deltaCents < BigInt(0)
+                  ? "text-rose-700 dark:text-rose-400"
+                  : "text-emerald-700 dark:text-emerald-400",
+              )}
+            >
+              {formatSignedCents(projection.deltaCentsStr)}
+            </span>
+            )
+          </p>
+          <ul className="text-muted-foreground ml-4 list-disc space-y-0.5 text-xs">
+            <li>
+              Compras nuevas:{" "}
+              <span className="tabular-nums">
+                {formatSignedCents(projection.breakdown.comprasNuevasCentsStr)}
+              </span>
+            </li>
+            <li>
+              Intereses causados:{" "}
+              {projection.breakdown.interesesCentsStr === null ? (
+                <span className="italic">se calculan al confirmar (no incluidos en el delta)</span>
+              ) : (
+                <span className="tabular-nums">
+                  {formatSignedCents(projection.breakdown.interesesCentsStr)}
+                </span>
+              )}
+            </li>
+            {plugsCents !== BigInt(0) ? (
+              <li>
+                Balance adjustments previos (≤ fin del ciclo):{" "}
+                <span className="tabular-nums">
+                  {formatSignedCents(projection.breakdown.plugsObsoletosCentsStr)}
+                </span>{" "}
+                <span className="italic">— podrían estar obsoletos</span>
+              </li>
+            ) : null}
+          </ul>
+        </>
+      )}
+
+      {projection.warn.exceeded ? (
+        <Alert
+          variant="default"
+          data-testid="consolidate-projection-warn"
+          className="border-amber-500/50 bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200"
+        >
+          <AlertTriangleIcon className="size-4" />
+          <AlertTitle>Delta grande</AlertTitle>
+          <AlertDescription>
+            Revisá la sección &quot;Nuevas&quot; antes de confirmar — ¿esperabas este cambio?
+          </AlertDescription>
+        </Alert>
+      ) : null}
+    </section>
   );
 }
 

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.test.ts
@@ -265,6 +265,27 @@ describe("previewStatementAction / commitStatementAction", () => {
       .where(eq(statementImports.userId, userId));
     expect(stillOne).toHaveLength(1);
   });
+
+  // #432 — preview delta + breakdown
+  it("dry-run projection reflects pre-commit saldo and compras insertables", async () => {
+    const buf = buildSyntheticXlsxBuffer("2575");
+    const report = asSingle(await previewStatementAction(formDataFor(buf, tcId, "2026-03")));
+    expect(report.projection).toBeDefined();
+    const p = report.projection!;
+    // No seeded txs → saldo actual 0.
+    expect(p.saldoActualCentsStr).toBe("0");
+    // 2 compras (300k + 200k) → ledger-signed total = -500.000,00 COP cents.
+    expect(p.breakdown.comprasNuevasCentsStr).toBe("-50000000");
+    // Dry-run: intereses are null (not yet calculated).
+    expect(p.breakdown.interesesCentsStr).toBeNull();
+    expect(p.breakdown.plugsObsoletosCentsStr).toBe("0");
+    // delta equals compras in dry-run (no intereses).
+    expect(p.deltaCentsStr).toBe("-50000000");
+    expect(p.saldoProyectadoCentsStr).toBe("-50000000");
+    // Floor is 500k COP = 50_000_000 cents → |delta|=50M is NOT strictly greater.
+    // Verify the threshold is at least the floor.
+    expect(BigInt(p.warn.thresholdCentsStr)).toBeGreaterThanOrEqual(BigInt(50_000_000));
+  });
 });
 
 // -----------------------------------------------------------------------------
@@ -507,5 +528,23 @@ describe("multi-sheet dispatch (#426)", () => {
     const byCurrency = Object.fromEntries(result.reports.map((r) => [r.currency, r]));
     expect(byCurrency.COP.accountId).toBe(copAccountId);
     expect(byCurrency.USD.accountId).toBe(usdAccountId);
+  });
+
+  // #432 — multi-sheet: each report carries its own projection with the right
+  // currency + delta (500k COP on PESOS, 500 USD on DOLARES, both in ledger sign).
+  it("multi-sheet preview returns one projection per currency with the right delta", async () => {
+    const buf = buildMultiSheetXlsxBuffer("7291");
+    const result = await previewStatementAction(formDataFor(buf, copAccountId, "2026-03"));
+    if (!isMultiReport(result)) throw new Error("expected multi-sheet result");
+    const byCurrency = Object.fromEntries(result.reports.map((r) => [r.currency, r]));
+    expect(byCurrency.COP.projection).toBeDefined();
+    expect(byCurrency.USD.projection).toBeDefined();
+    expect(byCurrency.COP.projection!.deltaCentsStr).toBe("-50000000");
+    expect(byCurrency.COP.projection!.breakdown.comprasNuevasCentsStr).toBe("-50000000");
+    // USD: 500,00 → 50000 cents, ledger-signed = -50000.
+    expect(byCurrency.USD.projection!.deltaCentsStr).toBe("-50000");
+    expect(byCurrency.USD.projection!.breakdown.comprasNuevasCentsStr).toBe("-50000");
+    // USD threshold floor is 125 USD = 12500 cents; |delta|=50000 > 12500 → warn.
+    expect(byCurrency.USD.projection!.warn.exceeded).toBe(true);
   });
 });

--- a/src/lib/ingestion/bancolombia-statement/consolidate.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.ts
@@ -3,8 +3,9 @@ import { createHash } from "node:crypto";
 import { and, eq, gte, lte, sql } from "drizzle-orm";
 
 import { db, type DB } from "@/lib/db";
-import { accounts, statementImports, transactions } from "@/lib/db/schema";
+import { accounts, physicalCards, statementImports, transactions } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
+import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
 import { applyInteresesCausadosForCycle } from "@/lib/finance/intereses-causados-job";
 import { createLogger } from "@/lib/logger";
 
@@ -42,6 +43,36 @@ export type MatchStats = {
   unmatchedInLedger: number;
 };
 
+// #432 — projection of how the account's saldo disponible will change when
+// this cycle is consolidated. Computed once BEFORE any ledger mutation so the
+// snapshot reflects the pre-commit state. All cent values are serialized as
+// strings to keep ConsolidationReport JSON-safe.
+//
+// Ledger-sign convention throughout: for a credit card, compras are negative
+// and pagos positive. `deltaCentsStr` + `saldoActualCentsStr` = projected.
+export type BalanceProjection = {
+  saldoActualCentsStr: string;
+  saldoProyectadoCentsStr: string;
+  deltaCentsStr: string;
+  breakdown: {
+    // Sum of missing-during-period rows that will be INSERTed (excludes
+    // synthetic bank-interest rows and auth-less rows we skip).
+    comprasNuevasCentsStr: string;
+    // Null when intereses haven't been run yet (dry-run); positive-or-zero
+    // ledger-signed value once inserted.
+    interesesCentsStr: string | null;
+    // Informational — sum of existing balance_adjustment plugs on this
+    // account with occurredAt ≤ cycle.endDate. These are NOT auto-retired
+    // (see epic #435 non-goals); capa 3 (#434) handles cleanup.
+    plugsObsoletosCentsStr: string;
+  };
+  warn: {
+    // |delta| threshold above which the UI paints a warning.
+    thresholdCentsStr: string;
+    exceeded: boolean;
+  };
+};
+
 export type ConsolidationReport = {
   userId: number;
   accountId: number;
@@ -76,6 +107,9 @@ export type ConsolidationReport = {
   unmatchedInLedgerIds: number[];
   statementImportId: number | null;
   intereses: InteresesOutcome;
+  // #432 — may be absent on legacy persisted reports (pre-#432). UI must
+  // treat `undefined` as "not available" and omit the section.
+  projection?: BalanceProjection;
 };
 
 export type ConsolidateOptions = {
@@ -131,6 +165,152 @@ async function loadAccount(
     );
   }
   return row;
+}
+
+// #432 — inputs for BalanceProjection. Split out so tests can unit-feed the
+// math helper without a live DB.
+type ProjectionInputs = {
+  saldoActualCents: bigint;
+  plugsObsoletosCents: bigint;
+  // Null when the account has no physical_card link AND no inline
+  // metadata.creditLimitCents — threshold falls back to the currency floor.
+  // Always in COP cents for multi-currency cards (physical_cards.credit_limit_cents
+  // is COP-denominated); callers pass `null` for USD sub-accounts where the
+  // shared COP cupo wouldn't convert cleanly to the account currency.
+  creditLimitCents: bigint | null;
+};
+
+async function loadProjectionInputs(
+  database: DB,
+  userId: number,
+  accountId: number,
+  currency: "COP" | "USD",
+  cycleEndDate: Date,
+): Promise<ProjectionInputs> {
+  // Saldo actual via the correlated subquery helper.
+  const [balanceRow] = await database
+    .select({ cents: derivedBalanceCentsSql })
+    .from(accounts)
+    .where(and(eq(accounts.userId, userId), eq(accounts.id, accountId)))
+    .limit(1);
+
+  // Sum of existing balance_adjustment plugs with occurredAt ≤ cycle.endDate,
+  // live only. These are the candidates for cleanup (capa 3 / #434).
+  const [plugsRow] = await database
+    .select({
+      cents: sql<string>`COALESCE(SUM(${transactions.amountCents}), 0)`,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.accountId, accountId),
+        eq(transactions.source, "balance_adjustment"),
+        lte(transactions.occurredAt, cycleEndDate),
+        notDeleted(transactions.deletedAt),
+      ),
+    );
+
+  // Credit limit lookup: physical_card wins when linked (shared-cupo MC/Amex),
+  // else fall back to metadata.creditLimitCents for single-currency TCs. For
+  // USD sub-accounts we deliberately skip the physical_card COP cupo since
+  // 15%-of-COP-cupo wouldn't map to USD cleanly — use floor only there.
+  let creditLimitCents: bigint | null = null;
+  if (currency === "COP") {
+    const [accountRow] = await database
+      .select({
+        metadata: accounts.metadata,
+        pcCredit: physicalCards.creditLimitCents,
+      })
+      .from(accounts)
+      .leftJoin(
+        physicalCards,
+        and(
+          eq(physicalCards.id, accounts.physicalCardId),
+          eq(physicalCards.userId, accounts.userId),
+        ),
+      )
+      .where(and(eq(accounts.userId, userId), eq(accounts.id, accountId)))
+      .limit(1);
+    if (accountRow?.pcCredit !== null && accountRow?.pcCredit !== undefined) {
+      creditLimitCents = accountRow.pcCredit;
+    } else if (accountRow?.metadata?.creditLimitCents) {
+      creditLimitCents = BigInt(accountRow.metadata.creditLimitCents);
+    }
+  }
+
+  return {
+    saldoActualCents: BigInt(balanceRow?.cents ?? "0"),
+    plugsObsoletosCents: BigInt(plugsRow?.cents ?? "0"),
+    creditLimitCents,
+  };
+}
+
+// COP floor: 500k COP cents; USD floor: 125 USD cents. Both chosen to match
+// the issue's "propongo $500k COP" and a sensible USD equivalent. For COP we
+// also compare against 15% of the credit limit; USD gets floor-only (see note
+// in loadProjectionInputs).
+const COP_THRESHOLD_FLOOR_CENTS = BigInt(500_000_00);
+const USD_THRESHOLD_FLOOR_CENTS = BigInt(125_00);
+
+function computeWarnThresholdCents(
+  currency: "COP" | "USD",
+  creditLimitCents: bigint | null,
+): bigint {
+  const floor = currency === "COP" ? COP_THRESHOLD_FLOOR_CENTS : USD_THRESHOLD_FLOOR_CENTS;
+  if (currency === "COP" && creditLimitCents !== null) {
+    // 15% = 15/100 — BigInt division truncates, fine for a threshold.
+    const fifteenPct = (creditLimitCents * BigInt(15)) / BigInt(100);
+    return fifteenPct > floor ? fifteenPct : floor;
+  }
+  return floor;
+}
+
+function absBigInt(x: bigint): bigint {
+  return x < BigInt(0) ? -x : x;
+}
+
+// #432 — builds the final BalanceProjection from pre-loaded inputs plus the
+// match result and (optionally) the intereses total in statement sign.
+// Export for tests; callers inside this module build it via the wrapper below.
+export function buildBalanceProjection(
+  inputs: ProjectionInputs,
+  match: MatchResult,
+  currency: "COP" | "USD",
+  interesesTotalCentsPositive: bigint | null,
+): BalanceProjection {
+  // Compras insertables: during-period, real auth, not synthetic bank-interest.
+  // Mirrors the filter in insertMissingRowInTx so the breakdown matches what
+  // actually lands in the ledger.
+  const extractoComprasCents = match.missingInLedger
+    .filter((r) => r.kind === "during-period")
+    .filter((r) => !isBankInterestRow(r))
+    .filter((r) => r.authorizationNumber !== null)
+    .reduce<bigint>((acc, r) => acc + r.amountCents, BigInt(0));
+  const comprasNuevasCents = statementAmountToLedger(extractoComprasCents);
+
+  const interesesLedgerCents =
+    interesesTotalCentsPositive === null ? null : -interesesTotalCentsPositive;
+
+  const deltaCents = comprasNuevasCents + (interesesLedgerCents ?? BigInt(0));
+  const saldoProyectadoCents = inputs.saldoActualCents + deltaCents;
+  const thresholdCents = computeWarnThresholdCents(currency, inputs.creditLimitCents);
+  const exceeded = absBigInt(deltaCents) > thresholdCents;
+
+  return {
+    saldoActualCentsStr: inputs.saldoActualCents.toString(),
+    saldoProyectadoCentsStr: saldoProyectadoCents.toString(),
+    deltaCentsStr: deltaCents.toString(),
+    breakdown: {
+      comprasNuevasCentsStr: comprasNuevasCents.toString(),
+      interesesCentsStr: interesesLedgerCents === null ? null : interesesLedgerCents.toString(),
+      plugsObsoletosCentsStr: inputs.plugsObsoletosCents.toString(),
+    },
+    warn: {
+      thresholdCentsStr: thresholdCents.toString(),
+      exceeded,
+    },
+  };
 }
 
 async function loadExistingTxs(
@@ -210,6 +390,7 @@ function emptyReport(
   status: ConsolidationStatus,
   statementImportId: number | null,
   intereses: InteresesOutcome,
+  projection: BalanceProjection,
 ): ConsolidationReport {
   return {
     userId: opts.userId,
@@ -226,6 +407,7 @@ function emptyReport(
     unmatchedInLedgerIds: match.unmatchedInLedger.map((t) => t.id),
     statementImportId,
     intereses,
+    projection,
   };
 }
 
@@ -279,11 +461,27 @@ export async function consolidateCycleFromStatement(
   const txs = await loadExistingTxs(database, opts.userId, opts.accountId, fromDate, toDate);
   const match = matchStatementAgainstLedger(opts.parsed, txs);
 
+  // #432 — snapshot saldo + plugs BEFORE any mutation so the projection
+  // reflects the pre-commit state in both dry-run and commit paths.
+  const projectionInputs = await loadProjectionInputs(
+    database,
+    opts.userId,
+    opts.accountId,
+    account.currency,
+    opts.parsed.period.endDate,
+  );
+
   if (opts.dryRun) {
-    return emptyReport(opts, account, match, "dry-run", null, {
-      status: "not-run",
-      reason: "dry-run",
-    });
+    const dryProjection = buildBalanceProjection(projectionInputs, match, account.currency, null);
+    return emptyReport(
+      opts,
+      account,
+      match,
+      "dry-run",
+      null,
+      { status: "not-run", reason: "dry-run" },
+      dryProjection,
+    );
   }
 
   const nothingToDo =
@@ -383,6 +581,17 @@ export async function consolidateCycleFromStatement(
   });
   const intereses: InteresesOutcome = interesesToOutcome(interesesResult);
 
+  // #432 — projection is anchored to the pre-commit saldo snapshot; intereses
+  // total is known only now, so it's plugged in at finalize time.
+  const interesesTotalCents =
+    intereses.status === "inserted" ? BigInt(intereses.totalInterestCentsStr) : BigInt(0);
+  const projection = buildBalanceProjection(
+    projectionInputs,
+    match,
+    account.currency,
+    interesesTotalCents,
+  );
+
   const finalReport: ConsolidationReport = {
     userId: opts.userId,
     accountId: opts.accountId,
@@ -398,6 +607,7 @@ export async function consolidateCycleFromStatement(
     unmatchedInLedgerIds: match.unmatchedInLedger.map((t) => t.id),
     statementImportId: imp.id,
     intereses,
+    projection,
   };
 
   await database


### PR DESCRIPTION
## Summary

- `ConsolidationReport` now carries a `projection` field with pre-commit `saldoActualCents`, `saldoProyectadoCents`, `deltaCents`, a breakdown (compras nuevas / intereses / plugs obsoletos), and a currency-aware |delta| warning threshold.
- Computed ONCE before any ledger mutation; commit path fills in the intereses component after the job runs.
- `ReportSection` renders a new "Proyección de saldo" block above the summary grid (omitted for legacy reports without a projection).
- Multi-sheet uploads already render one `ReportSection` per currency — each carries its own projection.

## Threshold

- COP: `max(500k COP floor, 15% of credit_limit)` where `credit_limit` = `physical_cards.credit_limit_cents` if linked else `metadata.creditLimitCents`.
- USD: floor only (125 USD) — skipping the 15% because the shared COP cupo doesn't convert cleanly without an FX rate we don't have at this layer.

## Test plan
- [x] `bun run test` — 1020/1020 green, 2 new cases in `actions.test.ts` (single-sheet dry-run delta, multi-sheet per-currency delta)
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [ ] Manual smoke test — visual verification pending (UI change)

Closes #432.

Part of epic #435.