### PR TITLE
feat(infra): user data snapshots — save/restore with UI (#471)

### DIFF
--- a/drizzle/0055_spicy_the_executioner.sql
+++ b/drizzle/0055_spicy_the_executioner.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "user_snapshots" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"name" varchar(200) NOT NULL,
+	"schema_version" varchar(128) NOT NULL,
+	"payload" jsonb NOT NULL,
+	"payload_bytes" bigint NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_snapshots" ADD CONSTRAINT "user_snapshots_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "user_snapshots_user_created_idx" ON "user_snapshots" USING btree ("user_id","created_at" DESC NULLS LAST);

--- a/drizzle/meta/0055_snapshot.json
+++ b/drizzle/meta/0055_snapshot.json
@@ -1,0 +1,5074 @@
+{
+  "id": "61c21c8c-821c-4ca4-ace8-3df6aa2d62ab",
+  "prevId": "19606039-4260-414a-9b02-d4c80623060d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_physical_card_id_physical_cards_id_fk": {
+          "name": "accounts_physical_card_id_physical_cards_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "physical_cards",
+          "columnsFrom": [
+            "physical_card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_corrections": {
+      "name": "classification_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_category_slug": {
+          "name": "new_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_corrections_learning_idx": {
+          "name": "classification_corrections_learning_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "new_category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_corrections_user_id_users_id_fk": {
+          "name": "classification_corrections_user_id_users_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_corrections_transaction_id_transactions_id_fk": {
+          "name": "classification_corrections_transaction_id_transactions_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_from_corrections": {
+          "name": "generated_from_corrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_receipts": {
+      "name": "email_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_connection_id": {
+          "name": "gmail_connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_msg_id": {
+          "name": "gmail_msg_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway": {
+          "name": "gateway",
+          "type": "email_receipt_gateway",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_html": {
+          "name": "raw_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_payload": {
+          "name": "parsed_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_transaction_id": {
+          "name": "matched_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_status": {
+          "name": "match_status",
+          "type": "email_receipt_match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "match_candidates": {
+          "name": "match_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_at": {
+          "name": "parsed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_receipts_user_msg_unique": {
+          "name": "email_receipts_user_msg_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_msg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_user_status_idx": {
+          "name": "email_receipts_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_match_lookup_idx": {
+          "name": "email_receipts_match_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "amount_cents",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'pending' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_connection_idx": {
+          "name": "email_receipts_connection_idx",
+          "columns": [
+            {
+              "expression": "gmail_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_receipts_user_id_users_id_fk": {
+          "name": "email_receipts_user_id_users_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_gmail_connection_id_gmail_connections_id_fk": {
+          "name": "email_receipts_gmail_connection_id_gmail_connections_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "gmail_connections",
+          "columnsFrom": [
+            "gmail_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_matched_transaction_id_transactions_id_fk": {
+          "name": "email_receipts_matched_transaction_id_transactions_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "matched_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_connections": {
+      "name": "gmail_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_email": {
+          "name": "gmail_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_enc": {
+          "name": "access_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_pull_at": {
+          "name": "last_pull_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_pull_history_id": {
+          "name": "last_pull_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "gmail_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_connections_user_email_unique": {
+          "name": "gmail_connections_user_email_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_user_status_idx": {
+          "name": "gmail_connections_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_active_idx": {
+          "name": "gmail_connections_active_idx",
+          "columns": [
+            {
+              "expression": "last_pull_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"status\" = 'active' AND \"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_connections_user_id_users_id_fk": {
+          "name": "gmail_connections_user_id_users_id_fk",
+          "tableFrom": "gmail_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.physical_cards": {
+      "name": "physical_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_limit_cents": {
+          "name": "credit_limit_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "statement_cutoff_day": {
+          "name": "statement_cutoff_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "physical_cards_user_idx": {
+          "name": "physical_cards_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "physical_cards_user_institution_idx": {
+          "name": "physical_cards_user_institution_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "physical_cards_user_id_users_id_fk": {
+          "name": "physical_cards_user_id_users_id_fk",
+          "tableFrom": "physical_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_proposals": {
+      "name": "rule_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_txn_ids": {
+          "name": "correction_txn_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rule_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rule_proposals_user_merchant_category_pending_unique": {
+          "name": "rule_proposals_user_merchant_category_pending_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rule_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rule_proposals_user_status_idx": {
+          "name": "rule_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_proposals_user_id_users_id_fk": {
+          "name": "rule_proposals_user_id_users_id_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_proposals_user_category_fk": {
+          "name": "rule_proposals_user_category_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skipped_consolidation_cycles": {
+      "name": "skipped_consolidation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "skipped_consolidation_cycles_live_unique": {
+          "name": "skipped_consolidation_cycles_live_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skipped_consolidation_cycles_user_account_idx": {
+          "name": "skipped_consolidation_cycles_user_account_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skipped_consolidation_cycles_user_id_users_id_fk": {
+          "name": "skipped_consolidation_cycles_user_id_users_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skipped_consolidation_cycles_account_id_accounts_id_fk": {
+          "name": "skipped_consolidation_cycles_account_id_accounts_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slo_alerts": {
+      "name": "slo_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slo_key": {
+          "name": "slo_key",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slo_alerts_open_idx": {
+          "name": "slo_alerts_open_idx",
+          "columns": [
+            {
+              "expression": "slo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"slo_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "statement_import_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movimientos'"
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synthetic_tx_id": {
+          "name": "synthetic_tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_cycle_unique": {
+          "name": "statement_imports_cycle_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"statement_imports\".\"kind\" = 'extracto_detallado' AND \"statement_imports\".\"cycle\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installments_total": {
+          "name": "installments_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "installment_rate_bps": {
+          "name": "installment_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retroactive_rule_id": {
+          "name": "retroactive_rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group_id": {
+          "name": "transfer_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enriched_merchant": {
+          "name": "enriched_merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_source": {
+          "name": "enrichment_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_mismatch": {
+          "name": "source_mismatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_mismatch_details": {
+          "name": "source_mismatch_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_group_idx": {
+          "name": "transactions_transfer_group_idx",
+          "columns": [
+            {
+              "expression": "transfer_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"transfer_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_occurred_live_idx": {
+          "name": "transactions_account_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_live_idx": {
+          "name": "transactions_user_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_retroactive_rule_id_classification_rules_id_fk": {
+          "name": "transactions_retroactive_rule_id_classification_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "classification_rules",
+          "columnsFrom": [
+            "retroactive_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_snapshots": {
+      "name": "user_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_bytes": {
+          "name": "payload_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_snapshots_user_created_idx": {
+          "name": "user_snapshots_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_snapshots_user_id_users_id_fk": {
+          "name": "user_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ui_preferences": {
+          "name": "ui_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "classification_context": {
+          "name": "classification_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "rule_retroactive",
+        "ai",
+        "manual",
+        "manual_confirmed",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.email_receipt_gateway": {
+      "name": "email_receipt_gateway",
+      "schema": "public",
+      "values": [
+        "mercado_pago",
+        "payu",
+        "wompi",
+        "apple",
+        "paypal",
+        "bancolombia"
+      ]
+    },
+    "public.email_receipt_match_status": {
+      "name": "email_receipt_match_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "matched",
+        "ambiguous",
+        "unmatched"
+      ]
+    },
+    "public.gmail_connection_status": {
+      "name": "gmail_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "revoked",
+        "error"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.rule_proposal_status": {
+      "name": "rule_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.statement_import_kind": {
+      "name": "statement_import_kind",
+      "schema": "public",
+      "values": [
+        "movimientos",
+        "extracto_detallado"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile",
+        "gmail_bancolombia",
+        "gmail_enrichment"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug",
+        "widget"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1777005513813,
       "tag": "0054_real_the_leader",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1777067342896,
+      "tag": "0055_spicy_the_executioner",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -68,6 +68,12 @@ const LINKS = [
     description:
       "Connect external accounts (Gmail, etc.) so Findash can enrich gateway transactions and pull bank receipts directly from your inbox.",
   },
+  {
+    href: "/settings/snapshots",
+    title: "Snapshots",
+    description:
+      "Save and restore your transactional data. Useful before a reset or a mass email ingestion — keeps accounts, categories, rules, and integrations untouched.",
+  },
 ];
 
 const ADMIN_LINK = {

--- a/src/app/(app)/settings/snapshots/actions.ts
+++ b/src/app/(app)/settings/snapshots/actions.ts
@@ -1,0 +1,111 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { getSessionUser } from "@/lib/auth/session";
+import { createLogger } from "@/lib/logger";
+import {
+  createSnapshotForUser,
+  deleteSnapshotForUser,
+  restoreSnapshotForUser,
+  type CreatedSnapshot,
+} from "@/lib/snapshots/create";
+
+const log = createLogger({ module: "snapshots.actions" });
+
+const createSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+});
+
+export type CreateSnapshotResult =
+  | { status: "ok"; snapshot: { id: number; name: string; payloadBytes: string } }
+  | { status: "error"; message: string };
+
+export async function createSnapshotAction(
+  input: z.input<typeof createSchema>,
+): Promise<CreateSnapshotResult> {
+  const session = await getSessionUser();
+  const parsed = createSchema.safeParse(input);
+  if (!parsed.success) {
+    return { status: "error", message: "Invalid snapshot name." };
+  }
+
+  try {
+    const row: CreatedSnapshot = await createSnapshotForUser({
+      userId: session.id,
+      name: parsed.data.name,
+    });
+    revalidatePath("/settings/snapshots");
+    return {
+      status: "ok",
+      snapshot: {
+        id: row.id,
+        name: row.name,
+        payloadBytes: row.payloadBytes.toString(),
+      },
+    };
+  } catch (err) {
+    log.error({ err, userId: session.id, event: "create_failed" }, "create snapshot failed");
+    return { status: "error", message: "Failed to create snapshot." };
+  }
+}
+
+const idSchema = z.object({
+  snapshotId: z.coerce.number().int().positive(),
+});
+
+export type RestoreSnapshotResult =
+  | { status: "ok" }
+  | { status: "not_found" }
+  | { status: "schema_mismatch"; snapshotVersion: string; currentVersion: string }
+  | { status: "error"; message: string };
+
+export async function restoreSnapshotAction(
+  input: z.input<typeof idSchema>,
+): Promise<RestoreSnapshotResult> {
+  const session = await getSessionUser();
+  const { snapshotId } = idSchema.parse(input);
+
+  try {
+    const result = await restoreSnapshotForUser({ userId: session.id, snapshotId });
+    if (!result.ok) {
+      if (result.reason === "not_found") {
+        return { status: "not_found" };
+      }
+      return {
+        status: "schema_mismatch",
+        snapshotVersion: result.snapshotVersion,
+        currentVersion: result.currentVersion,
+      };
+    }
+    revalidatePath("/settings/snapshots");
+    revalidatePath("/");
+    revalidatePath("/transactions");
+    return { status: "ok" };
+  } catch (err) {
+    log.error(
+      { err, userId: session.id, snapshotId, event: "restore_failed" },
+      "restore snapshot failed",
+    );
+    return { status: "error", message: "Failed to restore snapshot." };
+  }
+}
+
+export async function deleteSnapshotAction(
+  input: z.input<typeof idSchema>,
+): Promise<{ status: "ok" } | { status: "error"; message: string }> {
+  const session = await getSessionUser();
+  const { snapshotId } = idSchema.parse(input);
+
+  try {
+    const deleted = await deleteSnapshotForUser({ userId: session.id, snapshotId });
+    revalidatePath("/settings/snapshots");
+    return deleted ? { status: "ok" } : { status: "error", message: "Snapshot not found." };
+  } catch (err) {
+    log.error(
+      { err, userId: session.id, snapshotId, event: "delete_failed" },
+      "delete snapshot failed",
+    );
+    return { status: "error", message: "Failed to delete snapshot." };
+  }
+}

--- a/src/app/(app)/settings/snapshots/page.tsx
+++ b/src/app/(app)/settings/snapshots/page.tsx
@@ -1,0 +1,33 @@
+import { getSessionUser } from "@/lib/auth/session";
+import { listSnapshots } from "@/lib/snapshots/queries";
+import { SnapshotsManager, type SnapshotRow } from "./snapshots-manager";
+
+export const dynamic = "force-dynamic";
+
+export default async function SnapshotsPage() {
+  const session = await getSessionUser();
+  const snapshots = await listSnapshots(session.id);
+
+  const rows: SnapshotRow[] = snapshots.map((s) => ({
+    id: s.id,
+    name: s.name,
+    createdAt: s.createdAt.toISOString(),
+    payloadBytes: s.payloadBytes.toString(),
+    schemaVersion: s.schemaVersion,
+  }));
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-h1">Snapshots</h1>
+        <p className="text-body text-muted-foreground">
+          Save the current state of your transactional data — transactions, imports, ingestion
+          history, classifications — so you can roll it back later. Useful before a reset or a mass
+          email ingestion. Your accounts, categories, rules, budgets, and integrations are always
+          kept and never affected by a restore.
+        </p>
+      </header>
+      <SnapshotsManager snapshots={rows} />
+    </main>
+  );
+}

--- a/src/app/(app)/settings/snapshots/snapshots-manager.tsx
+++ b/src/app/(app)/settings/snapshots/snapshots-manager.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { CameraIcon, RotateCcwIcon, Trash2Icon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { createSnapshotAction, deleteSnapshotAction, restoreSnapshotAction } from "./actions";
+
+export type SnapshotRow = {
+  id: number;
+  name: string;
+  createdAt: string;
+  payloadBytes: string;
+  schemaVersion: string;
+};
+
+function defaultName(): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `snapshot-${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}`;
+}
+
+function formatBytes(bytesStr: string): string {
+  const n = Number(bytesStr);
+  if (!Number.isFinite(n) || n <= 0) return "—";
+  const units = ["B", "KB", "MB", "GB"];
+  let i = 0;
+  let value = n;
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024;
+    i++;
+  }
+  return `${value.toFixed(value >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+export function SnapshotsManager({ snapshots }: { snapshots: SnapshotRow[] }) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [name, setName] = useState(defaultName());
+  const [creating, startCreate] = useTransition();
+
+  const [restoreTarget, setRestoreTarget] = useState<SnapshotRow | null>(null);
+  const [restoreConfirm, setRestoreConfirm] = useState("");
+  const [restoring, startRestore] = useTransition();
+
+  const [deleteTarget, setDeleteTarget] = useState<SnapshotRow | null>(null);
+  const [deleting, startDelete] = useTransition();
+
+  function onCreateSubmit() {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      toast.error("Name is required");
+      return;
+    }
+    startCreate(async () => {
+      const result = await createSnapshotAction({ name: trimmed });
+      if (result.status === "ok") {
+        toast.success(`Snapshot saved: ${result.snapshot.name}`);
+        setCreateOpen(false);
+        setName(defaultName());
+      } else {
+        toast.error(result.message);
+      }
+    });
+  }
+
+  function onRestoreSubmit() {
+    if (!restoreTarget) return;
+    if (restoreConfirm !== restoreTarget.name) {
+      toast.error("Type the snapshot name exactly to confirm");
+      return;
+    }
+    startRestore(async () => {
+      const result = await restoreSnapshotAction({ snapshotId: restoreTarget.id });
+      if (result.status === "ok") {
+        toast.success(`Restored to ${restoreTarget.name}`);
+        setRestoreTarget(null);
+        setRestoreConfirm("");
+      } else if (result.status === "schema_mismatch") {
+        toast.error(
+          "Schema mismatch: this snapshot was taken on a different DB schema and can't be restored.",
+        );
+      } else if (result.status === "not_found") {
+        toast.error("Snapshot not found");
+      } else {
+        toast.error(result.message);
+      }
+    });
+  }
+
+  function onDeleteSubmit() {
+    if (!deleteTarget) return;
+    startDelete(async () => {
+      const result = await deleteSnapshotAction({ snapshotId: deleteTarget.id });
+      if (result.status === "ok") {
+        toast.success(`Deleted ${deleteTarget.name}`);
+        setDeleteTarget(null);
+      } else {
+        toast.error(result.message);
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-2">
+          <CardTitle>Your snapshots</CardTitle>
+          <Button onClick={() => setCreateOpen(true)} size="sm">
+            <CameraIcon className="size-4" />
+            Create snapshot
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {snapshots.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              No snapshots yet. Create one before doing anything risky.
+            </p>
+          ) : (
+            <ul className="divide-y">
+              {snapshots.map((s) => (
+                <li
+                  key={s.id}
+                  className="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="flex flex-col gap-1">
+                    <span className="text-body font-medium">{s.name}</span>
+                    <p className="text-muted-foreground text-xs">
+                      {new Date(s.createdAt).toLocaleString()} · {formatBytes(s.payloadBytes)}
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => {
+                        setRestoreTarget(s);
+                        setRestoreConfirm("");
+                      }}
+                    >
+                      <RotateCcwIcon className="size-4" />
+                      Restore
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setDeleteTarget(s)}
+                    >
+                      <Trash2Icon className="size-4" />
+                      Delete
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create snapshot</DialogTitle>
+            <DialogDescription>
+              Captures all transactional data (transactions, imports, ingestion history,
+              classifications, observability). Config — accounts, categories, rules, budgets,
+              integrations — is not snapshotted because it&apos;s never touched by reset.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="snapshot-name">Name</Label>
+            <Input
+              id="snapshot-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={200}
+              disabled={creating}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setCreateOpen(false)} disabled={creating}>
+              Cancel
+            </Button>
+            <Button onClick={onCreateSubmit} disabled={creating}>
+              {creating ? "Saving..." : "Save snapshot"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={!!restoreTarget}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRestoreTarget(null);
+            setRestoreConfirm("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Restore {restoreTarget?.name}?</DialogTitle>
+            <DialogDescription>
+              This will <strong>delete all current transactional data</strong> and replace it with
+              the snapshot. Config (accounts, categories, rules, budgets, integrations) will NOT
+              change. This cannot be undone unless you have another snapshot.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="restore-confirm">
+              Type <code className="font-mono">{restoreTarget?.name}</code> to confirm
+            </Label>
+            <Input
+              id="restore-confirm"
+              value={restoreConfirm}
+              onChange={(e) => setRestoreConfirm(e.target.value)}
+              disabled={restoring}
+              autoFocus
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setRestoreTarget(null);
+                setRestoreConfirm("");
+              }}
+              disabled={restoring}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={onRestoreSubmit}
+              disabled={restoring || restoreConfirm !== restoreTarget?.name}
+            >
+              {restoring ? "Restoring..." : "Restore"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {deleteTarget?.name}?</DialogTitle>
+            <DialogDescription>
+              The snapshot will be permanently deleted. Your current data is not affected.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleteTarget(null)} disabled={deleting}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={onDeleteSubmit} disabled={deleting}>
+              {deleting ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1314,3 +1314,27 @@ export const emailReceipts = pgTable(
     index("email_receipts_connection_idx").on(t.gmailConnectionId),
   ],
 );
+
+// #471 — Per-user snapshots of transactional data. Payload is a JSON dump of
+// every user-owned table that gets wiped by the reset flow (#472). Config
+// tables (accounts, categories, rules, budgets, tokens, etc.) are NOT
+// snapshotted — they survive reset and therefore survive restore too.
+//
+// schemaVersion pins the drizzle migration tag active at save time; a restore
+// against a different schema is rejected rather than risking partial column
+// mismatches. Cross-migration restore is out of scope for MVP.
+export const userSnapshots = pgTable(
+  "user_snapshots",
+  {
+    id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 200 }).notNull(),
+    schemaVersion: varchar("schema_version", { length: 128 }).notNull(),
+    payload: jsonb("payload").notNull(),
+    payloadBytes: bigint("payload_bytes", { mode: "bigint" }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index("user_snapshots_user_created_idx").on(t.userId, t.createdAt.desc())],
+);

--- a/src/lib/snapshots/create.ts
+++ b/src/lib/snapshots/create.ts
@@ -1,0 +1,124 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { userSnapshots } from "@/lib/db/schema";
+import { createLogger } from "@/lib/logger";
+import {
+  dumpUserPayload,
+  estimatePayloadBytes,
+  restoreUserPayload,
+  validatePayloadShape,
+  wipeUserData,
+  type SnapshotPayload,
+  type SnapshotTxn,
+} from "./payload";
+import { getCurrentSchemaVersion } from "./schema-version";
+
+const log = createLogger({ module: "snapshots.core" });
+
+export type CreatedSnapshot = {
+  id: number;
+  name: string;
+  createdAt: Date;
+  payloadBytes: bigint;
+};
+
+// Shared between the manual "Create snapshot" action (#471) and the
+// auto-snapshot that the reset flow (#472) takes before wiping. Both need
+// the same atomicity guarantees, so the work lives here and the "use server"
+// wrappers just call into it.
+export async function createSnapshotForUser(params: {
+  userId: number;
+  name: string;
+  executor?: SnapshotTxn;
+}): Promise<CreatedSnapshot> {
+  const executor = params.executor ?? db;
+  const payload = await dumpUserPayload(params.userId, executor);
+  const schemaVersion = await getCurrentSchemaVersion();
+  const payloadBytes = estimatePayloadBytes(payload);
+
+  const [row] = await executor
+    .insert(userSnapshots)
+    .values({
+      userId: params.userId,
+      name: params.name,
+      schemaVersion,
+      payload: payload as unknown as object,
+      payloadBytes,
+    })
+    .returning({
+      id: userSnapshots.id,
+      name: userSnapshots.name,
+      createdAt: userSnapshots.createdAt,
+      payloadBytes: userSnapshots.payloadBytes,
+    });
+
+  log.info(
+    { userId: params.userId, snapshotId: row.id, bytes: Number(payloadBytes) },
+    "snapshot created",
+  );
+  return row;
+}
+
+export type RestoreFailure =
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "schema_mismatch"; snapshotVersion: string; currentVersion: string };
+
+export type RestoreSuccess = { ok: true };
+
+export async function restoreSnapshotForUser(params: {
+  userId: number;
+  snapshotId: number;
+}): Promise<RestoreSuccess | RestoreFailure> {
+  const currentVersion = await getCurrentSchemaVersion();
+
+  // Fetch + restore happen in one transaction so a concurrent delete of
+  // the snapshot row can't leave the user half-wiped.
+  return db.transaction<RestoreSuccess | RestoreFailure>(async (tx) => {
+    const rows = await tx
+      .select({
+        id: userSnapshots.id,
+        payload: userSnapshots.payload,
+        schemaVersion: userSnapshots.schemaVersion,
+      })
+      .from(userSnapshots)
+      .where(and(eq(userSnapshots.id, params.snapshotId), eq(userSnapshots.userId, params.userId)))
+      .limit(1);
+
+    const snapshot = rows[0];
+    if (!snapshot) {
+      return { ok: false, reason: "not_found" };
+    }
+    if (snapshot.schemaVersion !== currentVersion) {
+      return {
+        ok: false,
+        reason: "schema_mismatch",
+        snapshotVersion: snapshot.schemaVersion,
+        currentVersion,
+      };
+    }
+
+    validatePayloadShape(snapshot.payload);
+    const payload = snapshot.payload as SnapshotPayload;
+
+    await wipeUserData(params.userId, tx);
+    await restoreUserPayload(params.userId, payload, tx);
+
+    log.info({ userId: params.userId, snapshotId: params.snapshotId }, "snapshot restored");
+    return { ok: true };
+  });
+}
+
+export async function deleteSnapshotForUser(params: {
+  userId: number;
+  snapshotId: number;
+}): Promise<boolean> {
+  const result = await db
+    .delete(userSnapshots)
+    .where(and(eq(userSnapshots.id, params.snapshotId), eq(userSnapshots.userId, params.userId)))
+    .returning({ id: userSnapshots.id });
+  const deleted = result.length > 0;
+  if (deleted) {
+    log.info({ userId: params.userId, snapshotId: params.snapshotId }, "snapshot deleted");
+  }
+  return deleted;
+}

--- a/src/lib/snapshots/payload.ts
+++ b/src/lib/snapshots/payload.ts
@@ -1,0 +1,206 @@
+import type { ExtractTablesWithRelations } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js";
+import { db, type DB } from "@/lib/db";
+import type * as schemaModule from "@/lib/db/schema";
+import { createLogger } from "@/lib/logger";
+import {
+  GMAIL_CURSOR_COLUMNS,
+  RESTORE_ORDER,
+  SNAPSHOT_TABLES,
+  WIPE_ORDER,
+  type SnapshotTable,
+} from "./tables";
+
+const log = createLogger({ module: "snapshots.payload" });
+
+// Drizzle's top-level `db` and the `tx` received inside `db.transaction` have
+// structurally compatible query methods but nominally different types (one
+// carries the schema generic, the other narrows it). Helpers accept either
+// via this union so they can be composed inside or outside a transaction.
+export type SnapshotTxn =
+  | DB
+  | PgTransaction<
+      PostgresJsQueryResultHKT,
+      typeof schemaModule,
+      ExtractTablesWithRelations<typeof schemaModule>
+    >;
+
+// Shape of a serialized user snapshot. `version` exists to let future
+// migrations of the payload format stay forward-compatible without breaking
+// existing snapshots (we only support v1 right now).
+export type SnapshotPayload = {
+  version: 1;
+  tables: Record<SnapshotTable, unknown[]>;
+  gmailCursors: Array<{
+    gmail_connection_id: number;
+    last_pull_at: string | null;
+    last_pull_history_id: string | null;
+  }>;
+};
+
+// Postgres `jsonb_agg(row_to_json(t))` handles type conversion natively:
+// bigints serialize to JSON numbers (or strings for out-of-range), timestamps
+// to ISO strings, arrays stay arrays. `jsonb_populate_recordset` on the way
+// back inflates into the target table, coercing types the same way. That's
+// why we reach for raw SQL here rather than hand-rolling a per-column
+// (de)serializer for each of the 14 snapshot tables.
+
+export async function dumpUserPayload(
+  userId: number,
+  executor: SnapshotTxn = db,
+): Promise<SnapshotPayload> {
+  const tables: Record<string, unknown[]> = {};
+
+  for (const table of SNAPSHOT_TABLES) {
+    const rows = await executor.execute<{ rows: unknown[] | null }>(sql`
+      SELECT COALESCE(jsonb_agg(t), '[]'::jsonb) AS rows
+      FROM ${sql.raw(table)} t
+      WHERE t.user_id = ${userId}
+    `);
+    tables[table] = (rows[0]?.rows ?? []) as unknown[];
+  }
+
+  const cursorRows = await executor.execute<{
+    gmail_connection_id: number;
+    last_pull_at: string | null;
+    last_pull_history_id: string | null;
+  }>(sql`
+    SELECT
+      id AS gmail_connection_id,
+      last_pull_at::text AS last_pull_at,
+      last_pull_history_id
+    FROM gmail_connections
+    WHERE user_id = ${userId}
+  `);
+
+  return {
+    version: 1,
+    tables: tables as SnapshotPayload["tables"],
+    gmailCursors: cursorRows.map((r) => ({
+      gmail_connection_id: r.gmail_connection_id,
+      last_pull_at: r.last_pull_at,
+      last_pull_history_id: r.last_pull_history_id,
+    })),
+  };
+}
+
+// Hard-deletes every per-user row from the snapshot tables and nulls out
+// the Gmail ingestion cursor on each of the user's connections. The OAuth
+// tokens / connection rows themselves are preserved so the user doesn't
+// have to reauthorize.
+//
+// MUST run inside a transaction — caller is responsible.
+export async function wipeUserData(userId: number, tx: SnapshotTxn): Promise<void> {
+  for (const table of WIPE_ORDER) {
+    await tx.execute(sql`
+      DELETE FROM ${sql.raw(table)} WHERE user_id = ${userId}
+    `);
+  }
+  await tx.execute(sql`
+    UPDATE gmail_connections
+    SET last_pull_at = NULL,
+        last_pull_history_id = NULL,
+        updated_at = NOW()
+    WHERE user_id = ${userId}
+  `);
+  log.info({ userId, tables: WIPE_ORDER.length }, "wipe complete");
+}
+
+// Reinflates every snapshot table for the given user from the payload,
+// preserving row IDs so FKs stay valid. Bumps the serial sequence of each
+// table to max(id)+1 afterwards so future inserts don't collide. Restores
+// Gmail cursor values onto matching connections.
+//
+// ASSUMES the user's transactional data has already been wiped — caller
+// controls the order. Runs inside a transaction.
+export async function restoreUserPayload(
+  userId: number,
+  payload: SnapshotPayload,
+  tx: SnapshotTxn,
+): Promise<void> {
+  if (payload.version !== 1) {
+    throw new Error(`snapshot.payload.unsupported_version: ${String(payload.version)}`);
+  }
+
+  for (const table of RESTORE_ORDER) {
+    const rows = payload.tables[table] ?? [];
+    if (rows.length === 0) continue;
+
+    const jsonLiteral = JSON.stringify(rows);
+
+    // jsonb_populate_recordset returns a set typed as the target table; we
+    // splat it into INSERT. Tenant-safety: the WHERE clause on the source
+    // payload already scoped to userId at dump time, but we double-check
+    // here — a malformed payload with a foreign user_id would otherwise
+    // break tenant isolation.
+    await tx.execute(sql`
+      INSERT INTO ${sql.raw(table)}
+      SELECT * FROM jsonb_populate_recordset(NULL::${sql.raw(table)}, ${jsonLiteral}::jsonb) r
+      WHERE r.user_id = ${userId}
+    `);
+
+    // Bump the id sequence past the highest restored id — otherwise the
+    // next INSERT ... DEFAULT would clash. pg_get_serial_sequence returns
+    // NULL for tables without a serial, but every snapshot table has one.
+    await tx.execute(sql`
+      SELECT setval(
+        pg_get_serial_sequence(${table}, 'id'),
+        GREATEST(
+          (SELECT COALESCE(MAX(id), 0) FROM ${sql.raw(table)}),
+          1
+        )
+      )
+    `);
+  }
+
+  for (const cursor of payload.gmailCursors) {
+    await tx.execute(sql`
+      UPDATE gmail_connections
+      SET last_pull_at = ${cursor.last_pull_at}::timestamptz,
+          last_pull_history_id = ${cursor.last_pull_history_id},
+          updated_at = NOW()
+      WHERE id = ${cursor.gmail_connection_id} AND user_id = ${userId}
+    `);
+  }
+
+  log.info(
+    { userId, tables: RESTORE_ORDER.length, cursors: payload.gmailCursors.length },
+    "restore complete",
+  );
+}
+
+// Small, cheap metric the UI uses to show the user how big a snapshot is
+// without having to parse the whole jsonb blob client-side.
+export function estimatePayloadBytes(payload: SnapshotPayload): bigint {
+  return BigInt(Buffer.byteLength(JSON.stringify(payload), "utf8"));
+}
+
+// Sanity guard: reject obviously bogus payloads before we try to restore.
+// Anything deeper (per-column validation) is delegated to Postgres — if
+// jsonb_populate_recordset can't coerce a value, it raises and we roll back.
+export function validatePayloadShape(value: unknown): asserts value is SnapshotPayload {
+  if (!value || typeof value !== "object") {
+    throw new Error("snapshot.payload.invalid: not an object");
+  }
+  const p = value as Record<string, unknown>;
+  if (p.version !== 1) {
+    throw new Error(`snapshot.payload.invalid: unsupported version ${String(p.version)}`);
+  }
+  if (!p.tables || typeof p.tables !== "object") {
+    throw new Error("snapshot.payload.invalid: missing tables");
+  }
+  const tables = p.tables as Record<string, unknown>;
+  for (const table of SNAPSHOT_TABLES) {
+    if (!Array.isArray(tables[table])) {
+      throw new Error(`snapshot.payload.invalid: tables.${table} is not an array`);
+    }
+  }
+  if (!Array.isArray(p.gmailCursors)) {
+    throw new Error("snapshot.payload.invalid: gmailCursors is not an array");
+  }
+}
+
+// Re-export for callers that want the type info without depending on tables.ts
+export { GMAIL_CURSOR_COLUMNS, SNAPSHOT_TABLES };

--- a/src/lib/snapshots/queries.ts
+++ b/src/lib/snapshots/queries.ts
@@ -1,0 +1,48 @@
+import { and, desc, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { userSnapshots } from "@/lib/db/schema";
+
+// Read-only views for server components. Tenant isolation is enforced by
+// every query scoping to `userId`; callers upstream are responsible for
+// passing the authenticated user — never trust client-supplied ids.
+
+export type SnapshotSummary = {
+  id: number;
+  name: string;
+  createdAt: Date;
+  payloadBytes: bigint;
+  schemaVersion: string;
+};
+
+export async function listSnapshots(userId: number): Promise<SnapshotSummary[]> {
+  const rows = await db
+    .select({
+      id: userSnapshots.id,
+      name: userSnapshots.name,
+      createdAt: userSnapshots.createdAt,
+      payloadBytes: userSnapshots.payloadBytes,
+      schemaVersion: userSnapshots.schemaVersion,
+    })
+    .from(userSnapshots)
+    .where(eq(userSnapshots.userId, userId))
+    .orderBy(desc(userSnapshots.createdAt));
+  return rows;
+}
+
+export async function getSnapshotSummary(
+  userId: number,
+  snapshotId: number,
+): Promise<SnapshotSummary | null> {
+  const rows = await db
+    .select({
+      id: userSnapshots.id,
+      name: userSnapshots.name,
+      createdAt: userSnapshots.createdAt,
+      payloadBytes: userSnapshots.payloadBytes,
+      schemaVersion: userSnapshots.schemaVersion,
+    })
+    .from(userSnapshots)
+    .where(and(eq(userSnapshots.id, snapshotId), eq(userSnapshots.userId, userId)))
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/lib/snapshots/schema-version.ts
+++ b/src/lib/snapshots/schema-version.ts
@@ -1,0 +1,23 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+
+// Drizzle tracks applied migrations in `drizzle.__drizzle_migrations`; the
+// `hash` of the most recent row is a content-addressed fingerprint of the
+// current schema. We pin snapshots to this hash at create time and refuse
+// to restore across mismatches — reinflating a JSON dump into a table whose
+// columns have shifted would silently corrupt data.
+//
+// Cross-migration restore is explicitly out of scope for MVP (#471). If you
+// migrate the schema, snapshots from before the migration become read-only
+// (user sees them but can't restore). That's fine for now.
+
+export async function getCurrentSchemaVersion(): Promise<string> {
+  const rows = await db.execute<{ hash: string }>(
+    sql`SELECT hash FROM drizzle.__drizzle_migrations ORDER BY id DESC LIMIT 1`,
+  );
+  const hash = rows[0]?.hash;
+  if (!hash) {
+    throw new Error("snapshot.schema_version.missing: drizzle.__drizzle_migrations is empty");
+  }
+  return hash;
+}

--- a/src/lib/snapshots/snapshots.test.ts
+++ b/src/lib/snapshots/snapshots.test.ts
@@ -1,0 +1,348 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  emailReceipts,
+  gmailConnections,
+  transactions,
+  userSnapshots,
+  users,
+} from "@/lib/db/schema";
+import { copyCategorySeedsToUser, copyRuleSeedsToUser } from "@/lib/auth/signup";
+import { createSnapshotForUser, deleteSnapshotForUser, restoreSnapshotForUser } from "./create";
+import { dumpUserPayload } from "./payload";
+
+// Integration tests for #471. Verifies three things:
+//   1. Roundtrip — snapshot → wipe → restore puts data back exactly.
+//   2. Tenant isolation — user A's snapshot cannot read/write user B's rows.
+//   3. Schema version guard — restore across a simulated version mismatch fails.
+// Config tables (accounts, categories, rules) MUST survive both wipe and
+// restore: they're never included in the payload.
+
+const TAG = "SNAPSHOT_TEST";
+
+async function createUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  await copyRuleSeedsToUser(row.id);
+  return row.id;
+}
+
+async function createAccount(userId: number, name: string): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name,
+      institution: TAG,
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createTransaction(
+  userId: number,
+  accountId: number,
+  amountCents: bigint,
+  externalId: string,
+): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: new Date("2026-04-10"),
+      amountCents,
+      currency: "COP",
+      descriptionRaw: `${TAG} ${externalId}`,
+      categorySlug: "otros",
+      classificationMethod: "manual",
+      source: "manual",
+      externalId,
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function createGmailConnection(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(gmailConnections)
+    .values({
+      userId,
+      gmailEmail: `${TAG}-${userId}@example.com`,
+      accessTokenEnc: "enc",
+      refreshTokenEnc: "enc",
+      accessTokenExpiresAt: new Date(Date.now() + 3600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      lastPullAt: new Date("2026-04-01T00:00:00Z"),
+      lastPullHistoryId: "hist-123",
+    })
+    .returning({ id: gmailConnections.id });
+  return row.id;
+}
+
+async function createEmailReceipt(
+  userId: number,
+  gmailConnectionId: number,
+  msgId: string,
+): Promise<void> {
+  await db.insert(emailReceipts).values({
+    userId,
+    gmailConnectionId,
+    gmailMsgId: msgId,
+    gateway: "mercado_pago",
+    rawHtml: "<html />",
+    matchStatus: "matched",
+  });
+}
+
+async function cleanup() {
+  await db.delete(users).where(sql`email LIKE ${TAG + "%"}`);
+}
+
+async function countTransactions(userId: number): Promise<number> {
+  const rows = await db.execute<{ c: number }>(sql`
+    SELECT COUNT(*)::int AS c FROM transactions WHERE user_id = ${userId}
+  `);
+  return rows[0].c;
+}
+
+async function countAccounts(userId: number): Promise<number> {
+  const rows = await db.execute<{ c: number }>(sql`
+    SELECT COUNT(*)::int AS c FROM accounts WHERE user_id = ${userId}
+  `);
+  return rows[0].c;
+}
+
+describe("#471 user snapshots", () => {
+  let userA: number;
+  let userB: number;
+  let accountA: number;
+  let connA: number;
+
+  beforeAll(async () => {
+    await cleanup();
+    userA = await createUser(`${TAG}-A@test.local`);
+    userB = await createUser(`${TAG}-B@test.local`);
+    accountA = await createAccount(userA, `${TAG}-A acct`);
+    await createAccount(userB, `${TAG}-B acct`);
+    connA = await createGmailConnection(userA);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  // Each test gets a clean transactional slate so ordering doesn't matter.
+  beforeEach(async () => {
+    await db.delete(userSnapshots).where(eq(userSnapshots.userId, userA));
+    await db.delete(userSnapshots).where(eq(userSnapshots.userId, userB));
+    await db.delete(transactions).where(eq(transactions.userId, userA));
+    await db.delete(transactions).where(eq(transactions.userId, userB));
+    await db.delete(emailReceipts).where(eq(emailReceipts.userId, userA));
+    await db.delete(emailReceipts).where(eq(emailReceipts.userId, userB));
+    await db
+      .update(gmailConnections)
+      .set({ lastPullAt: new Date("2026-04-01T00:00:00Z"), lastPullHistoryId: "hist-123" })
+      .where(eq(gmailConnections.userId, userA));
+  });
+
+  describe("roundtrip", () => {
+    it("restores transactions + email receipts + gmail cursor to pre-wipe state", async () => {
+      const tx1 = await createTransaction(userA, accountA, BigInt(-1000), `${TAG}-tx1`);
+      const tx2 = await createTransaction(userA, accountA, BigInt(-2000), `${TAG}-tx2`);
+      await createEmailReceipt(userA, connA, `${TAG}-msg-1`);
+
+      const snap = await createSnapshotForUser({ userId: userA, name: "t-roundtrip" });
+      expect(snap.payloadBytes).toBeGreaterThan(BigInt(0));
+
+      // Destructive change: wipe all txs, null cursor, delete receipts.
+      await db.delete(transactions).where(eq(transactions.userId, userA));
+      await db.delete(emailReceipts).where(eq(emailReceipts.userId, userA));
+      await db
+        .update(gmailConnections)
+        .set({ lastPullAt: null, lastPullHistoryId: null })
+        .where(eq(gmailConnections.id, connA));
+      expect(await countTransactions(userA)).toBe(0);
+
+      const result = await restoreSnapshotForUser({
+        userId: userA,
+        snapshotId: snap.id,
+      });
+      expect(result.ok).toBe(true);
+
+      const restored = await db
+        .select({ id: transactions.id, externalId: transactions.externalId })
+        .from(transactions)
+        .where(eq(transactions.userId, userA))
+        .orderBy(transactions.id);
+      expect(restored.map((r) => r.id)).toEqual([tx1, tx2]);
+
+      const receipts = await db
+        .select({ id: emailReceipts.id })
+        .from(emailReceipts)
+        .where(eq(emailReceipts.userId, userA));
+      expect(receipts).toHaveLength(1);
+
+      const [conn] = await db
+        .select({ lastPullHistoryId: gmailConnections.lastPullHistoryId })
+        .from(gmailConnections)
+        .where(eq(gmailConnections.id, connA));
+      expect(conn.lastPullHistoryId).toBe("hist-123");
+    });
+
+    it("advances the id sequence past restored rows", async () => {
+      await createTransaction(userA, accountA, BigInt(-500), `${TAG}-seq-1`);
+      const snap = await createSnapshotForUser({ userId: userA, name: "t-seq" });
+      await db.delete(transactions).where(eq(transactions.userId, userA));
+      await restoreSnapshotForUser({ userId: userA, snapshotId: snap.id });
+
+      // A subsequent DEFAULT insert must not collide with restored ids.
+      const nextId = await createTransaction(userA, accountA, BigInt(-999), `${TAG}-seq-next`);
+      const all = await db
+        .select({ id: transactions.id })
+        .from(transactions)
+        .where(eq(transactions.userId, userA))
+        .orderBy(transactions.id);
+      expect(all.map((r) => r.id)).toContain(nextId);
+      expect(new Set(all.map((r) => r.id)).size).toBe(all.length);
+    });
+
+    it("leaves config (accounts + categories + rules) intact through a wipe+restore cycle", async () => {
+      await createTransaction(userA, accountA, BigInt(-100), `${TAG}-cfg`);
+      const snap = await createSnapshotForUser({ userId: userA, name: "t-cfg" });
+
+      const accountsBefore = await countAccounts(userA);
+      const [{ c: catsBefore }] = await db.execute<{ c: number }>(sql`
+        SELECT COUNT(*)::int AS c FROM categories WHERE user_id = ${userA}
+      `);
+      const [{ c: rulesBefore }] = await db.execute<{ c: number }>(sql`
+        SELECT COUNT(*)::int AS c FROM classification_rules WHERE user_id = ${userA}
+      `);
+
+      await db.delete(transactions).where(eq(transactions.userId, userA));
+      await restoreSnapshotForUser({ userId: userA, snapshotId: snap.id });
+
+      expect(await countAccounts(userA)).toBe(accountsBefore);
+      const [{ c: catsAfter }] = await db.execute<{ c: number }>(sql`
+        SELECT COUNT(*)::int AS c FROM categories WHERE user_id = ${userA}
+      `);
+      const [{ c: rulesAfter }] = await db.execute<{ c: number }>(sql`
+        SELECT COUNT(*)::int AS c FROM classification_rules WHERE user_id = ${userA}
+      `);
+      expect(catsAfter).toBe(catsBefore);
+      expect(rulesAfter).toBe(rulesBefore);
+    });
+  });
+
+  describe("tenant isolation", () => {
+    it("dumpUserPayload for userA does not include userB's rows", async () => {
+      const [accountBId] = await db
+        .select({ id: accounts.id })
+        .from(accounts)
+        .where(eq(accounts.userId, userB));
+      await createTransaction(userA, accountA, BigInt(-111), `${TAG}-A-only`);
+      await createTransaction(userB, accountBId.id, BigInt(-222), `${TAG}-B-only`);
+
+      const payload = await dumpUserPayload(userA);
+      const descs = (payload.tables.transactions as Array<{ description_raw: string }>).map(
+        (r) => r.description_raw,
+      );
+      expect(descs.some((d) => d.includes(`${TAG}-A-only`))).toBe(true);
+      expect(descs.some((d) => d.includes(`${TAG}-B-only`))).toBe(false);
+    });
+
+    it("restoreSnapshotForUser cannot be called with a snapshot owned by another user", async () => {
+      await createTransaction(userA, accountA, BigInt(-333), `${TAG}-A-iso`);
+      const snap = await createSnapshotForUser({ userId: userA, name: "t-iso" });
+
+      const result = await restoreSnapshotForUser({
+        userId: userB,
+        snapshotId: snap.id,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("not_found");
+      }
+    });
+
+    it("deleteSnapshotForUser cannot delete another user's snapshot", async () => {
+      const snap = await createSnapshotForUser({ userId: userA, name: "t-iso-delete" });
+
+      const ok = await deleteSnapshotForUser({ userId: userB, snapshotId: snap.id });
+      expect(ok).toBe(false);
+
+      const remaining = await db
+        .select({ id: userSnapshots.id })
+        .from(userSnapshots)
+        .where(and(eq(userSnapshots.id, snap.id), eq(userSnapshots.userId, userA)));
+      expect(remaining).toHaveLength(1);
+    });
+
+    it("restoreSnapshotForUser does not wipe userB's data", async () => {
+      // userB has a transaction that must survive userA's restore operation.
+      const [accountBId] = await db
+        .select({ id: accounts.id })
+        .from(accounts)
+        .where(eq(accounts.userId, userB));
+      await createTransaction(userB, accountBId.id, BigInt(-7777), `${TAG}-B-protected`);
+
+      await createTransaction(userA, accountA, BigInt(-1), `${TAG}-A-rx`);
+      const snap = await createSnapshotForUser({ userId: userA, name: "t-noleak" });
+      await db.delete(transactions).where(eq(transactions.userId, userA));
+
+      const before = await countTransactions(userB);
+      await restoreSnapshotForUser({ userId: userA, snapshotId: snap.id });
+      const after = await countTransactions(userB);
+
+      expect(after).toBe(before);
+    });
+  });
+
+  describe("schema version guard", () => {
+    it("rejects restore when the snapshot's schema_version does not match current", async () => {
+      await createTransaction(userA, accountA, BigInt(-1), `${TAG}-ver`);
+      const snap = await createSnapshotForUser({ userId: userA, name: "t-ver" });
+
+      // Simulate a schema drift: overwrite the stored version with a bogus
+      // value. In real life this would be the result of a DB migration
+      // landing between snapshot creation and restore.
+      await db
+        .update(userSnapshots)
+        .set({ schemaVersion: "deadbeef-not-a-real-hash" })
+        .where(eq(userSnapshots.id, snap.id));
+
+      const result = await restoreSnapshotForUser({
+        userId: userA,
+        snapshotId: snap.id,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("schema_mismatch");
+      }
+    });
+  });
+
+  describe("listing + ordering", () => {
+    it("returns snapshots newest first for the calling user only", async () => {
+      await createSnapshotForUser({ userId: userA, name: "older" });
+      // A 10ms spin keeps createdAt ordering deterministic on fast machines
+      // where consecutive INSERTs land inside the same millisecond.
+      await new Promise((r) => setTimeout(r, 10));
+      const newer = await createSnapshotForUser({ userId: userA, name: "newer" });
+      await createSnapshotForUser({ userId: userB, name: "other-user" });
+
+      const rowsA = await db
+        .select({ id: userSnapshots.id, name: userSnapshots.name })
+        .from(userSnapshots)
+        .where(eq(userSnapshots.userId, userA))
+        .orderBy(desc(userSnapshots.createdAt));
+
+      expect(rowsA[0].id).toBe(newer.id);
+      expect(rowsA.every((r) => r.name !== "other-user")).toBe(true);
+    });
+  });
+});

--- a/src/lib/snapshots/tables.ts
+++ b/src/lib/snapshots/tables.ts
@@ -1,0 +1,57 @@
+// Tables that are fully dumped and restored by the snapshot system (#471)
+// and wiped by the reset action (#472). These are the "transactional" tables
+// — every row is per-user and survives only as long as the user hasn't
+// reset. Config tables (accounts, categories, rules, budgets, recurring
+// definitions, counterparties, OAuth tokens, seeds) are NOT listed here:
+// they outlive a reset and therefore outlive a restore too.
+//
+// IMPORTANT: the order of WIPE_ORDER matters — a table must be deleted
+// BEFORE any other snapshot table that holds an FK into it, because the
+// FKs between these tables are not deferrable. RESTORE_ORDER is the
+// reverse: parents first, then dependents.
+//
+// Cross-FK map (only the ones INSIDE this set; FKs to config tables like
+// accounts/categories/users are irrelevant because config survives):
+//   reconciliation_decisions.tx_id       → transactions.id
+//   reconciliation_decisions.merged_into → transactions.id
+//   classification_corrections.tx_id     → transactions.id
+//   email_receipts.matched_transaction_id→ transactions.id
+//   rule_proposals.source_tx_id          → transactions.id
+
+export const SNAPSHOT_TABLES = [
+  // Children of `transactions` — must be deleted first, restored last.
+  "reconciliation_decisions",
+  "rule_proposals",
+  "classification_corrections",
+  "email_receipts",
+  // Non-tx-dependent per-user tables.
+  "account_snapshots",
+  "skipped_consolidation_cycles",
+  "recurring_gaps",
+  // The core.
+  "transactions",
+  // Independent logs / reports / observability (per-user).
+  "statement_imports",
+  "ingestion_logs",
+  "insights_reports",
+  "parser_events",
+  "parser_canary_events",
+  "user_health_snapshots",
+] as const;
+
+export type SnapshotTable = (typeof SNAPSHOT_TABLES)[number];
+
+// Delete children before parents.
+export const WIPE_ORDER: readonly SnapshotTable[] = SNAPSHOT_TABLES;
+
+// Insert parents before children.
+export const RESTORE_ORDER: readonly SnapshotTable[] = [...SNAPSHOT_TABLES].reverse();
+
+// Columns on `gmail_connections` that track ingestion cursor state (what
+// messages we've already pulled). Reset nulls these out so re-ingest picks
+// up from scratch; snapshot captures them so restore can put the user back
+// exactly where they were. OAuth tokens, scopes, and the connection row
+// itself stay put — they're config.
+export const GMAIL_CURSOR_COLUMNS = ["last_pull_at", "last_pull_history_id"] as const;
+
+export type GmailCursorColumn = (typeof GMAIL_CURSOR_COLUMNS)[number];


### PR DESCRIPTION
## Summary

Per-user snapshot system for transactional data, scoped to give the user a safety net before destructive operations (reset of data in #472, mass email ingestion, etc.). Config (accounts, categories, rules, budgets, OAuth tokens) is never snapshotted and never touched by a restore.

Closes #471.

### What ships
- `user_snapshots` table (drizzle migration `0055_spicy_the_executioner`) — jsonb payload + schema version pin + created_at index on `(user_id, created_at desc)`
- Server actions in `/settings/snapshots`: create / restore / delete — all tenant-guarded through `getSessionUser()`
- Restore is atomic: wipe + reinsert + sequence-bump + cursor rehydrate all inside one drizzle transaction
- Schema version guard: restore across a mismatched drizzle migration hash returns `schema_mismatch` instead of corrupting data. Cross-migration restore is out of scope for MVP (documented in `schema-version.ts`).
- UI: `/settings/snapshots` page with list, create dialog, restore confirm (typing required), delete confirm
- 9 integration tests covering roundtrip, sequence bumping, config-survives-restore, tenant isolation across all operations, and schema-mismatch rejection

### Design notes
- Serialization uses `jsonb_agg(row_to_json(t))` on dump and `jsonb_populate_recordset` on restore — Postgres handles bigint / timestamp / array conversion natively, so no hand-rolled per-column (de)serializer
- Wipe order (children-before-parents) and restore order (parents-before-children) are hardcoded in `src/lib/snapshots/tables.ts` because the FKs between snapshot tables are not deferrable
- Gmail ingestion state (`last_pull_at`, `last_pull_history_id`) is part of the payload — restore puts the user's Gmail cursor back exactly where it was, but OAuth tokens are never touched (separate concern)

### What this does NOT do
- Auto-snapshot before reset (that's #472, which depends on this PR)
- Cross-migration restore (intentionally deferred)
- Snapshot export / download to file (possible follow-up)
- Retention / GC — user controls via delete button

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run format:check` — clean
- [x] `bun run test` — 1194/1194 tests passing, including 9 new in `src/lib/snapshots/snapshots.test.ts`
- [x] Drizzle migration applied to `findash` + `findash_test`
- [ ] Manual smoke in browser — deferred to follow-up session