### PR TITLE
feat(consolidation): saldo real + plug compensador (#433)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-form.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-form.tsx
@@ -12,7 +12,8 @@ import type { ConsolidationReport } from "@/lib/ingestion/bancolombia-statement/
 
 import { commitStatementAction, previewStatementAction } from "../actions";
 import { isMultiReport, type ConsolidateActionResult } from "../consolidate-types";
-import { ReportSection } from "./consolidate-report-view";
+import { formatCents, ReportSection } from "./consolidate-report-view";
+import { parseSignedAmountToCents } from "./parse-saldo-real";
 
 type Props = {
   accountId: number;
@@ -41,12 +42,16 @@ export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug
   const [file, setFile] = useState<File | null>(null);
   const [dragging, setDragging] = useState(false);
   const [preview, setPreview] = useState<ConsolidateActionResult | null>(null);
+  // #433 — per-account saldo-real input keyed by accountId. Empty string ==
+  // "user didn't fill it" → we don't send anything for that account.
+  const [saldoRealInputs, setSaldoRealInputs] = useState<Record<number, string>>({});
   const [parsing, startParsing] = useTransition();
   const [applying, startApplying] = useTransition();
 
   const onFileChosen = useCallback((chosen: File | null) => {
     setFile(chosen);
     setPreview(null);
+    setSaldoRealInputs({});
   }, []);
 
   function handleDragOver(e: React.DragEvent<HTMLLabelElement>) {
@@ -125,6 +130,19 @@ export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug
     fd.set("file", file);
     fd.set("accountId", String(accountId));
     fd.set("cycle", cycle);
+    // #433 — parse each account's saldo-real input into cents and attach.
+    // Empty → skipped. Invalid → block the commit and surface a toast.
+    for (const [rawAccountId, rawValue] of Object.entries(saldoRealInputs)) {
+      const parsed = parseSignedAmountToCents(rawValue);
+      if (parsed === undefined) continue; // empty field
+      if (parsed === null) {
+        toast.error(
+          `No pude leer el saldo real de la cuenta #${rawAccountId}. Usá números (con . o , opcional).`,
+        );
+        return;
+      }
+      fd.set(`saldoRealLedgerCents_${rawAccountId}`, parsed.toString());
+    }
     startApplying(async () => {
       try {
         const result = await commitStatementAction(fd);
@@ -142,6 +160,7 @@ export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug
         }
         setPreview(null);
         setFile(null);
+        setSaldoRealInputs({});
         if (fileInputRef.current) fileInputRef.current.value = "";
         router.refresh();
       } catch (err) {
@@ -230,6 +249,10 @@ export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug
           onConfirm={runCommit}
           canConfirm={canConfirm}
           applying={applying}
+          saldoRealInputs={saldoRealInputs}
+          onSaldoRealChange={(reportAccountId, value) =>
+            setSaldoRealInputs((prev) => ({ ...prev, [reportAccountId]: value }))
+          }
         />
       ) : null}
     </div>
@@ -241,11 +264,15 @@ function PreviewPanel({
   onConfirm,
   canConfirm,
   applying,
+  saldoRealInputs,
+  onSaldoRealChange,
 }: {
   reports: ConsolidationReport[];
   onConfirm: () => void;
   canConfirm: boolean;
   applying: boolean;
+  saldoRealInputs: Record<number, string>;
+  onSaldoRealChange: (accountId: number, value: string) => void;
 }) {
   const isMulti = reports.length > 1;
   return (
@@ -265,9 +292,94 @@ function PreviewPanel({
       </CardHeader>
       <CardContent className="flex flex-col gap-6">
         {reports.map((report, idx) => (
-          <ReportSection key={`${report.accountId}-${idx}`} report={report} showHeading={isMulti} />
+          <div key={`${report.accountId}-${idx}`} className="flex flex-col gap-3">
+            <ReportSection report={report} showHeading={isMulti} />
+            <SaldoRealInput
+              report={report}
+              value={saldoRealInputs[report.accountId] ?? ""}
+              onChange={(v) => onSaldoRealChange(report.accountId, v)}
+              disabled={applying}
+            />
+          </div>
         ))}
       </CardContent>
     </Card>
+  );
+}
+
+// #433 — per-account "saldo real" input. Rendered BELOW each ReportSection
+// in the preview panel so the user can eyeball the projected saldo first,
+// then decide whether to override it. Empty field == "accept the projected
+// delta" (no plug inserted). Non-empty is parsed at submit time via
+// `parseSignedAmountToCents`.
+function SaldoRealInput({
+  report,
+  value,
+  onChange,
+  disabled,
+}: {
+  report: ConsolidationReport;
+  value: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+}) {
+  const projected = report.projection?.saldoProyectadoCentsStr;
+  const parsed = parseSignedAmountToCents(value);
+  const isInvalid = parsed === null; // undefined (empty) is fine
+  const parsedLedger = typeof parsed === "bigint" ? parsed : null;
+
+  // Diff vs. projected so the user knows a plug will be inserted.
+  let plugPreview: string | null = null;
+  if (parsedLedger !== null && projected) {
+    const diff = parsedLedger - BigInt(projected);
+    if (diff !== BigInt(0)) {
+      plugPreview = `Se insertará un ajuste de ${formatCents(diff.toString())} para que el saldo quede exactamente en ${formatCents(parsedLedger.toString())}.`;
+    } else {
+      plugPreview = "El saldo real coincide con el proyectado — no se insertará ningún ajuste.";
+    }
+  }
+
+  const placeholder = projected ? formatCents(projected) : "—";
+  const inputId = `saldo-real-${report.accountId}`;
+
+  return (
+    <div
+      data-testid={`saldo-real-input-${report.accountId}`}
+      className="bg-muted/30 flex flex-col gap-2 rounded-md border border-dashed p-3 text-sm"
+    >
+      <label htmlFor={inputId} className="font-medium">
+        ¿Cuál es tu saldo real según el banco?{" "}
+        <span className="text-muted-foreground text-xs font-normal">
+          (opcional — dejá vacío para aceptar el delta proyectado)
+        </span>
+      </label>
+      <input
+        id={inputId}
+        type="text"
+        inputMode="decimal"
+        value={value}
+        disabled={disabled}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        className={cn(
+          "border-input focus-visible:ring-ring rounded-md border bg-transparent px-3 py-2 tabular-nums focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none",
+          isInvalid && "border-destructive",
+        )}
+        data-testid={`saldo-real-field-${report.accountId}`}
+      />
+      {isInvalid ? (
+        <p className="text-destructive text-xs">
+          Formato no válido. Usá un número (ej: -1.543.000,00 o -1543000.00).
+        </p>
+      ) : plugPreview ? (
+        <p className="text-muted-foreground text-xs">{plugPreview}</p>
+      ) : (
+        <p className="text-muted-foreground text-xs">
+          Si el saldo que ves en el banco difiere del proyectado, entralo acá y al confirmar se
+          inserta un ajuste de saldo para cuadrar. Puede estar compensando compras que Findash nunca
+          vio o plugs viejos obsoletos — andá a /reconcile a revisar después.
+        </p>
+      )}
+    </div>
   );
 }

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-report-view.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-report-view.tsx
@@ -332,6 +332,15 @@ function BalanceProjectionSection({
                 <span className="italic">— podrían estar obsoletos</span>
               </li>
             ) : null}
+            {projection.breakdown.balanceAdjustmentPlugCentsStr !== null &&
+            BigInt(projection.breakdown.balanceAdjustmentPlugCentsStr) !== BigInt(0) ? (
+              <li data-testid="consolidate-projection-adjustment-plug">
+                Ajuste de saldo (saldo real ingresado):{" "}
+                <span className="tabular-nums">
+                  {formatSignedCents(projection.breakdown.balanceAdjustmentPlugCentsStr)}
+                </span>
+              </li>
+            ) : null}
           </ul>
         </>
       )}

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/parse-saldo-real.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/parse-saldo-real.test.ts
@@ -1,0 +1,59 @@
+// #433 — unit tests for the flexible "saldo real" amount parser. Pure
+// function, no DOM / no DB.
+
+import { describe, expect, it } from "vitest";
+
+import { parseSignedAmountToCents } from "./parse-saldo-real";
+
+describe("parseSignedAmountToCents (#433)", () => {
+  it("returns undefined for an empty field", () => {
+    expect(parseSignedAmountToCents("")).toBeUndefined();
+    expect(parseSignedAmountToCents("   ")).toBeUndefined();
+  });
+
+  it("parses plain integers", () => {
+    expect(parseSignedAmountToCents("100")).toBe(BigInt(10000));
+    expect(parseSignedAmountToCents("-100")).toBe(BigInt(-10000));
+    expect(parseSignedAmountToCents("0")).toBe(BigInt(0));
+  });
+
+  it("parses COP-style thousand separators", () => {
+    // 1.500.000,00 → 150_000_000 cents
+    expect(parseSignedAmountToCents("1.500.000,00")).toBe(BigInt(150_000_000));
+    expect(parseSignedAmountToCents("-1.500.000,50")).toBe(BigInt(-150_000_050));
+  });
+
+  it("parses US-style thousand separators", () => {
+    // 1,500,000.00 → 150_000_000 cents
+    expect(parseSignedAmountToCents("1,500,000.00")).toBe(BigInt(150_000_000));
+    expect(parseSignedAmountToCents("-1,500,000.50")).toBe(BigInt(-150_000_050));
+  });
+
+  it("parses plain decimals with . or , as decimal separator", () => {
+    expect(parseSignedAmountToCents("1500000.50")).toBe(BigInt(150_000_050));
+    expect(parseSignedAmountToCents("1500000,50")).toBe(BigInt(150_000_050));
+    expect(parseSignedAmountToCents("-1500000.5")).toBe(BigInt(-150_000_050));
+  });
+
+  it("treats ambiguous 3-digit fractions as thousand separators", () => {
+    // "1.234" is usually "1234", not "1.234"
+    expect(parseSignedAmountToCents("1.234")).toBe(BigInt(123_400));
+    expect(parseSignedAmountToCents("1,234")).toBe(BigInt(123_400));
+  });
+
+  it("strips currency symbols + whitespace", () => {
+    expect(parseSignedAmountToCents("$ 1.500,00")).toBe(BigInt(150_000));
+    expect(parseSignedAmountToCents("- $1,500.00 ")).toBe(BigInt(-150_000));
+  });
+
+  it("returns null for non-numeric garbage", () => {
+    expect(parseSignedAmountToCents("abc")).toBeNull();
+    expect(parseSignedAmountToCents("1.5.00a")).toBeNull();
+    expect(parseSignedAmountToCents("--5")).toBeNull();
+  });
+
+  it("handles 1-digit fractional part by padding", () => {
+    expect(parseSignedAmountToCents("1.5")).toBe(BigInt(150));
+    expect(parseSignedAmountToCents("100,5")).toBe(BigInt(10050));
+  });
+});

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/parse-saldo-real.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/parse-saldo-real.ts
@@ -1,0 +1,46 @@
+// #433 — flexible amount parser for the "saldo real" input. Handles both COP
+// ("1.500.000,50") and US ("1,500,000.50") formats, plus plain decimals
+// ("-1500000.5") and bare integers ("-1500000"). Returns `null` for invalid
+// input; `undefined` when the field is empty (user opted out).
+//
+// Heuristic: if the last separator is followed by MORE THAN 2 digits, treat
+// it as a thousand-separator (not a decimal) — 3+ digits after the decimal
+// is vanishingly rare in money.
+//
+// Lives in a separate module (not the "use client" form) so tests can import
+// it directly without pulling the whole next-auth / next/navigation tree.
+export function parseSignedAmountToCents(raw: string): bigint | null | undefined {
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  let s = trimmed;
+  const negative = s.startsWith("-");
+  if (negative) s = s.slice(1);
+  s = s.replace(/[\s$]/g, "");
+  if (!/^[0-9.,]+$/.test(s)) return null;
+
+  const lastDot = s.lastIndexOf(".");
+  const lastComma = s.lastIndexOf(",");
+  let integerPart: string;
+  let fractionalPart: string;
+  if (lastDot === -1 && lastComma === -1) {
+    integerPart = s;
+    fractionalPart = "0";
+  } else {
+    const idx = lastDot > lastComma ? lastDot : lastComma;
+    const tail = s.slice(idx + 1);
+    if (tail.length === 0 || tail.length > 2) {
+      integerPart = s.replace(/[.,]/g, "");
+      fractionalPart = "0";
+    } else {
+      integerPart = s.slice(0, idx).replace(/[.,]/g, "");
+      fractionalPart = tail;
+    }
+  }
+
+  if (integerPart === "" || !/^\d+$/.test(integerPart)) return null;
+  if (!/^\d+$/.test(fractionalPart)) return null;
+
+  const centsFrac = fractionalPart.padEnd(2, "0").slice(0, 2);
+  const cents = BigInt(integerPart) * BigInt(100) + BigInt(centsFrac);
+  return negative ? -cents : cents;
+}

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import * as XLSX from "xlsx";
 
 import { db } from "@/lib/db";
 import { accounts, physicalCards, statementImports, transactions, users } from "@/lib/db/schema";
+import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
 import { copyCategorySeedsToUser } from "@/lib/auth/signup";
 
 import type { ConsolidationReport } from "@/lib/ingestion/bancolombia-statement/consolidate";
@@ -177,6 +178,9 @@ describe("previewStatementAction / commitStatementAction", () => {
     await db.execute(
       sql`DELETE FROM transactions WHERE user_id = ${userId} AND external_id LIKE 'bancolombia-stmt:%'`,
     );
+    await db.execute(
+      sql`DELETE FROM transactions WHERE user_id = ${userId} AND source = 'balance_adjustment'`,
+    );
     await db.delete(statementImports).where(eq(statementImports.userId, userId));
     await db.execute(
       sql`DELETE FROM transactions WHERE user_id = ${userId} AND category_slug = 'intereses-tc'`,
@@ -285,6 +289,74 @@ describe("previewStatementAction / commitStatementAction", () => {
     // Floor is 500k COP = 50_000_000 cents → |delta|=50M is NOT strictly greater.
     // Verify the threshold is at least the floor.
     expect(BigInt(p.warn.thresholdCentsStr)).toBeGreaterThanOrEqual(BigInt(50_000_000));
+  });
+
+  // #433 — saldo real + plug compensador
+  it("commit without saldo real input behaves identically (no plug inserted)", async () => {
+    const buf = buildSyntheticXlsxBuffer("2575");
+    const report = asSingle(await commitStatementAction(formDataFor(buf, tcId, "2026-03")));
+    expect(report.balanceAdjustment).toBeNull();
+    expect(report.projection?.breakdown.balanceAdjustmentPlugCentsStr).toBeNull();
+
+    // Ledger SUM == compras (-500k); intereses was skipped for the 1-cuota
+    // fixture so no synthetic tx was added.
+    const [bal] = await db
+      .select({ cents: derivedBalanceCentsSql })
+      .from(accounts)
+      .where(eq(accounts.id, tcId));
+    expect(BigInt(bal.cents)).toBe(BigInt(-50_000_000));
+  });
+
+  it("commit with saldo real matching the projected amount inserts NO plug", async () => {
+    const buf = buildSyntheticXlsxBuffer("2575");
+    const fd = formDataFor(buf, tcId, "2026-03");
+    fd.set(`saldoRealLedgerCents_${tcId}`, "-50000000");
+    const report = asSingle(await commitStatementAction(fd));
+    expect(report.balanceAdjustment).toBeNull();
+    expect(report.projection?.breakdown.balanceAdjustmentPlugCentsStr).toBeNull();
+  });
+
+  it("commit with saldo real differing from projected inserts a compensator plug", async () => {
+    const buf = buildSyntheticXlsxBuffer("2575");
+    const fd = formDataFor(buf, tcId, "2026-03");
+    // User claims real saldo is -600k (vs projected -500k) → plug = -100k.
+    fd.set(`saldoRealLedgerCents_${tcId}`, "-60000000");
+    const report = asSingle(await commitStatementAction(fd));
+    expect(report.balanceAdjustment).not.toBeNull();
+    expect(report.balanceAdjustment!.amountCentsStr).toBe("-10000000");
+    expect(report.balanceAdjustment!.userInputCentsStr).toBe("-60000000");
+    expect(report.projection?.breakdown.balanceAdjustmentPlugCentsStr).toBe("-10000000");
+
+    // Ledger SUM post-plug MUST equal the user's input exactly.
+    const [bal] = await db
+      .select({ cents: derivedBalanceCentsSql })
+      .from(accounts)
+      .where(eq(accounts.id, tcId));
+    expect(BigInt(bal.cents)).toBe(BigInt(-60_000_000));
+
+    // The plug tx is a live balance_adjustment row linked to the import.
+    const plugs = await db
+      .select({
+        id: transactions.id,
+        amountCents: transactions.amountCents,
+        source: transactions.source,
+        categorySlug: transactions.categorySlug,
+        statementImportId: transactions.statementImportId,
+        isAdjustment: transactions.isAdjustment,
+      })
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.userId, userId),
+          eq(transactions.accountId, tcId),
+          eq(transactions.source, "balance_adjustment"),
+        ),
+      );
+    expect(plugs).toHaveLength(1);
+    expect(plugs[0].amountCents).toBe(BigInt(-10_000_000));
+    expect(plugs[0].categorySlug).toBe("adjustments");
+    expect(plugs[0].isAdjustment).toBe(true);
+    expect(plugs[0].statementImportId).toBe(report.statementImportId);
   });
 });
 
@@ -452,6 +524,9 @@ describe("multi-sheet dispatch (#426)", () => {
     await db.execute(
       sql`DELETE FROM transactions WHERE user_id = ${userId} AND external_id LIKE 'bancolombia-stmt:%'`,
     );
+    await db.execute(
+      sql`DELETE FROM transactions WHERE user_id = ${userId} AND source = 'balance_adjustment'`,
+    );
     await db.delete(statementImports).where(eq(statementImports.userId, userId));
     await db.execute(
       sql`DELETE FROM transactions WHERE user_id = ${userId} AND category_slug = 'intereses-tc'`,
@@ -528,6 +603,38 @@ describe("multi-sheet dispatch (#426)", () => {
     const byCurrency = Object.fromEntries(result.reports.map((r) => [r.currency, r]));
     expect(byCurrency.COP.accountId).toBe(copAccountId);
     expect(byCurrency.USD.accountId).toBe(usdAccountId);
+  });
+
+  // #433 — multi-sheet: user provides a saldo real per currency → one plug
+  // per sub-account. Empty field on one side means no plug on that currency.
+  it("multi-sheet commit inserts one plug per currency the user provided", async () => {
+    const buf = buildMultiSheetXlsxBuffer("7291");
+    const fd = formDataFor(buf, copAccountId, "2026-03");
+    // COP side: claim -600k (projected -500k) → plug -100k.
+    fd.set(`saldoRealLedgerCents_${copAccountId}`, "-60000000");
+    // USD side: claim -600 USD (-60000 cents) vs projected -500 USD (-50000 cents) → plug -10000.
+    fd.set(`saldoRealLedgerCents_${usdAccountId}`, "-60000");
+    const result = await commitStatementAction(fd);
+    if (!isMultiReport(result)) throw new Error("expected multi-sheet result");
+    const byCurrency = Object.fromEntries(result.reports.map((r) => [r.currency, r]));
+    expect(byCurrency.COP.balanceAdjustment).not.toBeNull();
+    expect(byCurrency.COP.balanceAdjustment!.amountCentsStr).toBe("-10000000");
+    expect(byCurrency.USD.balanceAdjustment).not.toBeNull();
+    expect(byCurrency.USD.balanceAdjustment!.amountCentsStr).toBe("-10000");
+
+    // Both plug txs are present in the ledger, linked to the respective imports.
+    const plugs = await db
+      .select({
+        accountId: transactions.accountId,
+        amountCents: transactions.amountCents,
+        statementImportId: transactions.statementImportId,
+      })
+      .from(transactions)
+      .where(and(eq(transactions.userId, userId), eq(transactions.source, "balance_adjustment")));
+    expect(plugs).toHaveLength(2);
+    const plugByAccount = new Map(plugs.map((p) => [p.accountId, p]));
+    expect(plugByAccount.get(copAccountId)?.amountCents).toBe(BigInt(-10_000_000));
+    expect(plugByAccount.get(usdAccountId)?.amountCents).toBe(BigInt(-10_000));
   });
 
   // #432 — multi-sheet: each report carries its own projection with the right

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.ts
@@ -31,6 +31,28 @@ const inputSchema = z.object({
   cycle: z.string().regex(/^\d{4}-\d{2}$/, "cycle must be YYYY-MM"),
 });
 
+// #433 — FormData keys follow `saldoRealLedgerCents_<accountId>` and carry
+// the user-typed saldo real ALREADY CONVERTED TO CENTS (bigint string) by
+// the client. Empty / missing → no input for that account.
+function parseSaldoRealInputs(formData: FormData): Map<number, bigint> {
+  const out = new Map<number, bigint>();
+  for (const [key, value] of formData.entries()) {
+    if (!key.startsWith("saldoRealLedgerCents_")) continue;
+    const rawAccountId = key.slice("saldoRealLedgerCents_".length);
+    const accountId = Number(rawAccountId);
+    if (!Number.isInteger(accountId) || accountId <= 0) continue;
+    const str = typeof value === "string" ? value.trim() : "";
+    if (str === "") continue;
+    try {
+      const parsed = BigInt(str);
+      out.set(accountId, parsed);
+    } catch {
+      throw new Error(`saldo_real_not_integer:accountId=${accountId},value=${str}`);
+    }
+  }
+  return out;
+}
+
 type TcAccount = {
   id: number;
   name: string;
@@ -245,6 +267,8 @@ export async function commitStatementAction(formData: FormData): Promise<Consoli
   const parsedSheets = parseBancolombiaStatementAllSheets(buffer);
   const dispatch = await resolveDispatch(session.id, origin, parsedSheets);
   const fileHash = hashStatementBuffer(buffer);
+  // #433 — per-account saldo real inputs (empty map when user didn't fill any).
+  const saldoRealInputs = parseSaldoRealInputs(formData);
 
   const reports: ConsolidationReport[] = [];
   for (const { account, parsed } of dispatch) {
@@ -255,6 +279,7 @@ export async function commitStatementAction(formData: FormData): Promise<Consoli
       parsed,
       fileHash,
       dryRun: false,
+      saldoRealLedgerCents: saldoRealInputs.get(account.id) ?? null,
     });
     reports.push(r);
   }

--- a/src/lib/ingestion/bancolombia-statement/consolidate.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.ts
@@ -3,11 +3,23 @@ import { createHash } from "node:crypto";
 import { and, eq, gte, lte, sql } from "drizzle-orm";
 
 import { db, type DB } from "@/lib/db";
-import { accounts, physicalCards, statementImports, transactions } from "@/lib/db/schema";
+import {
+  accounts,
+  categories,
+  physicalCards,
+  statementImports,
+  transactions,
+} from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
 import { applyInteresesCausadosForCycle } from "@/lib/finance/intereses-causados-job";
 import { createLogger } from "@/lib/logger";
+
+// #433 — the balance_adjustment plug goes into the user's Ajustes de saldo
+// category (same one the reconcile flow + opening-balance tx use). We always
+// call ensureAdjustmentsCategory before insert so this never FK-fails on
+// accounts whose category was soft-deleted by the user.
+const ADJUSTMENTS_CATEGORY_SLUG = "adjustments";
 
 import {
   isBankInterestRow,
@@ -65,12 +77,25 @@ export type BalanceProjection = {
     // account with occurredAt ≤ cycle.endDate. These are NOT auto-retired
     // (see epic #435 non-goals); capa 3 (#434) handles cleanup.
     plugsObsoletosCentsStr: string;
+    // #433 — the compensator plug inserted by this consolidation to reconcile
+    // the ledger against a user-provided "saldo real". Null when no input was
+    // provided OR when the ledger already matched exactly (no plug needed).
+    balanceAdjustmentPlugCentsStr: string | null;
   };
   warn: {
     // |delta| threshold above which the UI paints a warning.
     thresholdCentsStr: string;
     exceeded: boolean;
   };
+};
+
+// #433 — info about a balance_adjustment tx inserted to reconcile the ledger
+// against a user-provided "saldo real". Null at the report level when no
+// input was provided or ledger already matched.
+export type BalanceAdjustmentPlug = {
+  txId: number;
+  amountCentsStr: string; // ledger-signed plug value
+  userInputCentsStr: string; // the saldo real the user typed (ledger sign)
 };
 
 export type ConsolidationReport = {
@@ -110,6 +135,9 @@ export type ConsolidationReport = {
   // #432 — may be absent on legacy persisted reports (pre-#432). UI must
   // treat `undefined` as "not available" and omit the section.
   projection?: BalanceProjection;
+  // #433 — plug tx info when `saldoRealLedgerCents` was provided on commit.
+  // Null when input was absent OR no plug was needed (already-matching).
+  balanceAdjustment?: BalanceAdjustmentPlug | null;
 };
 
 export type ConsolidateOptions = {
@@ -120,6 +148,12 @@ export type ConsolidateOptions = {
   fileHash: string;
   dryRun: boolean;
   database?: DB;
+  // #433 — optional user input "saldo real" in the account currency's ledger
+  // sign (negative for TC debt, positive for savings). When provided AND
+  // dryRun=false AND status ends up "consolidated", inserts a
+  // balance_adjustment tx post-intereses so the final ledger SUM matches
+  // this value exactly.
+  saldoRealLedgerCents?: bigint | null;
 };
 
 export function hashStatementBuffer(buffer: Buffer): string {
@@ -278,6 +312,7 @@ export function buildBalanceProjection(
   match: MatchResult,
   currency: "COP" | "USD",
   interesesTotalCentsPositive: bigint | null,
+  balanceAdjustmentPlugCents: bigint | null = null,
 ): BalanceProjection {
   // Compras insertables: during-period, real auth, not synthetic bank-interest.
   // Mirrors the filter in insertMissingRowInTx so the breakdown matches what
@@ -292,7 +327,10 @@ export function buildBalanceProjection(
   const interesesLedgerCents =
     interesesTotalCentsPositive === null ? null : -interesesTotalCentsPositive;
 
-  const deltaCents = comprasNuevasCents + (interesesLedgerCents ?? BigInt(0));
+  const deltaCents =
+    comprasNuevasCents +
+    (interesesLedgerCents ?? BigInt(0)) +
+    (balanceAdjustmentPlugCents ?? BigInt(0));
   const saldoProyectadoCents = inputs.saldoActualCents + deltaCents;
   const thresholdCents = computeWarnThresholdCents(currency, inputs.creditLimitCents);
   const exceeded = absBigInt(deltaCents) > thresholdCents;
@@ -305,11 +343,99 @@ export function buildBalanceProjection(
       comprasNuevasCentsStr: comprasNuevasCents.toString(),
       interesesCentsStr: interesesLedgerCents === null ? null : interesesLedgerCents.toString(),
       plugsObsoletosCentsStr: inputs.plugsObsoletosCents.toString(),
+      balanceAdjustmentPlugCentsStr:
+        balanceAdjustmentPlugCents === null ? null : balanceAdjustmentPlugCents.toString(),
     },
     warn: {
       thresholdCentsStr: thresholdCents.toString(),
       exceeded,
     },
+  };
+}
+
+// #433 — idempotent category upsert. Matches the reconcile-flow convention
+// (same slug, name, icon, color) so plugs inserted here live in the same
+// bucket as manual balance-adjustments from `/reconcile`.
+async function ensureAdjustmentsCategory(database: DB, userId: number): Promise<void> {
+  await database
+    .insert(categories)
+    .values({
+      userId,
+      slug: ADJUSTMENTS_CATEGORY_SLUG,
+      name: "Ajustes de saldo",
+      icon: "wrench",
+      color: "#475569",
+      sortOrder: 1000,
+    })
+    .onConflictDoNothing({ target: [categories.userId, categories.slug] });
+  // Un-archive if the user had soft-deleted the category previously.
+  await database
+    .update(categories)
+    .set({ deletedAt: null, updatedAt: new Date() })
+    .where(and(eq(categories.userId, userId), eq(categories.slug, ADJUSTMENTS_CATEGORY_SLUG)));
+}
+
+type PlugInsertArgs = {
+  userId: number;
+  accountId: number;
+  currency: "COP" | "USD";
+  cycle: string;
+  cycleEndDate: Date;
+  statementImportId: number;
+  saldoRealLedgerCents: bigint;
+};
+
+// #433 — after the main consolidation txn + intereses job have committed, if
+// the user gave a saldo real we insert a single balance_adjustment tx for
+// the delta so the ledger SUM matches the user's input exactly. No-op when
+// the delta is zero. Runs OUTSIDE the consolidation transaction on purpose
+// (intereses job is already outside — see its comment — and keeping the plug
+// outside too means a failed insert doesn't roll back the ledger fix).
+async function insertSaldoRealPlug(
+  database: DB,
+  args: PlugInsertArgs,
+): Promise<BalanceAdjustmentPlug | null> {
+  const [balanceRow] = await database
+    .select({ cents: derivedBalanceCentsSql })
+    .from(accounts)
+    .where(and(eq(accounts.userId, args.userId), eq(accounts.id, args.accountId)))
+    .limit(1);
+  const ledgerSumCents = BigInt(balanceRow?.cents ?? "0");
+  const plugCents = args.saldoRealLedgerCents - ledgerSumCents;
+  if (plugCents === BigInt(0)) return null;
+
+  await ensureAdjustmentsCategory(database, args.userId);
+  const [inserted] = await database
+    .insert(transactions)
+    .values({
+      userId: args.userId,
+      accountId: args.accountId,
+      occurredAt: args.cycleEndDate,
+      amountCents: plugCents,
+      currency: args.currency,
+      descriptionRaw: `Ajuste post-consolidación ${args.cycle} · saldo ingresado por user`,
+      merchant: "Balance adjustment",
+      categorySlug: ADJUSTMENTS_CATEGORY_SLUG,
+      classificationMethod: "manual",
+      source: "balance_adjustment",
+      channel: "manual",
+      isAdjustment: true,
+      statementImportId: args.statementImportId,
+      rawData: {
+        event: "saldo_real_consolidation_plug",
+        issue: 433,
+        cycle: args.cycle,
+        declaredLedgerCents: args.saldoRealLedgerCents.toString(),
+        previousLedgerCents: ledgerSumCents.toString(),
+        statementImportId: args.statementImportId,
+      },
+    })
+    .returning({ id: transactions.id });
+
+  return {
+    txId: inserted.id,
+    amountCentsStr: plugCents.toString(),
+    userInputCentsStr: args.saldoRealLedgerCents.toString(),
   };
 }
 
@@ -408,6 +534,7 @@ function emptyReport(
     statementImportId,
     intereses,
     projection,
+    balanceAdjustment: null,
   };
 }
 
@@ -581,15 +708,50 @@ export async function consolidateCycleFromStatement(
   });
   const intereses: InteresesOutcome = interesesToOutcome(interesesResult);
 
-  // #432 — projection is anchored to the pre-commit saldo snapshot; intereses
-  // total is known only now, so it's plugged in at finalize time.
   const interesesTotalCents =
     intereses.status === "inserted" ? BigInt(intereses.totalInterestCentsStr) : BigInt(0);
+
+  // #433 — optional plug to reconcile ledger SUM against a user-provided
+  // saldo real. Runs AFTER intereses so the plug balances the final state.
+  // `null` when no input was given OR when the ledger already matched
+  // (plug insert would have been zero).
+  let balanceAdjustment: BalanceAdjustmentPlug | null = null;
+  if (opts.saldoRealLedgerCents != null) {
+    balanceAdjustment = await insertSaldoRealPlug(database, {
+      userId: opts.userId,
+      accountId: opts.accountId,
+      currency: account.currency,
+      cycle: opts.cycle,
+      cycleEndDate: opts.parsed.period.endDate,
+      statementImportId: imp.id,
+      saldoRealLedgerCents: opts.saldoRealLedgerCents,
+    });
+    log.info(
+      {
+        userId: opts.userId,
+        accountId: opts.accountId,
+        cycle: opts.cycle,
+        saldoRealLedgerCents: opts.saldoRealLedgerCents.toString(),
+        plugInserted: balanceAdjustment !== null,
+        plugTxId: balanceAdjustment?.txId ?? null,
+        event: "saldo_real_plug",
+      },
+      balanceAdjustment
+        ? "consolidate: inserted saldo-real compensator plug"
+        : "consolidate: saldo-real matched ledger, no plug needed",
+    );
+  }
+
+  // #432 — projection pins `saldoActualCents` to the pre-commit snapshot so
+  // delta = what *this consolidation* moved (compras + intereses + optional
+  // plug). Intereses + plug are filled in here since both run AFTER the main
+  // txn commits.
   const projection = buildBalanceProjection(
     projectionInputs,
     match,
     account.currency,
     interesesTotalCents,
+    balanceAdjustment === null ? null : BigInt(balanceAdjustment.amountCentsStr),
   );
 
   const finalReport: ConsolidationReport = {
@@ -608,6 +770,7 @@ export async function consolidateCycleFromStatement(
     statementImportId: imp.id,
     intereses,
     projection,
+    balanceAdjustment,
   };
 
   await database


### PR DESCRIPTION
## Summary

Optional \"saldo real\" input on the consolidation confirm step. When the user types the saldo their bank shows, a \`balance_adjustment\` tx is inserted post-intereses so the ledger SUM matches that input exactly.

- \`ConsolidateOptions.saldoRealLedgerCents\` (bigint | null) — opt-in knob on the lib API
- \`ConsolidationReport.balanceAdjustment\` — \`{ txId, amountCentsStr, userInputCentsStr }\` when a plug was inserted, null when ledger already matched or no input was given
- \`BalanceProjection.breakdown.balanceAdjustmentPlugCentsStr\` surfaced in the delta breakdown
- Plug insert: \`occurred_at = cycle.endDate\`, \`source = balance_adjustment\`, \`categorySlug = adjustments\` (same bucket as /reconcile), \`is_adjustment = true\`, \`statement_import_id\` linked for #434 cleanup
- Runs outside the consolidation txn (same pattern as intereses job) so a failed plug doesn't roll back ledger fixes
- \`ensureAdjustmentsCategory\` un-archives the slug if the user soft-deleted it
- Per-account inputs (\`saldoRealLedgerCents_<accountId>\` FormData keys) — multi-sheet gets one plug per currency

## Flexible amount parser

\`parse-saldo-real.ts\` handles COP (\`1.500.000,50\`), US (\`1,500,000.50\`), plain decimals, bare integers. Heuristic: separator followed by >2 digits is a thousand-separator. Lives in a non-\"use client\" sibling so tests don't pull the next-auth chain.

## Micro-decisions (from the #433 issue body)
1. \`occurred_at = cycle.endDate\` — plug belongs to the consolidated cycle, not \"today\"
2. \`categorySlug = adjustments\` — reuse the existing /reconcile constant; \`ensureAdjustmentsCategory\` matches the accounts-action helper verbatim

Both are easy to flip if you want a different behavior — lmk and I adjust.

## Test plan
- [x] \`bun run test\` — 1033/1033 green, new cases: parser unit (9), no-input commit, zero-delta input, non-zero plug with ledger verification, multi-sheet per-currency plugs
- [x] \`bun run lint\`, \`typecheck\`, \`format:check\`
- [ ] Manual smoke (UI change) — pending

Closes #433. Stacked on merged #432. Part of epic #435.