### PR TITLE
fix(ui): alinear saldo-real consolidate con convención cupo-disponible (#443)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-form.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/consolidate-form.tsx
@@ -8,12 +8,15 @@ import { UploadCloudIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-import type { ConsolidationReport } from "@/lib/ingestion/bancolombia-statement/consolidate";
+import type {
+  ConsolidationReport,
+  CreditContext,
+} from "@/lib/ingestion/bancolombia-statement/consolidate";
 
 import { commitStatementAction, previewStatementAction } from "../actions";
 import { isMultiReport, type ConsolidateActionResult } from "../consolidate-types";
 import { formatCents, ReportSection } from "./consolidate-report-view";
-import { parseSignedAmountToCents } from "./parse-saldo-real";
+import { deriveLedgerFromInput, projectedCupoCents } from "./derive-cupo-ledger";
 
 type Props = {
   accountId: number;
@@ -130,18 +133,29 @@ export function ConsolidateForm({ accountId, accountName, cycle, institutionSlug
     fd.set("file", file);
     fd.set("accountId", String(accountId));
     fd.set("cycle", cycle);
-    // #433 — parse each account's saldo-real input into cents and attach.
-    // Empty → skipped. Invalid → block the commit and surface a toast.
-    for (const [rawAccountId, rawValue] of Object.entries(saldoRealInputs)) {
-      const parsed = parseSignedAmountToCents(rawValue);
-      if (parsed === undefined) continue; // empty field
-      if (parsed === null) {
-        toast.error(
-          `No pude leer el saldo real de la cuenta #${rawAccountId}. Usá números (con . o , opcional).`,
-        );
+    // #433 + #443 — derive each account's ledger-signed saldo from the raw
+    // input + its creditContext. Empty → skipped. Invalid → block commit with
+    // a toast that points at the specific report that failed.
+    const previewReportsList = preview ? toReportList(preview) : [];
+    for (const report of previewReportsList) {
+      const raw = saldoRealInputs[report.accountId] ?? "";
+      const derived = deriveLedgerFromInput({
+        raw,
+        targetCurrency: report.currency,
+        creditContext: report.projection?.creditContext ?? null,
+      });
+      if (derived.kind === "empty") continue;
+      if (derived.kind === "invalid") {
+        const msg =
+          derived.reason === "negative-cupo"
+            ? "El cupo disponible no puede ser negativo."
+            : derived.reason === "exceeds-limit"
+              ? "El cupo disponible no puede superar el límite de la tarjeta."
+              : "No pude leer el valor ingresado. Usá un número (con . o , opcional).";
+        toast.error(`Cuenta #${report.accountId}: ${msg}`);
         return;
       }
-      fd.set(`saldoRealLedgerCents_${rawAccountId}`, parsed.toString());
+      fd.set(`saldoRealLedgerCents_${report.accountId}`, derived.ledgerCents.toString());
     }
     startApplying(async () => {
       try {
@@ -309,9 +323,19 @@ function PreviewPanel({
 
 // #433 — per-account "saldo real" input. Rendered BELOW each ReportSection
 // in the preview panel so the user can eyeball the projected saldo first,
-// then decide whether to override it. Empty field == "accept the projected
-// delta" (no plug inserted). Non-empty is parsed at submit time via
-// `parseSignedAmountToCents`.
+// then decide whether to override it.
+//
+// #443 — input semantics branch on `projection.creditContext`:
+//
+//   - creditContext is null (savings / loan / no-limit TC) → the legacy
+//     ledger-signed positive input. Empty == "accept the projected delta".
+//   - creditContext.kind === "single-currency" → label "Cupo disponible
+//     (según tu banco)", input positive, <=limit. Client derives
+//     `ledger = cupo - limit`.
+//   - creditContext.kind === "shared-cupo" → label "Cupo disponible (COP,
+//     según tu banco)", input positive in COP. Client derives the target
+//     sub-account's ledger using sibling debt + TRM (same math as
+//     `BalanceAdjustDialog::SharedCupoForm`).
 function SaldoRealInput({
   report,
   value,
@@ -323,24 +347,62 @@ function SaldoRealInput({
   onChange: (value: string) => void;
   disabled: boolean;
 }) {
-  const projected = report.projection?.saldoProyectadoCentsStr;
-  const parsed = parseSignedAmountToCents(value);
-  const isInvalid = parsed === null; // undefined (empty) is fine
-  const parsedLedger = typeof parsed === "bigint" ? parsed : null;
+  const projection = report.projection;
+  const ctx = projection?.creditContext ?? null;
+  const derived = deriveLedgerFromInput({
+    raw: value,
+    targetCurrency: report.currency,
+    creditContext: ctx,
+  });
 
-  // Diff vs. projected so the user knows a plug will be inserted.
-  let plugPreview: string | null = null;
-  if (parsedLedger !== null && projected) {
-    const diff = parsedLedger - BigInt(projected);
-    if (diff !== BigInt(0)) {
-      plugPreview = `Se insertará un ajuste de ${formatCents(diff.toString())} para que el saldo quede exactamente en ${formatCents(parsedLedger.toString())}.`;
-    } else {
-      plugPreview = "El saldo real coincide con el proyectado — no se insertará ningún ajuste.";
+  const projectedLedger = projection ? BigInt(projection.saldoProyectadoCentsStr) : null;
+  const plugCents =
+    derived.kind === "ok" && projectedLedger !== null
+      ? derived.ledgerCents - projectedLedger
+      : null;
+
+  const invalidMessage = (() => {
+    if (derived.kind !== "invalid") return null;
+    if (derived.reason === "negative-cupo") return "El cupo disponible no puede ser negativo.";
+    if (derived.reason === "exceeds-limit" && ctx !== null) {
+      const limitStr =
+        ctx.kind === "single-currency" ? ctx.creditLimitCentsStr : ctx.creditLimitCopCentsStr;
+      const tag = ctx.kind === "single-currency" ? "el límite" : "el cupo total";
+      return `El cupo disponible no puede superar ${tag} (${formatCents(limitStr)}).`;
     }
-  }
+    return ctx === null
+      ? "Formato no válido. Usá un número (ej: -1.543.000,00 o -1543000.00)."
+      : "Formato no válido. Usá un número (ej: 1.543.000 o 1543000).";
+  })();
 
-  const placeholder = projected ? formatCents(projected) : "—";
+  const plugPreview = (() => {
+    if (plugCents === null || derived.kind !== "ok") return null;
+    if (plugCents === BigInt(0)) {
+      return ctx === null
+        ? "El saldo real coincide con el proyectado — no se insertará ningún ajuste."
+        : "El cupo declarado coincide con el proyectado — no se insertará ningún ajuste.";
+    }
+    if (ctx === null) {
+      return `Se insertará un ajuste de ${formatCents(plugCents.toString())} para que el saldo quede en ${formatCents(derived.ledgerCents.toString())}.`;
+    }
+    // TC: phrase in terms of debt ("se suma/resta deuda") since users think in
+    // cupo/deuda, not ledger-sign.
+    const absPlug = plugCents < BigInt(0) ? -plugCents : plugCents;
+    const debtChangeVerb = plugCents < BigInt(0) ? "sumará" : "restará";
+    const debtCents = derived.ledgerCents < BigInt(0) ? -derived.ledgerCents : BigInt(0);
+    return `Se ${debtChangeVerb} una deuda de ${formatCents(absPlug.toString())} — tu deuda en esta cuenta quedará en ${formatCents(debtCents.toString())}.`;
+  })();
+
+  const placeholderCents =
+    projectedLedger !== null
+      ? ctx === null
+        ? projectedLedger
+        : (projectedCupoCents(projectedLedger, report.currency, ctx) ?? null)
+      : null;
+  const placeholder = placeholderCents !== null ? formatCents(placeholderCents.toString()) : "—";
   const inputId = `saldo-real-${report.accountId}`;
+
+  const { label, help } = inputCopy(ctx);
 
   return (
     <div
@@ -348,7 +410,7 @@ function SaldoRealInput({
       className="bg-muted/30 flex flex-col gap-2 rounded-md border border-dashed p-3 text-sm"
     >
       <label htmlFor={inputId} className="font-medium">
-        ¿Cuál es tu saldo real según el banco?{" "}
+        {label}{" "}
         <span className="text-muted-foreground text-xs font-normal">
           (opcional — dejá vacío para aceptar el delta proyectado)
         </span>
@@ -363,23 +425,36 @@ function SaldoRealInput({
         onChange={(e) => onChange(e.target.value)}
         className={cn(
           "border-input focus-visible:ring-ring rounded-md border bg-transparent px-3 py-2 tabular-nums focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none",
-          isInvalid && "border-destructive",
+          invalidMessage !== null && "border-destructive",
         )}
         data-testid={`saldo-real-field-${report.accountId}`}
       />
-      {isInvalid ? (
-        <p className="text-destructive text-xs">
-          Formato no válido. Usá un número (ej: -1.543.000,00 o -1543000.00).
-        </p>
-      ) : plugPreview ? (
+      {invalidMessage !== null ? (
+        <p className="text-destructive text-xs">{invalidMessage}</p>
+      ) : plugPreview !== null ? (
         <p className="text-muted-foreground text-xs">{plugPreview}</p>
       ) : (
-        <p className="text-muted-foreground text-xs">
-          Si el saldo que ves en el banco difiere del proyectado, entralo acá y al confirmar se
-          inserta un ajuste de saldo para cuadrar. Puede estar compensando compras que Findash nunca
-          vio o plugs viejos obsoletos — andá a /reconcile a revisar después.
-        </p>
+        <p className="text-muted-foreground text-xs">{help}</p>
       )}
     </div>
   );
+}
+
+function inputCopy(ctx: CreditContext | null): { label: string; help: string } {
+  if (ctx === null) {
+    return {
+      label: "¿Cuál es tu saldo real según el banco?",
+      help: "Si el saldo que ves en el banco difiere del proyectado, entralo acá y al confirmar se inserta un ajuste de saldo para cuadrar.",
+    };
+  }
+  if (ctx.kind === "single-currency") {
+    return {
+      label: "Cupo disponible (según tu banco)",
+      help: "Copiá el cupo disponible que te muestra Bancolombia — no la deuda. Al confirmar derivamos la deuda restando del límite y armamos un ajuste si cuadra distinto del proyectado.",
+    };
+  }
+  return {
+    label: "Cupo disponible (COP, según tu banco)",
+    help: "En tarjetas multi-moneda el banco muestra un solo cupo en COP. Pegá ese número: vamos a ajustar solo esta sub-cuenta usando la TRM actual — las siblings quedan intactas.",
+  };
 }

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/derive-cupo-ledger.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/derive-cupo-ledger.test.ts
@@ -1,0 +1,222 @@
+// #443 — unit tests for the cupo → ledger derivation used by consolidate-form.
+// Exercises the three modes (legacy ledger-signed, single-currency cupo,
+// shared-cupo multi-currency) + the projected-cupo placeholder helper.
+
+import { describe, expect, it } from "vitest";
+
+import { deriveLedgerFromInput, projectedCupoCents } from "./derive-cupo-ledger";
+
+describe("deriveLedgerFromInput (#443)", () => {
+  it("returns empty for blank input regardless of context", () => {
+    expect(
+      deriveLedgerFromInput({ raw: "", targetCurrency: "COP", creditContext: null }).kind,
+    ).toBe("empty");
+    expect(
+      deriveLedgerFromInput({
+        raw: "   ",
+        targetCurrency: "COP",
+        creditContext: { kind: "single-currency", creditLimitCentsStr: "1000000000" },
+      }).kind,
+    ).toBe("empty");
+  });
+
+  it("legacy (creditContext=null): passes input through as ledger-signed", () => {
+    const r = deriveLedgerFromInput({
+      raw: "-500.000,00",
+      targetCurrency: "COP",
+      creditContext: null,
+    });
+    expect(r).toEqual({ kind: "ok", cupoCents: null, ledgerCents: BigInt(-50_000_000) });
+
+    const pos = deriveLedgerFromInput({
+      raw: "1.000.000",
+      targetCurrency: "COP",
+      creditContext: null,
+    });
+    // Savings ledger positive is also valid.
+    expect(pos).toEqual({ kind: "ok", cupoCents: null, ledgerCents: BigInt(100_000_000) });
+  });
+
+  it("single-currency: derives ledger = cupo - limit", () => {
+    const ctx = { kind: "single-currency", creditLimitCentsStr: "1000000000" } as const;
+    // limit 10M COP, cupo 4M → debt 6M → ledger -6M.
+    const r = deriveLedgerFromInput({
+      raw: "4.000.000,00",
+      targetCurrency: "COP",
+      creditContext: ctx,
+    });
+    expect(r).toEqual({
+      kind: "ok",
+      cupoCents: BigInt(400_000_000),
+      ledgerCents: BigInt(-600_000_000),
+    });
+  });
+
+  it("single-currency: cupo == limit ⇒ ledger 0 (no debt)", () => {
+    const ctx = { kind: "single-currency", creditLimitCentsStr: "1000000000" } as const;
+    const r = deriveLedgerFromInput({
+      raw: "10.000.000",
+      targetCurrency: "COP",
+      creditContext: ctx,
+    });
+    expect(r).toEqual({
+      kind: "ok",
+      cupoCents: BigInt(1_000_000_000),
+      ledgerCents: BigInt(0),
+    });
+  });
+
+  it("single-currency: rejects cupo > limit with exceeds-limit", () => {
+    const ctx = { kind: "single-currency", creditLimitCentsStr: "1000000000" } as const;
+    const r = deriveLedgerFromInput({
+      raw: "11.000.000",
+      targetCurrency: "COP",
+      creditContext: ctx,
+    });
+    expect(r).toEqual({ kind: "invalid", reason: "exceeds-limit" });
+  });
+
+  it("single-currency: rejects negative cupo", () => {
+    const ctx = { kind: "single-currency", creditLimitCentsStr: "1000000000" } as const;
+    const r = deriveLedgerFromInput({
+      raw: "-100.000",
+      targetCurrency: "COP",
+      creditContext: ctx,
+    });
+    expect(r).toEqual({ kind: "invalid", reason: "negative-cupo" });
+  });
+
+  it("single-currency: rejects non-numeric input", () => {
+    const ctx = { kind: "single-currency", creditLimitCentsStr: "1000000000" } as const;
+    const r = deriveLedgerFromInput({ raw: "abc", targetCurrency: "COP", creditContext: ctx });
+    expect(r).toEqual({ kind: "invalid", reason: "parse-failed" });
+  });
+
+  it("shared-cupo: COP target with no sibling debt ⇒ ledger = cupo - limit", () => {
+    // 10M limit, no sibling debt, declared cupo 4M COP → target debt 6M COP,
+    // target currency COP ⇒ convert is a no-op ⇒ ledger -6M.
+    const r = deriveLedgerFromInput({
+      raw: "4.000.000",
+      targetCurrency: "COP",
+      creditContext: {
+        kind: "shared-cupo",
+        creditLimitCopCentsStr: "1000000000",
+        siblingDebtCopCentsStr: "0",
+        copPerUsd: 4000,
+      },
+    });
+    expect(r).toEqual({
+      kind: "ok",
+      cupoCents: BigInt(400_000_000),
+      ledgerCents: BigInt(-600_000_000),
+    });
+  });
+
+  it("shared-cupo: USD target subtracts sibling COP debt and converts remainder", () => {
+    // limit 10M COP (1e9 cents), sibling (COP side) owes 2M COP (2e8 cents),
+    // declared cupo 3M COP (3e8 cents) → total debt 7M COP → remaining after
+    // siblings = 5M COP (5e8 cents). Convert to USD at 4000 COP/USD:
+    //   (500_000_000 * 1_000_000) / (4000 * 1_000_000) = 125_000 USD cents
+    //   = $1,250 USD debt → ledger -125_000.
+    const r = deriveLedgerFromInput({
+      raw: "3.000.000",
+      targetCurrency: "USD",
+      creditContext: {
+        kind: "shared-cupo",
+        creditLimitCopCentsStr: "1000000000",
+        siblingDebtCopCentsStr: "200000000",
+        copPerUsd: 4000,
+      },
+    });
+    expect(r).toEqual({
+      kind: "ok",
+      cupoCents: BigInt(300_000_000),
+      ledgerCents: BigInt(-125_000),
+    });
+  });
+
+  it("shared-cupo: sibling already covers total debt ⇒ target ledger 0 (no debt)", () => {
+    // limit 10M, sibling debt 8M, declared cupo 3M → total debt 7M COP.
+    // Sibling already covers 8M > 7M → target debt clamps to 0.
+    const r = deriveLedgerFromInput({
+      raw: "3.000.000",
+      targetCurrency: "COP",
+      creditContext: {
+        kind: "shared-cupo",
+        creditLimitCopCentsStr: "1000000000",
+        siblingDebtCopCentsStr: "800000000",
+        copPerUsd: 4000,
+      },
+    });
+    expect(r).toEqual({
+      kind: "ok",
+      cupoCents: BigInt(300_000_000),
+      ledgerCents: BigInt(0),
+    });
+  });
+
+  it("shared-cupo: rejects cupo > shared COP limit", () => {
+    const r = deriveLedgerFromInput({
+      raw: "11.000.000",
+      targetCurrency: "COP",
+      creditContext: {
+        kind: "shared-cupo",
+        creditLimitCopCentsStr: "1000000000",
+        siblingDebtCopCentsStr: "0",
+        copPerUsd: 4000,
+      },
+    });
+    expect(r).toEqual({ kind: "invalid", reason: "exceeds-limit" });
+  });
+});
+
+describe("projectedCupoCents (#443)", () => {
+  it("returns null when creditContext is null", () => {
+    expect(projectedCupoCents(BigInt(-50_000_000), "COP", null)).toBeNull();
+  });
+
+  it("single-currency: limit + projected-ledger (negative) = cupo", () => {
+    // limit 10M, saldo proyectado -6M → cupo 4M.
+    const cupo = projectedCupoCents(BigInt(-600_000_000), "COP", {
+      kind: "single-currency",
+      creditLimitCentsStr: "1000000000",
+    });
+    expect(cupo).toBe(BigInt(400_000_000));
+  });
+
+  it("single-currency: positive ledger (credit balance) clamps cupo to limit max", () => {
+    // saldo proyectado +5M (credit, shouldn't happen but possible) → cupo
+    // would be limit + 5M = 15M. We don't clamp the upside; the user sees a
+    // placeholder higher than the limit, which is accurate for display.
+    const cupo = projectedCupoCents(BigInt(500_000_000), "COP", {
+      kind: "single-currency",
+      creditLimitCentsStr: "1000000000",
+    });
+    expect(cupo).toBe(BigInt(1_500_000_000));
+  });
+
+  it("shared-cupo: subtracts sibling debt + projected target debt in COP", () => {
+    // limit 10M COP, sibling debt 2M COP, saldo proyectado -1M COP →
+    // projected target debt 1M COP → cupo COP = 10M - 2M - 1M = 7M.
+    const cupo = projectedCupoCents(BigInt(-100_000_000), "COP", {
+      kind: "shared-cupo",
+      creditLimitCopCentsStr: "1000000000",
+      siblingDebtCopCentsStr: "200000000",
+      copPerUsd: 4000,
+    });
+    expect(cupo).toBe(BigInt(700_000_000));
+  });
+
+  it("shared-cupo: USD ledger converts debt to COP using TRM", () => {
+    // limit 10M COP (1e9 cents), no sibling debt. saldo proyectado -100 USD
+    // cents = -$1 USD at 4000 COP/USD → debt COP = 100 * 4000 * 1e6 / 1e6 =
+    // 400_000 cop cents ($4,000 COP). cupo COP = 1e9 - 0 - 400_000 = 999_600_000.
+    const cupo = projectedCupoCents(BigInt(-100), "USD", {
+      kind: "shared-cupo",
+      creditLimitCopCentsStr: "1000000000",
+      siblingDebtCopCentsStr: "0",
+      copPerUsd: 4000,
+    });
+    expect(cupo).toBe(BigInt(999_600_000));
+  });
+});

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/derive-cupo-ledger.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/[cycle]/derive-cupo-ledger.ts
@@ -1,0 +1,112 @@
+// #443 — derives a ledger-signed cents value from whatever the user typed in
+// the consolidate-form saldo-real input, branching on `BalanceProjection.creditContext`:
+//
+//   - null (savings/loan/etc.)  → input is ledger-signed positive (legacy).
+//   - single-currency TC        → input is Cupo disponible positive; ledger
+//                                 = -(limit - cupo).
+//   - shared-cupo multi-currency TC → input is Cupo disponible COP positive;
+//                                 derives the TARGET sub-account's ledger by
+//                                 subtracting sibling debt (COP) and converting
+//                                 the remainder back to target currency using
+//                                 the provided TRM. Mirrors the server-side
+//                                 math in `adjustAccountBalance::sharedAvailableCop`.
+//
+// Pure function — no DOM / no DB / no React. Unit-testable.
+
+import type { CreditContext } from "@/lib/ingestion/bancolombia-statement/consolidate";
+
+import { parseSignedAmountToCents } from "./parse-saldo-real";
+
+export type DeriveInput = {
+  raw: string;
+  targetCurrency: "COP" | "USD";
+  creditContext: CreditContext | null | undefined;
+};
+
+export type DeriveResult =
+  | { kind: "empty" }
+  | { kind: "invalid"; reason: "parse-failed" | "negative-cupo" | "exceeds-limit" }
+  | {
+      kind: "ok";
+      // Positive cupo (cents, in COP for shared-cupo else native). Undefined
+      // when creditContext is null (legacy savings path — input IS the ledger).
+      cupoCents: bigint | null;
+      // Ledger-signed cents value that the server will receive.
+      ledgerCents: bigint;
+    };
+
+const ONE_MILLION = BigInt(1_000_000);
+
+// Mirrors src/lib/money.ts::convertCents. Inlined so this helper stays
+// framework-free (no "import server" chain pulled into the client bundle).
+function convertCents(
+  amountCents: bigint,
+  from: "COP" | "USD",
+  to: "COP" | "USD",
+  copPerUsd: number,
+): bigint {
+  if (from === to) return amountCents;
+  const micros = BigInt(Math.round(copPerUsd * 1_000_000));
+  if (from === "USD" && to === "COP") {
+    return (amountCents * micros) / ONE_MILLION;
+  }
+  return (amountCents * ONE_MILLION) / micros;
+}
+
+export function deriveLedgerFromInput(params: DeriveInput): DeriveResult {
+  const parsed = parseSignedAmountToCents(params.raw);
+  if (parsed === undefined) return { kind: "empty" };
+  if (parsed === null) return { kind: "invalid", reason: "parse-failed" };
+
+  const ctx = params.creditContext ?? null;
+  if (ctx === null) {
+    return { kind: "ok", cupoCents: null, ledgerCents: parsed };
+  }
+
+  if (parsed < BigInt(0)) return { kind: "invalid", reason: "negative-cupo" };
+
+  if (ctx.kind === "single-currency") {
+    const limit = BigInt(ctx.creditLimitCentsStr);
+    if (parsed > limit) return { kind: "invalid", reason: "exceeds-limit" };
+    const ledger = parsed - limit;
+    return { kind: "ok", cupoCents: parsed, ledgerCents: ledger };
+  }
+
+  const limitCop = BigInt(ctx.creditLimitCopCentsStr);
+  const siblingDebtCop = BigInt(ctx.siblingDebtCopCentsStr);
+  if (parsed > limitCop) return { kind: "invalid", reason: "exceeds-limit" };
+  const totalDebtCop = limitCop - parsed;
+  const remainingCop = totalDebtCop - siblingDebtCop;
+  const targetDebtCop = remainingCop <= BigInt(0) ? BigInt(0) : remainingCop;
+  const targetDebtNative = convertCents(targetDebtCop, "COP", params.targetCurrency, ctx.copPerUsd);
+  return { kind: "ok", cupoCents: parsed, ledgerCents: -targetDebtNative };
+}
+
+// Convenience: the projected CUPO the user would have AFTER this consolidation
+// applies (matching the placeholder shown in the form). Computed from the
+// ledger-signed projected saldo:
+//   single-currency: cupo = max(0, limit + saldoProyectado)  (saldoProy ≤ 0 → cupo ≤ limit)
+//   shared-cupo:     projected target debt (native)       = max(0, -saldoProy)
+//                    projected target debt COP            = convert(..., "COP")
+//                    projected cupo COP                   = max(0, limit_cop - sibling_debt_cop - target_debt_cop)
+// Returns null when creditContext is null (savings/loan — no cupo concept).
+export function projectedCupoCents(
+  saldoProyectadoLedgerCents: bigint,
+  targetCurrency: "COP" | "USD",
+  creditContext: CreditContext | null | undefined,
+): bigint | null {
+  const ctx = creditContext ?? null;
+  if (ctx === null) return null;
+  if (ctx.kind === "single-currency") {
+    const limit = BigInt(ctx.creditLimitCentsStr);
+    const cupo = limit + saldoProyectadoLedgerCents;
+    return cupo < BigInt(0) ? BigInt(0) : cupo;
+  }
+  const limitCop = BigInt(ctx.creditLimitCopCentsStr);
+  const siblingDebtCop = BigInt(ctx.siblingDebtCopCentsStr);
+  const targetDebtNative =
+    saldoProyectadoLedgerCents < BigInt(0) ? -saldoProyectadoLedgerCents : BigInt(0);
+  const targetDebtCop = convertCents(targetDebtNative, targetCurrency, "COP", ctx.copPerUsd);
+  const cupoCop = limitCop - siblingDebtCop - targetDebtCop;
+  return cupoCop < BigInt(0) ? BigInt(0) : cupoCop;
+}

--- a/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/consolidate/actions.test.ts
@@ -654,4 +654,84 @@ describe("multi-sheet dispatch (#426)", () => {
     // USD threshold floor is 125 USD = 12500 cents; |delta|=50000 > 12500 → warn.
     expect(byCurrency.USD.projection!.warn.exceeded).toBe(true);
   });
+
+  // #443 — projection carries a creditContext so the client form can render
+  // a positive "Cupo disponible" input and back-solve the ledger locally.
+  // Shared-cupo TCs populate both sub-accounts' context with the physical
+  // card's limit + sibling-debt-in-COP + TRM.
+  it("multi-sheet preview populates shared-cupo creditContext on both reports", async () => {
+    const buf = buildMultiSheetXlsxBuffer("7291");
+    const result = await previewStatementAction(formDataFor(buf, copAccountId, "2026-03"));
+    if (!isMultiReport(result)) throw new Error("expected multi-sheet result");
+    const byCurrency = Object.fromEntries(result.reports.map((r) => [r.currency, r]));
+    const copCtx = byCurrency.COP.projection!.creditContext!;
+    const usdCtx = byCurrency.USD.projection!.creditContext!;
+    expect(copCtx).toBeDefined();
+    expect(copCtx.kind).toBe("shared-cupo");
+    expect(usdCtx.kind).toBe("shared-cupo");
+    if (copCtx.kind !== "shared-cupo" || usdCtx.kind !== "shared-cupo") {
+      throw new Error("expected shared-cupo context on both sub-accounts");
+    }
+    // Physical card limit = 10M COP * 100 cents = 1e9 stored as bigint.
+    expect(copCtx.creditLimitCopCentsStr).toBe("1000000000");
+    expect(usdCtx.creditLimitCopCentsStr).toBe("1000000000");
+    // Pre-commit ledger is empty on both (no seeded txs) → sibling debt 0.
+    expect(copCtx.siblingDebtCopCentsStr).toBe("0");
+    expect(usdCtx.siblingDebtCopCentsStr).toBe("0");
+    expect(copCtx.copPerUsd).toBeGreaterThan(0);
+    expect(usdCtx.copPerUsd).toBeGreaterThan(0);
+  });
+});
+
+describe("single-currency creditContext (#443)", () => {
+  let userId!: number;
+  let tcId!: number;
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.scc.${Date.now()}@test.local`);
+    sessionMock.id = userId;
+    // Single-currency TC with metadata.creditLimitCents set — triggers
+    // `creditContext.kind === "single-currency"` on projection output.
+    const [row] = await db
+      .insert(accounts)
+      .values({
+        userId,
+        name: `${TAG} visa 9999`,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        type: "credit_card",
+        currency: "COP",
+        metadata: { last4s: ["9999"], cutoffDay: 30, creditLimitCents: 2_000_000_00 },
+      })
+      .returning({ id: accounts.id });
+    tcId = row.id;
+  });
+
+  afterEach(async () => {
+    await db.execute(
+      sql`DELETE FROM transactions WHERE user_id = ${userId} AND external_id LIKE 'bancolombia-stmt:%'`,
+    );
+    await db.execute(
+      sql`DELETE FROM transactions WHERE user_id = ${userId} AND source = 'balance_adjustment'`,
+    );
+    await db.delete(statementImports).where(eq(statementImports.userId, userId));
+    await db.execute(
+      sql`DELETE FROM transactions WHERE user_id = ${userId} AND category_slug = 'intereses-tc'`,
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  it("preview emits single-currency creditContext with the account's credit limit", async () => {
+    const buf = buildSyntheticXlsxBuffer("9999");
+    const report = asSingle(await previewStatementAction(formDataFor(buf, tcId, "2026-03")));
+    const ctx = report.projection?.creditContext;
+    expect(ctx).toBeDefined();
+    expect(ctx?.kind).toBe("single-currency");
+    if (ctx?.kind !== "single-currency") throw new Error("expected single-currency ctx");
+    // 2_000_000_00 cents = 2M COP.
+    expect(ctx.creditLimitCentsStr).toBe("200000000");
+  });
 });

--- a/src/lib/ingestion/bancolombia-statement/consolidate.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.ts
@@ -14,6 +14,8 @@ import { notDeleted } from "@/lib/db/helpers";
 import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
 import { applyInteresesCausadosForCycle } from "@/lib/finance/intereses-causados-job";
 import { createLogger } from "@/lib/logger";
+import { convertCents } from "@/lib/money";
+import { getCurrentFxRate } from "@/lib/fx/repo";
 
 // #433 — the balance_adjustment plug goes into the user's Ajustes de saldo
 // category (same one the reconcile flow + opening-balance tx use). We always
@@ -87,7 +89,26 @@ export type BalanceProjection = {
     thresholdCentsStr: string;
     exceeded: boolean;
   };
+  // #443 — client-facing credit-limit info so consolidate-form can render a
+  // positive "Cupo disponible (según tu banco)" input for credit_card accounts
+  // and derive the ledger-signed value locally before submitting. Absent/null
+  // on savings & loans (client keeps the legacy ledger-signed input for those).
+  creditContext?: CreditContext | null;
 };
+
+// #443 — credit-limit context surfaced to the client. For single-currency TCs
+// we only need the limit. For shared-cupo multi-currency TCs (MC/Amex
+// internacional) we also need the siblings' current debt in COP and the TRM
+// so the client can back-solve the target sub-account's ledger value using
+// the same math as `BalanceAdjustDialog::SharedCupoForm`.
+export type CreditContext =
+  | { kind: "single-currency"; creditLimitCentsStr: string }
+  | {
+      kind: "shared-cupo";
+      creditLimitCopCentsStr: string;
+      siblingDebtCopCentsStr: string;
+      copPerUsd: number;
+    };
 
 // #433 — info about a balance_adjustment tx inserted to reconcile the ledger
 // against a user-provided "saldo real". Null at the report level when no
@@ -212,7 +233,20 @@ type ProjectionInputs = {
   // is COP-denominated); callers pass `null` for USD sub-accounts where the
   // shared COP cupo wouldn't convert cleanly to the account currency.
   creditLimitCents: bigint | null;
+  // #443 — in-memory twin of the output `CreditContext`. Bigints kept native
+  // so builders don't have to re-parse. Null when the account isn't a credit
+  // card OR is a TC without a configured limit (UI falls back to ledger-sign).
+  creditContext: ProjectionCreditContext | null;
 };
+
+type ProjectionCreditContext =
+  | { kind: "single-currency"; creditLimitCents: bigint }
+  | {
+      kind: "shared-cupo";
+      creditLimitCopCents: bigint;
+      siblingDebtCopCents: bigint;
+      copPerUsd: number;
+    };
 
 async function loadProjectionInputs(
   database: DB,
@@ -245,27 +279,32 @@ async function loadProjectionInputs(
       ),
     );
 
-  // Credit limit lookup: physical_card wins when linked (shared-cupo MC/Amex),
-  // else fall back to metadata.creditLimitCents for single-currency TCs. For
-  // USD sub-accounts we deliberately skip the physical_card COP cupo since
-  // 15%-of-COP-cupo wouldn't map to USD cleanly — use floor only there.
+  // Account + optional physical-card join. Used BOTH for the COP 15%-floor
+  // threshold (creditLimitCents) and for the client-facing creditContext
+  // (single-currency vs shared-cupo). We always load this — even for USD
+  // sub-accounts — so the shared-cupo context is populated on both sides.
+  const [accountRow] = await database
+    .select({
+      type: accounts.type,
+      metadata: accounts.metadata,
+      physicalCardId: accounts.physicalCardId,
+      pcCredit: physicalCards.creditLimitCents,
+    })
+    .from(accounts)
+    .leftJoin(
+      physicalCards,
+      and(eq(physicalCards.id, accounts.physicalCardId), eq(physicalCards.userId, accounts.userId)),
+    )
+    .where(and(eq(accounts.userId, userId), eq(accounts.id, accountId)))
+    .limit(1);
+
+  // Credit limit lookup for the COP 15%-floor warn threshold: physical_card
+  // wins when linked (shared-cupo MC/Amex), else fall back to
+  // metadata.creditLimitCents for single-currency TCs. For USD sub-accounts
+  // we deliberately skip the physical_card COP cupo since 15%-of-COP-cupo
+  // wouldn't map to USD cleanly — use floor only there.
   let creditLimitCents: bigint | null = null;
   if (currency === "COP") {
-    const [accountRow] = await database
-      .select({
-        metadata: accounts.metadata,
-        pcCredit: physicalCards.creditLimitCents,
-      })
-      .from(accounts)
-      .leftJoin(
-        physicalCards,
-        and(
-          eq(physicalCards.id, accounts.physicalCardId),
-          eq(physicalCards.userId, accounts.userId),
-        ),
-      )
-      .where(and(eq(accounts.userId, userId), eq(accounts.id, accountId)))
-      .limit(1);
     if (accountRow?.pcCredit !== null && accountRow?.pcCredit !== undefined) {
       creditLimitCents = accountRow.pcCredit;
     } else if (accountRow?.metadata?.creditLimitCents) {
@@ -273,10 +312,56 @@ async function loadProjectionInputs(
     }
   }
 
+  // #443 — creditContext payload for the client. Only populated for credit
+  // cards with a known limit. Shared-cupo (multi-currency) branch needs
+  // siblings' live debt in COP + current TRM so the client can back-solve
+  // the target sub-account's ledger value.
+  let creditContext: ProjectionCreditContext | null = null;
+  if (accountRow?.type === "credit_card") {
+    const pcLimit = accountRow.pcCredit ?? null;
+    const metaLimit = accountRow.metadata?.creditLimitCents;
+    if (accountRow.physicalCardId && pcLimit !== null && pcLimit > BigInt(0)) {
+      const siblingRows = await database
+        .select({
+          id: accounts.id,
+          currency: accounts.currency,
+          balanceCents: derivedBalanceCentsSql,
+        })
+        .from(accounts)
+        .where(
+          and(
+            eq(accounts.userId, userId),
+            eq(accounts.physicalCardId, accountRow.physicalCardId),
+            sql`${accounts.id} != ${accountId}`,
+            notDeleted(accounts.deletedAt),
+          ),
+        );
+      const fx = await getCurrentFxRate(database);
+      let siblingDebtCopCents = BigInt(0);
+      for (const sib of siblingRows) {
+        const bal = BigInt(sib.balanceCents);
+        const nativeDebt = bal < BigInt(0) ? -bal : BigInt(0);
+        siblingDebtCopCents += convertCents(nativeDebt, sib.currency, "COP", fx.rate);
+      }
+      creditContext = {
+        kind: "shared-cupo",
+        creditLimitCopCents: pcLimit,
+        siblingDebtCopCents,
+        copPerUsd: fx.rate,
+      };
+    } else if (metaLimit !== undefined && metaLimit > 0) {
+      creditContext = {
+        kind: "single-currency",
+        creditLimitCents: BigInt(metaLimit),
+      };
+    }
+  }
+
   return {
     saldoActualCents: BigInt(balanceRow?.cents ?? "0"),
     plugsObsoletosCents: BigInt(plugsRow?.cents ?? "0"),
     creditLimitCents,
+    creditContext,
   };
 }
 
@@ -350,6 +435,23 @@ export function buildBalanceProjection(
       thresholdCentsStr: thresholdCents.toString(),
       exceeded,
     },
+    creditContext: serializeCreditContext(inputs.creditContext),
+  };
+}
+
+function serializeCreditContext(ctx: ProjectionCreditContext | null): CreditContext | null {
+  if (ctx === null) return null;
+  if (ctx.kind === "single-currency") {
+    return {
+      kind: "single-currency",
+      creditLimitCentsStr: ctx.creditLimitCents.toString(),
+    };
+  }
+  return {
+    kind: "shared-cupo",
+    creditLimitCopCentsStr: ctx.creditLimitCopCents.toString(),
+    siblingDebtCopCentsStr: ctx.siblingDebtCopCents.toString(),
+    copPerUsd: ctx.copPerUsd,
   };
 }
 


### PR DESCRIPTION
## Summary

- `BalanceProjection` ahora emite `creditContext` (single-currency | shared-cupo | null) con la info necesaria para que `consolidate-form` renderice un input de **Cupo disponible positivo** en vez del saldo ledger-signed, matching la UX de `BalanceAdjustDialog` (referencia en el issue #443).
- Nuevo helper client-side `deriveLedgerFromInput` deriva el ledger localmente a partir del cupo declarado + límite (+ TRM/sibling debt para multi-moneda). El contrato del lib layer (`saldoRealLedgerCents`) queda estable.
- `SaldoRealInput` branchea label/placeholder/validación/diff-preview según el tipo de cuenta — savings siguen con la UX ledger-signed anterior.

## Test plan

- [x] `bun run vitest run` — 83 files / 1070 tests (incluye 16 nuevos en `derive-cupo-ledger.test.ts` + 2 en `actions.test.ts` para `creditContext`).
- [x] `bun run typecheck` + `bun run lint` verdes.
- [ ] Dogfood en prod: Visa 2575 (single-currency) + MC 7291 (shared-cupo) en el próximo ciclo.

Closes #443