### PR TITLE
feat(ingestion): backfill Bancolombia 2026 from email (#458)

### DIFF
--- a/src/app/api/cron/gmail-backfill/route.ts
+++ b/src/app/api/cron/gmail-backfill/route.ts
@@ -1,0 +1,107 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  backfillBancolombia,
+  backfillBancolombiaDryRun,
+  BackfillConnectionError,
+} from "@/lib/gmail/backfill";
+import { createLogger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// #458 — one-shot backfill trigger for operators / cc-infra scripts. Mirrors
+// the bot's /backfill-gmail flow: dry-run is the default, `confirm: true`
+// actually writes. The bot is the primary surface for end users; this route
+// exists so ops can re-run or backfill other years without touching Telegram.
+
+const log = createLogger({ module: "api/cron/gmail-backfill" });
+
+const BodySchema = z.object({
+  userId: z.number().int().positive(),
+  from: z.coerce.date(),
+  to: z.coerce.date(),
+  confirm: z.boolean().optional().default(false),
+});
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+function resolveToken(req: Request): string | null {
+  const header = req.headers.get("authorization");
+  if (!header?.startsWith("Bearer ")) return null;
+  return header.slice(7).trim() || null;
+}
+
+export async function POST(req: Request) {
+  const expected = process.env.CRON_TOKEN;
+  if (!expected) {
+    return NextResponse.json({ error: "CRON_TOKEN not configured" }, { status: 500 });
+  }
+  const provided = resolveToken(req);
+  if (!provided || !constantTimeEquals(provided, expected)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let payload: z.infer<typeof BodySchema>;
+  try {
+    const parsed = BodySchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "invalid body", details: parsed.error.format() },
+        { status: 400 },
+      );
+    }
+    payload = parsed.data;
+  } catch {
+    return NextResponse.json({ error: "bad request" }, { status: 400 });
+  }
+
+  if (payload.from >= payload.to) {
+    return NextResponse.json({ error: "`from` must be earlier than `to`" }, { status: 400 });
+  }
+
+  try {
+    if (!payload.confirm) {
+      const dryRun = await backfillBancolombiaDryRun(payload.userId, {
+        from: payload.from,
+        to: payload.to,
+      });
+      return NextResponse.json({ ok: true, dryRun: true, report: dryRun });
+    }
+
+    const report = await backfillBancolombia(payload.userId, {
+      from: payload.from,
+      to: payload.to,
+    });
+    log.info(
+      {
+        userId: payload.userId,
+        totalEmails: report.totalEmails,
+        inserted: report.inserted,
+        matchedExisting: report.matchedExisting,
+        errors: report.errors.length,
+        event: "gmail_backfill_http_completed",
+      },
+      "gmail backfill via HTTP cron",
+    );
+    return NextResponse.json({ ok: true, dryRun: false, report });
+  } catch (err) {
+    if (err instanceof BackfillConnectionError) {
+      return NextResponse.json(
+        { error: "gmail_connection_error", reason: err.reason },
+        { status: 409 },
+      );
+    }
+    log.error(
+      { err, userId: payload.userId, event: "gmail_backfill_http_failed" },
+      "gmail backfill route threw",
+    );
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
+  }
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -961,7 +961,9 @@ export type TelegramSessionStep =
   | "awaiting_category"
   | "awaiting_confirm"
   | "awaiting_photo_account"
-  | "awaiting_batch_confirm";
+  | "awaiting_batch_confirm"
+  | "awaiting_backfill_confirm"
+  | "backfill_running";
 
 export type TelegramBatchItem = {
   draft: TelegramDraft;
@@ -988,6 +990,16 @@ export type TelegramDraft = {
   };
 };
 
+// #458 — when `step` is `awaiting_backfill_confirm` or `backfill_running`,
+// this block holds the requested window (ISO yyyy-mm-dd). `step` is the
+// cancel signal the backfill loop polls — when the user hits /cancel the
+// session row is deleted, and the loop sees `getSession() === null`.
+export type TelegramBackfillState = {
+  from: string;
+  to: string;
+  gateway: "bancolombia";
+};
+
 export type TelegramSessionState = {
   step: TelegramSessionStep;
   draft: TelegramDraft;
@@ -997,6 +1009,7 @@ export type TelegramSessionState = {
   externalIdOverride?: string;
   photoFileId?: string;
   batch?: TelegramBatchItem[];
+  backfill?: TelegramBackfillState;
 };
 
 export const telegramBots = pgTable("telegram_bots", {

--- a/src/lib/gmail/backfill.test.ts
+++ b/src/lib/gmail/backfill.test.ts
@@ -1,0 +1,557 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, emailReceipts, gmailConnections, transactions, users } from "@/lib/db/schema";
+import { gmailCipher } from "@/lib/crypto/gmail-cipher";
+import {
+  backfillBancolombia,
+  backfillBancolombiaDryRun,
+  BackfillConnectionError,
+} from "./backfill";
+import type { AuthedGmailClient } from "./client";
+import { GmailConnectionUnusableError, GmailNotConnectedError } from "./client";
+
+const TAG = "GMAIL_BACKFILL_TEST";
+
+let userA: number;
+let userB: number;
+let connA: number;
+
+const ORIGINAL_GMAIL_KEY = process.env.GMAIL_TOKEN_ENCRYPTION_KEY;
+
+async function wipeData(): Promise<void> {
+  await db.execute(sql`DELETE FROM email_receipts WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM transactions WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM accounts WHERE user_id IN (${userA}, ${userB})`);
+}
+
+async function createUser(suffix: string): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `${TAG}-${suffix}@test.local`, name: `${TAG}-${suffix}` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function seedActiveConnection(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(gmailConnections)
+    .values({
+      userId,
+      gmailEmail: `${TAG}-${userId}@example.com`,
+      accessTokenEnc: gmailCipher.encrypt("dummy-access-token"),
+      refreshTokenEnc: gmailCipher.encrypt("dummy-refresh-token"),
+      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  return row.id;
+}
+
+async function seedCreditCard(userId: number, last4: string): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} tc ${last4}`,
+      institution: "Bancolombia",
+      type: "credit_card",
+      currency: "COP",
+      metadata: { last4s: [last4], creditLimitCents: 10_000_000 },
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+// Wraps a transactional sentence in the same HTML scaffold the real parser
+// tests use — proves the parser's extractVisibleText path works end-to-end.
+function wrapBancolombiaEmail(sentence: string): string {
+  return `<!DOCTYPE html><html><head><title>Alertas y Notificaciones</title></head><body>
+<table><tr><td><h1>&iexcl;Listo! Todo sali&oacute; bien con tus movimientos</h1></td></tr>
+<tr><td><p>${sentence}</p></td></tr>
+</table></body></html>`;
+}
+
+function purchaseSentence(amountCop: string, merchant: string, last4: string, dateDmy: string) {
+  return `Bancolombia: Compraste COP${amountCop},00 en ${merchant} con tu T.Cred *${last4}, el ${dateDmy} a las 10:00.`;
+}
+
+function fakeMessage(id: string, html: string) {
+  const encoded = Buffer.from(html, "utf8").toString("base64url");
+  return {
+    data: {
+      id,
+      payload: {
+        mimeType: "text/html",
+        body: { data: encoded },
+      },
+    },
+  };
+}
+
+interface FakeAuthedOpts {
+  userId: number;
+  connectionId: number;
+  // Map of msg_id → HTML body. list() returns every id; get() returns the
+  // mapped body. Keeps the fake deterministic and small.
+  messages: Record<string, string>;
+  // Force list() to paginate via nextPageToken. Used by the pagination test.
+  pageSize?: number;
+  // When set, throws on the Nth list call. Used to test error handling.
+  throwOnListAttempt?: number;
+  throwOnListError?: unknown;
+}
+
+interface FakeAuthedResult {
+  authed: AuthedGmailClient;
+  listCalls: { q: string | undefined; pageToken: string | undefined }[];
+  getCalls: string[];
+}
+
+function fakeAuthed(opts: FakeAuthedOpts): FakeAuthedResult {
+  const listCalls: { q: string | undefined; pageToken: string | undefined }[] = [];
+  const getCalls: string[] = [];
+  const ids = Object.keys(opts.messages);
+  let listAttempts = 0;
+
+  const authed = {
+    oauth: {} as unknown,
+    gmail: {
+      users: {
+        messages: {
+          async list(params: { q?: string; pageToken?: string }) {
+            listAttempts++;
+            if (opts.throwOnListAttempt === listAttempts && opts.throwOnListError) {
+              throw opts.throwOnListError;
+            }
+            listCalls.push({ q: params.q, pageToken: params.pageToken });
+            const pageSize = opts.pageSize ?? ids.length;
+            const startIdx = params.pageToken ? Number.parseInt(params.pageToken, 10) : 0;
+            const slice = ids.slice(startIdx, startIdx + pageSize);
+            const next = startIdx + pageSize < ids.length ? String(startIdx + pageSize) : undefined;
+            return {
+              data: {
+                messages: slice.map((id) => ({ id, threadId: id })),
+                nextPageToken: next,
+              },
+            };
+          },
+          async get(params: { id: string }) {
+            getCalls.push(params.id);
+            const body = opts.messages[params.id];
+            if (!body) throw new Error(`fake: no body for ${params.id}`);
+            return fakeMessage(params.id, body);
+          },
+        },
+      },
+    },
+    connection: {
+      id: opts.connectionId,
+      gmailEmail: `${TAG}-${opts.userId}@example.com`,
+      accessTokenStale: false,
+    },
+  } as unknown as AuthedGmailClient;
+
+  return { authed, listCalls, getCalls };
+}
+
+describe("gmail/backfill", () => {
+  beforeAll(async () => {
+    process.env.GMAIL_TOKEN_ENCRYPTION_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    userA = await createUser("A");
+    userB = await createUser("B");
+  });
+
+  beforeEach(async () => {
+    await wipeData();
+    await db.execute(sql`DELETE FROM gmail_connections WHERE user_id IN (${userA}, ${userB})`);
+    connA = await seedActiveConnection(userA);
+  });
+
+  afterEach(async () => {
+    await wipeData();
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`DELETE FROM gmail_connections WHERE user_id IN (${userA}, ${userB})`);
+    await db.delete(users).where(sql`id IN (${userA}, ${userB})`);
+    if (ORIGINAL_GMAIL_KEY === undefined) delete process.env.GMAIL_TOKEN_ENCRYPTION_KEY;
+    else process.env.GMAIL_TOKEN_ENCRYPTION_KEY = ORIGINAL_GMAIL_KEY;
+    // Do not close db — see gmail-isolation.test.ts for the shared-pool policy.
+  });
+
+  const FROM = new Date("2026-01-01T00:00:00Z");
+  const TO = new Date("2027-01-01T00:00:00Z");
+
+  // ---------------------------------------------------------------------------
+  // Connection-level errors
+  // ---------------------------------------------------------------------------
+
+  it("throws BackfillConnectionError(not_connected) when user has no connection", async () => {
+    const getClient = async () => {
+      throw new GmailNotConnectedError(userB);
+    };
+    await expect(
+      backfillBancolombiaDryRun(userB, { from: FROM, to: TO }, { getClient }),
+    ).rejects.toSatisfy((err) => {
+      return err instanceof BackfillConnectionError && err.reason === "not_connected";
+    });
+  });
+
+  it("throws BackfillConnectionError(revoked) when connection is revoked", async () => {
+    const getClient = async () => {
+      throw new GmailConnectionUnusableError("revoked", "token revoked");
+    };
+    await expect(
+      backfillBancolombia(userA, { from: FROM, to: TO }, { getClient }),
+    ).rejects.toSatisfy((err) => {
+      return err instanceof BackfillConnectionError && err.reason === "revoked";
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dry-run: no writes, accurate counts
+  // ---------------------------------------------------------------------------
+
+  it("dry-run does NOT write to DB; reports totals and alreadyStored", async () => {
+    await seedCreditCard(userA, "2575");
+    const html1 = wrapBancolombiaEmail(
+      purchaseSentence("44.247", "MERCHANT_A", "2575", "08/04/2026"),
+    );
+    const html2 = wrapBancolombiaEmail(
+      purchaseSentence("22.100", "MERCHANT_B", "2575", "09/04/2026"),
+    );
+
+    // Pre-seed: msg-1 already stored for userA. So dry-run should report
+    // alreadyStored=1, newEmails=1.
+    await db.insert(emailReceipts).values({
+      userId: userA,
+      gmailConnectionId: connA,
+      gmailMsgId: "msg-1",
+      gateway: "bancolombia",
+      rawHtml: html1,
+    });
+
+    const { authed } = fakeAuthed({
+      userId: userA,
+      connectionId: connA,
+      messages: { "msg-1": html1, "msg-2": html2 },
+    });
+    const getClient = async () => authed;
+
+    const receiptsBefore = await db
+      .select({ id: emailReceipts.id })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.userId, userA));
+    const txsBefore = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, userA));
+
+    const report = await backfillBancolombiaDryRun(userA, { from: FROM, to: TO }, { getClient });
+
+    expect(report.totalEmails).toBe(2);
+    expect(report.alreadyStored).toBe(1);
+    expect(report.newEmails).toBe(1);
+
+    // Nothing written.
+    const receiptsAfter = await db
+      .select({ id: emailReceipts.id })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.userId, userA));
+    const txsAfter = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, userA));
+    expect(receiptsAfter.length).toBe(receiptsBefore.length);
+    expect(txsAfter.length).toBe(txsBefore.length);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Happy path: lists + fetches + inserts + ingests end-to-end
+  // ---------------------------------------------------------------------------
+
+  it("ingests parsed emails into transactions; tenant-scoped to userId", async () => {
+    await seedCreditCard(userA, "2575");
+    // userB has a different account + connection but NOT receiving this backfill.
+    await seedCreditCard(userB, "9999");
+    await seedActiveConnection(userB);
+
+    const html1 = wrapBancolombiaEmail(
+      purchaseSentence("44.247", "MERCHANT_A", "2575", "08/04/2026"),
+    );
+    const html2 = wrapBancolombiaEmail(
+      purchaseSentence("22.100", "MERCHANT_B", "2575", "09/04/2026"),
+    );
+
+    const { authed, getCalls } = fakeAuthed({
+      userId: userA,
+      connectionId: connA,
+      messages: { "msg-1": html1, "msg-2": html2 },
+    });
+    const getClient = async () => authed;
+
+    const report = await backfillBancolombia(
+      userA,
+      { from: FROM, to: TO },
+      { getClient, sleep: async () => {} },
+    );
+
+    expect(report.totalEmails).toBe(2);
+    expect(report.alreadyStored).toBe(0);
+    expect(report.parsed).toBe(2);
+    expect(report.inserted).toBe(2);
+    expect(report.matchedExisting).toBe(0);
+    expect(report.errors).toHaveLength(0);
+    expect(report.canceled).toBe(false);
+    expect(getCalls.sort()).toEqual(["msg-1", "msg-2"]);
+
+    // Tenant isolation: userB has zero receipts/txs.
+    const userBReceipts = await db
+      .select({ id: emailReceipts.id })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.userId, userB));
+    const userBTxs = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, userB));
+    expect(userBReceipts).toHaveLength(0);
+    expect(userBTxs).toHaveLength(0);
+
+    // userA receives the 2 receipts + 2 transactions.
+    const userAReceipts = await db
+      .select({ id: emailReceipts.id, status: emailReceipts.matchStatus })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.userId, userA));
+    const userATxs = await db
+      .select({ id: transactions.id, source: transactions.source })
+      .from(transactions)
+      .where(eq(transactions.userId, userA));
+    expect(userAReceipts).toHaveLength(2);
+    expect(userATxs).toHaveLength(2);
+    expect(userATxs.every((t) => t.source === "gmail_bancolombia")).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Idempotency: running twice inserts once
+  // ---------------------------------------------------------------------------
+
+  it("is idempotent — second run reports inserted=0 and doesn't duplicate txs", async () => {
+    await seedCreditCard(userA, "2575");
+    const html1 = wrapBancolombiaEmail(
+      purchaseSentence("44.247", "MERCHANT_A", "2575", "08/04/2026"),
+    );
+    const { authed } = fakeAuthed({
+      userId: userA,
+      connectionId: connA,
+      messages: { "msg-1": html1 },
+    });
+    const getClient = async () => authed;
+
+    const first = await backfillBancolombia(
+      userA,
+      { from: FROM, to: TO },
+      { getClient, sleep: async () => {} },
+    );
+    expect(first.inserted).toBe(1);
+
+    const second = await backfillBancolombia(
+      userA,
+      { from: FROM, to: TO },
+      { getClient, sleep: async () => {} },
+    );
+    expect(second.totalEmails).toBe(1);
+    expect(second.alreadyStored).toBe(1);
+    expect(second.inserted).toBe(0);
+
+    // Still exactly ONE transaction after two runs.
+    const txs = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, userA));
+    expect(txs).toHaveLength(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cancel mid-run
+  // ---------------------------------------------------------------------------
+
+  it("stops cleanly when shouldCancel returns true; preserves partial results", async () => {
+    await seedCreditCard(userA, "2575");
+    const messages: Record<string, string> = {};
+    for (let i = 1; i <= 4; i++) {
+      messages[`msg-${i}`] = wrapBancolombiaEmail(
+        purchaseSentence(
+          `10.00${i}`,
+          `MERCHANT_${i}`,
+          "2575",
+          `${String(i).padStart(2, "0")}/04/2026`,
+        ),
+      );
+    }
+    const { authed } = fakeAuthed({ userId: userA, connectionId: connA, messages });
+    const getClient = async () => authed;
+
+    let seen = 0;
+    const shouldCancel = async () => {
+      seen++;
+      return seen >= 3; // cancel before processing the 3rd msg
+    };
+
+    const report = await backfillBancolombia(
+      userA,
+      { from: FROM, to: TO, shouldCancel },
+      { getClient, sleep: async () => {} },
+    );
+
+    expect(report.canceled).toBe(true);
+    expect(report.inserted).toBe(2); // first two were processed
+    const receipts = await db
+      .select({ id: emailReceipts.id })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.userId, userA));
+    expect(receipts.length).toBe(2);
+  });
+
+  // ---------------------------------------------------------------------------
+  // A+ dedup: matching an existing tx counts as matchedExisting, not inserted
+  // ---------------------------------------------------------------------------
+
+  it("A+ dedup: existing tx from SMS path counts as matchedExisting, not inserted", async () => {
+    const accountId = await seedCreditCard(userA, "2575");
+
+    // Simulate an SMS-ingested tx that matches the email we're about to
+    // backfill: same user, same account, same amount, same occurred_at, same
+    // kind. Expected outcome: dedup A+ identifies it and marks the receipt
+    // matched without inserting a duplicate.
+    const occurredAt = new Date("2026-04-08T15:00:00.000Z"); // 10:00 COP
+    await db.insert(transactions).values({
+      userId: userA,
+      accountId,
+      occurredAt,
+      amountCents: BigInt(-4424700), // SMS purchases store negative amounts
+      currency: "COP",
+      descriptionRaw: "MERCHANT_A",
+      merchant: "MERCHANT_A",
+      classificationMethod: "unclassified",
+      source: "sms",
+      externalId: "bcol-sms:existing-1",
+      rawData: { kind: "purchase", sms: "raw sms body" },
+    });
+
+    const html = wrapBancolombiaEmail(
+      purchaseSentence("44.247", "MERCHANT_A", "2575", "08/04/2026"),
+    );
+    const { authed } = fakeAuthed({
+      userId: userA,
+      connectionId: connA,
+      messages: { "msg-1": html },
+    });
+    const getClient = async () => authed;
+
+    const report = await backfillBancolombia(
+      userA,
+      { from: FROM, to: TO },
+      { getClient, sleep: async () => {} },
+    );
+    expect(report.parsed).toBe(1);
+    expect(report.inserted).toBe(0);
+    expect(report.matchedExisting).toBe(1);
+
+    const txs = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, userA));
+    expect(txs).toHaveLength(1); // no duplicate
+
+    // Receipt was marked matched to the existing tx.
+    const [receipt] = await db
+      .select({
+        status: emailReceipts.matchStatus,
+        matchedTxId: emailReceipts.matchedTransactionId,
+      })
+      .from(emailReceipts)
+      .where(and(eq(emailReceipts.userId, userA), eq(emailReceipts.gmailMsgId, "msg-1")));
+    expect(receipt.status).toBe("matched");
+    expect(receipt.matchedTxId).not.toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Progress callback
+  // ---------------------------------------------------------------------------
+
+  it("fires onProgress at the configured stride and once at 'done'", async () => {
+    await seedCreditCard(userA, "2575");
+    const messages: Record<string, string> = {};
+    for (let i = 1; i <= 5; i++) {
+      messages[`msg-${i}`] = wrapBancolombiaEmail(
+        purchaseSentence(
+          `10.00${i}`,
+          `MERCHANT_${i}`,
+          "2575",
+          `${String(i).padStart(2, "0")}/04/2026`,
+        ),
+      );
+    }
+    const { authed } = fakeAuthed({ userId: userA, connectionId: connA, messages });
+    const getClient = async () => authed;
+
+    const events: { phase: string; processed: number; total: number }[] = [];
+    await backfillBancolombia(
+      userA,
+      {
+        from: FROM,
+        to: TO,
+        progressStride: 2,
+        onProgress: async (p) => {
+          events.push(p);
+        },
+      },
+      { getClient, sleep: async () => {} },
+    );
+
+    // 'listing' once, 'fetching' at 2/4/5 (stride=2 plus the final count),
+    // and 'done' once at the end.
+    const phases = events.map((e) => e.phase);
+    expect(phases[0]).toBe("listing");
+    expect(phases[phases.length - 1]).toBe("done");
+    const fetchingEvents = events.filter((e) => e.phase === "fetching");
+    expect(fetchingEvents.map((e) => e.processed)).toEqual([2, 4, 5]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Pagination: walks all pages via nextPageToken
+  // ---------------------------------------------------------------------------
+
+  it("paginates through all list pages (no page cap)", async () => {
+    await seedCreditCard(userA, "2575");
+    const messages: Record<string, string> = {};
+    for (let i = 1; i <= 7; i++) {
+      messages[`msg-${i}`] = wrapBancolombiaEmail(
+        purchaseSentence(
+          `10.00${i}`,
+          `MERCHANT_${i}`,
+          "2575",
+          `${String(i).padStart(2, "0")}/04/2026`,
+        ),
+      );
+    }
+    const { authed, listCalls } = fakeAuthed({
+      userId: userA,
+      connectionId: connA,
+      messages,
+      pageSize: 2,
+    });
+    const getClient = async () => authed;
+
+    const report = await backfillBancolombia(
+      userA,
+      { from: FROM, to: TO },
+      { getClient, sleep: async () => {} },
+    );
+    expect(report.totalEmails).toBe(7);
+    // 7 msgs / pageSize=2 → 4 list calls (2+2+2+1).
+    expect(listCalls).toHaveLength(4);
+  });
+});

--- a/src/lib/gmail/backfill.ts
+++ b/src/lib/gmail/backfill.ts
@@ -1,0 +1,494 @@
+import type { gmail_v1 } from "googleapis";
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { emailReceipts } from "@/lib/db/schema";
+import { createLogger } from "@/lib/logger";
+import {
+  getAuthedClient,
+  isInvalidGrantError,
+  markConnectionUnusable,
+  GmailConnectionUnusableError,
+  GmailNotConnectedError,
+  type AuthedGmailClient,
+} from "@/lib/gmail/client";
+import { buildSenderQuery, getGatewayById } from "@/lib/gmail/registry";
+import { parseBancolombiaEmail } from "@/lib/gmail/parsers/bancolombia";
+import { ingestParsedEmail } from "@/lib/ingestion/email-bancolombia";
+
+const log = createLogger({ module: "gmail/backfill" });
+
+// Gmail read quota is 250 units/user/second; `list` and `get` each cost 5
+// units, so 20 msgs/sec leaves headroom for retries and bursty traffic. With
+// ~500 msgs/year the full-year backfill takes ~25 s, safely under Telegram's
+// ~60 s webhook budget.
+const DEFAULT_SLEEP_BETWEEN_GETS_MS = 50;
+
+// How often to invoke the progress callback during the fetch+ingest loop.
+const DEFAULT_PROGRESS_STRIDE = 100;
+
+// Retry budget for transient (429 / 5xx) errors on individual Gmail calls.
+// Lower than the pull engine's because backfill loops are longer — we'd
+// rather surface an error and keep going than chain waits into minutes.
+const MAX_RETRIES = 3;
+
+export interface BackfillErrorDetail {
+  phase: "auth" | "list" | "get" | "persist" | "ingest";
+  messageId?: string;
+  code?: string;
+  message: string;
+}
+
+export interface BackfillReport {
+  totalEmails: number;
+  alreadyStored: number;
+  parsed: number;
+  skipped: number;
+  needsReview: number;
+  inserted: number;
+  matchedExisting: number;
+  sourceMismatches: number;
+  errors: BackfillErrorDetail[];
+  durationMs: number;
+  canceled: boolean;
+}
+
+export interface BackfillDryRunReport {
+  totalEmails: number;
+  alreadyStored: number;
+  newEmails: number;
+  durationMs: number;
+}
+
+export interface BackfillOpts {
+  from: Date;
+  to: Date;
+  // Fires every `progressStride` messages processed during the ingest phase
+  // (post-list). Also fires once at phase transitions so the caller can show
+  // the user "listing... 318 found. fetching...". Not awaited — the caller
+  // controls whether it blocks.
+  onProgress?: (progress: {
+    phase: "listing" | "fetching" | "done";
+    processed: number;
+    total: number;
+  }) => void | Promise<void>;
+  // Polled between every message fetch. Returning true aborts cleanly and
+  // `report.canceled` is set. Partial results are preserved.
+  shouldCancel?: () => boolean | Promise<boolean>;
+  // Override for tests. The default is `DEFAULT_PROGRESS_STRIDE`.
+  progressStride?: number;
+}
+
+export interface BackfillDeps {
+  getClient?: (userId: number) => Promise<AuthedGmailClient>;
+  now?: () => Date;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export class BackfillConnectionError extends Error {
+  constructor(
+    message: string,
+    readonly reason: "not_connected" | "revoked" | "unusable",
+  ) {
+    super(message);
+    this.name = "BackfillConnectionError";
+  }
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// Gmail accepts yyyy/mm/dd for `after:` / `before:`. `before:` is EXCLUSIVE
+// at midnight UTC, so callers who want "through day X inclusive" should pass
+// day X+1 as `to`.
+function toGmailDateQuery(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
+  return `${y}/${m}/${d}`;
+}
+
+function getHttpStatus(err: unknown): number | null {
+  if (!err || typeof err !== "object") return null;
+  const e = err as { code?: number | string; status?: number; response?: { status?: number } };
+  if (typeof e.code === "number") return e.code;
+  if (typeof e.status === "number") return e.status;
+  if (typeof e.response?.status === "number") return e.response.status;
+  return null;
+}
+
+function getRetryAfterSeconds(err: unknown): number | null {
+  if (!err || typeof err !== "object") return null;
+  const headers = (err as { response?: { headers?: Record<string, unknown> } }).response?.headers;
+  const raw = headers?.["retry-after"];
+  if (typeof raw !== "string") return null;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  deps: { sleep: (ms: number) => Promise<void> },
+): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const status = getHttpStatus(err);
+      const isRetryable = status === 429 || (status !== null && status >= 500);
+      if (!isRetryable) throw err;
+      const retryAfter = getRetryAfterSeconds(err);
+      const delayMs = retryAfter ? retryAfter * 1000 : 500 * Math.pow(2, attempt);
+      await deps.sleep(delayMs);
+    }
+  }
+  throw lastErr;
+}
+
+function extractBody(payload: gmail_v1.Schema$MessagePart | undefined): string {
+  if (!payload) return "";
+  const html = findByMimeType(payload, "text/html");
+  if (html) return html;
+  const plain = findByMimeType(payload, "text/plain");
+  return plain ?? "";
+}
+
+function findByMimeType(part: gmail_v1.Schema$MessagePart, mimeType: string): string | null {
+  if (part.mimeType === mimeType && part.body?.data) {
+    return Buffer.from(part.body.data, "base64url").toString("utf8");
+  }
+  for (const child of part.parts ?? []) {
+    const found = findByMimeType(child, mimeType);
+    if (found) return found;
+  }
+  return null;
+}
+
+// Tenant-scoped existing-msg-id lookup. Chunked so we don't pass an IN-list
+// of thousands of strings to Postgres.
+async function findExistingMsgIds(userId: number, msgIds: string[]): Promise<Set<string>> {
+  if (msgIds.length === 0) return new Set();
+  const out = new Set<string>();
+  const CHUNK = 500;
+  for (let i = 0; i < msgIds.length; i += CHUNK) {
+    const chunk = msgIds.slice(i, i + CHUNK);
+    const rows = await db
+      .select({ gmailMsgId: emailReceipts.gmailMsgId })
+      .from(emailReceipts)
+      .where(and(eq(emailReceipts.userId, userId), inArray(emailReceipts.gmailMsgId, chunk)));
+    for (const r of rows) out.add(r.gmailMsgId);
+  }
+  return out;
+}
+
+// Resolve the authed Gmail client OR throw a typed connection error. Used by
+// both dry-run and real backfill so bot/HTTP callers can branch on reason.
+async function resolveAuthed(
+  userId: number,
+  getClient: (id: number) => Promise<AuthedGmailClient>,
+): Promise<AuthedGmailClient> {
+  try {
+    return await getClient(userId);
+  } catch (err) {
+    if (err instanceof GmailNotConnectedError) {
+      throw new BackfillConnectionError(
+        "no active Gmail connection for this user",
+        "not_connected",
+      );
+    }
+    if (err instanceof GmailConnectionUnusableError) {
+      throw new BackfillConnectionError(
+        `Gmail connection unusable: ${err.status}`,
+        err.status === "revoked" ? "revoked" : "unusable",
+      );
+    }
+    throw err;
+  }
+}
+
+// List every candidate message id matching the bancolombia sender query
+// within [from, to]. Walks nextPageToken without a hard page cap — callers
+// expected to invoke this only against a bounded date window.
+async function listAllMsgIds(opts: {
+  authed: AuthedGmailClient;
+  q: string;
+  sleep: (ms: number) => Promise<void>;
+}): Promise<string[]> {
+  const { authed, q, sleep } = opts;
+  const allIds: string[] = [];
+  let pageToken: string | undefined;
+  for (;;) {
+    const res = await withRetry(
+      () =>
+        authed.gmail.users.messages.list({
+          userId: "me",
+          q,
+          maxResults: 500,
+          pageToken,
+        }),
+      { sleep },
+    );
+    const batch = res.data.messages ?? [];
+    for (const m of batch) {
+      if (m.id) allIds.push(m.id);
+    }
+    pageToken = res.data.nextPageToken ?? undefined;
+    if (!pageToken) break;
+  }
+  return allIds;
+}
+
+function buildQuery(from: Date, to: Date): string {
+  const cfg = getGatewayById("bancolombia");
+  // `after:` is inclusive; `before:` is exclusive (midnight UTC of that day).
+  return `${buildSenderQuery(cfg)} after:${toGmailDateQuery(from)} before:${toGmailDateQuery(to)}`;
+}
+
+/**
+ * Dry-run preview: lists candidate emails and counts how many are new for
+ * this user without fetching bodies or writing anything. Cheap — one Gmail
+ * `list` call (5 quota units) per page.
+ *
+ * This is intentionally lighter than a "would-insert/would-skip" simulation:
+ * the heavy signal is "N emails new, M already stored", which is enough to
+ * confirm the user wants to proceed. Per-email parse/ingest outcomes are
+ * only available after a real run.
+ */
+export async function backfillBancolombiaDryRun(
+  userId: number,
+  opts: BackfillOpts,
+  deps: BackfillDeps = {},
+): Promise<BackfillDryRunReport> {
+  const getClient = deps.getClient ?? getAuthedClient;
+  const sleep = deps.sleep ?? defaultSleep;
+  const startedAt = Date.now();
+
+  const authed = await resolveAuthed(userId, getClient);
+  const q = buildQuery(opts.from, opts.to);
+
+  try {
+    const allIds = await listAllMsgIds({ authed, q, sleep });
+    const existing = await findExistingMsgIds(userId, allIds);
+    const alreadyStored = allIds.filter((id) => existing.has(id)).length;
+    return {
+      totalEmails: allIds.length,
+      alreadyStored,
+      newEmails: allIds.length - alreadyStored,
+      durationMs: Date.now() - startedAt,
+    };
+  } catch (err) {
+    if (isInvalidGrantError(err)) {
+      await markConnectionUnusable(
+        authed.connection.id,
+        "revoked",
+        "invalid_grant during backfill dry-run",
+      );
+      throw new BackfillConnectionError("Gmail refresh token revoked", "revoked");
+    }
+    throw err;
+  }
+}
+
+/**
+ * Real backfill: lists + fetches + inserts + ingests every new Bancolombia
+ * notification email in [from, to]. Reuses the same parser and A+ dedup path
+ * as the regular pull (#457) so semantics match exactly — running this after
+ * a cron tick is idempotent.
+ *
+ * Tenant isolation: every DB read/write is scoped by `userId` via the
+ * existing pipeline helpers. A caller that mishandles the userId cannot
+ * cross-pollinate another tenant.
+ *
+ * Does NOT advance `gmail_connections.last_pull_at` — backfill is a
+ * one-shot parallel operation and should not interfere with the cron
+ * watermark.
+ */
+export async function backfillBancolombia(
+  userId: number,
+  opts: BackfillOpts,
+  deps: BackfillDeps = {},
+): Promise<BackfillReport> {
+  const getClient = deps.getClient ?? getAuthedClient;
+  const sleep = deps.sleep ?? defaultSleep;
+  const startedAt = Date.now();
+  const progressStride = opts.progressStride ?? DEFAULT_PROGRESS_STRIDE;
+  const onProgress = opts.onProgress ?? (() => {});
+
+  const report: BackfillReport = {
+    totalEmails: 0,
+    alreadyStored: 0,
+    parsed: 0,
+    skipped: 0,
+    needsReview: 0,
+    inserted: 0,
+    matchedExisting: 0,
+    sourceMismatches: 0,
+    errors: [],
+    durationMs: 0,
+    canceled: false,
+  };
+
+  const authed = await resolveAuthed(userId, getClient);
+  const q = buildQuery(opts.from, opts.to);
+
+  let allIds: string[];
+  try {
+    await onProgress({ phase: "listing", processed: 0, total: 0 });
+    allIds = await listAllMsgIds({ authed, q, sleep });
+  } catch (err) {
+    if (isInvalidGrantError(err)) {
+      await markConnectionUnusable(
+        authed.connection.id,
+        "revoked",
+        "invalid_grant during backfill list",
+      );
+      throw new BackfillConnectionError("Gmail refresh token revoked", "revoked");
+    }
+    report.errors.push({
+      phase: "list",
+      message: err instanceof Error ? err.message : String(err),
+    });
+    report.durationMs = Date.now() - startedAt;
+    return report;
+  }
+
+  report.totalEmails = allIds.length;
+
+  // Filter out already-stored msg_ids for this user so we don't re-fetch
+  // bodies we already have. The dedup A+ layer also catches double-inserts
+  // downstream, but skipping here saves quota and wall-clock time.
+  const existing = await findExistingMsgIds(userId, allIds);
+  const newIds = allIds.filter((id) => !existing.has(id));
+  report.alreadyStored = allIds.length - newIds.length;
+
+  // Fetch bodies + insert receipts one at a time. Each new receipt is then
+  // fed through ingestParsedEmail in the same loop so memory pressure stays
+  // O(1) — we never hold more than one raw body at a time.
+  for (let i = 0; i < newIds.length; i++) {
+    if (opts.shouldCancel && (await opts.shouldCancel())) {
+      report.canceled = true;
+      break;
+    }
+
+    const msgId = newIds[i];
+    try {
+      const res = await withRetry(
+        () =>
+          authed.gmail.users.messages.get({
+            userId: "me",
+            id: msgId,
+            format: "full",
+          }),
+        { sleep },
+      );
+      const rawBody = extractBody(res.data.payload ?? undefined);
+      if (!rawBody) {
+        report.errors.push({
+          phase: "get",
+          messageId: msgId,
+          message: "no text/html or text/plain body found",
+        });
+        continue;
+      }
+
+      const [inserted] = await db
+        .insert(emailReceipts)
+        .values({
+          userId,
+          gmailConnectionId: authed.connection.id,
+          gmailMsgId: msgId,
+          gateway: "bancolombia",
+          rawHtml: rawBody,
+        })
+        .onConflictDoNothing()
+        .returning({ id: emailReceipts.id });
+      if (!inserted) {
+        // Someone else (parallel cron / another /enriquecer) beat us to it.
+        // Count as alreadyStored for the report and move on — the regular
+        // pull will ingest whichever pending receipt is present.
+        report.alreadyStored++;
+        continue;
+      }
+
+      const parsed = parseBancolombiaEmail(rawBody);
+      if (parsed.kind === "skip") {
+        report.skipped++;
+      } else if (parsed.kind === "needs_review") {
+        report.needsReview++;
+      } else {
+        report.parsed++;
+      }
+
+      const outcome = await ingestParsedEmail(userId, parsed, inserted.id);
+      if (outcome.status === "inserted") {
+        report.inserted++;
+      } else if (outcome.status === "duplicated") {
+        report.matchedExisting++;
+        if (outcome.flaggedMismatch) report.sourceMismatches++;
+      } else if (outcome.status === "error") {
+        report.errors.push({
+          phase: "ingest",
+          messageId: msgId,
+          message: outcome.reason,
+        });
+      }
+      // "skipped" ingest outcomes are already covered by the parser-skip
+      // counter — no double count.
+
+      // Rate-limit after every successful get so a long run doesn't exhaust
+      // the per-user quota. Skipped when nothing to fetch (i === len - 1
+      // branch falls through naturally).
+      await sleep(DEFAULT_SLEEP_BETWEEN_GETS_MS);
+    } catch (err) {
+      if (isInvalidGrantError(err)) {
+        await markConnectionUnusable(
+          authed.connection.id,
+          "revoked",
+          "invalid_grant during backfill",
+        );
+        report.errors.push({
+          phase: "auth",
+          code: "invalid_grant",
+          message: "refresh token revoked — connection marked revoked",
+        });
+        break;
+      }
+      log.error(
+        { err, userId, gmailMsgId: msgId, event: "gmail_backfill_message_failed" },
+        "failed to fetch/persist a backfill message",
+      );
+      report.errors.push({
+        phase: "get",
+        messageId: msgId,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const processedCount = i + 1;
+    if (processedCount % progressStride === 0 || processedCount === newIds.length) {
+      await onProgress({ phase: "fetching", processed: processedCount, total: newIds.length });
+    }
+  }
+
+  await onProgress({
+    phase: "done",
+    processed: report.inserted + report.matchedExisting + report.skipped + report.needsReview,
+    total: newIds.length,
+  });
+  report.durationMs = Date.now() - startedAt;
+  log.info(
+    {
+      userId,
+      totalEmails: report.totalEmails,
+      inserted: report.inserted,
+      matchedExisting: report.matchedExisting,
+      sourceMismatches: report.sourceMismatches,
+      errors: report.errors.length,
+      canceled: report.canceled,
+      durationMs: report.durationMs,
+      event: "gmail_backfill_completed",
+    },
+    "bancolombia email backfill completed",
+  );
+  return report;
+}

--- a/src/lib/ingestion/email-bancolombia.ts
+++ b/src/lib/ingestion/email-bancolombia.ts
@@ -112,7 +112,8 @@ export async function ingestParsedEmail(
   const match = await findMatchingTransaction(userId, routed.id, parsed);
   if (match) {
     const diffs = computeDiffs(match, parsed);
-    if (diffs.length > 0) {
+    const flaggedMismatch = diffs.length > 0;
+    if (flaggedMismatch) {
       await flagSourceMismatch(match.id, match.source ?? "unknown", diffs);
       log.info(
         {
@@ -127,7 +128,7 @@ export async function ingestParsedEmail(
       );
     }
     await markReceiptMatched(receiptId, userId, match.id, parsed);
-    return { status: "duplicated" };
+    return { status: "duplicated", flaggedMismatch };
   }
 
   // No existing tx covers this event — insert fresh through the shared

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -28,7 +28,10 @@ const COP_TIMEZONE_OFFSET = "-05:00";
 
 export type IngestOutcome =
   | { status: "inserted"; txId: number; via?: "regex" | "ai_fallback" }
-  | { status: "duplicated" }
+  // `flaggedMismatch` is set by the email pipeline when a duplicate was
+  // detected AND the existing tx had divergences that were recorded on the
+  // tx's `source_mismatch_details`. SMS callers leave it undefined.
+  | { status: "duplicated"; flaggedMismatch?: boolean }
   | { status: "skipped"; reason: string }
   | { status: "error"; reason: string };
 

--- a/src/lib/telegram/commands.ts
+++ b/src/lib/telegram/commands.ts
@@ -1,6 +1,14 @@
 import type { TelegramClient } from "@/lib/telegram/client";
-import { clearSession } from "@/lib/telegram/session";
+import type { TelegramSessionState } from "@/lib/db/schema";
+import { clearSession, getSession, upsertSession } from "@/lib/telegram/session";
 import {
+  renderBackfillConfirmPrompt,
+  renderBackfillConnectPrompt,
+  renderBackfillFailed,
+  renderBackfillNothingPending,
+  renderBackfillProgress,
+  renderBackfillResult,
+  renderBackfillStarting,
   renderCanceled,
   renderEnrichConnectPrompt,
   renderEnrichFailed,
@@ -10,21 +18,31 @@ import {
   renderStart,
 } from "@/lib/telegram/formatter";
 import { pullForUser } from "@/lib/gmail/pull";
+import {
+  backfillBancolombia,
+  backfillBancolombiaDryRun,
+  BackfillConnectionError,
+} from "@/lib/gmail/backfill";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger({ module: "telegram/commands" });
 
-export type CommandName = "/start" | "/help" | "/cancel" | "/enriquecer";
+export type CommandName = "/start" | "/help" | "/cancel" | "/enriquecer" | "/backfill" | "/si";
 
 // Maps aliases to canonical command names. `/enrich` is the English alias
-// requested by #452. Add locale-specific aliases here; the canonical set
-// above stays stable.
+// requested by #452. `/backfill-gmail` maps to the canonical `/backfill`.
+// `/sí`, `/yes` map to `/si` for confirmation flows (#458).
 const COMMAND_ALIASES: Record<string, CommandName> = {
   "/start": "/start",
   "/help": "/help",
   "/cancel": "/cancel",
   "/enriquecer": "/enriquecer",
   "/enrich": "/enriquecer",
+  "/backfill": "/backfill",
+  "/backfill-gmail": "/backfill",
+  "/si": "/si",
+  "/sí": "/si",
+  "/yes": "/si",
 };
 
 export function parseCommand(text: string): CommandName | null {
@@ -38,8 +56,10 @@ export async function handleCommand(opts: {
   chatId: number;
   client: TelegramClient;
   userId: number;
+  telegramUserId: number;
+  text: string;
 }): Promise<void> {
-  const { command, chatId, client, userId } = opts;
+  const { command, chatId, client, userId, telegramUserId, text } = opts;
   switch (command) {
     case "/start":
       await client.sendMessage({ chat_id: chatId, text: renderStart(), parse_mode: "Markdown" });
@@ -53,6 +73,12 @@ export async function handleCommand(opts: {
       return;
     case "/enriquecer":
       await handleEnriquecer({ chatId, client, userId });
+      return;
+    case "/backfill":
+      await handleBackfill({ chatId, client, userId, telegramUserId, text });
+      return;
+    case "/si":
+      await handleBackfillConfirm({ chatId, client, userId, telegramUserId });
       return;
   }
 }
@@ -81,5 +107,161 @@ async function handleEnriquecer(opts: {
   } catch (err) {
     log.error({ err, userId, event: "telegram_enriquecer_failed" }, "/enriquecer threw");
     await client.sendMessage({ chat_id: chatId, text: renderEnrichFailed() });
+  }
+}
+
+// Parses the optional `[year]` argument from `/backfill-gmail 2025` style
+// input. Rejects anything outside a sensible range so a typo doesn't trigger
+// a quota-exhausting 10-year scan.
+function parseBackfillYear(text: string, now: Date): number | null {
+  const parts = text.trim().split(/\s+/);
+  if (parts.length < 2) return now.getUTCFullYear();
+  const year = Number.parseInt(parts[1], 10);
+  if (!Number.isInteger(year)) return null;
+  const currentYear = now.getUTCFullYear();
+  if (year < 2020 || year > currentYear) return null;
+  return year;
+}
+
+async function handleBackfill(opts: {
+  chatId: number;
+  client: TelegramClient;
+  userId: number;
+  telegramUserId: number;
+  text: string;
+}): Promise<void> {
+  const { chatId, client, userId, telegramUserId, text } = opts;
+  const now = new Date();
+  const year = parseBackfillYear(text, now);
+  if (year === null) {
+    await client.sendMessage({
+      chat_id: chatId,
+      text: "⚠️ Año inválido. Usá `/backfill-gmail` (año actual) o `/backfill-gmail 2025`.",
+      parse_mode: "Markdown",
+    });
+    return;
+  }
+
+  // `before:` is exclusive at midnight UTC, so passing Jan 1 of the next
+  // year covers through Dec 31. When backfilling the current year we stop
+  // at tomorrow UTC to cover today's messages.
+  const from = new Date(Date.UTC(year, 0, 1));
+  const isCurrentYear = year === now.getUTCFullYear();
+  const to = isCurrentYear
+    ? new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1))
+    : new Date(Date.UTC(year + 1, 0, 1));
+
+  await client.sendMessage({
+    chat_id: chatId,
+    text: `📧 Revisando emails de Bancolombia ${year}…`,
+  });
+
+  let preview;
+  try {
+    preview = await backfillBancolombiaDryRun(userId, { from, to });
+  } catch (err) {
+    if (err instanceof BackfillConnectionError) {
+      await client.sendMessage({
+        chat_id: chatId,
+        text: renderBackfillConnectPrompt(err.reason),
+        parse_mode: "Markdown",
+      });
+      return;
+    }
+    log.error({ err, userId, year, event: "telegram_backfill_dryrun_failed" }, "dry-run threw");
+    await client.sendMessage({ chat_id: chatId, text: renderBackfillFailed() });
+    return;
+  }
+
+  const state: TelegramSessionState = {
+    step: "awaiting_backfill_confirm",
+    draft: {},
+    sourceChatId: chatId,
+    backfill: {
+      from: from.toISOString(),
+      to: to.toISOString(),
+      gateway: "bancolombia",
+    },
+  };
+  await upsertSession({ chatId, userId, telegramUserId, state });
+
+  await client.sendMessage({
+    chat_id: chatId,
+    text: renderBackfillConfirmPrompt({ year, preview }),
+    parse_mode: "Markdown",
+  });
+}
+
+async function handleBackfillConfirm(opts: {
+  chatId: number;
+  client: TelegramClient;
+  userId: number;
+  telegramUserId: number;
+}): Promise<void> {
+  const { chatId, client, userId, telegramUserId } = opts;
+  const session = await getSession(chatId);
+  if (!session) {
+    await client.sendMessage({ chat_id: chatId, text: renderBackfillNothingPending() });
+    return;
+  }
+  if (session.step === "backfill_running") {
+    await client.sendMessage({
+      chat_id: chatId,
+      text: "⏳ Ya hay un backfill corriendo. Esperá a que termine o usá /cancel para abortar.",
+    });
+    return;
+  }
+  if (session.step !== "awaiting_backfill_confirm" || !session.backfill) {
+    await client.sendMessage({ chat_id: chatId, text: renderBackfillNothingPending() });
+    return;
+  }
+
+  const from = new Date(session.backfill.from);
+  const to = new Date(session.backfill.to);
+
+  // Atomic transition: any subsequent /si arrives, reads backfill_running,
+  // and bails. A /cancel deletes the session row so the loop's shouldCancel
+  // poll returns true.
+  await upsertSession({
+    chatId,
+    userId,
+    telegramUserId,
+    state: { ...session, step: "backfill_running" },
+  });
+
+  await client.sendMessage({ chat_id: chatId, text: renderBackfillStarting() });
+
+  try {
+    const report = await backfillBancolombia(userId, {
+      from,
+      to,
+      shouldCancel: async () => {
+        const s = await getSession(chatId);
+        return !s || s.step !== "backfill_running";
+      },
+      onProgress: async ({ phase, processed, total }) => {
+        if (phase !== "fetching") return;
+        await client.sendMessage({
+          chat_id: chatId,
+          text: renderBackfillProgress({ processed, total }),
+        });
+      },
+    });
+    await client.sendMessage({ chat_id: chatId, text: renderBackfillResult(report) });
+  } catch (err) {
+    if (err instanceof BackfillConnectionError) {
+      await client.sendMessage({
+        chat_id: chatId,
+        text: renderBackfillConnectPrompt(err.reason),
+        parse_mode: "Markdown",
+      });
+      return;
+    }
+    log.error({ err, userId, event: "telegram_backfill_failed" }, "backfill threw");
+    await client.sendMessage({ chat_id: chatId, text: renderBackfillFailed() });
+  } finally {
+    // Always clear the session at the end — successful, errored, or canceled.
+    // A /cancel mid-flight has already deleted it; clearSession is idempotent.
+    await clearSession(chatId);
   }
 }

--- a/src/lib/telegram/formatter.ts
+++ b/src/lib/telegram/formatter.ts
@@ -1,6 +1,7 @@
 import type { TelegramBatchItem, TelegramDraft } from "@/lib/db/schema";
 import type { NluAccountOption, NluCategoryOption } from "@/lib/ai/transaction-nlu";
 import type { PullResult } from "@/lib/gmail/pull";
+import type { BackfillDryRunReport, BackfillReport } from "@/lib/gmail/backfill";
 import type { GatewayId } from "@/lib/gmail/registry";
 import { formatAccountLabel } from "@/lib/accounts/format";
 
@@ -233,4 +234,81 @@ export function renderEnrichConnectPrompt(): string {
 
 export function renderEnrichFailed(): string {
   return "⚠️ Algo falló buscando emails. Probá de nuevo en un rato.";
+}
+
+export function renderBackfillConfirmPrompt(opts: {
+  year: number;
+  preview: BackfillDryRunReport;
+}): string {
+  const { year, preview } = opts;
+  const lines = [
+    `📧 Backfill Bancolombia *${year}*`,
+    "",
+    `• Emails encontrados: ${preview.totalEmails}`,
+    `• Ya ingresados: ${preview.alreadyStored}`,
+    `• Nuevos a procesar: ${preview.newEmails}`,
+  ];
+  if (preview.newEmails === 0) {
+    lines.push("", "✅ No hay nada nuevo que ingresar. Listo.");
+    return lines.join("\n");
+  }
+  lines.push("", "Confirmá con /si para arrancar, o /cancel para abortar.");
+  return lines.join("\n");
+}
+
+export function renderBackfillStarting(): string {
+  return "📧 Arrancando backfill… te mando progreso cada 100 emails.";
+}
+
+export function renderBackfillProgress(opts: { processed: number; total: number }): string {
+  return `📧 Backfill: ${opts.processed}/${opts.total} procesados…`;
+}
+
+export function renderBackfillResult(report: BackfillReport): string {
+  const lines: string[] = [];
+  if (report.canceled) {
+    lines.push("🛑 Backfill cancelado.");
+  } else {
+    lines.push("✅ Backfill completo.");
+  }
+  lines.push(
+    `• Emails revisados: ${report.totalEmails} (ya vistos: ${report.alreadyStored})`,
+    `• Parseados: ${report.parsed} · omitidos: ${report.skipped} · no reconocidos: ${report.needsReview}`,
+    `• Transacciones nuevas: ${report.inserted}`,
+    `• Ya existían (dedup A+): ${report.matchedExisting}`,
+  );
+  if (report.sourceMismatches > 0) {
+    lines.push(`⚠️ Divergencias con otra fuente: ${report.sourceMismatches} — revisá en la web.`);
+  }
+  if (report.errors.length > 0) {
+    lines.push(`⚠️ ${report.errors.length} errores — revisá los logs.`);
+  }
+  const seconds = Math.round(report.durationMs / 100) / 10;
+  lines.push(`⏱️ ${seconds}s`);
+  return lines.join("\n");
+}
+
+export function renderBackfillConnectPrompt(
+  reason: "not_connected" | "revoked" | "unusable",
+): string {
+  if (reason === "not_connected") {
+    return [
+      "📧 Todavía no tenés una cuenta de Gmail conectada.",
+      "",
+      "Entrá a *Settings → Integrations* en la web para conectarla.",
+    ].join("\n");
+  }
+  return [
+    "📧 Tu conexión de Gmail dejó de funcionar (token revocado o expirado).",
+    "",
+    "Entrá a *Settings → Integrations* en la web para reconectarla.",
+  ].join("\n");
+}
+
+export function renderBackfillFailed(): string {
+  return "⚠️ Algo falló con el backfill. Probá de nuevo en un rato.";
+}
+
+export function renderBackfillNothingPending(): string {
+  return "Nada pendiente que confirmar. Escribí /backfill-gmail para arrancar uno.";
 }

--- a/src/lib/telegram/router.ts
+++ b/src/lib/telegram/router.ts
@@ -368,7 +368,14 @@ async function handleText(
 
   const command = parseCommand(text);
   if (command) {
-    await handleCommand({ command, chatId, client, userId: deps.userId });
+    await handleCommand({
+      command,
+      chatId,
+      client,
+      userId: deps.userId,
+      telegramUserId: userId,
+      text,
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary

- One-shot backfill for Bancolombia notification emails in `[from, to]`, built on top of the #457 parser and A+ dedup — running it after a cron tick is idempotent and never double-inserts.
- Telegram command `/backfill-gmail [year]` with dry-run preview → `/si` confirmation → streaming progress updates every 100 emails → final report. `/cancel` aborts mid-flight.
- `POST /api/cron/gmail-backfill` (CRON_TOKEN bearer) for ops: `{ userId, from, to, confirm? }`. Defaults to dry-run unless `confirm: true` is set.
- No watermark advance — backfill is a side channel and does not interfere with the hourly pull's `last_pull_at`.

## Key design choices

- Separate `backfillBancolombia` function rather than extending `pullForUser`: the pull engine has a 500-msg/gateway cap that's right for cron but wrong for a full-year backfill, and the report shape differs.
- Dry-run is list-only (one `list` API call per page, no `get`). Gives the user "N nuevos emails" as preview without burning quota on fetches that may never be confirmed.
- Rate limit: 50 ms sleep between `get` calls → ~20 msgs/sec, safely under Gmail's 250 units/user/sec quota.
- Cancel is a DB-mediated signal: the running loop polls the session state; a `/cancel` from another webhook deletes the row and the loop sees \`getSession() === null\`.
- \`IngestOutcome.duplicated\` gained an optional \`flaggedMismatch?: boolean\` so the report's \`sourceMismatches\` count reflects the dedup path's divergence flagging without a second DB round-trip.

## Test plan

- [x] \`src/lib/gmail/backfill.test.ts\` — 9 new tests covering dry-run (no writes), happy path, idempotency (second run inserted=0), multi-tenant isolation, A+ dedup (matches SMS tx), cancel mid-run, progress callback stride, pagination.
- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun run test\` — 1185/1185 green
- [ ] Manual prod validation: \`/backfill-gmail\` in Telegram against real inbox after deploy

Closes #458