### PR TITLE
feat(ui): cleanup de balance_adjustments obsoletos en /reconcile (#434)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/page.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/page.tsx
@@ -1,14 +1,15 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, max, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, transactions } from "@/lib/db/schema";
+import { accounts, statementImports, transactions } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
 import { formatAccountLabel } from "@/lib/accounts/format";
 import { getSessionUser } from "@/lib/auth/session";
 import { ReconcileForm } from "./reconcile-form";
 import { FlaggedReview, type FlaggedRow, type MergeCandidate } from "./flagged-review";
+import { PlugCleanupSection, type Plug } from "./plug-cleanup";
 
 export const dynamic = "force-dynamic";
 
@@ -104,6 +105,55 @@ export default async function ReconcilePage({
     descriptionRaw: r.descriptionRaw,
   }));
 
+  // #434: load ALL balance_adjustment txs for this account (live + soft-deleted).
+  // The cleanup UI filters client-side via a "Mostrar borrados" toggle so the
+  // user can un-archive a row without a round-trip.
+  const plugRows = await db
+    .select({
+      id: transactions.id,
+      occurredAt: transactions.occurredAt,
+      amountCents: transactions.amountCents,
+      descriptionRaw: transactions.descriptionRaw,
+      merchant: transactions.merchant,
+      statementImportId: transactions.statementImportId,
+      deletedAt: transactions.deletedAt,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, session.id),
+        eq(transactions.accountId, accountId),
+        eq(transactions.source, "balance_adjustment"),
+      ),
+    )
+    .orderBy(desc(transactions.occurredAt));
+
+  const plugs: Plug[] = plugRows.map((r) => ({
+    id: r.id,
+    occurredAtISO: r.occurredAt.toISOString(),
+    amountCentsStr: r.amountCents.toString(),
+    description: r.descriptionRaw || r.merchant || "Ajuste de saldo",
+    statementImportId: r.statementImportId,
+    deleted: r.deletedAt !== null,
+  }));
+
+  // Latest statement_imports.periodEnd drives the "probablemente obsoleto"
+  // heuristic — a plug dated ≤ this value is likely compensating for data
+  // that's now been imported.
+  const [lastPeriodRow] = await db
+    .select({ periodEnd: max(statementImports.periodEnd) })
+    .from(statementImports)
+    .where(
+      and(
+        eq(statementImports.userId, session.id),
+        eq(statementImports.accountId, accountId),
+        sql`${statementImports.cycle} IS NOT NULL`,
+      ),
+    );
+  const lastStatementPeriodEndISO = lastPeriodRow?.periodEnd
+    ? new Date(lastPeriodRow.periodEnd).toISOString()
+    : null;
+
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
       <header className="flex items-center justify-between gap-2">
@@ -141,6 +191,15 @@ export default async function ReconcilePage({
           rows={flagged}
           currency={account.currency}
           mergeCandidates={mergeCandidates}
+        />
+      ) : null}
+
+      {plugs.length > 0 ? (
+        <PlugCleanupSection
+          accountId={account.id}
+          currentBalanceCentsStr={account.balanceCents.toString()}
+          plugs={plugs}
+          lastStatementPeriodEndISO={lastStatementPeriodEndISO}
         />
       ) : null}
     </main>

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/plug-cleanup-actions.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/plug-cleanup-actions.test.ts
@@ -1,0 +1,221 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { and, eq, isNull } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { accounts, transactions, users } from "@/lib/db/schema";
+import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
+import { copyCategorySeedsToUser } from "@/lib/auth/signup";
+
+const TAG = "PLUG_CLEAN_TEST";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+const sessionMock = { id: 0, email: "test@test.local", name: "Test" };
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockImplementation(async () => sessionMock),
+}));
+
+const { archiveBalanceAdjustmentsAction, restoreBalanceAdjustmentAction } =
+  await import("./plug-cleanup-actions");
+
+async function createUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  return row.id;
+}
+
+async function createTc(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} visa`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      type: "credit_card",
+      currency: "COP",
+      metadata: { last4s: ["9999"], cutoffDay: 30 },
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function insertPlug(userId: number, accountId: number, amountCents: bigint): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: new Date("2026-03-30T12:00:00Z"),
+      amountCents,
+      currency: "COP",
+      descriptionRaw: `${TAG} plug ${amountCents}`,
+      categorySlug: "adjustments",
+      classificationMethod: "manual",
+      source: "balance_adjustment",
+      channel: "manual",
+      isAdjustment: true,
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function insertNonPlug(userId: number, accountId: number): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: new Date("2026-03-10T12:00:00Z"),
+      amountCents: BigInt(-100_000),
+      currency: "COP",
+      descriptionRaw: `${TAG} regular purchase`,
+      categorySlug: "adjustments",
+      classificationMethod: "manual",
+      source: "manual",
+      channel: "bank",
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+function archiveFd(accountId: number, txIds: number[]): FormData {
+  const fd = new FormData();
+  fd.set("accountId", String(accountId));
+  fd.set("txIds", JSON.stringify(txIds));
+  return fd;
+}
+
+describe("archiveBalanceAdjustmentsAction / restoreBalanceAdjustmentAction (#434)", () => {
+  let userId!: number;
+  let otherUserId!: number;
+  let accountId!: number;
+  let otherAccountId!: number;
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.${Date.now()}@test.local`);
+    otherUserId = await createUser(`${TAG.toLowerCase()}.other.${Date.now()}@test.local`);
+    sessionMock.id = userId;
+    accountId = await createTc(userId);
+    otherAccountId = await createTc(otherUserId);
+  });
+
+  beforeEach(async () => {
+    await db.delete(transactions).where(eq(transactions.userId, userId));
+    await db.delete(transactions).where(eq(transactions.userId, otherUserId));
+  });
+
+  afterAll(async () => {
+    await db.delete(transactions).where(eq(transactions.userId, userId));
+    await db.delete(transactions).where(eq(transactions.userId, otherUserId));
+    await db.delete(accounts).where(eq(accounts.userId, userId));
+    await db.delete(accounts).where(eq(accounts.userId, otherUserId));
+    await db.delete(users).where(eq(users.id, userId));
+    await db.delete(users).where(eq(users.id, otherUserId));
+  });
+
+  it("soft-deletes the selected plugs and returns the new derived balance", async () => {
+    const plug1 = await insertPlug(userId, accountId, BigInt(-100_000)); // -1.000,00 COP
+    const plug2 = await insertPlug(userId, accountId, BigInt(-50_000)); // -500,00 COP
+    const plug3 = await insertPlug(userId, accountId, BigInt(200_000)); // +2.000,00 COP
+
+    const result = await archiveBalanceAdjustmentsAction(archiveFd(accountId, [plug1, plug3]));
+    expect(result.archivedCount).toBe(2);
+    // Remaining live: only plug2 → balance = -50_000.
+    expect(result.newBalanceCentsStr).toBe("-50000");
+
+    // DB side: 2 rows have deletedAt, 1 is still live.
+    const live = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.userId, userId),
+          eq(transactions.accountId, accountId),
+          isNull(transactions.deletedAt),
+        ),
+      );
+    expect(live).toHaveLength(1);
+    expect(live[0].id).toBe(plug2);
+  });
+
+  it("batch is idempotent — second call on already-deleted rows is a no-op", async () => {
+    const plug1 = await insertPlug(userId, accountId, BigInt(-100_000));
+    await archiveBalanceAdjustmentsAction(archiveFd(accountId, [plug1]));
+    const result = await archiveBalanceAdjustmentsAction(archiveFd(accountId, [plug1]));
+    expect(result.archivedCount).toBe(0);
+  });
+
+  it("skips non-plug txs even when their ids are in the batch", async () => {
+    const plug1 = await insertPlug(userId, accountId, BigInt(-100_000));
+    const nonPlug = await insertNonPlug(userId, accountId);
+
+    const result = await archiveBalanceAdjustmentsAction(archiveFd(accountId, [plug1, nonPlug]));
+    expect(result.archivedCount).toBe(1);
+
+    // The non-plug tx remains live + undeleted.
+    const [row] = await db
+      .select({ deletedAt: transactions.deletedAt })
+      .from(transactions)
+      .where(eq(transactions.id, nonPlug));
+    expect(row.deletedAt).toBeNull();
+  });
+
+  it("tenancy guard: rejects an accountId that doesn't belong to the session user", async () => {
+    await expect(archiveBalanceAdjustmentsAction(archiveFd(otherAccountId, [1]))).rejects.toThrow(
+      /account_not_found/,
+    );
+  });
+
+  it("rejects when txIds is missing or not JSON", async () => {
+    const fd = new FormData();
+    fd.set("accountId", String(accountId));
+    await expect(archiveBalanceAdjustmentsAction(fd)).rejects.toThrow(/tx_ids_missing/);
+
+    const fd2 = new FormData();
+    fd2.set("accountId", String(accountId));
+    fd2.set("txIds", "not-json");
+    await expect(archiveBalanceAdjustmentsAction(fd2)).rejects.toThrow(/tx_ids_not_json/);
+  });
+
+  it("restore un-archives a soft-deleted plug and leaves live ones alone", async () => {
+    const plug1 = await insertPlug(userId, accountId, BigInt(-100_000));
+    await archiveBalanceAdjustmentsAction(archiveFd(accountId, [plug1]));
+
+    const fd = new FormData();
+    fd.set("accountId", String(accountId));
+    fd.set("txId", String(plug1));
+    const result = await restoreBalanceAdjustmentAction(fd);
+    expect(result.restored).toBe(true);
+
+    const [row] = await db
+      .select({ deletedAt: transactions.deletedAt })
+      .from(transactions)
+      .where(eq(transactions.id, plug1));
+    expect(row.deletedAt).toBeNull();
+
+    // Second restore on an already-live row is a no-op.
+    const second = await restoreBalanceAdjustmentAction(fd);
+    expect(second.restored).toBe(false);
+  });
+
+  it("derived balance excludes soft-deleted plugs", async () => {
+    const plug1 = await insertPlug(userId, accountId, BigInt(-100_000));
+    const plug2 = await insertPlug(userId, accountId, BigInt(-50_000));
+
+    const [before] = await db
+      .select({ cents: derivedBalanceCentsSql })
+      .from(accounts)
+      .where(eq(accounts.id, accountId));
+    expect(BigInt(before.cents)).toBe(BigInt(-150_000));
+
+    await archiveBalanceAdjustmentsAction(archiveFd(accountId, [plug1]));
+
+    const [after] = await db
+      .select({ cents: derivedBalanceCentsSql })
+      .from(accounts)
+      .where(eq(accounts.id, accountId));
+    expect(BigInt(after.cents)).toBe(BigInt(-50_000));
+    // Only plug2 remains live.
+    void plug2;
+  });
+});

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/plug-cleanup-actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/plug-cleanup-actions.ts
@@ -1,0 +1,181 @@
+"use server";
+
+// #434 — batch soft-delete balance_adjustment txs from the reconcile page.
+// Complements #433 (which creates plugs) — users end up with stale plugs
+// once they import real data that supersedes the manual adjustment. This
+// action lets them clear the obsolete ones in bulk.
+
+import { revalidatePath } from "next/cache";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { db } from "@/lib/db";
+import { accounts, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
+import { getSessionUser } from "@/lib/auth/session";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "plug-cleanup-actions" });
+
+const archiveSchema = z.object({
+  accountId: z.coerce.number().int().positive(),
+  // JSON-encoded array of tx ids. We parse + validate manually so an
+  // empty / invalid payload rejects before touching the DB.
+  txIds: z.array(z.coerce.number().int().positive()).min(1).max(500),
+});
+
+export type ArchivePlugsResult = {
+  ok: true;
+  archivedCount: number;
+  newBalanceCentsStr: string;
+};
+
+// Soft-deletes the given balance_adjustment txs IF they belong to the user +
+// account AND are currently live. Rows that don't match (wrong user/account,
+// wrong source, already deleted, unknown id) are silently skipped — the
+// action is idempotent and safe to retry on partial success.
+export async function archiveBalanceAdjustmentsAction(
+  formData: FormData,
+): Promise<ArchivePlugsResult> {
+  const session = await getSessionUser();
+
+  const rawAccountId = formData.get("accountId");
+  const rawTxIds = formData.get("txIds");
+  if (typeof rawTxIds !== "string") {
+    throw new Error("tx_ids_missing");
+  }
+  let parsedIds: unknown;
+  try {
+    parsedIds = JSON.parse(rawTxIds);
+  } catch {
+    throw new Error("tx_ids_not_json");
+  }
+  const input = archiveSchema.parse({
+    accountId: rawAccountId,
+    txIds: parsedIds,
+  });
+
+  // Tenancy guard: verify the account belongs to the user.
+  const [account] = await db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        eq(accounts.id, input.accountId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!account) throw new Error("account_not_found");
+
+  const now = new Date();
+  const result = await db
+    .update(transactions)
+    .set({ deletedAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(transactions.userId, session.id),
+        eq(transactions.accountId, input.accountId),
+        eq(transactions.source, "balance_adjustment"),
+        inArray(transactions.id, input.txIds),
+        notDeleted(transactions.deletedAt),
+      ),
+    )
+    .returning({ id: transactions.id });
+
+  // Recompute the account's derived balance so the caller can confirm-show
+  // the post-archive state without another round-trip.
+  const [balanceRow] = await db
+    .select({ cents: derivedBalanceCentsSql })
+    .from(accounts)
+    .where(and(eq(accounts.userId, session.id), eq(accounts.id, input.accountId)))
+    .limit(1);
+
+  log.info(
+    {
+      event: "plug_cleanup_batch",
+      userId: session.id,
+      accountId: input.accountId,
+      requestedIds: input.txIds.length,
+      archivedCount: result.length,
+      newBalanceCents: balanceRow?.cents ?? "0",
+    },
+    "archived balance_adjustment plugs in batch",
+  );
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+  revalidatePath(`/settings/accounts/${input.accountId}/reconcile`);
+  revalidatePath("/settings/accounts");
+
+  return {
+    ok: true,
+    archivedCount: result.length,
+    newBalanceCentsStr: balanceRow?.cents ?? "0",
+  };
+}
+
+// Un-archive for auditability — the issue explicitly lists undo as non-goal,
+// but callers need a way to recover from a mistaken bulk-archive. Scoped to
+// a single tx id to keep the blast radius small.
+const restoreSchema = z.object({
+  accountId: z.coerce.number().int().positive(),
+  txId: z.coerce.number().int().positive(),
+});
+
+export async function restoreBalanceAdjustmentAction(
+  formData: FormData,
+): Promise<{ ok: true; restored: boolean }> {
+  const session = await getSessionUser();
+  const input = restoreSchema.parse({
+    accountId: formData.get("accountId"),
+    txId: formData.get("txId"),
+  });
+
+  const [account] = await db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, session.id),
+        eq(accounts.id, input.accountId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!account) throw new Error("account_not_found");
+
+  const result = await db
+    .update(transactions)
+    .set({ deletedAt: null, updatedAt: new Date() })
+    .where(
+      and(
+        eq(transactions.userId, session.id),
+        eq(transactions.accountId, input.accountId),
+        eq(transactions.id, input.txId),
+        eq(transactions.source, "balance_adjustment"),
+        sql`${transactions.deletedAt} IS NOT NULL`,
+      ),
+    )
+    .returning({ id: transactions.id });
+
+  log.info(
+    {
+      event: "plug_cleanup_restore",
+      userId: session.id,
+      accountId: input.accountId,
+      txId: input.txId,
+      restored: result.length > 0,
+    },
+    "restored (or no-op) balance_adjustment plug",
+  );
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+  revalidatePath(`/settings/accounts/${input.accountId}/reconcile`);
+  revalidatePath("/settings/accounts");
+
+  return { ok: true, restored: result.length > 0 };
+}

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/plug-cleanup.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/plug-cleanup.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+// #434 — UI for reviewing + batch-archiving balance_adjustment plugs on a
+// single account. Pairs with the #433 saldo-real flow: consolidating with
+// a "saldo real" input leaves a plug tx behind; after several months of real
+// imports, older plugs become obsolete. This surface lets the user clear
+// them in batch with a projected-balance preview.
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+import {
+  archiveBalanceAdjustmentsAction,
+  restoreBalanceAdjustmentAction,
+} from "./plug-cleanup-actions";
+
+export type Plug = {
+  id: number;
+  occurredAtISO: string;
+  amountCentsStr: string; // ledger-signed
+  description: string;
+  statementImportId: number | null;
+  deleted: boolean; // true when soft-deleted (deletedAt IS NOT NULL)
+};
+
+type Props = {
+  accountId: number;
+  currentBalanceCentsStr: string;
+  plugs: Plug[];
+  // Cut-off used for the "probablemente obsoleto" heuristic: plugs dated ≤
+  // max(statement_imports.periodEnd) for this account are candidates (we've
+  // likely imported the real data they were compensating for).
+  lastStatementPeriodEndISO: string | null;
+};
+
+function formatSignedCents(str: string): string {
+  if (!str) return "—";
+  const big = BigInt(str);
+  const negative = big < BigInt(0);
+  const abs = negative ? -big : big;
+  const units = abs / BigInt(100);
+  const frac = (abs % BigInt(100)).toString().padStart(2, "0");
+  const unitsStr = units.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  const sign = negative ? "-" : big > BigInt(0) ? "+" : "";
+  return `${sign}$${unitsStr},${frac}`;
+}
+
+function formatBogotaDate(iso: string): string {
+  return new Intl.DateTimeFormat("es-CO", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    timeZone: "America/Bogota",
+  }).format(new Date(iso));
+}
+
+export function PlugCleanupSection({
+  accountId,
+  currentBalanceCentsStr,
+  plugs,
+  lastStatementPeriodEndISO,
+}: Props) {
+  const router = useRouter();
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [showDeleted, setShowDeleted] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [archiving, startArchiving] = useTransition();
+  const [restoringId, setRestoringId] = useState<number | null>(null);
+
+  const visiblePlugs = useMemo(
+    () => (showDeleted ? plugs : plugs.filter((p) => !p.deleted)),
+    [plugs, showDeleted],
+  );
+
+  const obsoleteCutoff = lastStatementPeriodEndISO
+    ? new Date(lastStatementPeriodEndISO).getTime()
+    : null;
+
+  function isProbablyObsolete(p: Plug): boolean {
+    if (obsoleteCutoff === null || p.deleted) return false;
+    return new Date(p.occurredAtISO).getTime() <= obsoleteCutoff;
+  }
+
+  const selectedPlugs = useMemo(
+    () => visiblePlugs.filter((p) => selectedIds.has(p.id) && !p.deleted),
+    [visiblePlugs, selectedIds],
+  );
+  const selectedSumCents = useMemo(
+    () => selectedPlugs.reduce((acc, p) => acc + BigInt(p.amountCentsStr), BigInt(0)),
+    [selectedPlugs],
+  );
+
+  const currentBalance = BigInt(currentBalanceCentsStr);
+  // Archiving a plug removes its contribution from the derived balance, i.e.
+  // subtracts its amount. Projected = current - sum(selected).
+  const projectedBalance = currentBalance - selectedSumCents;
+
+  function toggleId(id: number, checked: boolean) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }
+
+  function toggleAllLive(checked: boolean) {
+    setSelectedIds(() => {
+      if (!checked) return new Set();
+      const next = new Set<number>();
+      for (const p of visiblePlugs) if (!p.deleted) next.add(p.id);
+      return next;
+    });
+  }
+
+  function onConfirmArchive() {
+    if (selectedPlugs.length === 0) return;
+    const fd = new FormData();
+    fd.set("accountId", String(accountId));
+    fd.set("txIds", JSON.stringify(selectedPlugs.map((p) => p.id)));
+    startArchiving(async () => {
+      try {
+        const result = await archiveBalanceAdjustmentsAction(fd);
+        toast.success(
+          `${result.archivedCount} ajuste${result.archivedCount === 1 ? "" : "s"} archivado${
+            result.archivedCount === 1 ? "" : "s"
+          }.`,
+        );
+        setSelectedIds(new Set());
+        setConfirmOpen(false);
+        router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "No pude archivar los ajustes.");
+      }
+    });
+  }
+
+  function onRestore(txId: number) {
+    setRestoringId(txId);
+    const fd = new FormData();
+    fd.set("accountId", String(accountId));
+    fd.set("txId", String(txId));
+    startArchiving(async () => {
+      try {
+        await restoreBalanceAdjustmentAction(fd);
+        toast.success("Ajuste restaurado.");
+        router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "No pude restaurar.");
+      } finally {
+        setRestoringId(null);
+      }
+    });
+  }
+
+  const anyLive = visiblePlugs.some((p) => !p.deleted);
+  const allLiveSelected =
+    anyLive && visiblePlugs.filter((p) => !p.deleted).every((p) => selectedIds.has(p.id));
+
+  return (
+    <Card data-testid="plug-cleanup-section">
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <CardTitle>Ajustes de saldo</CardTitle>
+          <CardDescription>
+            Los <code>balance_adjustment</code> plugs de esta cuenta. Borralos cuando ya no aplican
+            (importaste los movimientos que estaban tapando, o cuadraste por otro lado). Soft-delete
+            — podés deshacer desde acá.
+          </CardDescription>
+        </div>
+        <label className="text-muted-foreground flex items-center gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={showDeleted}
+            onChange={(e) => setShowDeleted(e.target.checked)}
+            className="size-4"
+          />
+          Mostrar borrados
+        </label>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {visiblePlugs.length === 0 ? (
+          <p className="text-muted-foreground py-4 text-center text-sm">
+            {showDeleted
+              ? "No hay ajustes en esta cuenta."
+              : "No hay ajustes activos. Activá 'Mostrar borrados' para ver el historial."}
+          </p>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead className="text-muted-foreground text-xs">
+                  <tr>
+                    <th className="w-8 py-2">
+                      <input
+                        type="checkbox"
+                        checked={allLiveSelected}
+                        disabled={!anyLive}
+                        aria-label="Seleccionar todos"
+                        onChange={(e) => toggleAllLive(e.target.checked)}
+                        className="size-4"
+                      />
+                    </th>
+                    <th className="py-2 pr-3">Fecha</th>
+                    <th className="py-2 pr-3 text-right">Monto</th>
+                    <th className="py-2 pr-3">Descripción</th>
+                    <th className="py-2 pr-3">Origen</th>
+                    <th className="py-2 pr-3 text-right">Acciones</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visiblePlugs.map((p) => {
+                    const isPostConsolidation = p.statementImportId !== null;
+                    const obsolete = isProbablyObsolete(p);
+                    return (
+                      <tr
+                        key={p.id}
+                        data-testid={`plug-row-${p.id}`}
+                        className={cn("border-t", p.deleted && "text-muted-foreground opacity-60")}
+                      >
+                        <td className="py-2">
+                          {!p.deleted ? (
+                            <input
+                              type="checkbox"
+                              checked={selectedIds.has(p.id)}
+                              onChange={(e) => toggleId(p.id, e.target.checked)}
+                              className="size-4"
+                              data-testid={`plug-row-checkbox-${p.id}`}
+                              aria-label={`Seleccionar ajuste #${p.id}`}
+                            />
+                          ) : (
+                            <span className="text-muted-foreground text-xs">—</span>
+                          )}
+                        </td>
+                        <td className="py-2 pr-3 whitespace-nowrap">
+                          {formatBogotaDate(p.occurredAtISO)}
+                        </td>
+                        <td className="py-2 pr-3 text-right tabular-nums">
+                          {formatSignedCents(p.amountCentsStr)}
+                        </td>
+                        <td className="truncate py-2 pr-3">{p.description}</td>
+                        <td className="flex flex-wrap gap-1 py-2 pr-3">
+                          {isPostConsolidation ? (
+                            <Badge variant="secondary" className="text-[10px]">
+                              post-consolidación
+                            </Badge>
+                          ) : (
+                            <Badge variant="outline" className="text-[10px]">
+                              manual
+                            </Badge>
+                          )}
+                          {obsolete ? (
+                            <Badge
+                              variant="outline"
+                              className="border-amber-500/50 bg-amber-50 text-[10px] text-amber-900 dark:bg-amber-950/40 dark:text-amber-200"
+                              title="Fue creado antes del último ciclo consolidado — probablemente compensaba movimientos que ya tenés importados."
+                            >
+                              probablemente obsoleto
+                            </Badge>
+                          ) : null}
+                          {p.deleted ? (
+                            <Badge variant="outline" className="text-[10px]">
+                              borrado
+                            </Badge>
+                          ) : null}
+                        </td>
+                        <td className="py-2 pr-3 text-right">
+                          {p.deleted ? (
+                            <button
+                              type="button"
+                              onClick={() => onRestore(p.id)}
+                              disabled={restoringId === p.id || archiving}
+                              className="text-primary text-xs underline"
+                              data-testid={`plug-restore-${p.id}`}
+                            >
+                              {restoringId === p.id ? "Restaurando…" : "Restaurar"}
+                            </button>
+                          ) : null}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex flex-col gap-2 border-t pt-3 text-sm sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-muted-foreground">
+                {selectedPlugs.length > 0 ? (
+                  <span data-testid="plug-cleanup-selection-summary">
+                    {selectedPlugs.length} seleccionado{selectedPlugs.length === 1 ? "" : "s"} ·
+                    suma{" "}
+                    <span className="text-foreground tabular-nums">
+                      {formatSignedCents(selectedSumCents.toString())}
+                    </span>
+                  </span>
+                ) : (
+                  <span className="text-xs">Seleccioná al menos uno para borrar.</span>
+                )}
+              </div>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                disabled={selectedPlugs.length === 0 || archiving}
+                onClick={() => setConfirmOpen(true)}
+                data-testid="plug-cleanup-archive-button"
+              >
+                Borrar seleccionados
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Borrar {selectedPlugs.length} ajuste{selectedPlugs.length === 1 ? "" : "s"}
+            </AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="flex flex-col gap-2 text-sm">
+                <span>
+                  Vas a archivar {selectedPlugs.length} ajuste
+                  {selectedPlugs.length === 1 ? "" : "s"} por un total de{" "}
+                  <span className="font-semibold tabular-nums">
+                    {formatSignedCents(selectedSumCents.toString())}
+                  </span>
+                  .
+                </span>
+                <span>
+                  Tu saldo disponible cambiará de{" "}
+                  <span className="font-medium tabular-nums">
+                    {formatSignedCents(currentBalance.toString())}
+                  </span>{" "}
+                  a{" "}
+                  <span className="font-medium tabular-nums">
+                    {formatSignedCents(projectedBalance.toString())}
+                  </span>
+                  .
+                </span>
+                <span className="text-muted-foreground text-xs">
+                  Soft-delete: podés deshacerlo después activando &quot;Mostrar borrados&quot;.
+                </span>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={archiving}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={archiving}
+              onClick={(e) => {
+                e.preventDefault();
+                onConfirmArchive();
+              }}
+              data-testid="plug-cleanup-archive-confirm"
+            >
+              {archiving ? "Archivando…" : "Borrar"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

Final layer of epic #435 — a \"Ajustes de saldo\" section in \`/reconcile/<accountId>\` for reviewing and batch-soft-deleting balance_adjustment txs on an account. Pairs with #433: once the user has consolidated several months with \"saldo real\" inputs, older plugs become stale; this surface clears them with a projected-balance preview.

- \`archiveBalanceAdjustmentsAction\` — batch soft-delete. Tenancy guard (user + account), source filter (\`balance_adjustment\`), returns \`archivedCount\` + recomputed derived balance
- \`restoreBalanceAdjustmentAction\` — un-archive a single soft-deleted plug. Issue lists undo as non-goal; this is the escape hatch for a mistaken bulk-archive, scoped to one id to keep blast radius small
- \`PlugCleanupSection\` (client) — checkbox table with:
  - \"Mostrar borrados\" toggle for historical rows
  - \"probablemente obsoleto\" badge for plugs dated ≤ \`max(statement_imports.periodEnd)\`
  - \"post-consolidación\" vs \"manual\" badges (inferred from \`statement_import_id\`)
  - \"Borrar seleccionados\" with AlertDialog projecting the post-archive balance delta
  - \"Restaurar\" link on soft-deleted rows
- \`page.tsx\` loads ALL plugs (live + deleted) + the last statement \`periodEnd\` and renders the section below \`FlaggedReview\`

## Non-goals honored
- No audit log table — Pino logger is the audit trail (issue called for \"algún log\"; a dedicated table would be a separate issue)
- No auto-retire on consolidate (explicitly rejected in the epic — too much magic for plugs that cover multiple cycles)

## Test plan
- [x] \`bun run test\` — 1039/1039 green, 7 new cases on \`plug-cleanup-actions.test.ts\` (batch soft-delete + balance recompute, idempotency, non-plug skip, tenancy guard, malformed input, restore, derived balance excludes soft-deleted)
- [x] \`bun run lint\`, \`typecheck\`, \`format:check\`
- [ ] Manual smoke (UI change) pending

Closes #434. Completes epic #435 (balance consistency post-consolidation).