### PR TITLE
fix(ingestion): dispatch multi-currency TC movimientos xlsx al sibling correcto (#444)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.test.ts
@@ -1,0 +1,284 @@
+// #444 — integration tests for previewReconcile + applyReconcile with the
+// multi-currency Mastercard Internacional flow. Exercises:
+//   - single-currency upload (no sibling) → legacy behavior
+//   - currency_mismatch rejection
+//   - multi_currency_without_physical_card rejection
+//   - missing_usd_sibling rejection
+//   - shared-plastic dispatch: preview + apply routes per-row to the
+//     correct sub-account
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import * as XLSX from "xlsx";
+
+import { db } from "@/lib/db";
+import { accounts, physicalCards, statementImports, transactions, users } from "@/lib/db/schema";
+import { copyCategorySeedsToUser } from "@/lib/auth/signup";
+
+const TAG = "RECON_ACT_TEST";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+const sessionMock = { id: 0, email: "test@test.local", name: "Test" };
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockImplementation(async () => sessionMock),
+}));
+
+const { previewReconcile, applyReconcile } = await import("./actions");
+
+// Builds a Mastercard-style TC xlsx (single sheet, 6 columns: Fecha,
+// Descripción, Fecha de corte, Valor, Tipo de moneda, Cuotas). When
+// `rows` is provided we use it verbatim; otherwise we ship a default
+// mixed COP+USD + pure-COP fixture matching the real file shape.
+function buildXlsxBuffer(
+  rows: Array<[number, string, number | null, number, "COP" | "USD", number]>,
+): Buffer {
+  const aoa: (string | number | null)[][] = [
+    ["Fecha", "Descripción", "Fecha de corte", "Valor", "Tipo de moneda", "Cuotas"],
+    ...rows,
+  ];
+  const wb = XLSX.utils.book_new();
+  const sheet = XLSX.utils.aoa_to_sheet(aoa);
+  XLSX.utils.book_append_sheet(wb, sheet, "Hoja 1");
+  return Buffer.from(XLSX.write(wb, { bookType: "xlsx", type: "buffer" }));
+}
+
+function mixedFixture(): Buffer {
+  return buildXlsxBuffer([
+    [46127, "RAPPI COP", null, 30000, "COP", 1],
+    [46127, "AMAZON PRIME", null, 14.99, "USD", 36],
+    [46126, "ABONO VIRTUAL", null, -130469, "COP", 0],
+  ]);
+}
+
+function copOnlyFixture(): Buffer {
+  return buildXlsxBuffer([
+    [46127, "RAPPI", null, 30000, "COP", 1],
+    [46127, "DIDI", null, 15000, "COP", 1],
+  ]);
+}
+
+function usdOnlyFixture(): Buffer {
+  return buildXlsxBuffer([[46127, "USD MERCHANT", null, 10, "USD", 1]]);
+}
+
+function formDataFor(buffer: Buffer, accountId: number, filename = "mov.xlsx"): FormData {
+  const fd = new FormData();
+  const blob = new Blob([new Uint8Array(buffer)], {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+  fd.set("file", blob, filename);
+  fd.set("accountId", String(accountId));
+  return fd;
+}
+
+async function createUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  return row.id;
+}
+
+async function createPhysicalCard(userId: number, last4: string): Promise<string> {
+  const [row] = await db
+    .insert(physicalCards)
+    .values({
+      id: sql`gen_random_uuid()`,
+      userId,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      name: `${TAG} mc ${last4}`,
+      creditLimitCents: BigInt(10_000_000_00),
+      network: "mastercard",
+      last4,
+    })
+    .returning({ id: physicalCards.id });
+  return row.id;
+}
+
+async function createLinkedTc(
+  userId: number,
+  currency: "COP" | "USD",
+  physicalCardId: string,
+  last4: string,
+): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} mc ${last4} ${currency}`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      type: "credit_card",
+      currency,
+      physicalCardId,
+      metadata: { last4s: [last4] },
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createSoloTc(
+  userId: number,
+  currency: "COP" | "USD",
+  last4: string,
+): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} solo ${last4}`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      type: "credit_card",
+      currency,
+      metadata: { last4s: [last4] },
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function cleanupUser(userId: number): Promise<void> {
+  await db.delete(transactions).where(eq(transactions.userId, userId));
+  await db.delete(statementImports).where(eq(statementImports.userId, userId));
+  await db.delete(accounts).where(eq(accounts.userId, userId));
+  await db.delete(physicalCards).where(eq(physicalCards.userId, userId));
+  await db.delete(users).where(eq(users.id, userId));
+}
+
+describe("previewReconcile + applyReconcile — multi-currency (#444)", () => {
+  let userId!: number;
+  let pcId!: string;
+  let copAccountId!: number;
+  let usdAccountId!: number;
+  let soloCopAccountId!: number;
+  let soloCopWithPcId!: number;
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.${Date.now()}@test.local`);
+    sessionMock.id = userId;
+    pcId = await createPhysicalCard(userId, "7291");
+    copAccountId = await createLinkedTc(userId, "COP", pcId, "7291");
+    usdAccountId = await createLinkedTc(userId, "USD", pcId, "7291");
+    soloCopAccountId = await createSoloTc(userId, "COP", "2575");
+    // A COP account with a physical_card but NO sibling → used to validate
+    // `missing_usd_sibling` dispatches the correct error.
+    const soloPc = await createPhysicalCard(userId, "5555");
+    soloCopWithPcId = await createLinkedTc(userId, "COP", soloPc, "5555");
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  it("single-currency upload returns multiCurrency=null and preserves legacy shape", async () => {
+    const buf = copOnlyFixture();
+    const preview = await previewReconcile(formDataFor(buf, soloCopAccountId));
+    expect(preview.multiCurrency).toBeNull();
+    expect(preview.accountId).toBe(soloCopAccountId);
+    expect(preview.parsed.rows).toHaveLength(2);
+  });
+
+  it("rejects currency_mismatch when a USD-only file is uploaded to a COP account", async () => {
+    const buf = usdOnlyFixture();
+    await expect(previewReconcile(formDataFor(buf, soloCopAccountId))).rejects.toThrow(
+      /currency_mismatch/,
+    );
+  });
+
+  it("rejects multi_currency_without_physical_card when the origin has no plastic link", async () => {
+    const buf = mixedFixture();
+    await expect(previewReconcile(formDataFor(buf, soloCopAccountId))).rejects.toThrow(
+      /multi_currency_without_physical_card/,
+    );
+  });
+
+  it("rejects missing_usd_sibling when the plastic has no USD sibling linked", async () => {
+    const buf = mixedFixture();
+    await expect(previewReconcile(formDataFor(buf, soloCopWithPcId))).rejects.toThrow(
+      /missing_usd_sibling/,
+    );
+  });
+
+  it("preview resolves plastic-linked siblings and counts rows per currency", async () => {
+    const buf = mixedFixture();
+    const preview = await previewReconcile(formDataFor(buf, copAccountId));
+    expect(preview.multiCurrency).not.toBeNull();
+    expect(preview.multiCurrency!.siblingAccountId).toBe(usdAccountId);
+    expect(preview.multiCurrency!.siblingCurrency).toBe("USD");
+    expect(preview.multiCurrency!.originCurrency).toBe("COP");
+    expect(preview.multiCurrency!.rowsByCurrency.COP).toBe(2); // RAPPI + ABONO
+    expect(preview.multiCurrency!.rowsByCurrency.USD).toBe(1); // AMAZON PRIME
+  });
+
+  it("preview entered from the USD sibling dispatches the same way", async () => {
+    const buf = mixedFixture();
+    const preview = await previewReconcile(formDataFor(buf, usdAccountId));
+    expect(preview.multiCurrency).not.toBeNull();
+    expect(preview.accountId).toBe(usdAccountId);
+    expect(preview.multiCurrency!.siblingAccountId).toBe(copAccountId);
+    expect(preview.multiCurrency!.originCurrency).toBe("USD");
+    expect(preview.multiCurrency!.siblingCurrency).toBe("COP");
+  });
+
+  it("apply writes txs to the correct sub-account by parsedRow.currency", async () => {
+    const buf = mixedFixture();
+    const preview = await previewReconcile(formDataFor(buf, copAccountId));
+    const result = await applyReconcile({
+      accountId: copAccountId,
+      fileHash: preview.fileHash,
+      parsed: preview.parsed,
+      plan: preview.plan,
+      userBalanceAtEndCents: null,
+    });
+    expect(result.status).toBe("applied");
+    expect(result.inserted).toBe(3);
+
+    const copTxs = await db
+      .select()
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.userId, userId),
+          eq(transactions.accountId, copAccountId),
+          eq(transactions.source, "csv_reconcile"),
+        ),
+      );
+    const usdTxs = await db
+      .select()
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.userId, userId),
+          eq(transactions.accountId, usdAccountId),
+          eq(transactions.source, "csv_reconcile"),
+        ),
+      );
+    expect(copTxs).toHaveLength(2);
+    expect(usdTxs).toHaveLength(1);
+    expect(copTxs.every((t) => t.currency === "COP")).toBe(true);
+    // The amazon prime row must persist as USD -14.99 on the USD sibling —
+    // this is the exact scenario that produced 25 mis-currency txs in prod
+    // before the fix.
+    expect(usdTxs[0].currency).toBe("USD");
+    expect(usdTxs[0].amountCents).toBe(BigInt(-14_99));
+
+    // Two statement_imports rows (one per sub-account, both with the same
+    // fileHash for idempotent re-apply per-side).
+    const imports = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.userId, userId));
+    const byAccount = new Map(imports.map((i) => [i.accountId, i]));
+    expect(byAccount.get(copAccountId)?.fileHash).toBe(preview.fileHash);
+    expect(byAccount.get(usdAccountId)?.fileHash).toBe(preview.fileHash);
+
+    // Re-apply = already_imported (no new rows).
+    const second = await applyReconcile({
+      accountId: copAccountId,
+      fileHash: preview.fileHash,
+      parsed: preview.parsed,
+      plan: preview.plan,
+      userBalanceAtEndCents: null,
+    });
+    expect(second.status).toBe("already_imported");
+  });
+});

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { and, eq, gte, lte } from "drizzle-orm";
+import { and, eq, gte, lte, ne } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { accounts, transactions } from "@/lib/db/schema";
@@ -29,6 +29,21 @@ export interface ReconcilePreview {
   fileHash: string;
   parsed: SerializedParsed;
   plan: MatchingPlan;
+  // #444 — populated when the parsed xlsx contains rows of a currency that
+  // doesn't match the origin account, and the origin is linked via
+  // `physicalCardId` to a sibling in the other currency. Tells the UI to
+  // surface "se aplicará a 2 cuentas" and tells applyReconcile which sibling
+  // to route the other-currency rows into. Null for single-currency uploads.
+  multiCurrency: MultiCurrencyDispatchInfo | null;
+}
+
+export interface MultiCurrencyDispatchInfo {
+  siblingAccountId: number;
+  siblingCurrency: "COP" | "USD";
+  originCurrency: "COP" | "USD";
+  // Pre-computed counts per currency so the preview UI can render a
+  // "N COP + M USD" banner without re-walking parsed.rows.
+  rowsByCurrency: Record<"COP" | "USD", number>;
 }
 
 interface SerializedParsedRow {
@@ -97,6 +112,7 @@ async function loadAccount(userId: number, accountId: number) {
       id: accounts.id,
       currency: accounts.currency,
       institutionSlug: accounts.institutionSlug,
+      physicalCardId: accounts.physicalCardId,
     })
     .from(accounts)
     .where(
@@ -105,6 +121,92 @@ async function loadAccount(userId: number, accountId: number) {
     .limit(1);
   if (!account) throw new Error("account_not_found");
   return account;
+}
+
+// #444 — finds the other-currency sibling linked to the same physical card.
+// Returns null when the origin isn't linked to a plastic or has no sibling.
+async function loadReconcileSibling(
+  userId: number,
+  physicalCardId: string,
+  excludeAccountId: number,
+) {
+  const [sibling] = await db
+    .select({
+      id: accounts.id,
+      currency: accounts.currency,
+      institutionSlug: accounts.institutionSlug,
+      physicalCardId: accounts.physicalCardId,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, userId),
+        eq(accounts.physicalCardId, physicalCardId),
+        ne(accounts.id, excludeAccountId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .limit(1);
+  return sibling ?? null;
+}
+
+type ReconcileDispatch = {
+  origin: Awaited<ReturnType<typeof loadAccount>>;
+  sibling: Awaited<ReturnType<typeof loadAccount>> | null;
+};
+
+// #444 — decides whether a parsed statement must dispatch to the origin
+// account alone (single-currency) or split across an origin + plastic-linked
+// sibling (Mastercard Internacional mixing COP+USD in one sheet).
+//
+// Validates upfront: every parsed row's currency must land on either origin
+// or sibling; otherwise we throw a precise error the UI can translate.
+async function resolveReconcileDispatch(
+  userId: number,
+  origin: Awaited<ReturnType<typeof loadAccount>>,
+  parsed: ParsedStatement,
+): Promise<ReconcileDispatch> {
+  const currenciesInFile = new Set<"COP" | "USD">();
+  for (const row of parsed.rows) currenciesInFile.add(row.currency);
+
+  if (currenciesInFile.size <= 1) {
+    const only = currenciesInFile.values().next().value as "COP" | "USD" | undefined;
+    if (only !== undefined && only !== origin.currency) {
+      throw new Error(`currency_mismatch:file=${only},account=${origin.currency}`);
+    }
+    return { origin, sibling: null };
+  }
+
+  // Multi-currency xlsx — we need a plastic-linked sibling to absorb the
+  // other-currency rows. Without one we reject (issue #444 acceptance: rows
+  // must never land on an account whose currency doesn't match).
+  if (!origin.physicalCardId) {
+    throw new Error("multi_currency_without_physical_card");
+  }
+  const sibling = await loadReconcileSibling(userId, origin.physicalCardId, origin.id);
+  if (!sibling) {
+    // Name the error by the missing currency (COP or USD) so the UI can point
+    // the user at exactly which sub-account is missing.
+    const missing = [...currenciesInFile].find((c) => c !== origin.currency);
+    throw new Error(`missing_${(missing ?? "usd").toLowerCase()}_sibling`);
+  }
+  if (sibling.institutionSlug !== origin.institutionSlug) {
+    throw new Error(`sibling_institution_mismatch:${sibling.institutionSlug}`);
+  }
+  // Every parsed row must land on origin or sibling — guard against a 3rd
+  // currency leaking in through a future parser change.
+  for (const c of currenciesInFile) {
+    if (c !== origin.currency && c !== sibling.currency) {
+      throw new Error(`currency_not_in_plastic:${c}`);
+    }
+  }
+  return { origin, sibling };
+}
+
+function rowsByCurrencyCount(parsed: ParsedStatement): Record<"COP" | "USD", number> {
+  const counts: Record<"COP" | "USD", number> = { COP: 0, USD: 0 };
+  for (const row of parsed.rows) counts[row.currency] += 1;
+  return counts;
 }
 
 async function loadExistingTxns(
@@ -178,19 +280,40 @@ export async function previewReconcile(formData: FormData): Promise<ReconcilePre
     );
   }
 
-  const existing = await loadExistingTxns(
+  // #444 — resolve multi-currency dispatch. For single-currency uploads this
+  // is a no-op (sibling=null) and the flow proceeds account-scoped. For
+  // Mastercard Internacional xlsx mixing COP+USD we fetch the plastic-linked
+  // sibling and load existingTxns from BOTH sides so the match engine can see
+  // candidates across currencies.
+  const dispatch = await resolveReconcileDispatch(session.id, account, parsed);
+
+  const existingOrigin = await loadExistingTxns(
     session.id,
     account.id,
     parsed.periodStart,
     parsed.periodEnd,
   );
+  const existingSibling = dispatch.sibling
+    ? await loadExistingTxns(session.id, dispatch.sibling.id, parsed.periodStart, parsed.periodEnd)
+    : [];
+  const existing: ExistingTxnForMatch[] = [...existingOrigin, ...existingSibling];
   const plan = matchStatement({ parsedRows: parsed.rows, existingTxns: existing });
+
+  const multiCurrency: MultiCurrencyDispatchInfo | null = dispatch.sibling
+    ? {
+        siblingAccountId: dispatch.sibling.id,
+        siblingCurrency: dispatch.sibling.currency,
+        originCurrency: account.currency,
+        rowsByCurrency: rowsByCurrencyCount(parsed),
+      }
+    : null;
 
   return {
     accountId: account.id,
     fileHash,
     parsed: serializeParsed(parsed),
     plan,
+    multiCurrency,
   };
 }
 
@@ -214,13 +337,27 @@ export async function applyReconcile(input: ApplyReconcileInput) {
   const account = await loadAccount(session.id, accountId);
 
   const parsedStatement = deserializeParsed(parsed as SerializedParsed);
+  // #444 — re-resolve dispatch on the server (don't trust client-side state).
+  // Matches the preview call so the commit routes every row through the same
+  // plastic-aware plan.
+  const dispatch = await resolveReconcileDispatch(session.id, account, parsedStatement);
   const result = await commitReconciliation({
     userId: session.id,
-    account: { id: account.id, currency: account.currency },
+    account: { id: dispatch.origin.id, currency: dispatch.origin.currency },
+    siblingAccount: dispatch.sibling
+      ? { id: dispatch.sibling.id, currency: dispatch.sibling.currency }
+      : undefined,
     parsed: parsedStatement,
     plan: plan as MatchingPlan,
     fileHash,
-    userBalanceAtEndCents: userBalanceAtEndCents ? BigInt(userBalanceAtEndCents) : null,
+    // `userBalanceAtEndCents` is a single-account concept — the commit layer
+    // ignores it in multi-currency mode, but we also pass null explicitly
+    // here so the intent is obvious at the call site.
+    userBalanceAtEndCents: dispatch.sibling
+      ? null
+      : userBalanceAtEndCents
+        ? BigInt(userBalanceAtEndCents)
+        : null,
   });
 
   log.info(
@@ -228,6 +365,7 @@ export async function applyReconcile(input: ApplyReconcileInput) {
       event: "reconciliation_applied",
       userId: session.id,
       accountId: account.id,
+      siblingAccountId: dispatch.sibling?.id ?? null,
       statementImportId: result.statementImportId,
       status: result.status,
       inserted: result.inserted,
@@ -240,6 +378,9 @@ export async function applyReconcile(input: ApplyReconcileInput) {
   revalidatePath("/");
   revalidatePath("/transactions");
   revalidatePath(`/settings/accounts/${account.id}/reconcile`);
+  if (dispatch.sibling) {
+    revalidatePath(`/settings/accounts/${dispatch.sibling.id}/reconcile`);
+  }
 
   return result;
 }

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/reconcile-form.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/reconcile-form.tsx
@@ -53,6 +53,22 @@ export function ReconcileForm({
           toast.error(
             `The file appears to be from a different bank than this account (${accountInstitutionSlug}). Upload the right statement or edit the account's institution.`,
           );
+        } else if (msg.startsWith("currency_mismatch")) {
+          toast.error(
+            `La moneda del archivo no coincide con esta cuenta (${accountCurrency}). Subí el xlsx correspondiente.`,
+          );
+        } else if (msg === "multi_currency_without_physical_card") {
+          toast.error(
+            "El xlsx mezcla COP y USD, pero esta cuenta no está linkeada a una tarjeta física. Asocíala primero para poder reconciliar las 2 sub-cuentas juntas.",
+          );
+        } else if (msg.startsWith("missing_usd_sibling")) {
+          toast.error(
+            "El xlsx incluye filas USD pero este plástico no tiene una sub-cuenta USD linkeada. Creala desde Cuentas → Tarjetas físicas.",
+          );
+        } else if (msg.startsWith("missing_cop_sibling")) {
+          toast.error(
+            "El xlsx incluye filas COP pero no hay una sub-cuenta COP linkeada a este plástico.",
+          );
         } else {
           toast.error(msg);
         }
@@ -144,6 +160,20 @@ export function ReconcileForm({
             </CardDescription>
           </CardHeader>
           <CardContent className="flex flex-col gap-4">
+            {preview.multiCurrency ? (
+              <div
+                className="rounded-md border border-dashed border-sky-400/40 bg-sky-50 p-3 text-sm text-sky-900 dark:bg-sky-950/40 dark:text-sky-200"
+                data-testid="reconcile-multicurrency-banner"
+              >
+                <strong>Tarjeta multi-moneda detectada.</strong> El xlsx trae{" "}
+                {preview.multiCurrency.rowsByCurrency.COP} fila
+                {preview.multiCurrency.rowsByCurrency.COP === 1 ? "" : "s"} COP +{" "}
+                {preview.multiCurrency.rowsByCurrency.USD} fila
+                {preview.multiCurrency.rowsByCurrency.USD === 1 ? "" : "s"} USD. Al confirmar se
+                aplica a 2 cuentas (#{preview.accountId} {preview.multiCurrency.originCurrency} + #
+                {preview.multiCurrency.siblingAccountId} {preview.multiCurrency.siblingCurrency}).
+              </div>
+            ) : null}
             <div className="flex flex-wrap gap-2">
               <Badge variant="outline" className="bg-emerald-50 text-emerald-900">
                 {preview.plan.summary.matched} matched
@@ -231,33 +261,34 @@ export function ReconcileForm({
             </div>
 
             <p className="text-muted-foreground text-xs">
-              Currency note: rows are displayed in their statement currency. Inserts persist in the
-              account&apos;s currency ({accountCurrency}). If you&apos;re reconciling a
-              dual-currency card, upload separate statements for COP and USD against the linked
-              accounts.
+              {preview.multiCurrency
+                ? `Cada fila se inserta en la sub-cuenta de su moneda: COP en #${preview.accountId}, USD en #${preview.multiCurrency.siblingAccountId}.`
+                : `Currency note: rows are displayed in their statement currency. Inserts persist in the account's currency (${accountCurrency}). If you're reconciling a dual-currency card, upload the plastic-level xlsx once — we dispatch per-row to the linked siblings.`}
             </p>
 
-            <div className="flex flex-col gap-1.5 rounded-md border border-dashed p-3">
-              <Label htmlFor="recon-balance">Balance al cierre según el banco (opcional)</Label>
-              <Input
-                id="recon-balance"
-                name="balanceAtEnd"
-                type="text"
-                inputMode="decimal"
-                placeholder={accountCurrency === "USD" ? "1234.56" : "1234567"}
-                value={balanceInput}
-                onChange={(e) => setBalanceInput(e.target.value)}
-                disabled={applying}
-              />
-              <p className="text-muted-foreground text-xs">
-                Copialo del app del banco. Si lo ingresás, habilitamos la métrica de divergencia en{" "}
-                <code>/admin/health</code>. Findash actual:{" "}
-                <span className="tabular-nums">
-                  <Money cents={currentFindashBalance} currency={accountCurrency} />
-                </span>
-                .
-              </p>
-            </div>
+            {preview.multiCurrency ? null : (
+              <div className="flex flex-col gap-1.5 rounded-md border border-dashed p-3">
+                <Label htmlFor="recon-balance">Balance al cierre según el banco (opcional)</Label>
+                <Input
+                  id="recon-balance"
+                  name="balanceAtEnd"
+                  type="text"
+                  inputMode="decimal"
+                  placeholder={accountCurrency === "USD" ? "1234.56" : "1234567"}
+                  value={balanceInput}
+                  onChange={(e) => setBalanceInput(e.target.value)}
+                  disabled={applying}
+                />
+                <p className="text-muted-foreground text-xs">
+                  Copialo del app del banco. Si lo ingresás, habilitamos la métrica de divergencia
+                  en <code>/admin/health</code>. Findash actual:{" "}
+                  <span className="tabular-nums">
+                    <Money cents={currentFindashBalance} currency={accountCurrency} />
+                  </span>
+                  .
+                </p>
+              </div>
+            )}
 
             <div className="flex items-center justify-end gap-2">
               <Button variant="outline" onClick={() => setPreview(null)} disabled={applying}>

--- a/src/lib/reconciliation/commit.test.ts
+++ b/src/lib/reconciliation/commit.test.ts
@@ -1,8 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   accounts,
+  physicalCards,
   reconciliationDecisions,
   statementImports,
   transactions,
@@ -88,6 +89,7 @@ async function cleanupUser(userId: number): Promise<void> {
   await db.delete(transactions).where(eq(transactions.userId, userId));
   await db.delete(statementImports).where(eq(statementImports.userId, userId));
   await db.delete(accounts).where(eq(accounts.userId, userId));
+  await db.delete(physicalCards).where(eq(physicalCards.userId, userId));
   await db.delete(users).where(eq(users.id, userId));
 }
 
@@ -578,5 +580,212 @@ describe("recordReconciliationDecision — merge_into path", () => {
     // Flagged row unchanged
     const [still] = await db.select().from(transactions).where(eq(transactions.id, flagged));
     expect(still.reconciliationStatus).toBe("flagged");
+  });
+});
+
+// #444 — multi-currency Mastercard Internacional movimientos xlsx commits
+// split rows across origin + sibling accounts by parsedRow.currency. Each
+// sub-account gets its own statement_imports row (idempotent per side).
+describe("commitReconciliation — multi-currency dispatch (#444)", () => {
+  let userId!: number;
+  let copAccountId!: number;
+  let usdAccountId!: number;
+  let soloAccountId!: number;
+  let pcId!: string;
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG.toLowerCase()}.mc.${Date.now()}@test.local`);
+    // Plastic-linked siblings (COP + USD) sharing one physical card.
+    const [pc] = await db
+      .insert(physicalCards)
+      .values({
+        id: sql`gen_random_uuid()`,
+        userId,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        name: `${TAG} mc 7291`,
+        creditLimitCents: BigInt(10_000_000_00),
+        network: "mastercard",
+        last4: "7291",
+      })
+      .returning({ id: physicalCards.id });
+    pcId = pc.id;
+    const [copRow] = await db
+      .insert(accounts)
+      .values({
+        userId,
+        name: `${TAG} mc cop`,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        type: "credit_card",
+        currency: "COP",
+        physicalCardId: pcId,
+      })
+      .returning({ id: accounts.id });
+    copAccountId = copRow.id;
+    const [usdRow] = await db
+      .insert(accounts)
+      .values({
+        userId,
+        name: `${TAG} mc usd`,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        type: "credit_card",
+        currency: "USD",
+        physicalCardId: pcId,
+      })
+      .returning({ id: accounts.id });
+    usdAccountId = usdRow.id;
+    // Unrelated solo account (no plastic link) — used to validate commit
+    // rejects when a USD row lands on a card without a USD sibling.
+    soloAccountId = await createAccount(userId);
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  function buildMixedParsed(): ParsedStatement {
+    const base = new Date("2026-04-15T05:00:00Z");
+    return buildParsed(
+      [
+        {
+          occurredAt: base,
+          amountCents: BigInt(30_000_00),
+          currency: "COP",
+          direction: "out",
+          descriptionRaw: `${TAG} rappi cop`,
+          rawData: { cuotas: 1 },
+          isMetadata: false,
+        },
+        {
+          occurredAt: base,
+          amountCents: BigInt(14_99),
+          currency: "USD",
+          direction: "out",
+          descriptionRaw: `${TAG} amazon prime usd`,
+          rawData: { cuotas: 36 },
+          isMetadata: false,
+        },
+        {
+          occurredAt: base,
+          amountCents: BigInt(1_30_469_00),
+          currency: "COP",
+          direction: "in",
+          descriptionRaw: `${TAG} abono virtual cop`,
+          rawData: { cuotas: 0 },
+          isMetadata: true,
+        },
+      ],
+      { format: "bancolombia_tc" },
+    );
+  }
+
+  function buildInsertPlan(rowCount: number): MatchingPlan {
+    return {
+      decisions: Array.from({ length: rowCount }, (_, i) => ({
+        statementRowIndex: i,
+        action: "insert_new" as const,
+        matchedTxnId: null,
+        matchScore: 0,
+        matchReason: "no_match" as const,
+      })),
+      flaggedExisting: [],
+      summary: { matched: 0, newInserts: rowCount, nearMatches: 0, flaggedExisting: 0 },
+    };
+  }
+
+  it("splits inserts per parsedRow.currency into the matching sub-account", async () => {
+    const parsed = buildMixedParsed();
+    const plan = buildInsertPlan(parsed.rows.length);
+    const result = await commitReconciliation({
+      userId,
+      account: { id: copAccountId, currency: "COP" },
+      siblingAccount: { id: usdAccountId, currency: "USD" },
+      parsed,
+      plan,
+      fileHash: hashFileBuffer(Buffer.from(`${TAG}-mc-dispatch`)),
+    });
+    expect(result.status).toBe("applied");
+    expect(result.inserted).toBe(3);
+
+    // Two statement_imports rows — one per sub-account, both with the same
+    // fileHash so re-upload is idempotent per-side.
+    const imports = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.userId, userId));
+    const accountIds = new Set(imports.map((i) => i.accountId));
+    expect(accountIds.has(copAccountId)).toBe(true);
+    expect(accountIds.has(usdAccountId)).toBe(true);
+
+    // Txs land on the right account + carry the row's currency (NOT the
+    // origin account's currency — that was the #444 bug).
+    const txs = await db
+      .select()
+      .from(transactions)
+      .where(and(eq(transactions.userId, userId), eq(transactions.source, "csv_reconcile")));
+    const copTxs = txs.filter((t) => t.accountId === copAccountId);
+    const usdTxs = txs.filter((t) => t.accountId === usdAccountId);
+    expect(copTxs).toHaveLength(2); // the 30k compra + the 130k abono
+    expect(usdTxs).toHaveLength(1); // the amazon prime USD
+    expect(copTxs.every((t) => t.currency === "COP")).toBe(true);
+    expect(usdTxs.every((t) => t.currency === "USD")).toBe(true);
+    expect(usdTxs[0].amountCents).toBe(BigInt(-14_99));
+  });
+
+  it("is idempotent on re-commit: same fileHash returns already_imported", async () => {
+    const parsed = buildMixedParsed();
+    const plan = buildInsertPlan(parsed.rows.length);
+    const fileHash = hashFileBuffer(Buffer.from(`${TAG}-mc-idempo`));
+    await commitReconciliation({
+      userId,
+      account: { id: copAccountId, currency: "COP" },
+      siblingAccount: { id: usdAccountId, currency: "USD" },
+      parsed,
+      plan,
+      fileHash,
+    });
+    const second = await commitReconciliation({
+      userId,
+      account: { id: copAccountId, currency: "COP" },
+      siblingAccount: { id: usdAccountId, currency: "USD" },
+      parsed,
+      plan,
+      fileHash,
+    });
+    expect(second.status).toBe("already_imported");
+    expect(second.inserted).toBe(0);
+  });
+
+  it("throws when a parsed row's currency has no matching target account", async () => {
+    // Solo single-currency COP account (no sibling) + a USD row in the file.
+    const parsed = buildMixedParsed();
+    const plan = buildInsertPlan(parsed.rows.length);
+    await expect(
+      commitReconciliation({
+        userId,
+        account: { id: soloAccountId, currency: "COP" },
+        // No siblingAccount → USD row has nowhere to go.
+        parsed,
+        plan,
+        fileHash: hashFileBuffer(Buffer.from(`${TAG}-mc-missing-target`)),
+      }),
+    ).rejects.toThrow(/missing_account_for_currency:USD/);
+  });
+
+  it("rejects a sibling of the same currency as the primary account", async () => {
+    const parsed = buildMixedParsed();
+    const plan = buildInsertPlan(parsed.rows.length);
+    await expect(
+      commitReconciliation({
+        userId,
+        account: { id: copAccountId, currency: "COP" },
+        siblingAccount: { id: soloAccountId, currency: "COP" },
+        parsed,
+        plan,
+        fileHash: hashFileBuffer(Buffer.from(`${TAG}-mc-same-cur`)),
+      }),
+    ).rejects.toThrow(/sibling_same_currency/);
   });
 });

--- a/src/lib/reconciliation/commit.ts
+++ b/src/lib/reconciliation/commit.ts
@@ -23,7 +23,24 @@ export interface CommitAccount {
 
 export interface CommitInput {
   userId: number;
+  /**
+   * Primary target. Rows whose `parsedRow.currency === account.currency`
+   * insert into this account. Single-currency statements use this
+   * exclusively and don't pass `siblingAccount`.
+   */
   account: CommitAccount;
+  /**
+   * #444 — optional other-currency sibling for Mastercard Internacional
+   * (plastic-level xlsx mixing COP + USD rows in one sheet). When provided,
+   * rows whose `parsedRow.currency === siblingAccount.currency` insert into
+   * `siblingAccount` (NOT `account`). Caller guarantees:
+   *   - `account.currency !== siblingAccount.currency`
+   *   - every `parsed.row.currency` ∈ { account.currency, siblingAccount.currency }
+   *
+   * Commit throws on violations. One `statement_imports` row is created per
+   * sub-account so re-upload is idempotent per-side.
+   */
+  siblingAccount?: CommitAccount;
   parsed: ParsedStatement;
   plan: MatchingPlan;
   fileHash: string;
@@ -32,6 +49,9 @@ export interface CommitInput {
    * `parsed.balanceAtEndCents` held (parsers for most banks can't extract
    * this — see #302 / #304). Null = no balance captured for this import;
    * divergence stays blank on /admin/health.
+   *
+   * Ignored in multi-currency mode (TC movimientos don't carry a closing
+   * balance; caller is expected to pass null when siblingAccount is set).
    */
   userBalanceAtEndCents?: bigint | null;
 }
@@ -49,7 +69,33 @@ export interface CommitInput {
  * ingreso, negative = gasto).
  */
 export async function commitReconciliation(input: CommitInput): Promise<CommitResult> {
+  // #444 — build a currency → account map covering the primary + optional
+  // sibling. Validate once up-front so we fail before touching the DB if the
+  // caller is inconsistent (sibling of same currency, row pointing at a
+  // currency neither target covers, etc.).
+  const accountsByCurrency: Partial<Record<"COP" | "USD", CommitAccount>> = {
+    [input.account.currency]: input.account,
+  };
+  if (input.siblingAccount) {
+    if (input.siblingAccount.currency === input.account.currency) {
+      throw new Error(`sibling_same_currency:${input.account.currency}`);
+    }
+    if (input.siblingAccount.id === input.account.id) {
+      throw new Error("sibling_same_account");
+    }
+    accountsByCurrency[input.siblingAccount.currency] = input.siblingAccount;
+  }
+  for (const row of input.parsed.rows) {
+    if (!accountsByCurrency[row.currency]) {
+      throw new Error(`missing_account_for_currency:${row.currency}`);
+    }
+  }
+
   return db.transaction(async (tx) => {
+    // Idempotency check on the primary account — multi-currency commits run
+    // in a single transaction, so if the primary-side import exists, the
+    // sibling-side one was created atomically in the same retry's tx (or
+    // both rolled back). Checking primary alone is sufficient.
     const existingImport = await tx
       .select({ id: statementImports.id })
       .from(statementImports)
@@ -71,29 +117,49 @@ export async function commitReconciliation(input: CommitInput): Promise<CommitRe
       };
     }
 
-    const balanceAtEndCents =
-      input.userBalanceAtEndCents !== undefined && input.userBalanceAtEndCents !== null
+    const multiCurrency = input.siblingAccount !== undefined;
+    // `userBalanceAtEndCents` only makes sense for a single-account import
+    // (savings closing balance). TC movimientos don't carry it, and in the
+    // multi-currency case the file doesn't ship a per-side closing balance
+    // anyway — force null on both sides to keep the statement_imports row
+    // honest.
+    const balanceAtEndCents = multiCurrency
+      ? null
+      : input.userBalanceAtEndCents !== undefined && input.userBalanceAtEndCents !== null
         ? input.userBalanceAtEndCents
         : input.parsed.balanceAtEndCents;
-    const [imp] = await tx
-      .insert(statementImports)
-      .values({
-        userId: input.userId,
-        accountId: input.account.id,
-        fileHash: input.fileHash,
-        periodStart: toIsoDate(input.parsed.periodStart),
-        periodEnd: toIsoDate(input.parsed.periodEnd),
-        txnCount: 0,
-        balanceAtEndCents,
-      })
-      .returning({ id: statementImports.id });
+
+    // Insert one statement_imports row per target account. Bigint counts are
+    // patched below once we know the per-import txn totals.
+    const importIdByCurrency: Partial<Record<"COP" | "USD", number>> = {};
+    for (const currency of Object.keys(accountsByCurrency) as Array<"COP" | "USD">) {
+      const target = accountsByCurrency[currency]!;
+      const [imp] = await tx
+        .insert(statementImports)
+        .values({
+          userId: input.userId,
+          accountId: target.id,
+          fileHash: input.fileHash,
+          periodStart: toIsoDate(input.parsed.periodStart),
+          periodEnd: toIsoDate(input.parsed.periodEnd),
+          txnCount: 0,
+          // Only the primary target carries the user-supplied closing balance
+          // in single-currency mode; the sibling (when present) never does.
+          balanceAtEndCents: target.id === input.account.id ? balanceAtEndCents : null,
+        })
+        .returning({ id: statementImports.id });
+      importIdByCurrency[currency] = imp.id;
+    }
 
     let matched = 0;
     let inserted = 0;
+    const txnCountByImport = new Map<number, number>();
 
     for (const decision of input.plan.decisions) {
       const parsedRow = input.parsed.rows[decision.statementRowIndex];
       if (!parsedRow) continue;
+      const target = accountsByCurrency[parsedRow.currency]!;
+      const importId = importIdByCurrency[parsedRow.currency]!;
 
       if (decision.action === "match" && decision.matchedTxnId !== null) {
         await tx
@@ -101,7 +167,7 @@ export async function commitReconciliation(input: CommitInput): Promise<CommitRe
           .set({
             reconciliationStatus: "matched",
             reconciledAt: new Date(),
-            statementImportId: imp.id,
+            statementImportId: importId,
             updatedAt: new Date(),
           })
           .where(
@@ -111,20 +177,21 @@ export async function commitReconciliation(input: CommitInput): Promise<CommitRe
       } else {
         await tx.insert(transactions).values({
           userId: input.userId,
-          accountId: input.account.id,
+          accountId: target.id,
           occurredAt: parsedRow.occurredAt,
           amountCents: signedAmount(parsedRow),
-          currency: input.account.currency,
+          currency: parsedRow.currency,
           descriptionRaw: parsedRow.descriptionRaw,
           source: "csv_reconcile",
           channel: "bank",
           reconciliationStatus: "imported_from_statement",
           reconciledAt: new Date(),
-          statementImportId: imp.id,
+          statementImportId: importId,
           rawData: parsedRow.rawData,
         });
         inserted++;
       }
+      txnCountByImport.set(importId, (txnCountByImport.get(importId) ?? 0) + 1);
     }
 
     if (input.plan.flaggedExisting.length > 0) {
@@ -139,14 +206,18 @@ export async function commitReconciliation(input: CommitInput): Promise<CommitRe
         .where(and(eq(transactions.userId, input.userId), inArray(transactions.id, ids)));
     }
 
-    await tx
-      .update(statementImports)
-      .set({ txnCount: matched + inserted })
-      .where(eq(statementImports.id, imp.id));
+    // Patch per-import txn counts (update-per-import keeps the statement_imports
+    // row's `txn_count` accurate even when rows split across siblings).
+    for (const [importId, count] of txnCountByImport) {
+      await tx
+        .update(statementImports)
+        .set({ txnCount: count })
+        .where(eq(statementImports.id, importId));
+    }
 
     return {
       status: "applied" as const,
-      statementImportId: imp.id,
+      statementImportId: importIdByCurrency[input.account.currency]!,
       inserted,
       matched,
       flagged: input.plan.flaggedExisting.length,


### PR DESCRIPTION
## Summary

- **Bug root cause (pre-PR)**: `/reconcile` era single-account / single-currency. Para el xlsx de movimientos MC Internacional (COP + USD en una misma hoja), `commit.ts:117` hardcodeaba `currency: input.account.currency` → todas las filas USD quedaban etiquetadas COP en la cuenta origen. Confirmado en prod con 25 txs mal-clasificadas (rollback manual en issue #444).
- **Fix**: nuevo dispatcher plastic-aware en `reconcile/actions.ts` espejando el patrón de `#426/resolveDispatch` (consolidate). `commit.ts` acepta un `siblingAccount` opcional y rutea cada fila a la sub-cuenta cuya currency matchea `parsedRow.currency`, con un `statement_imports` por sub-cuenta (idempotente por lado).
- **UI**: el preview del form muestra un banner "tarjeta multi-moneda detectada · N COP + M USD → 2 cuentas" cuando aplica, y oculta el input de "Balance al cierre" en ese caso (las TC movimientos no traen cierre).
- **Errores precisos**: `currency_mismatch`, `multi_currency_without_physical_card`, `missing_usd_sibling`, `missing_cop_sibling` → cada uno con su toast explicativo.

## Test plan

- [x] `bun run vitest run` — 83 files / 1063 tests. Nuevos:
  - `commit.test.ts` — 4 tests multi-currency (dispatch, idempotencia, missing target, sibling-same-currency).
  - `reconcile/actions.test.ts` — 7 tests end-to-end (single-currency legacy, rejects, preview + apply con plastic-linked siblings).
- [x] `bun run typecheck` + `bun run lint` verdes.
- [ ] Dogfood en prod: re-subir `~/findash-fixtures-private/MovimientosTusTarjetasBancolombia23Abr2026.xlsx` contra cuenta 6 — debería crear 2 statement_imports (#6 COP + #7 USD) con txs routed por fila sin duplicados.

## Non-goals

- No se tocó el parser (ya leía `Tipo de moneda` per-row correctamente).
- No migramos txs históricas mal-clasificadas (rollback manual ya aplicado en prod).

Closes #444