### PR TITLE
feat(ingestion): Gmail pull engine + cron + /enriquecer bot command (#452)

### DIFF
--- a/src/app/api/cron/gmail-pull/route.ts
+++ b/src/app/api/cron/gmail-pull/route.ts
@@ -1,0 +1,61 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import { pullAllActiveConnections } from "@/lib/gmail/pull";
+import { createLogger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Same handler shape as canary-check: CRON_TOKEN bearer, no session. Useful
+// for manual invocation from ops, for health probes, and for a future
+// external scheduler (e.g. DO scheduled function) if we ever move off
+// in-process node-cron.
+
+const log = createLogger({ module: "api/cron/gmail-pull" });
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+function resolveToken(req: Request): string | null {
+  const header = req.headers.get("authorization");
+  if (!header?.startsWith("Bearer ")) return null;
+  return header.slice(7).trim() || null;
+}
+
+export async function POST(req: Request) {
+  const expected = process.env.CRON_TOKEN;
+  if (!expected) {
+    return NextResponse.json({ error: "CRON_TOKEN not configured" }, { status: 500 });
+  }
+  const provided = resolveToken(req);
+  if (!provided || !constantTimeEquals(provided, expected)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const results = await pullAllActiveConnections();
+  const totalPulled = results.reduce((acc, r) => acc + r.pulled, 0);
+  const totalSkipped = results.reduce((acc, r) => acc + r.skipped, 0);
+  const withErrors = results.filter((r) => r.errors.length > 0).length;
+  log.info(
+    {
+      users: results.length,
+      pulled: totalPulled,
+      skipped: totalSkipped,
+      withErrors,
+      event: "gmail_pull_http_tick",
+    },
+    "gmail pull via HTTP cron",
+  );
+
+  return NextResponse.json({
+    ok: true,
+    users: results.length,
+    pulled: totalPulled,
+    skipped: totalSkipped,
+    errorUsers: withErrors,
+  });
+}

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -30,6 +30,7 @@ export async function registerNode() {
   const { checkAndAlertSlos } = await import("@/lib/observability/slo-alerts");
   const { fetchTrm } = await import("@/lib/fx/trm");
   const { getCurrentFxRate, upsertFxRate } = await import("@/lib/fx/repo");
+  const { pullAllActiveConnections } = await import("@/lib/gmail/pull");
   const { createLogger } = await import("@/lib/logger");
   const log = createLogger({ module: "instrumentation" });
 
@@ -145,9 +146,40 @@ export async function registerNode() {
     timezone: "America/Bogota",
   });
 
+  // Hourly Gmail enrichment pull (#452, Epic G). Each tick fans out over
+  // every active gmail_connections row and pulls new gateway receipts +
+  // Bancolombia emails into email_receipts. Per-user failures are logged
+  // but do NOT break the loop — one user's revoked token cannot block the
+  // others. Manual backfills go through /enriquecer (bot) or
+  // POST /api/cron/gmail-pull.
+  cron.schedule(
+    "0 * * * *",
+    async () => {
+      try {
+        const results = await pullAllActiveConnections();
+        const totalPulled = results.reduce((acc, r) => acc + r.pulled, 0);
+        const totalSkipped = results.reduce((acc, r) => acc + r.skipped, 0);
+        const withErrors = results.filter((r) => r.errors.length > 0).length;
+        log.info(
+          {
+            users: results.length,
+            pulled: totalPulled,
+            skipped: totalSkipped,
+            withErrors,
+            event: "gmail_pull_cron_tick",
+          },
+          "gmail pull cron tick",
+        );
+      } catch (err) {
+        log.error({ err, event: "gmail_pull_fanout_failed" }, "gmail pull fan-out failed");
+      }
+    },
+    { timezone: "America/Bogota" },
+  );
+
   log.info(
     { event: "crons_registered" },
-    "crons registered: recurring-gap (0 6 5 * *), user-health (0 3 * * *), slo-alerts (*/30 * * * *), fx-refresh (15 6,18 * * *) America/Bogota",
+    "crons registered: recurring-gap (0 6 5 * *), user-health (0 3 * * *), slo-alerts (*/30 * * * *), fx-refresh (15 6,18 * * *), gmail-pull (0 * * * *) America/Bogota",
   );
 
   // Backfill on boot when the repo is empty or last known rate came from the

--- a/src/lib/gmail/pull.test.ts
+++ b/src/lib/gmail/pull.test.ts
@@ -1,0 +1,453 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { emailReceipts, gmailConnections, users } from "@/lib/db/schema";
+import { gmailCipher } from "@/lib/crypto/gmail-cipher";
+import type { AuthedGmailClient } from "./client";
+import { GmailConnectionUnusableError, GmailNotConnectedError } from "./client";
+import { pullForUser } from "./pull";
+
+const TAG = "GMAIL_PULL_TEST";
+
+let userA: number;
+let userB: number;
+
+const ORIGINAL_GMAIL_KEY = process.env.GMAIL_TOKEN_ENCRYPTION_KEY;
+
+async function cleanup(): Promise<void> {
+  await db.delete(users).where(sql`email LIKE ${TAG + "%"}`);
+}
+
+async function createUser(suffix: string): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `${TAG}-${suffix}@test.local`, name: `${TAG}-${suffix}` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function seedActiveConnection(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(gmailConnections)
+    .values({
+      userId,
+      gmailEmail: `${TAG}-${userId}@example.com`,
+      accessTokenEnc: gmailCipher.encrypt("dummy-access-token"),
+      refreshTokenEnc: gmailCipher.encrypt("dummy-refresh-token"),
+      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  return row.id;
+}
+
+// Build a fake message payload with a single text/html part. Body is
+// base64url-encoded per the Gmail API contract.
+function fakeMessage(id: string, html: string): { data: { payload: unknown; id: string } } {
+  const encoded = Buffer.from(html, "utf8").toString("base64url");
+  return {
+    data: {
+      id,
+      payload: {
+        mimeType: "text/html",
+        body: { data: encoded },
+      },
+    },
+  };
+}
+
+interface ListCall {
+  q: string | undefined;
+  pageToken: string | undefined;
+}
+
+interface GetCall {
+  id: string;
+}
+
+// Minimal Gmail API surface matching what pullForUser uses. Keeps the
+// tests self-contained and deterministic — no mocking library, no real
+// googleapis HTTP client.
+function fakeAuthed(opts: {
+  userId: number;
+  connectionId: number;
+  gmailEmail: string;
+  onList: (call: ListCall) => { messageIds: string[]; nextPageToken?: string };
+  onGet?: (call: GetCall) => ReturnType<typeof fakeMessage> | Promise<unknown>;
+}): {
+  authed: AuthedGmailClient;
+  listCalls: ListCall[];
+  getCalls: GetCall[];
+} {
+  const listCalls: ListCall[] = [];
+  const getCalls: GetCall[] = [];
+  const onGet =
+    opts.onGet ??
+    ((call: GetCall) => fakeMessage(call.id, `<html><body>body for ${call.id}</body></html>`));
+  const authed = {
+    oauth: {} as unknown,
+    gmail: {
+      users: {
+        messages: {
+          async list(params: { q?: string; pageToken?: string }) {
+            listCalls.push({ q: params.q, pageToken: params.pageToken });
+            const { messageIds, nextPageToken } = opts.onList({
+              q: params.q,
+              pageToken: params.pageToken,
+            });
+            return {
+              data: {
+                messages: messageIds.map((id) => ({ id, threadId: id })),
+                nextPageToken,
+              },
+            };
+          },
+          async get(params: { id: string }) {
+            getCalls.push({ id: params.id });
+            return await onGet({ id: params.id });
+          },
+        },
+      },
+    },
+    connection: { id: opts.connectionId, gmailEmail: opts.gmailEmail, accessTokenStale: false },
+  } as unknown as AuthedGmailClient;
+  return { authed, listCalls, getCalls };
+}
+
+describe("gmail/pull", () => {
+  beforeAll(async () => {
+    process.env.GMAIL_TOKEN_ENCRYPTION_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    await cleanup();
+    userA = await createUser("A");
+    userB = await createUser("B");
+  });
+
+  beforeEach(async () => {
+    await db.delete(emailReceipts).where(sql`user_id IN (${userA}, ${userB})`);
+    await db.delete(gmailConnections).where(sql`user_id IN (${userA}, ${userB})`);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    if (ORIGINAL_GMAIL_KEY === undefined) delete process.env.GMAIL_TOKEN_ENCRYPTION_KEY;
+    else process.env.GMAIL_TOKEN_ENCRYPTION_KEY = ORIGINAL_GMAIL_KEY;
+    // See gmail-isolation.test.ts — only that file may call db.$client.end().
+  });
+
+  // -------------------------------------------------------------------------
+  // Not-connected + unusable connection paths (acceptance criterion: graceful
+  // return, not throw; caller surfaces a reconnect nudge).
+  // -------------------------------------------------------------------------
+
+  it("returns empty result with connectionId null when user has no connection", async () => {
+    const getClient = async () => {
+      throw new GmailNotConnectedError(userA);
+    };
+    const result = await pullForUser(userA, {}, { getClient });
+    expect(result.connectionId).toBeNull();
+    expect(result.pulled).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("returns an 'auth' error when connection is marked expired", async () => {
+    const getClient = async () => {
+      throw new GmailConnectionUnusableError("expired", "refresh token expired");
+    };
+    const result = await pullForUser(userA, {}, { getClient });
+    expect(result.connectionId).toBeNull();
+    expect(result.pulled).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].phase).toBe("auth");
+    expect(result.errors[0].code).toBe("expired");
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path + idempotency
+  // -------------------------------------------------------------------------
+
+  it("inserts new email_receipts rows scoped to userId; watermark advances on success", async () => {
+    const connId = await seedActiveConnection(userA);
+    const { authed, listCalls, getCalls } = fakeAuthed({
+      userId: userA,
+      connectionId: connId,
+      gmailEmail: `${TAG}-${userA}@example.com`,
+      onList: (call) => {
+        // Only the mercado_pago gateway returns messages. All others return
+        // empty, so we verify the per-gateway query + insert behavior.
+        if (call.q?.includes("mercadopago.com.co")) {
+          return { messageIds: ["mp-msg-1", "mp-msg-2"] };
+        }
+        return { messageIds: [] };
+      },
+    });
+
+    const now = new Date("2026-04-24T12:00:00Z");
+    const result = await pullForUser(
+      userA,
+      { gateways: ["mercado_pago", "payu"] },
+      { getClient: async () => authed, now: () => now },
+    );
+
+    expect(result.connectionId).toBe(connId);
+    expect(result.pulled).toBe(2);
+    expect(result.byGateway.mercado_pago.pulled).toBe(2);
+    expect(result.byGateway.payu.pulled).toBe(0);
+    expect(result.errors).toHaveLength(0);
+    // one list call per gateway (no pagination needed for 2 msgs)
+    expect(listCalls).toHaveLength(2);
+    expect(getCalls).toHaveLength(2);
+
+    const rows = await db
+      .select({
+        msgId: emailReceipts.gmailMsgId,
+        gateway: emailReceipts.gateway,
+        userId: emailReceipts.userId,
+        rawHtml: emailReceipts.rawHtml,
+      })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.userId, userA));
+    expect(rows.map((r) => r.msgId).sort()).toEqual(["mp-msg-1", "mp-msg-2"]);
+    expect(rows.every((r) => r.gateway === "mercado_pago")).toBe(true);
+    expect(rows.every((r) => r.userId === userA)).toBe(true);
+    expect(rows.every((r) => r.rawHtml.includes("body for"))).toBe(true);
+
+    const [conn] = await db
+      .select({ lastPullAt: gmailConnections.lastPullAt })
+      .from(gmailConnections)
+      .where(eq(gmailConnections.id, connId));
+    expect(conn.lastPullAt?.getTime()).toBe(now.getTime());
+  });
+
+  it("is idempotent — running twice in a row does not re-ingest", async () => {
+    const connId = await seedActiveConnection(userA);
+    let listCount = 0;
+    const { authed } = fakeAuthed({
+      userId: userA,
+      connectionId: connId,
+      gmailEmail: `${TAG}-${userA}@example.com`,
+      onList: (call) => {
+        if (call.q?.includes("mercadopago.com.co")) {
+          listCount++;
+          return { messageIds: ["mp-msg-1", "mp-msg-2"] };
+        }
+        return { messageIds: [] };
+      },
+    });
+
+    const first = await pullForUser(
+      userA,
+      { gateways: ["mercado_pago"] },
+      { getClient: async () => authed },
+    );
+    expect(first.pulled).toBe(2);
+    expect(first.skipped).toBe(0);
+
+    const second = await pullForUser(
+      userA,
+      { gateways: ["mercado_pago"] },
+      { getClient: async () => authed },
+    );
+    expect(second.pulled).toBe(0);
+    expect(second.skipped).toBe(2);
+    expect(listCount).toBe(2);
+
+    const rows = await db
+      .select({ msgId: emailReceipts.gmailMsgId })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.userId, userA));
+    expect(rows).toHaveLength(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Tenant isolation — THE acceptance criterion of #452.
+  // -------------------------------------------------------------------------
+
+  it("pullForUser(A) does not write a row with user_id=B even if B has a connection", async () => {
+    const connA = await seedActiveConnection(userA);
+    await seedActiveConnection(userB);
+
+    const { authed } = fakeAuthed({
+      userId: userA,
+      connectionId: connA,
+      gmailEmail: `${TAG}-${userA}@example.com`,
+      onList: (call) => {
+        if (call.q?.includes("mercadopago.com.co")) return { messageIds: ["shared-msg-1"] };
+        return { messageIds: [] };
+      },
+    });
+
+    await pullForUser(userA, { gateways: ["mercado_pago"] }, { getClient: async () => authed });
+
+    const rowsA = await db
+      .select({ msgId: emailReceipts.gmailMsgId })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.userId, userA));
+    const rowsB = await db
+      .select({ msgId: emailReceipts.gmailMsgId })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.userId, userB));
+    expect(rowsA).toHaveLength(1);
+    expect(rowsB).toHaveLength(0);
+  });
+
+  it("pullForUser(A) idempotency is not confused by a different user holding the same msg_id", async () => {
+    // Simulate the edge case where userB already has a row with the same
+    // Gmail message id (they would only ever collide if both users
+    // connected the same Gmail account — unlikely but the unique index is
+    // scoped per-user, so the pull must NOT treat B's row as already-seen
+    // for A.
+    const connA = await seedActiveConnection(userA);
+    const connB = await seedActiveConnection(userB);
+    await db.insert(emailReceipts).values({
+      userId: userB,
+      gmailConnectionId: connB,
+      gmailMsgId: "shared-msg-1",
+      gateway: "mercado_pago",
+      rawHtml: "B's copy",
+    });
+
+    const { authed } = fakeAuthed({
+      userId: userA,
+      connectionId: connA,
+      gmailEmail: `${TAG}-${userA}@example.com`,
+      onList: (call) => {
+        if (call.q?.includes("mercadopago.com.co")) return { messageIds: ["shared-msg-1"] };
+        return { messageIds: [] };
+      },
+    });
+
+    const result = await pullForUser(
+      userA,
+      { gateways: ["mercado_pago"] },
+      { getClient: async () => authed },
+    );
+    expect(result.pulled).toBe(1);
+
+    const rowsA = await db
+      .select({ msgId: emailReceipts.gmailMsgId })
+      .from(emailReceipts)
+      .where(and(eq(emailReceipts.userId, userA), eq(emailReceipts.gmailMsgId, "shared-msg-1")));
+    expect(rowsA).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // invalid_grant mid-pull → mark connection revoked, return error, don't throw.
+  // -------------------------------------------------------------------------
+
+  it("marks connection revoked on invalid_grant during message.get", async () => {
+    const connId = await seedActiveConnection(userA);
+    const { authed } = fakeAuthed({
+      userId: userA,
+      connectionId: connId,
+      gmailEmail: `${TAG}-${userA}@example.com`,
+      onList: (call) => {
+        if (call.q?.includes("mercadopago.com.co")) return { messageIds: ["mp-msg-boom"] };
+        return { messageIds: [] };
+      },
+      onGet: () => {
+        throw Object.assign(new Error("Token has been expired. invalid_grant"), {
+          response: { data: { error: "invalid_grant" } },
+        });
+      },
+    });
+
+    const result = await pullForUser(
+      userA,
+      { gateways: ["mercado_pago"] },
+      { getClient: async () => authed },
+    );
+
+    expect(result.connectionId).toBe(connId);
+    expect(result.pulled).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].code).toBe("invalid_grant");
+
+    const [row] = await db
+      .select({ status: gmailConnections.status, reason: gmailConnections.statusReason })
+      .from(gmailConnections)
+      .where(eq(gmailConnections.id, connId));
+    expect(row.status).toBe("revoked");
+    expect(row.reason).toContain("invalid_grant");
+  });
+
+  // -------------------------------------------------------------------------
+  // Watermark semantics.
+  // -------------------------------------------------------------------------
+
+  it("does not advance last_pull_at when there are per-message errors", async () => {
+    const connId = await seedActiveConnection(userA);
+    const { authed } = fakeAuthed({
+      userId: userA,
+      connectionId: connId,
+      gmailEmail: `${TAG}-${userA}@example.com`,
+      onList: (call) => {
+        if (call.q?.includes("mercadopago.com.co")) return { messageIds: ["mp-empty"] };
+        return { messageIds: [] };
+      },
+      onGet: () => {
+        // No payload → extractBody returns empty string → "no text/html or
+        // text/plain body found" error detail, but pull keeps running.
+        return { data: { id: "mp-empty", payload: {} } };
+      },
+    });
+
+    const now = new Date("2026-04-24T12:00:00Z");
+    const result = await pullForUser(
+      userA,
+      { gateways: ["mercado_pago"] },
+      { getClient: async () => authed, now: () => now },
+    );
+    expect(result.pulled).toBe(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+
+    const [conn] = await db
+      .select({ lastPullAt: gmailConnections.lastPullAt })
+      .from(gmailConnections)
+      .where(eq(gmailConnections.id, connId));
+    expect(conn.lastPullAt).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // 429 retry with backoff — exponential, honors Retry-After.
+  // -------------------------------------------------------------------------
+
+  it("retries on 429 with Retry-After and eventually succeeds", async () => {
+    const connId = await seedActiveConnection(userA);
+    let listAttempts = 0;
+    const { authed } = fakeAuthed({
+      userId: userA,
+      connectionId: connId,
+      gmailEmail: `${TAG}-${userA}@example.com`,
+      onList: (call) => {
+        if (!call.q?.includes("mercadopago.com.co")) return { messageIds: [] };
+        listAttempts++;
+        if (listAttempts === 1) {
+          const err = new Error("Rate limit exceeded") as Error & {
+            code: number;
+            response: { status: number; headers: Record<string, string> };
+          };
+          err.code = 429;
+          err.response = { status: 429, headers: { "retry-after": "1" } };
+          throw err;
+        }
+        return { messageIds: ["mp-msg-retry"] };
+      },
+    });
+
+    const sleeps: number[] = [];
+    const result = await pullForUser(
+      userA,
+      { gateways: ["mercado_pago"] },
+      {
+        getClient: async () => authed,
+        sleep: async (ms) => {
+          sleeps.push(ms);
+        },
+      },
+    );
+    expect(result.pulled).toBe(1);
+    expect(listAttempts).toBe(2);
+    expect(sleeps).toEqual([1000]);
+  });
+});

--- a/src/lib/gmail/pull.ts
+++ b/src/lib/gmail/pull.ts
@@ -1,0 +1,453 @@
+import type { gmail_v1 } from "googleapis";
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { emailReceipts, gmailConnections } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { createLogger } from "@/lib/logger";
+import {
+  getAuthedClient,
+  isInvalidGrantError,
+  markConnectionUnusable,
+  GmailConnectionUnusableError,
+  GmailNotConnectedError,
+  type AuthedGmailClient,
+} from "@/lib/gmail/client";
+import {
+  GATEWAYS,
+  buildSenderQuery,
+  type GatewayConfig,
+  type GatewayId,
+} from "@/lib/gmail/registry";
+
+const log = createLogger({ module: "gmail/pull" });
+
+// Keeps the worst-case pull bounded if someone triggers /enriquecer after a
+// long disconnect: 100 messages/page * 5 pages = 500 msgs/gateway per run.
+// Subsequent runs pick up whatever remains (the watermark advances, but
+// `after:` is inclusive so there is some overlap — dedup by msg_id handles
+// that).
+const MAX_PAGES_PER_GATEWAY = 5;
+const PAGE_SIZE = 100;
+
+// Used when no previous pull watermark exists. Wider than the cron cadence
+// so users who connect mid-week can backfill the current billing period.
+// Manual backfills (#458) will pass sinceDays=180+ explicitly.
+const DEFAULT_SINCE_DAYS = 30;
+
+// Cron runs hourly, but Gmail's `after:` resolution is seconds so a small
+// overlap ensures we don't drop a message whose insertion we raced with.
+// Dedup on (user_id, gmail_msg_id) absorbs the overlap.
+const WATERMARK_OVERLAP_SECONDS = 30 * 60; // 30 min
+
+// Max retries on 429 / 5xx before we surface the error. Low because the
+// hourly cron will retry soon anyway; we're not trying to heroically finish
+// a pull under load.
+const MAX_RETRIES = 3;
+
+export interface PullErrorDetail {
+  gateway: GatewayId | "connection";
+  phase: "auth" | "list" | "get" | "persist";
+  messageId?: string;
+  code?: string;
+  message: string;
+}
+
+export type PullResult = {
+  userId: number;
+  pulled: number;
+  skipped: number;
+  byGateway: Record<GatewayId, { pulled: number; skipped: number }>;
+  errors: PullErrorDetail[];
+  // Null when the user has no active connection (caller decides how to
+  // surface — bot replies with a connect link; cron just logs and moves on).
+  connectionId: number | null;
+};
+
+export interface PullOpts {
+  // When set, overrides the last-pull watermark with now-<sinceDays>.
+  // Used by the manual backfill (#458) and tests.
+  sinceDays?: number;
+  // When provided, only pulls the named gateways. Otherwise scans all.
+  gateways?: GatewayId[];
+}
+
+export interface PullDeps {
+  // Swappable for tests — no need to spin up real OAuth or call Google.
+  getClient?: (userId: number) => Promise<AuthedGmailClient>;
+  now?: () => Date;
+  // Sleep between retries. Tests override to avoid real waits.
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function sinceToQueryFragment(sinceDate: Date): string {
+  // Gmail accepts a unix timestamp (seconds) after `after:`.
+  const unixSeconds = Math.floor(sinceDate.getTime() / 1000);
+  return `after:${unixSeconds}`;
+}
+
+function computeSinceDate(opts: { now: Date; lastPullAt: Date | null; sinceDays?: number }): Date {
+  if (opts.sinceDays !== undefined) {
+    return new Date(opts.now.getTime() - opts.sinceDays * 86_400_000);
+  }
+  if (opts.lastPullAt) {
+    return new Date(opts.lastPullAt.getTime() - WATERMARK_OVERLAP_SECONDS * 1000);
+  }
+  return new Date(opts.now.getTime() - DEFAULT_SINCE_DAYS * 86_400_000);
+}
+
+function getHttpStatus(err: unknown): number | null {
+  if (!err || typeof err !== "object") return null;
+  const e = err as { code?: number | string; status?: number; response?: { status?: number } };
+  if (typeof e.code === "number") return e.code;
+  if (typeof e.status === "number") return e.status;
+  if (typeof e.response?.status === "number") return e.response.status;
+  return null;
+}
+
+function getRetryAfterSeconds(err: unknown): number | null {
+  if (!err || typeof err !== "object") return null;
+  const headers = (err as { response?: { headers?: Record<string, unknown> } }).response?.headers;
+  const raw = headers?.["retry-after"];
+  if (typeof raw !== "string") return null;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  ctx: { gateway: GatewayId; phase: "list" | "get"; gmailEmail: string },
+  deps: Required<Pick<PullDeps, "sleep">>,
+): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const status = getHttpStatus(err);
+      const isRetryable = status === 429 || (status !== null && status >= 500);
+      if (!isRetryable) throw err;
+      const retryAfter = getRetryAfterSeconds(err);
+      const delayMs = retryAfter ? retryAfter * 1000 : 500 * Math.pow(2, attempt);
+      log.warn(
+        {
+          attempt: attempt + 1,
+          maxRetries: MAX_RETRIES,
+          delayMs,
+          status,
+          retryAfter,
+          gateway: ctx.gateway,
+          phase: ctx.phase,
+          gmailEmail: ctx.gmailEmail,
+          event: "gmail_pull_retry",
+        },
+        "retrying Gmail call after transient error",
+      );
+      await deps.sleep(delayMs);
+    }
+  }
+  throw lastErr;
+}
+
+// Walks a Gmail MIME tree to find the best body. Prefers text/html because
+// the downstream parsers (#453/#457) expect HTML. Falls back to text/plain
+// if no HTML part is present (some gateways send plain-only for security).
+function extractBody(payload: gmail_v1.Schema$MessagePart | undefined): string {
+  if (!payload) return "";
+  const html = findByMimeType(payload, "text/html");
+  if (html) return html;
+  const plain = findByMimeType(payload, "text/plain");
+  return plain ?? "";
+}
+
+function findByMimeType(part: gmail_v1.Schema$MessagePart, mimeType: string): string | null {
+  if (part.mimeType === mimeType && part.body?.data) {
+    return Buffer.from(part.body.data, "base64url").toString("utf8");
+  }
+  for (const child of part.parts ?? []) {
+    const found = findByMimeType(child, mimeType);
+    if (found) return found;
+  }
+  return null;
+}
+
+// Tenant-scoped: returns ONLY msg_ids already stored for THIS userId.
+// A cross-tenant race (same gmail_msg_id stored under userB) must not
+// cause userA's pull to skip — the DB unique index is scoped to user_id.
+async function findExistingMsgIds(userId: number, msgIds: string[]): Promise<Set<string>> {
+  if (msgIds.length === 0) return new Set();
+  const rows = await db
+    .select({ gmailMsgId: emailReceipts.gmailMsgId })
+    .from(emailReceipts)
+    .where(and(eq(emailReceipts.userId, userId), inArray(emailReceipts.gmailMsgId, msgIds)));
+  return new Set(rows.map((r) => r.gmailMsgId));
+}
+
+async function pullGateway(opts: {
+  userId: number;
+  connectionId: number;
+  gmailEmail: string;
+  authed: AuthedGmailClient;
+  gateway: GatewayConfig;
+  since: Date;
+  deps: Required<Pick<PullDeps, "sleep">>;
+}): Promise<{ pulled: number; skipped: number; errors: PullErrorDetail[] }> {
+  const { userId, connectionId, gmailEmail, authed, gateway, since, deps } = opts;
+  const errors: PullErrorDetail[] = [];
+  const q = `${buildSenderQuery(gateway)} ${sinceToQueryFragment(since)}`;
+
+  // 1) List all candidate message ids for this gateway.
+  const allIds: string[] = [];
+  let pageToken: string | undefined;
+  for (let page = 0; page < MAX_PAGES_PER_GATEWAY; page++) {
+    const res = await withRetry(
+      () =>
+        authed.gmail.users.messages.list({
+          userId: "me",
+          q,
+          maxResults: PAGE_SIZE,
+          pageToken,
+        }),
+      { gateway: gateway.id, phase: "list", gmailEmail },
+      deps,
+    );
+    const batch = res.data.messages ?? [];
+    for (const m of batch) {
+      if (m.id) allIds.push(m.id);
+    }
+    pageToken = res.data.nextPageToken ?? undefined;
+    if (!pageToken) break;
+  }
+
+  // 2) Filter out msg_ids we already have for THIS user.
+  const existing = await findExistingMsgIds(userId, allIds);
+  const newIds = allIds.filter((id) => !existing.has(id));
+  const skipped = allIds.length - newIds.length;
+
+  // 3) Fetch each new msg and persist. We do this one-at-a-time rather than
+  // firing a batch because googleapis batch endpoints add complexity for
+  // little wall-clock win at our scale (100s of msgs per pull, not 1000s).
+  let pulled = 0;
+  for (const msgId of newIds) {
+    try {
+      const res = await withRetry(
+        () =>
+          authed.gmail.users.messages.get({
+            userId: "me",
+            id: msgId,
+            format: "full",
+          }),
+        { gateway: gateway.id, phase: "get", gmailEmail },
+        deps,
+      );
+      const rawBody = extractBody(res.data.payload ?? undefined);
+      if (!rawBody) {
+        errors.push({
+          gateway: gateway.id,
+          phase: "get",
+          messageId: msgId,
+          message: "no text/html or text/plain body found",
+        });
+        continue;
+      }
+      // Idempotent insert — if a parallel pull (manual /enriquecer while
+      // cron is also running) races us, onConflictDoNothing eats the dup.
+      // No `target` specified because the unique index on
+      // (user_id, gmail_msg_id) is partial (WHERE deleted_at IS NULL) and
+      // Postgres rejects an ON CONFLICT target that doesn't match a full
+      // unique constraint. Letting it bind to whichever unique constraint
+      // violated is fine — emailReceipts has only the one.
+      const insertResult = await db
+        .insert(emailReceipts)
+        .values({
+          userId,
+          gmailConnectionId: connectionId,
+          gmailMsgId: msgId,
+          gateway: gateway.id,
+          rawHtml: rawBody,
+        })
+        .onConflictDoNothing()
+        .returning({ id: emailReceipts.id });
+      if (insertResult.length > 0) pulled++;
+    } catch (err) {
+      // invalid_grant is a connection-level failure — abort the gateway
+      // loop and let the outer pullForUser surface it.
+      if (isInvalidGrantError(err)) throw err;
+      log.error(
+        {
+          err,
+          userId,
+          gmailEmail,
+          gateway: gateway.id,
+          gmailMsgId: msgId,
+          event: "gmail_pull_message_failed",
+        },
+        "failed to fetch/persist a Gmail message",
+      );
+      errors.push({
+        gateway: gateway.id,
+        phase: "get",
+        messageId: msgId,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { pulled, skipped, errors };
+}
+
+function emptyByGateway(): PullResult["byGateway"] {
+  const out = {} as PullResult["byGateway"];
+  for (const g of GATEWAYS) {
+    out[g.id] = { pulled: 0, skipped: 0 };
+  }
+  return out;
+}
+
+/**
+ * Pull new Gmail messages for one user, store them in `email_receipts`, and
+ * update the connection's `last_pull_at` watermark.
+ *
+ * Tenant isolation: every DB read/write is scoped by `userId`. A caller that
+ * hands a userId from one request context cannot accidentally ingest into
+ * another tenant's rows.
+ *
+ * Idempotency: safe to call repeatedly — duplicate `gmail_msg_id`s are
+ * filtered before insert AND the DB has a UNIQUE `(user_id, gmail_msg_id)`.
+ *
+ * On `invalid_grant` (refresh token revoked / Google testing-mode 7-day
+ * expiry): transitions the connection to `status='revoked'` and returns a
+ * result with a `connection` error rather than throwing. The caller (cron
+ * or /enriquecer) can surface a reconnect nudge.
+ */
+export async function pullForUser(
+  userId: number,
+  opts: PullOpts = {},
+  deps: PullDeps = {},
+): Promise<PullResult> {
+  const getClient = deps.getClient ?? getAuthedClient;
+  const sleep = deps.sleep ?? defaultSleep;
+  const now = deps.now ? deps.now() : new Date();
+
+  const errors: PullErrorDetail[] = [];
+  const byGateway = emptyByGateway();
+
+  let authed: AuthedGmailClient;
+  try {
+    authed = await getClient(userId);
+  } catch (err) {
+    if (err instanceof GmailNotConnectedError) {
+      return { userId, pulled: 0, skipped: 0, byGateway, errors, connectionId: null };
+    }
+    if (err instanceof GmailConnectionUnusableError) {
+      errors.push({
+        gateway: "connection",
+        phase: "auth",
+        code: err.status,
+        message: err.message,
+      });
+      return { userId, pulled: 0, skipped: 0, byGateway, errors, connectionId: null };
+    }
+    throw err;
+  }
+
+  // Read watermark for the since-date computation.
+  const [connRow] = await db
+    .select({ lastPullAt: gmailConnections.lastPullAt })
+    .from(gmailConnections)
+    .where(eq(gmailConnections.id, authed.connection.id));
+  const since = computeSinceDate({
+    now,
+    lastPullAt: connRow?.lastPullAt ?? null,
+    sinceDays: opts.sinceDays,
+  });
+
+  const selectedGateways = opts.gateways
+    ? GATEWAYS.filter((g) => opts.gateways!.includes(g.id))
+    : GATEWAYS;
+
+  let totalPulled = 0;
+  let totalSkipped = 0;
+  try {
+    for (const gateway of selectedGateways) {
+      const res = await pullGateway({
+        userId,
+        connectionId: authed.connection.id,
+        gmailEmail: authed.connection.gmailEmail,
+        authed,
+        gateway,
+        since,
+        deps: { sleep },
+      });
+      byGateway[gateway.id] = { pulled: res.pulled, skipped: res.skipped };
+      totalPulled += res.pulled;
+      totalSkipped += res.skipped;
+      errors.push(...res.errors);
+    }
+  } catch (err) {
+    if (isInvalidGrantError(err)) {
+      await markConnectionUnusable(authed.connection.id, "revoked", "invalid_grant during pull");
+      errors.push({
+        gateway: "connection",
+        phase: "auth",
+        code: "invalid_grant",
+        message: "refresh token revoked — connection marked revoked",
+      });
+      return {
+        userId,
+        pulled: totalPulled,
+        skipped: totalSkipped,
+        byGateway,
+        errors,
+        connectionId: authed.connection.id,
+      };
+    }
+    throw err;
+  }
+
+  // Only advance the watermark on fully successful pulls — partial failures
+  // leave last_pull_at alone so the next run retries the same window. The
+  // DB unique index on (user_id, gmail_msg_id) keeps that safe.
+  if (errors.length === 0) {
+    await db
+      .update(gmailConnections)
+      .set({ lastPullAt: now, updatedAt: now })
+      .where(eq(gmailConnections.id, authed.connection.id));
+  }
+
+  return {
+    userId,
+    pulled: totalPulled,
+    skipped: totalSkipped,
+    byGateway,
+    errors,
+    connectionId: authed.connection.id,
+  };
+}
+
+/**
+ * Fan-out across every active Gmail connection. Used by the hourly cron
+ * and the HTTP cron route. Per-user failures are logged and do NOT break
+ * the loop.
+ */
+export async function pullAllActiveConnections(deps: PullDeps = {}): Promise<PullResult[]> {
+  const rows = await db
+    .select({ userId: gmailConnections.userId })
+    .from(gmailConnections)
+    .where(and(eq(gmailConnections.status, "active"), notDeleted(gmailConnections.deletedAt)));
+  const results: PullResult[] = [];
+  for (const row of rows) {
+    try {
+      const res = await pullForUser(row.userId, {}, deps);
+      results.push(res);
+    } catch (err) {
+      log.error(
+        { err, userId: row.userId, event: "gmail_pull_user_failed" },
+        "gmail pull failed for user",
+      );
+    }
+  }
+  return results;
+}

--- a/src/lib/gmail/registry.test.ts
+++ b/src/lib/gmail/registry.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { emailReceiptGateway } from "@/lib/db/schema";
+import { GATEWAYS, buildSenderQuery, getGatewayById } from "./registry";
+
+describe("gmail/registry", () => {
+  it("covers every enum value in email_receipt_gateway", () => {
+    const enumIds = new Set(emailReceiptGateway.enumValues);
+    const registryIds = new Set(GATEWAYS.map((g) => g.id));
+    expect(registryIds).toEqual(enumIds);
+  });
+
+  it("marks bancolombia as ingest mode, all other gateways as enrich", () => {
+    const byId = new Map(GATEWAYS.map((g) => [g.id, g] as const));
+    expect(byId.get("bancolombia")!.mode).toBe("ingest");
+    expect(byId.get("mercado_pago")!.mode).toBe("enrich");
+    expect(byId.get("payu")!.mode).toBe("enrich");
+    expect(byId.get("wompi")!.mode).toBe("enrich");
+    expect(byId.get("apple")!.mode).toBe("enrich");
+    expect(byId.get("paypal")!.mode).toBe("enrich");
+  });
+
+  it("buildSenderQuery returns a single fragment when only one sender is configured", () => {
+    const cfg = getGatewayById("wompi");
+    expect(cfg.senderQueries).toHaveLength(1);
+    expect(buildSenderQuery(cfg)).toBe("from:(@wompi.co)");
+  });
+
+  it("buildSenderQuery ORs multiple fragments inside parens", () => {
+    const cfg = getGatewayById("mercado_pago");
+    const q = buildSenderQuery(cfg);
+    expect(q.startsWith("(")).toBe(true);
+    expect(q.endsWith(")")).toBe(true);
+    expect(q).toContain(" OR ");
+    for (const frag of cfg.senderQueries) expect(q).toContain(frag);
+  });
+
+  it("bankDescriptionRegex matches canonical bank descriptions for enrich gateways", () => {
+    expect(getGatewayById("mercado_pago").bankDescriptionRegex.test("MERCADOPAGO COLOMBIA")).toBe(
+      true,
+    );
+    expect(getGatewayById("payu").bankDescriptionRegex.test("PAYU*TIENDA")).toBe(true);
+    expect(getGatewayById("wompi").bankDescriptionRegex.test("WOMPI*SERVICIO")).toBe(true);
+    expect(getGatewayById("apple").bankDescriptionRegex.test("APPLE.COM/BILL")).toBe(true);
+    expect(getGatewayById("paypal").bankDescriptionRegex.test("PAYPAL *TIENDA")).toBe(true);
+  });
+
+  it("bancolombia bankDescriptionRegex never matches (ingest gateways skip matcher)", () => {
+    const cfg = getGatewayById("bancolombia");
+    expect(cfg.bankDescriptionRegex.test("BANCOLOMBIA")).toBe(false);
+    expect(cfg.bankDescriptionRegex.test("anything")).toBe(false);
+    expect(cfg.bankDescriptionRegex.test("")).toBe(false);
+  });
+
+  it("getGatewayById throws for an unknown id", () => {
+    // @ts-expect-error — intentionally out-of-enum to exercise runtime guard.
+    expect(() => getGatewayById("stripe")).toThrow(/unknown gateway/);
+  });
+});

--- a/src/lib/gmail/registry.test.ts
+++ b/src/lib/gmail/registry.test.ts
@@ -35,20 +35,19 @@ describe("gmail/registry", () => {
   });
 
   it("bankDescriptionRegex matches canonical bank descriptions for enrich gateways", () => {
-    expect(getGatewayById("mercado_pago").bankDescriptionRegex.test("MERCADOPAGO COLOMBIA")).toBe(
+    expect(getGatewayById("mercado_pago").bankDescriptionRegex!.test("MERCADOPAGO COLOMBIA")).toBe(
       true,
     );
-    expect(getGatewayById("payu").bankDescriptionRegex.test("PAYU*TIENDA")).toBe(true);
-    expect(getGatewayById("wompi").bankDescriptionRegex.test("WOMPI*SERVICIO")).toBe(true);
-    expect(getGatewayById("apple").bankDescriptionRegex.test("APPLE.COM/BILL")).toBe(true);
-    expect(getGatewayById("paypal").bankDescriptionRegex.test("PAYPAL *TIENDA")).toBe(true);
+    expect(getGatewayById("payu").bankDescriptionRegex!.test("PAYU*TIENDA")).toBe(true);
+    expect(getGatewayById("wompi").bankDescriptionRegex!.test("WOMPI*SERVICIO")).toBe(true);
+    expect(getGatewayById("apple").bankDescriptionRegex!.test("APPLE.COM/BILL")).toBe(true);
+    expect(getGatewayById("paypal").bankDescriptionRegex!.test("PAYPAL *TIENDA")).toBe(true);
   });
 
-  it("bancolombia bankDescriptionRegex never matches (ingest gateways skip matcher)", () => {
+  it("ingest gateways expose bankDescriptionRegex=null (matcher skips them)", () => {
     const cfg = getGatewayById("bancolombia");
-    expect(cfg.bankDescriptionRegex.test("BANCOLOMBIA")).toBe(false);
-    expect(cfg.bankDescriptionRegex.test("anything")).toBe(false);
-    expect(cfg.bankDescriptionRegex.test("")).toBe(false);
+    expect(cfg.mode).toBe("ingest");
+    expect(cfg.bankDescriptionRegex).toBeNull();
   });
 
   it("getGatewayById throws for an unknown id", () => {

--- a/src/lib/gmail/registry.ts
+++ b/src/lib/gmail/registry.ts
@@ -16,10 +16,12 @@ export interface GatewayConfig {
   // broader filters (domain wildcards) let spoofed/marketing mail slip in.
   senderQueries: string[];
   // Matcher (#454) uses this to check whether a bank tx description
-  // plausibly corresponds to a receipt from this gateway. For `ingest`
-  // gateways (bancolombia) it's never consulted — left as /.^/ to never
-  // match. Values sourced from PLAN.md §Gateway opacity table.
-  bankDescriptionRegex: RegExp;
+  // plausibly corresponds to a receipt from this gateway. `null` for
+  // `ingest` gateways (bancolombia): the matcher never tries to pair their
+  // receipts with a bank tx, so no regex is needed. Values sourced from
+  // PLAN.md §Gateway opacity table. Word boundaries on each pattern so
+  // they only match whole tokens in the bank's description line.
+  bankDescriptionRegex: RegExp | null;
   // `enrich`: receipts are matched back to bank transactions and used to
   // overwrite merchant/category when the bank description is opaque.
   // `ingest`: receipts are ingested as transactions themselves (Bancolombia
@@ -33,31 +35,31 @@ export const GATEWAYS: readonly GatewayConfig[] = [
   {
     id: "mercado_pago",
     senderQueries: ["from:(@mercadopago.com.co)", "from:(@mercadopago.com)"],
-    bankDescriptionRegex: /MERCADOPAGO/i,
+    bankDescriptionRegex: /\bMERCADOPAGO\b/i,
     mode: "enrich",
   },
   {
     id: "payu",
     senderQueries: ["from:(@payu.com)", "from:(@payulatam.com)"],
-    bankDescriptionRegex: /PAYU/i,
+    bankDescriptionRegex: /\bPAYU\b/i,
     mode: "enrich",
   },
   {
     id: "wompi",
     senderQueries: ["from:(@wompi.co)"],
-    bankDescriptionRegex: /WOMPI/i,
+    bankDescriptionRegex: /\bWOMPI\b/i,
     mode: "enrich",
   },
   {
     id: "apple",
     senderQueries: ["from:(no_reply@email.apple.com)", "from:(do_not_reply@email.apple.com)"],
-    bankDescriptionRegex: /APPLE\.COM\/BILL/i,
+    bankDescriptionRegex: /\bAPPLE\.COM\/BILL\b/i,
     mode: "enrich",
   },
   {
     id: "paypal",
     senderQueries: ["from:(service@paypal.com)", "from:(service@intl.paypal.com)"],
-    bankDescriptionRegex: /PAYPAL/i,
+    bankDescriptionRegex: /\bPAYPAL\b/i,
     mode: "enrich",
   },
   {
@@ -68,7 +70,7 @@ export const GATEWAYS: readonly GatewayConfig[] = [
     ],
     // Bancolombia is direct-ingest: the matcher never tries to pair an email
     // receipt with a bank tx (the email *is* the source of truth).
-    bankDescriptionRegex: /.^/,
+    bankDescriptionRegex: null,
     mode: "ingest",
   },
 ] as const;

--- a/src/lib/gmail/registry.ts
+++ b/src/lib/gmail/registry.ts
@@ -1,0 +1,90 @@
+import type { PgEnum } from "drizzle-orm/pg-core";
+import { emailReceiptGateway } from "@/lib/db/schema";
+
+// Mirror the pgEnum so the registry's GatewayId stays in lockstep with the
+// DB column type. If a new gateway is added to the enum, a missing registry
+// entry will surface as a TS error where the registry is consumed.
+type EnumValues<T> = T extends PgEnum<infer V> ? V[number] : never;
+export type GatewayId = EnumValues<typeof emailReceiptGateway>;
+
+export type GatewayMode = "enrich" | "ingest";
+
+export interface GatewayConfig {
+  id: GatewayId;
+  // Gmail search query fragments. Combined with OR at pull time; each is
+  // dropped verbatim into users.messages.list?q=... . Keep them narrow —
+  // broader filters (domain wildcards) let spoofed/marketing mail slip in.
+  senderQueries: string[];
+  // Matcher (#454) uses this to check whether a bank tx description
+  // plausibly corresponds to a receipt from this gateway. For `ingest`
+  // gateways (bancolombia) it's never consulted — left as /.^/ to never
+  // match. Values sourced from PLAN.md §Gateway opacity table.
+  bankDescriptionRegex: RegExp;
+  // `enrich`: receipts are matched back to bank transactions and used to
+  // overwrite merchant/category when the bank description is opaque.
+  // `ingest`: receipts are ingested as transactions themselves (Bancolombia
+  // email is a parallel ingestion source to SMS — #457).
+  mode: GatewayMode;
+}
+
+// Source: PLAN.md §6b + §Gateway opacity table. Senders investigated from
+// real inbox samples; domain-anchored to avoid spoof matches.
+export const GATEWAYS: readonly GatewayConfig[] = [
+  {
+    id: "mercado_pago",
+    senderQueries: ["from:(@mercadopago.com.co)", "from:(@mercadopago.com)"],
+    bankDescriptionRegex: /MERCADOPAGO/i,
+    mode: "enrich",
+  },
+  {
+    id: "payu",
+    senderQueries: ["from:(@payu.com)", "from:(@payulatam.com)"],
+    bankDescriptionRegex: /PAYU/i,
+    mode: "enrich",
+  },
+  {
+    id: "wompi",
+    senderQueries: ["from:(@wompi.co)"],
+    bankDescriptionRegex: /WOMPI/i,
+    mode: "enrich",
+  },
+  {
+    id: "apple",
+    senderQueries: ["from:(no_reply@email.apple.com)", "from:(do_not_reply@email.apple.com)"],
+    bankDescriptionRegex: /APPLE\.COM\/BILL/i,
+    mode: "enrich",
+  },
+  {
+    id: "paypal",
+    senderQueries: ["from:(service@paypal.com)", "from:(service@intl.paypal.com)"],
+    bankDescriptionRegex: /PAYPAL/i,
+    mode: "enrich",
+  },
+  {
+    id: "bancolombia",
+    senderQueries: [
+      "from:(alertasynotificaciones@an.notificacionesbancolombia.com)",
+      "from:(@bancolombia.com.co)",
+    ],
+    // Bancolombia is direct-ingest: the matcher never tries to pair an email
+    // receipt with a bank tx (the email *is* the source of truth).
+    bankDescriptionRegex: /.^/,
+    mode: "ingest",
+  },
+] as const;
+
+export function getGatewayById(id: GatewayId): GatewayConfig {
+  const cfg = GATEWAYS.find((g) => g.id === id);
+  if (!cfg) throw new Error(`[gmail/registry] unknown gateway id: ${id}`);
+  return cfg;
+}
+
+// Compose the `from:(...) OR from:(...)` portion of the Gmail query for one
+// gateway. Callers append the `after:` and any other constraints.
+export function buildSenderQuery(cfg: GatewayConfig): string {
+  if (cfg.senderQueries.length === 0) {
+    throw new Error(`[gmail/registry] gateway ${cfg.id} has empty senderQueries`);
+  }
+  if (cfg.senderQueries.length === 1) return cfg.senderQueries[0];
+  return `(${cfg.senderQueries.join(" OR ")})`;
+}

--- a/src/lib/telegram/commands.ts
+++ b/src/lib/telegram/commands.ts
@@ -1,22 +1,45 @@
 import type { TelegramClient } from "@/lib/telegram/client";
 import { clearSession } from "@/lib/telegram/session";
-import { renderCanceled, renderHelp, renderStart } from "@/lib/telegram/formatter";
+import {
+  renderCanceled,
+  renderEnrichConnectPrompt,
+  renderEnrichFailed,
+  renderEnrichProcessing,
+  renderEnrichResult,
+  renderHelp,
+  renderStart,
+} from "@/lib/telegram/formatter";
+import { pullForUser } from "@/lib/gmail/pull";
+import { createLogger } from "@/lib/logger";
 
-export type CommandName = "/start" | "/help" | "/cancel";
+const log = createLogger({ module: "telegram/commands" });
+
+export type CommandName = "/start" | "/help" | "/cancel" | "/enriquecer";
+
+// Maps aliases to canonical command names. `/enrich` is the English alias
+// requested by #452. Add locale-specific aliases here; the canonical set
+// above stays stable.
+const COMMAND_ALIASES: Record<string, CommandName> = {
+  "/start": "/start",
+  "/help": "/help",
+  "/cancel": "/cancel",
+  "/enriquecer": "/enriquecer",
+  "/enrich": "/enriquecer",
+};
 
 export function parseCommand(text: string): CommandName | null {
   const trimmed = text.trim().toLowerCase().split(/\s+/)[0];
   const base = trimmed?.split("@")[0] ?? "";
-  if (base === "/start" || base === "/help" || base === "/cancel") return base;
-  return null;
+  return COMMAND_ALIASES[base] ?? null;
 }
 
 export async function handleCommand(opts: {
   command: CommandName;
   chatId: number;
   client: TelegramClient;
+  userId: number;
 }): Promise<void> {
-  const { command, chatId, client } = opts;
+  const { command, chatId, client, userId } = opts;
   switch (command) {
     case "/start":
       await client.sendMessage({ chat_id: chatId, text: renderStart(), parse_mode: "Markdown" });
@@ -28,5 +51,35 @@ export async function handleCommand(opts: {
       await clearSession(chatId);
       await client.sendMessage({ chat_id: chatId, text: renderCanceled() });
       return;
+    case "/enriquecer":
+      await handleEnriquecer({ chatId, client, userId });
+      return;
+  }
+}
+
+async function handleEnriquecer(opts: {
+  chatId: number;
+  client: TelegramClient;
+  userId: number;
+}): Promise<void> {
+  const { chatId, client, userId } = opts;
+  // Acknowledge first — the Gmail pull can take multiple seconds on a cold
+  // inbox, and Telegram clients show no progress otherwise.
+  await client.sendMessage({ chat_id: chatId, text: renderEnrichProcessing() });
+
+  try {
+    const result = await pullForUser(userId);
+    if (result.connectionId === null) {
+      await client.sendMessage({
+        chat_id: chatId,
+        text: renderEnrichConnectPrompt(),
+        parse_mode: "Markdown",
+      });
+      return;
+    }
+    await client.sendMessage({ chat_id: chatId, text: renderEnrichResult(result) });
+  } catch (err) {
+    log.error({ err, userId, event: "telegram_enriquecer_failed" }, "/enriquecer threw");
+    await client.sendMessage({ chat_id: chatId, text: renderEnrichFailed() });
   }
 }

--- a/src/lib/telegram/formatter.ts
+++ b/src/lib/telegram/formatter.ts
@@ -1,5 +1,7 @@
 import type { TelegramBatchItem, TelegramDraft } from "@/lib/db/schema";
 import type { NluAccountOption, NluCategoryOption } from "@/lib/ai/transaction-nlu";
+import type { PullResult } from "@/lib/gmail/pull";
+import type { GatewayId } from "@/lib/gmail/registry";
 import { formatAccountLabel } from "@/lib/accounts/format";
 
 function formatAmount(amountCentsStr: string, currency: "COP" | "USD"): string {
@@ -186,4 +188,49 @@ export function renderBatchInserted(opts: {
   if (opts.duplicated > 0) parts.push(`🔁 ${opts.duplicated} duplicadas`);
   if (opts.errors > 0) parts.push(`⚠️ ${opts.errors} con error`);
   return parts.join(" · ") || "Sin cambios.";
+}
+
+const GATEWAY_LABELS: Record<GatewayId, string> = {
+  mercado_pago: "Mercado Pago",
+  payu: "PayU",
+  wompi: "Wompi",
+  apple: "Apple",
+  paypal: "PayPal",
+  bancolombia: "Bancolombia",
+};
+
+export function renderEnrichProcessing(): string {
+  return "📧 Buscando emails nuevos en tu Gmail…";
+}
+
+export function renderEnrichResult(result: PullResult): string {
+  const breakdown = (Object.entries(result.byGateway) as [GatewayId, { pulled: number }][])
+    .filter(([, v]) => v.pulled > 0)
+    .map(([id, v]) => `${v.pulled} ${GATEWAY_LABELS[id]}`)
+    .join(", ");
+
+  const lines: string[] = [];
+  if (result.pulled === 0 && result.skipped === 0) {
+    lines.push("📭 No encontré emails nuevos.");
+  } else {
+    const tail = breakdown ? ` (${breakdown})` : "";
+    lines.push(`📧 Ingresé ${result.pulled} recibos nuevos${tail}.`);
+    if (result.skipped > 0) lines.push(`🔁 Omití ${result.skipped} ya vistos.`);
+  }
+  if (result.errors.length > 0) {
+    lines.push(`⚠️ ${result.errors.length} errores — revisá los logs.`);
+  }
+  return lines.join("\n");
+}
+
+export function renderEnrichConnectPrompt(): string {
+  return [
+    "📧 Todavía no tenés una cuenta de Gmail conectada.",
+    "",
+    "Entrá a *Settings → Integrations* en la web para conectarla.",
+  ].join("\n");
+}
+
+export function renderEnrichFailed(): string {
+  return "⚠️ Algo falló buscando emails. Probá de nuevo en un rato.";
 }

--- a/src/lib/telegram/router.ts
+++ b/src/lib/telegram/router.ts
@@ -368,7 +368,7 @@ async function handleText(
 
   const command = parseCommand(text);
   if (command) {
-    await handleCommand({ command, chatId, client });
+    await handleCommand({ command, chatId, client, userId: deps.userId });
     return;
   }
 


### PR DESCRIPTION
Closes #452.

Epic G — Gmail Email Integration, builds on the OAuth flow shipped in #451 / #462.

## Summary

- **Gateway registry** (`src/lib/gmail/registry.ts`) wired to the `email_receipt_gateway` pgEnum so a new enum value surfaces as a TS error until the registry is extended. Six entries: `mercado_pago`, `payu`, `wompi`, `apple`, `paypal` (enrich) + `bancolombia` (ingest). Each has `senderQueries` for Gmail search and `bankDescriptionRegex` for the matcher (#454 consumes).
- **`pullForUser(userId, opts?, deps?)`** in `src/lib/gmail/pull.ts`. Strictly tenant-scoped — every DB read and write is keyed on `userId`. Idempotent via pre-filter + `ON CONFLICT DO NOTHING` on the partial unique index. Watermark advances only when `errors.length === 0`; partial failures retry the same window on the next tick.
- **Error handling** — `invalid_grant` mid-pull transitions the connection to `status='revoked'` and surfaces an auth-phase error in the result instead of throwing. 429 / 5xx retry with exponential backoff and honor `Retry-After`.
- **Hourly cron** — `0 * * * * America/Bogota` in `instrumentation.node.ts`. Fans out over every active connection; per-user failures are logged and do not break the loop. Respects `FINDASH_DISABLE_CRON=1`.
- **`/enriquecer` + `/enrich`** — extended `handleCommand` to plumb `deps.userId` so the bot pulls for the right tenant. Replies with per-gateway breakdown; prompts for a connect when no active connection.
- **`POST /api/cron/gmail-pull`** — `CRON_TOKEN` bearer, same pattern as `/api/cron/canary-check`. Useful for manual invocation and external schedulers.

## Acceptance checklist from #452

- [x] Tenant isolation — \`pullForUser(A)\` never inserts for user B, even when B has a connection or already holds the same \`gmail_msg_id\`.
- [x] Idempotency — running twice only ingests on the first call.
- [x] Cron registered in \`instrumentation.node.ts\`; respects \`FINDASH_DISABLE_CRON=1\`.
- [x] \`/enriquecer\` bot command works end-to-end.
- [x] 429 → exponential backoff + \`Retry-After\` honored.
- [x] Expired refresh token → connection transitions to \`revoked\` and result surfaces an auth-phase error.
- [x] Pino logging throughout; no raw email bodies or non-connected email addresses in logs.
- [x] CI green (1141 tests passing, +17 new).

## Out of scope (deferred to Epic G siblings)

- Gateway parsers (#453 — MP, PayU, Wompi, Apple, PayPal). This issue persists \`raw_html\` + \`gateway\`; \`parsed_payload\` stays null.
- Bancolombia email parser (#457).
- Matcher + enrichment (#454).
- Backfill UI / \`/backfill-gmail\` command (#458).
- Gmail history-cursor delta sync (\`last_pull_history_id\` stays null; \`after:\` filter is the MVP path).

## Test plan

- [x] \`bun run test\` — 1141 passed
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun run lint\` — clean
- [ ] Post-merge, validate a real pull in prod against the connected Gmail (trigger via \`/enriquecer\` on Telegram) and spot-check a row in \`email_receipts\`.