### PR TITLE
fix(integrations): add userinfo.email to Gmail OAuth scopes (#462)

### DIFF
--- a/src/lib/gmail/client.test.ts
+++ b/src/lib/gmail/client.test.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { gmailConnections, users } from "@/lib/db/schema";
 import { gmailCipher } from "@/lib/crypto/gmail-cipher";
 import {
+  GMAIL_SCOPES,
   GmailConnectionUnusableError,
   GmailNotConnectedError,
   getAuthedClient,
@@ -84,6 +85,21 @@ describe("gmail/client", () => {
     if (ORIGINAL_GMAIL_KEY === undefined) delete process.env.GMAIL_TOKEN_ENCRYPTION_KEY;
     else process.env.GMAIL_TOKEN_ENCRYPTION_KEY = ORIGINAL_GMAIL_KEY;
     // Do NOT call db.$client.end() — see gmail-isolation.test.ts for why.
+  });
+
+  // -------------------------------------------------------------------------
+  // Scope set — sentinel for #462
+  // -------------------------------------------------------------------------
+
+  it("GMAIL_SCOPES includes userinfo.email so the callback's userinfo.get() works", () => {
+    // Without this scope the access token returned post-consent has only
+    // gmail.readonly, and google.oauth2(...).userinfo.get() returns 401
+    // UNAUTHENTICATED. The first connect-after-NextAuth-login may seem to
+    // work via include_granted_scopes inheriting the email grant, but a
+    // disconnect+reconnect cycle exposes the gap (revokeToken wipes all
+    // grants at Google).
+    expect(GMAIL_SCOPES).toContain("https://www.googleapis.com/auth/userinfo.email");
+    expect(GMAIL_SCOPES).toContain("https://www.googleapis.com/auth/gmail.readonly");
   });
 
   // -------------------------------------------------------------------------

--- a/src/lib/gmail/client.ts
+++ b/src/lib/gmail/client.ts
@@ -9,10 +9,19 @@ import { createLogger } from "@/lib/logger";
 
 const log = createLogger({ module: "gmail/client" });
 
-// Single scope for the MVP. Listed as readonly array so callers can pass it
-// directly to oauth.generateAuthUrl({ scope: GMAIL_SCOPES }) without
+// Scopes requested at consent time. Listed as readonly array so callers can
+// pass it directly to oauth.generateAuthUrl({ scope: GMAIL_SCOPES }) without
 // readonly→mutable coercion.
-export const GMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"] as const;
+//
+// `userinfo.email` is REQUIRED for the callback's google.oauth2(...).userinfo.get()
+// call to succeed. Without it the access token returns 401 UNAUTHENTICATED.
+// Discovered via #462 — first connect happened to work via include_granted_scopes
+// inheriting NextAuth's `email` grant, but post-disconnect (which calls
+// oauth.revokeToken and wipes ALL grants) the reconnect failed.
+export const GMAIL_SCOPES = [
+  "https://www.googleapis.com/auth/gmail.readonly",
+  "https://www.googleapis.com/auth/userinfo.email",
+] as const;
 
 // Connection rows are loaded from gmail_connections; one of these errors is
 // thrown for every reason the connection cannot serve a request. Callers


### PR DESCRIPTION
## Summary

Closes #462. The Gmail OAuth callback was failing with \`401 UNAUTHENTICATED\` after a disconnect+reconnect cycle. Root cause: \`GMAIL_SCOPES\` only requested \`gmail.readonly\` but the callback's \`google.oauth2(...).userinfo.get()\` needs \`userinfo.email\`. The first connect happened to inherit it from a previous NextAuth login via \`include_granted_scopes: true\` — \`oauth.revokeToken\` on disconnect wiped that grant, exposing the gap.

## Diff

\`\`\`diff
- export const GMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"] as const;
+ export const GMAIL_SCOPES = [
+   "https://www.googleapis.com/auth/gmail.readonly",
+   "https://www.googleapis.com/auth/userinfo.email",
+ ] as const;
\`\`\`

Plus a sentinel test in \`client.test.ts\` that asserts \`GMAIL_SCOPES\` contains both entries — so a future "let's clean up the scopes" refactor can't silently regress this.

## Test plan

Automated:
- \`bun run test src/lib/gmail/\` → 22/22 (was 21, +1 sentinel)
- \`bun run lint && bun run format:check && bun run typecheck\` all clean

Manual (after merge + deploy):
- [ ] /settings/integrations → Conectar Gmail → consent → success row in DB
- [ ] Desconectar → \`deleted_at\` set
- [ ] **Conectar AGAIN** → success again (this was the broken case)
- [ ] Verify in DB: same row id (#1) gets reactivated via the \`onConflictDoUpdate\` path, not a new row id

## Why not the alternatives

- **Decode \`id_token\` instead of calling userinfo** — needs \`openid\` scope + JWT parse. More code surface for a one-time-per-connection field.
- **Drop \`oauth.revokeToken\` from disconnect** — leaves the grant alive at Google after Desconectar. Bad UX (manual cleanup at \`myaccount.google.com/permissions\`) and a real security smell.