### PR TITLE
feat(ui): snapshot dual-debt COP+USD independiente en BalanceAdjustDialog (#447)

### DIFF
--- a/src/app/(app)/settings/accounts/accounts-manager.tsx
+++ b/src/app/(app)/settings/accounts/accounts-manager.tsx
@@ -520,6 +520,13 @@ export function AccountsManager({ items, copPerUsd }: { items: AccountRow[]; cop
           if (result.status === "ok") {
             toast.success("Saldo ajustado — transacción creada.");
             setAdjust({ open: false, target: null });
+          } else if (result.status === "ok_dual") {
+            // #447 — one toast with both diffs so the user sees the dual write
+            // as a single action.
+            toast.success(
+              `Saldo ajustado en ${result.results.length} sub-cuenta${result.results.length === 1 ? "" : "s"}.`,
+            );
+            setAdjust({ open: false, target: null });
           } else if (result.status === "noop") {
             toast.info("El saldo declarado coincide con el actual — no hubo cambio.");
             setAdjust({ open: false, target: null });

--- a/src/app/(app)/settings/accounts/actions.test.ts
+++ b/src/app/(app)/settings/accounts/actions.test.ts
@@ -909,4 +909,190 @@ describe("adjustAccountBalance", () => {
       }
     });
   });
+
+  // #447 — dual-debt snapshot: enter both currency debts independently so
+  // drift in one sub-account never propagates to the other (unlike
+  // sharedAvailableCop, which back-solves through sibling × TRM).
+  describe("kind: perCurrencyDualDebt (#447)", () => {
+    async function seedPair(params: {
+      limitCents: number;
+      copBalanceCents: number;
+      usdBalanceCents: number;
+    }): Promise<{ copId: number; usdId: number; pcId: string }> {
+      await upsertAccount({
+        name: `${ADJ_MARKER}-dual`,
+        institution: "Bancolombia",
+        type: "credit_card",
+        primary: { currency: "COP", balance: params.copBalanceCents / 100 },
+        secondary: { currency: "USD", balance: params.usdBalanceCents / 100 },
+        physicalCard: { creditLimitCents: params.limitCents, network: "mastercard" },
+      });
+      const rows = await db
+        .select()
+        .from(accounts)
+        .where(and(eq(accounts.userId, TEST_USER_ID), eq(accounts.name, `${ADJ_MARKER}-dual`)));
+      const cop = rows.find((r) => r.currency === "COP")!;
+      const usd = rows.find((r) => r.currency === "USD")!;
+      return { copId: cop.id, usdId: usd.id, pcId: cop.physicalCardId! };
+    }
+
+    async function stubFxRate(rate: number) {
+      await db.execute(sql`
+        INSERT INTO fx_rates (base, quote, rate_micros, as_of, source)
+        VALUES ('USD', 'COP', ${BigInt(Math.round(rate * 1_000_000))}, CURRENT_DATE, 'test')
+        ON CONFLICT (base, quote, as_of) DO UPDATE SET
+          rate_micros = EXCLUDED.rate_micros,
+          source = EXCLUDED.source,
+          fetched_at = NOW()
+      `);
+    }
+
+    afterEach(async () => {
+      await db.execute(sql`DELETE FROM fx_rates WHERE source = 'test'`);
+    });
+
+    it("snapshots both debts atomically — one balance_adjustment per sub-account", async () => {
+      // Current ledger: COP -500k, USD -100 USD. Bank says: debt_cop=4.031.198,
+      // debt_usd=$2.885,00 (the real MC 7291 screenshot). Expected diffs:
+      //   COP: new balance -403_119_800 - current -500_000_00 = -353_119_800
+      //   USD: new balance -288_500    - current -10_000     = -278_500
+      await stubFxRate(3568.88);
+      const { copId, usdId } = await seedPair({
+        limitCents: 17_000_000_00,
+        copBalanceCents: -500_000_00,
+        usdBalanceCents: -100_00,
+      });
+
+      const result = await adjustAccountBalance({
+        accountId: copId,
+        declared: {
+          kind: "perCurrencyDualDebt",
+          debtCopCents: 403_119_800,
+          debtUsdCents: 288_500,
+        },
+      });
+
+      expect(result.status).toBe("ok_dual");
+      if (result.status !== "ok_dual") throw new Error("expected ok_dual");
+      expect(result.results).toHaveLength(2);
+
+      // Ledger settles to the declared debts exactly — no TRM-dependent math
+      // leaked into either sub-account.
+      expect(await derivedBalance(copId)).toBe(BigInt(-403_119_800));
+      expect(await derivedBalance(usdId)).toBe(BigInt(-288_500));
+
+      // Two balance_adjustment rows present — one per sub-account.
+      const plugs = await db
+        .select()
+        .from(transactions)
+        .where(
+          and(eq(transactions.userId, TEST_USER_ID), eq(transactions.source, "balance_adjustment")),
+        );
+      const byAccount = new Map(plugs.map((p) => [p.accountId, p]));
+      expect(byAccount.get(copId)?.amountCents).toBe(BigInt(-353_119_800));
+      expect(byAccount.get(copId)?.currency).toBe("COP");
+      expect(byAccount.get(usdId)?.amountCents).toBe(BigInt(-278_500));
+      expect(byAccount.get(usdId)?.currency).toBe("USD");
+      // Both flagged as adjustments so they stay out of spend/insights.
+      expect(plugs.every((p) => p.isAdjustment === true)).toBe(true);
+      expect(plugs.every((p) => p.categorySlug === "adjustments")).toBe(true);
+    });
+
+    it("returns noop when both declared debts match current balances exactly", async () => {
+      await stubFxRate(3568.88);
+      const { copId } = await seedPair({
+        limitCents: 17_000_000_00,
+        copBalanceCents: -403_119_800,
+        usdBalanceCents: -288_500,
+      });
+
+      const result = await adjustAccountBalance({
+        accountId: copId,
+        declared: {
+          kind: "perCurrencyDualDebt",
+          debtCopCents: 403_119_800,
+          debtUsdCents: 288_500,
+        },
+      });
+
+      expect(result.status).toBe("noop");
+    });
+
+    it("only inserts a plug for the side that actually changed", async () => {
+      await stubFxRate(3568.88);
+      const { copId, usdId } = await seedPair({
+        limitCents: 17_000_000_00,
+        copBalanceCents: -400_000_00,
+        usdBalanceCents: -288_500, // already matches
+      });
+
+      const result = await adjustAccountBalance({
+        accountId: copId,
+        declared: {
+          kind: "perCurrencyDualDebt",
+          debtCopCents: 403_119_800,
+          debtUsdCents: 288_500,
+        },
+      });
+
+      expect(result.status).toBe("ok_dual");
+      if (result.status !== "ok_dual") throw new Error("expected ok_dual");
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].accountId).toBe(copId);
+      expect(result.results[0].currency).toBe("COP");
+      expect(await derivedBalance(usdId)).toBe(BigInt(-288_500));
+    });
+
+    it("rejects when the combined debt (COP + USD×TRM) exceeds the plastic limit", async () => {
+      await stubFxRate(4000);
+      const { copId } = await seedPair({
+        limitCents: 10_000_000_00,
+        copBalanceCents: 0,
+        usdBalanceCents: 0,
+      });
+
+      // 9MM COP + 500 USD × 4000 = 9MM + 2MM = 11MM > 10MM limit.
+      const result = await adjustAccountBalance({
+        accountId: copId,
+        declared: {
+          kind: "perCurrencyDualDebt",
+          debtCopCents: 9_000_000_00,
+          debtUsdCents: 500_00,
+        },
+      });
+
+      expect(result.status).toBe("error");
+      if (result.status === "error") {
+        expect(result.message).toMatch(/cupo total/i);
+      }
+    });
+
+    it("rejects on a single-currency TC (no physicalCardId)", async () => {
+      const [cc] = await db
+        .insert(accounts)
+        .values({
+          userId: TEST_USER_ID,
+          name: `${ADJ_MARKER}-solo`,
+          institution: "Bancolombia",
+          type: "credit_card",
+          currency: "COP",
+          metadata: { creditLimitCents: 5_000_000 },
+        })
+        .returning({ id: accounts.id });
+
+      const result = await adjustAccountBalance({
+        accountId: cc.id,
+        declared: {
+          kind: "perCurrencyDualDebt",
+          debtCopCents: 100_000,
+          debtUsdCents: 10_000,
+        },
+      });
+
+      expect(result.status).toBe("error");
+      if (result.status === "error") {
+        expect(result.message).toMatch(/multi-moneda/i);
+      }
+    });
+  });
 });

--- a/src/app/(app)/settings/accounts/actions.ts
+++ b/src/app/(app)/settings/accounts/actions.ts
@@ -402,6 +402,18 @@ const declaredSchema = z.discriminatedUnion("kind", [
     // la deuda del target a partir del sibling + TRM (#346 AS-4/AS-5).
     availableCopCents: z.coerce.number().int().nonnegative(),
   }),
+  // #447 — dual-debt snapshot for shared-cupo multi-currency TCs. User enters
+  // BOTH currency debts separately (the two numbers the bank app displays) and
+  // the server applies one balance_adjustment per sub-account atomically. No
+  // back-solve, no TRM, no dependency on the sibling's ledger state — so drift
+  // in one side never propagates to the other.
+  z.object({
+    kind: z.literal("perCurrencyDualDebt"),
+    // Positive cents in native currency — e.g. 403_119_800 for "COP $4.031.198,00"
+    // and 288_500 for "USD $2.885,00" as shown in the Bancolombia app.
+    debtCopCents: z.coerce.number().int().nonnegative(),
+    debtUsdCents: z.coerce.number().int().nonnegative(),
+  }),
 ]);
 
 const adjustSchema = z.object({
@@ -414,6 +426,17 @@ export type AdjustBalanceInput = z.input<typeof adjustSchema>;
 
 export type AdjustBalanceResult =
   | { status: "ok"; diffCents: string; txId: number }
+  // #447 — dual-debt commit returns one entry per sub-account (ordered
+  // primary-then-sibling) so the UI can surface both diffs in a single toast.
+  | {
+      status: "ok_dual";
+      results: Array<{
+        accountId: number;
+        currency: "COP" | "USD";
+        diffCents: string;
+        txId: number;
+      }>;
+    }
   | { status: "noop" }
   | { status: "error"; message: string };
 
@@ -471,6 +494,157 @@ export async function adjustAccountBalance(
       return { status: "error", message: "Cuenta no encontrada." };
     }
     const account = { ...accountRow, balanceCents: BigInt(accountRow.balanceCents) };
+
+    // #447 — dual-debt is the only kind that applies changes to BOTH
+    // sub-accounts of a shared-cupo plastic atomically, so it branches OUT of
+    // the single-target flow below and returns directly.
+    if (parsed.data.declared.kind === "perCurrencyDualDebt") {
+      if (account.type !== "credit_card" || !account.physicalCardId) {
+        return {
+          status: "error",
+          message: "Las deudas por moneda solo aplican a tarjetas multi-moneda.",
+        };
+      }
+      const [pc] = await tx
+        .select({
+          id: physicalCards.id,
+          creditLimitCents: physicalCards.creditLimitCents,
+        })
+        .from(physicalCards)
+        .where(
+          and(eq(physicalCards.id, account.physicalCardId), eq(physicalCards.userId, session.id)),
+        );
+      if (!pc || pc.creditLimitCents <= BigInt(0)) {
+        return {
+          status: "error",
+          message:
+            "El plástico no tiene cupo configurado. Editá la tarjeta física y cargá el cupo primero.",
+        };
+      }
+      // Load BOTH sibling sub-accounts (including the target itself — simpler
+      // than conditional branching on which one the user opened the dialog
+      // from). Validate we have exactly one COP + one USD, otherwise reject.
+      const plasticRows = await tx
+        .select({
+          id: accounts.id,
+          currency: accounts.currency,
+          balanceCents: derivedBalanceCentsSql,
+          metadata: accounts.metadata,
+        })
+        .from(accounts)
+        .where(
+          and(
+            eq(accounts.userId, session.id),
+            eq(accounts.physicalCardId, account.physicalCardId),
+            notDeleted(accounts.deletedAt),
+          ),
+        );
+      const copRow = plasticRows.find((r) => r.currency === "COP");
+      const usdRow = plasticRows.find((r) => r.currency === "USD");
+      if (!copRow || !usdRow || plasticRows.length !== 2) {
+        return {
+          status: "error",
+          message:
+            "El plástico necesita exactamente una sub-cuenta COP y una USD para usar este flujo.",
+        };
+      }
+
+      const debtCopCents = BigInt(parsed.data.declared.debtCopCents);
+      const debtUsdCents = BigInt(parsed.data.declared.debtUsdCents);
+      // Sanity check: combined debt in COP must not exceed the plastic's
+      // credit limit. Uses the CURRENT TRM only for the sum check — the
+      // individual sub-account targets are stored in native currency so
+      // TRM drift never taints them post-commit.
+      const fx = await getCurrentFxRate();
+      const debtUsdInCop = convertCents(debtUsdCents, "USD", "COP", fx.rate);
+      if (debtCopCents + debtUsdInCop > pc.creditLimitCents) {
+        return {
+          status: "error",
+          message:
+            "La suma de deudas (COP + USD × TRM) supera el cupo total del plástico. Revisá los números.",
+        };
+      }
+
+      // Ensure adjustments category once (self-heal same as single-target path).
+      await tx
+        .insert(categories)
+        .values({
+          userId: session.id,
+          slug: ADJUSTMENT_CATEGORY_SLUG,
+          name: "Ajustes de saldo",
+          icon: "wrench",
+          color: "#475569",
+          sortOrder: 1000,
+        })
+        .onConflictDoNothing({ target: [categories.userId, categories.slug] });
+      await tx
+        .update(categories)
+        .set({ deletedAt: null, updatedAt: new Date() })
+        .where(
+          and(eq(categories.userId, session.id), eq(categories.slug, ADJUSTMENT_CATEGORY_SLUG)),
+        );
+
+      const today = new Date();
+      const ymd = today.toISOString().slice(0, 10);
+      const results: Array<{
+        accountId: number;
+        currency: "COP" | "USD";
+        diffCents: string;
+        txId: number;
+      }> = [];
+
+      for (const sub of [copRow, usdRow] as const) {
+        const currentBalance = BigInt(sub.balanceCents);
+        const targetBalance = sub.currency === "COP" ? -debtCopCents : -debtUsdCents;
+        const diff = targetBalance - currentBalance;
+        if (diff === BigInt(0)) continue;
+        const [inserted] = await tx
+          .insert(transactions)
+          .values({
+            userId: session.id,
+            accountId: sub.id,
+            occurredAt: today,
+            amountCents: diff,
+            currency: sub.currency,
+            descriptionRaw: `Ajuste de saldo (deuda declarada ${ymd})`,
+            categorySlug: ADJUSTMENT_CATEGORY_SLUG,
+            classificationMethod: "manual",
+            source: "balance_adjustment",
+            channel: "manual",
+            isAdjustment: true,
+            rawData: {
+              reason: parsed.data.reason ?? null,
+              declared: parsed.data.declared,
+              declaredBalanceCents: targetBalance.toString(),
+              previousBalanceCents: currentBalance.toString(),
+            },
+          })
+          .returning({ id: transactions.id });
+        results.push({
+          accountId: sub.id,
+          currency: sub.currency,
+          diffCents: diff.toString(),
+          txId: inserted.id,
+        });
+        // Strip stale `availableCreditCents` snapshot if present on this
+        // sub-account's metadata (same convergence pattern as other kinds).
+        if (sub.metadata?.availableCreditCents !== undefined) {
+          const { availableCreditCents: _drop, ...rest } = sub.metadata;
+          void _drop;
+          await tx
+            .update(accounts)
+            .set({ metadata: rest, updatedAt: today })
+            .where(eq(accounts.id, sub.id));
+        }
+      }
+
+      if (results.length === 0) {
+        revalidate();
+        return { status: "noop" };
+      }
+      revalidate();
+      return { status: "ok_dual", results };
+    }
 
     let targetBalanceCents: bigint;
     let nextMetadata: AccountMetadata = account.metadata;

--- a/src/app/(app)/settings/accounts/balance-adjust-dialog.tsx
+++ b/src/app/(app)/settings/accounts/balance-adjust-dialog.tsx
@@ -65,7 +65,7 @@ export function BalanceAdjustDialog({
           </DialogTitle>
         </DialogHeader>
         {target.type === "credit_card" && target.physicalCard ? (
-          <SharedCupoForm
+          <SharedCupoWrapper
             target={target}
             siblings={siblings}
             physicalCard={target.physicalCard}
@@ -316,6 +316,283 @@ function CreditCardFormInner({
               <Money cents={diffCents} currency={target.currency} />
             </span>{" "}
             marcada como <strong>Ajuste</strong>. Queda fuera de spend / insights / budgets.
+          </div>
+        </div>
+      ) : null}
+
+      <ReasonField reason={reason} setReason={setReason} />
+      <Actions pending={pending} canSubmit={canSubmit} onClose={onClose} />
+    </form>
+  );
+}
+
+// #447 — picker that lets the user choose between entering the two per-currency
+// debts (the numbers the bank app shows by default) or the shared cupo disponible
+// (legacy back-solve, kept as an "advanced" option for when only the real-time
+// cupo is available).
+type SharedCupoMode = "dualDebt" | "cupoDisponible";
+
+function parseNonNegativeCents(raw: string): bigint | null {
+  if (raw.trim() === "") return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return BigInt(Math.round(n * 100));
+}
+
+function SharedCupoWrapper({
+  target,
+  siblings,
+  physicalCard,
+  copPerUsd,
+  onConfirm,
+  onClose,
+}: {
+  target: AccountRow;
+  siblings: AccountRow[];
+  physicalCard: AccountRowPhysicalCard;
+  copPerUsd: number;
+  onConfirm: (declared: DeclaredValue, reason?: string) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [mode, setMode] = useState<SharedCupoMode>("dualDebt");
+  // Dual-debt mode only makes sense when we actually have ONE COP sub-account
+  // and ONE USD sub-account. Anything else (future plastic with 3 currencies,
+  // or a broken link) falls back to the cupo-disponible form.
+  const canDualDebt = (() => {
+    const all = [target, ...siblings];
+    const cop = all.filter((a) => a.currency === "COP");
+    const usd = all.filter((a) => a.currency === "USD");
+    return all.length === 2 && cop.length === 1 && usd.length === 1;
+  })();
+  const effectiveMode: SharedCupoMode = canDualDebt ? mode : "cupoDisponible";
+  return (
+    <div className="flex flex-col gap-3">
+      {canDualDebt ? (
+        <div className="flex flex-wrap gap-2 text-xs">
+          <Button
+            type="button"
+            size="sm"
+            variant={effectiveMode === "dualDebt" ? "default" : "outline"}
+            onClick={() => setMode("dualDebt")}
+          >
+            Deuda COP + USD
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant={effectiveMode === "cupoDisponible" ? "default" : "outline"}
+            onClick={() => setMode("cupoDisponible")}
+          >
+            Cupo disponible (avanzado)
+          </Button>
+        </div>
+      ) : null}
+      {effectiveMode === "dualDebt" ? (
+        <DualDebtForm
+          target={target}
+          siblings={siblings}
+          physicalCard={physicalCard}
+          copPerUsd={copPerUsd}
+          onConfirm={onConfirm}
+          onClose={onClose}
+        />
+      ) : (
+        <SharedCupoForm
+          target={target}
+          siblings={siblings}
+          physicalCard={physicalCard}
+          copPerUsd={copPerUsd}
+          onConfirm={onConfirm}
+          onClose={onClose}
+        />
+      )}
+    </div>
+  );
+}
+
+// #447 — enter the two per-currency debts the bank app displays (e.g. "Deuda a
+// la fecha en pesos $4.031.198,00" + "Deuda a la fecha en dólares $2.885,00").
+// Each input back-solves to its OWN sub-account's target balance independently
+// — no sibling cross-talk, no TRM at the individual level. The only TRM use
+// is the sanity check (sum ≤ limit), and that lives server-side.
+function DualDebtForm({
+  target,
+  siblings,
+  physicalCard,
+  copPerUsd,
+  onConfirm,
+  onClose,
+}: {
+  target: AccountRow;
+  siblings: AccountRow[];
+  physicalCard: AccountRowPhysicalCard;
+  copPerUsd: number;
+  onConfirm: (declared: DeclaredValue, reason?: string) => Promise<void>;
+  onClose: () => void;
+}) {
+  // ALL hook calls happen first — the early return below lives after them to
+  // keep react-hooks/rules-of-hooks happy.
+  const [debtCopInput, setDebtCopInput] = useState("");
+  const [debtUsdInput, setDebtUsdInput] = useState("");
+  const [reason, setReason] = useState("");
+  const [pending, startTransition] = useTransition();
+
+  const all = [target, ...siblings];
+  const copRow = all.find((a) => a.currency === "COP");
+  const usdRow = all.find((a) => a.currency === "USD");
+  const declaredDebtCop = useMemo(() => parseNonNegativeCents(debtCopInput), [debtCopInput]);
+  const declaredDebtUsd = useMemo(() => parseNonNegativeCents(debtUsdInput), [debtUsdInput]);
+
+  if (!copRow || !usdRow) {
+    // Defensive: should be unreachable because SharedCupoWrapper only renders
+    // DualDebtForm when canDualDebt is true. Render a non-destructive fallback.
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="border-border/60 bg-muted/40 rounded-md border p-3 text-sm">
+          Este plástico no tiene una sub-cuenta COP + USD. Usá el flujo &ldquo;Cupo
+          disponible&rdquo;.
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" type="button" onClick={onClose}>
+            Cerrar
+          </Button>
+        </DialogFooter>
+      </div>
+    );
+  }
+
+  const limitCop = BigInt(physicalCard.creditLimitCents);
+  const currentDebtCopCents = (() => {
+    const b = BigInt(copRow.balanceCents);
+    return b < BigInt(0) ? -b : BigInt(0);
+  })();
+  const currentDebtUsdCents = (() => {
+    const b = BigInt(usdRow.balanceCents);
+    return b < BigInt(0) ? -b : BigInt(0);
+  })();
+
+  const hasCop = declaredDebtCop !== null;
+  const hasUsd = declaredDebtUsd !== null;
+
+  // Sanity sum ≤ limit at current TRM (matches the server-side validation).
+  const combinedDebtCop =
+    hasCop && hasUsd
+      ? declaredDebtCop! + convertCents(declaredDebtUsd!, "USD", "COP", copPerUsd)
+      : null;
+  const exceedsLimit = combinedDebtCop !== null && combinedDebtCop > limitCop;
+
+  // Per-account diffs the server would emit — ledger-signed (negative for debt).
+  const copDiffCents = hasCop ? -declaredDebtCop! - BigInt(copRow.balanceCents) : null;
+  const usdDiffCents = hasUsd ? -declaredDebtUsd! - BigInt(usdRow.balanceCents) : null;
+  const hasChange =
+    (copDiffCents !== null && copDiffCents !== BigInt(0)) ||
+    (usdDiffCents !== null && usdDiffCents !== BigInt(0));
+  const canSubmit = hasCop && hasUsd && !exceedsLimit && hasChange;
+
+  function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!hasCop || !hasUsd || exceedsLimit) return;
+    startTransition(async () => {
+      await onConfirm(
+        {
+          kind: "perCurrencyDualDebt",
+          debtCopCents: Number(declaredDebtCop),
+          debtUsdCents: Number(declaredDebtUsd),
+        },
+        reason.trim() || undefined,
+      );
+    });
+  }
+
+  const currentAvailableCop =
+    limitCop - currentDebtCopCents - convertCents(currentDebtUsdCents, "USD", "COP", copPerUsd);
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <div className="border-border/60 bg-muted/30 rounded-md border p-3 text-xs">
+        <div className="text-muted-foreground">
+          Pegá las <strong>dos deudas</strong> que te muestra Bancolombia &mdash; son los números de
+          &ldquo;Deuda a la fecha en pesos&rdquo; y &ldquo;Deuda a la fecha en dólares&rdquo;.
+          Ajustamos cada sub-cuenta por separado, sin depender del cupo ni de la TRM para cada lado.
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-muted-foreground text-xs tracking-wide uppercase">
+            Cupo total
+          </Label>
+          <div className="bg-muted/40 rounded-md border px-3 py-2 text-sm font-medium tabular-nums">
+            <Money cents={limitCop} currency="COP" />
+          </div>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-muted-foreground text-xs tracking-wide uppercase">
+            Disponible en Findash
+          </Label>
+          <div className="bg-muted/40 rounded-md border px-3 py-2 text-sm font-medium tabular-nums">
+            <Money cents={currentAvailableCop} currency="COP" />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="dual-debt-cop">Deuda a la fecha en pesos (COP)</Label>
+        <Input
+          id="dual-debt-cop"
+          type="number"
+          inputMode="decimal"
+          step="1"
+          min="0"
+          value={debtCopInput}
+          onChange={(e) => setDebtCopInput(e.target.value)}
+          placeholder={(Number(currentDebtCopCents) / 100).toFixed(0)}
+          required
+          autoFocus
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="dual-debt-usd">Deuda a la fecha en dólares (USD)</Label>
+        <Input
+          id="dual-debt-usd"
+          type="number"
+          inputMode="decimal"
+          step="0.01"
+          min="0"
+          value={debtUsdInput}
+          onChange={(e) => setDebtUsdInput(e.target.value)}
+          placeholder={(Number(currentDebtUsdCents) / 100).toFixed(2)}
+          required
+        />
+      </div>
+
+      {exceedsLimit ? (
+        <p className="text-destructive text-xs">
+          La suma de deudas (COP + USD × {Math.round(copPerUsd).toLocaleString("es-CO")} COP/USD)
+          supera el cupo total. Revisá los números.
+        </p>
+      ) : null}
+
+      {hasChange && copDiffCents !== null && usdDiffCents !== null && !exceedsLimit ? (
+        <div className="border-border/60 rounded-md border p-3 text-sm">
+          <div>
+            Cuenta COP (#{copRow.id}):{" "}
+            <span className="font-semibold tabular-nums">
+              {copDiffCents > BigInt(0) ? "+" : ""}
+              <Money cents={copDiffCents} currency="COP" />
+            </span>
+          </div>
+          <div className="mt-1">
+            Cuenta USD (#{usdRow.id}):{" "}
+            <span className="font-semibold tabular-nums">
+              {usdDiffCents > BigInt(0) ? "+" : ""}
+              <Money cents={usdDiffCents} currency="USD" />
+            </span>
+          </div>
+          <div className="text-muted-foreground mt-2 text-xs">
+            Dos ajustes (marcados como <strong>Ajuste</strong>) creados en una sola transacción
+            atómica — quedan fuera de spend/insights/budgets.
           </div>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary

- Nuevo `kind: "perCurrencyDualDebt"` en `adjustAccountBalance` — recibe `{debtCopCents, debtUsdCents}` y aplica **2 balance_adjustment atómicos** (uno por sub-cuenta) en una sola tx. Sin back-solve, sin dependencia del sibling, sin TRM para cada lado individualmente (solo sanity check del cupo total).
- `BalanceAdjustDialog` ahora usa un wrapper con selector: **"Deuda COP + USD"** (default) vs **"Cupo disponible (avanzado)"**. El primero pide los 2 números que te muestra Bancolombia; el segundo preserva el `SharedCupoForm` existente.
- Solución al bug de dogfood 2026-04-24: ledger USD overstated arrastraba el error al COP vía back-solve. El nuevo flujo es drift-resistant per-side.

## Test plan

- [x] `bun run vitest run` — 84 files / 1086 tests (5 nuevos en `actions.test.ts` para `perCurrencyDualDebt`).
- [x] `bun run typecheck` + `bun run lint` verdes.
- [ ] Dogfood prod: cuadrar MC 7291 contra screenshot (COP 4.031.198 + USD 2.885). Esperado: 2 plugs insertados, ledger queda en esos dos números exactos sin depender del sibling.

## Non-goals

- No auto-archivar plugs viejos (opción C, separate issue si se necesita).
- No tocar el flow single-currency (`kind: "availableCredit"`) ni `kind: "balance"`.

Closes #447