### PR TITLE
feat(classification): tenant-safe matcher + enrichment + reclassify hook (#454)

### DIFF
--- a/src/lib/classification/reclassify.test.ts
+++ b/src/lib/classification/reclassify.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, categories, classificationRules, transactions, users } from "@/lib/db/schema";
+import { reclassifyTransaction } from "./reclassify";
+
+const TAG = "VITEST_RECLASSIFY_";
+
+let userId: number;
+let accountId: number;
+
+async function cleanup(): Promise<void> {
+  await db.execute(sql`DELETE FROM classification_rules WHERE user_id = ${userId}`);
+  await db.execute(sql`DELETE FROM transactions WHERE account_id = ${accountId}`);
+}
+
+async function createTx(overrides: {
+  descriptionRaw?: string;
+  enrichedMerchant?: string | null;
+  categorySlug?: string;
+  classificationMethod?:
+    | "rule"
+    | "ai"
+    | "manual"
+    | "unclassified"
+    | "rule_retroactive"
+    | "manual_confirmed";
+}): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: new Date("2026-04-19T12:00:00Z"),
+      amountCents: BigInt(-65990),
+      currency: "COP",
+      descriptionRaw: overrides.descriptionRaw ?? `${TAG}tx`,
+      enrichedMerchant: overrides.enrichedMerchant ?? null,
+      categorySlug: overrides.categorySlug ?? null,
+      classificationMethod: overrides.classificationMethod ?? "unclassified",
+      source: "sms",
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function insertRule(pattern: string, categorySlug: string): Promise<number> {
+  const [row] = await db
+    .insert(classificationRules)
+    .values({ userId, pattern, categorySlug, priority: 10, active: true })
+    .returning({ id: classificationRules.id });
+  return row.id;
+}
+
+async function getTx(id: number) {
+  const [row] = await db
+    .select({
+      categorySlug: transactions.categorySlug,
+      classificationMethod: transactions.classificationMethod,
+      classificationConfidence: transactions.classificationConfidence,
+      classificationReason: transactions.classificationReason,
+    })
+    .from(transactions)
+    .where(and(eq(transactions.id, id), eq(transactions.userId, userId)));
+  return row;
+}
+
+beforeAll(async () => {
+  const [u] = await db
+    .insert(users)
+    .values({ email: `${TAG}user@test.local`, name: `${TAG}user` })
+    .returning({ id: users.id });
+  userId = u.id;
+
+  const [a] = await db
+    .insert(accounts)
+    .values({ userId, name: `${TAG}acct`, institution: "Test", type: "savings", currency: "COP" })
+    .returning({ id: accounts.id });
+  accountId = a.id;
+
+  // Seed categories required by FK constraints.
+  await db.insert(categories).values([
+    { userId, slug: "food", name: "Food", icon: "utensils", color: "#ef4444", sortOrder: 1 },
+    { userId, slug: "delivery", name: "Delivery", icon: "truck", color: "#3b82f6", sortOrder: 2 },
+    { userId, slug: "otros", name: "Otros", icon: "circle", color: "#6b7280", sortOrder: 99 },
+  ]);
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM categories WHERE user_id = ${userId}`);
+  await db.execute(sql`DELETE FROM accounts WHERE id = ${accountId}`);
+  await db.execute(sql`DELETE FROM users WHERE id = ${userId}`);
+});
+
+describe("reclassifyTransaction", () => {
+  it("no-ops when enrichedMerchant is null", async () => {
+    const txId = await createTx({ categorySlug: "food", classificationMethod: "manual" });
+    await reclassifyTransaction(userId, txId);
+    const after = await getTx(txId);
+    expect(after.classificationMethod).toBe("manual");
+    expect(after.categorySlug).toBe("food");
+  });
+
+  it("no-ops when no rule matches enrichedMerchant", async () => {
+    const txId = await createTx({
+      enrichedMerchant: "Rappi",
+      categorySlug: "food",
+      classificationMethod: "ai",
+    });
+    // Rule that does NOT match "Rappi"
+    await insertRule(`%${TAG}NOMATCH%`, "otros");
+
+    await reclassifyTransaction(userId, txId);
+    const after = await getTx(txId);
+    expect(after.classificationMethod).toBe("ai");
+    expect(after.categorySlug).toBe("food");
+  });
+
+  it("applies rule_retroactive classification when rule matches enrichedMerchant", async () => {
+    const txId = await createTx({
+      descriptionRaw: "MERCADOPAGO COLOMBIA 123",
+      enrichedMerchant: "Rappi",
+      classificationMethod: "unclassified",
+    });
+    const ruleId = await insertRule("%Rappi%", "delivery");
+
+    await reclassifyTransaction(userId, txId);
+    const after = await getTx(txId);
+    expect(after.categorySlug).toBe("delivery");
+    expect(after.classificationMethod).toBe("rule_retroactive");
+    expect(after.classificationConfidence).toBe(100);
+    expect(after.classificationReason).toBe(
+      `rule_retroactive: matched rule #${ruleId} via enriched_merchant`,
+    );
+  });
+
+  it("is idempotent: calling twice produces identical state", async () => {
+    const txId = await createTx({
+      enrichedMerchant: "Rappi",
+      classificationMethod: "unclassified",
+    });
+    await insertRule("%Rappi%", "delivery");
+
+    await reclassifyTransaction(userId, txId);
+    const after1 = await getTx(txId);
+
+    await reclassifyTransaction(userId, txId);
+    const after2 = await getTx(txId);
+
+    expect(after1).toEqual(after2);
+  });
+
+  it("gracefully handles unknown txId without throwing", async () => {
+    await expect(reclassifyTransaction(userId, 999_999_999)).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/classification/reclassify.ts
+++ b/src/lib/classification/reclassify.ts
@@ -1,0 +1,121 @@
+import { and, eq } from "drizzle-orm";
+import type { ExtractTablesWithRelations } from "drizzle-orm";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js";
+import { db as defaultDb, type DB } from "@/lib/db";
+import type * as schemaModule from "@/lib/db/schema";
+import { transactions } from "@/lib/db/schema";
+import { createLogger } from "@/lib/logger";
+import { findMatchingRule, type ClassifiableTx } from "@/lib/classification/rules";
+
+const log = createLogger({ module: "classification/reclassify" });
+
+// Drizzle's top-level `db` and `tx` inside `db.transaction(...)` are nominally
+// different types but structurally compatible for queries. Accept either so
+// this function can be composed inside an existing transaction (atomicity with
+// `applyEnrichment`) or called standalone. Pattern sourced from
+// `src/lib/snapshots/payload.ts`.
+export type ReclassifyDb =
+  | DB
+  | PgTransaction<
+      PostgresJsQueryResultHKT,
+      typeof schemaModule,
+      ExtractTablesWithRelations<typeof schemaModule>
+    >;
+
+/**
+ * Retroactive reclassification: re-runs the rule engine for a transaction
+ * after enrichment (e.g. `enriched_merchant` set by Gmail matcher #454).
+ *
+ * Design decisions:
+ * - Uses `findMatchingRule` (read-only), NOT `classifyByRule`. Bumping
+ *   hit_count is a hot-path semantic that does not belong to retroactive runs.
+ * - Does NOT touch `descriptionRaw` — that is the immutable audit field.
+ * - Idempotent: calling twice with the same enriched_merchant produces
+ *   identical DB state.
+ * - Accepts an optional `database` param so callers can chain it inside an
+ *   existing Drizzle transaction (atomicity with `applyEnrichment`).
+ */
+export async function reclassifyTransaction(
+  userId: number,
+  txId: number,
+  database: ReclassifyDb = defaultDb,
+): Promise<void> {
+  // Load the transaction scoped by userId to prevent cross-tenant access.
+  const [tx] = await database
+    .select({
+      id: transactions.id,
+      userId: transactions.userId,
+      enrichedMerchant: transactions.enrichedMerchant,
+      descriptionClean: transactions.descriptionClean,
+      merchant: transactions.merchant,
+      descriptionRaw: transactions.descriptionRaw,
+    })
+    .from(transactions)
+    .where(and(eq(transactions.id, txId), eq(transactions.userId, userId)));
+
+  if (!tx) {
+    log.warn(
+      { userId, txId, event: "reclassify_tx_not_found" },
+      "transaction not found for reclassify",
+    );
+    return;
+  }
+
+  // No-op if no enriched merchant — there is nothing extra for the rule
+  // engine to match on beyond what the hot path already ran.
+  if (!tx.enrichedMerchant) {
+    log.debug(
+      { userId, txId, event: "reclassify_no_enriched_merchant" },
+      "no enriched_merchant; skipping reclassify",
+    );
+    return;
+  }
+
+  // Build a synthetic ClassifiableTx that prepends enriched_merchant so the
+  // rule engine sees the real merchant name first in the ILIKE haystack.
+  // We pack it into `descriptionClean` (slot 0 in txHaystack) because
+  // txHaystack inside rules.ts is unexported — this is the surgical approach
+  // to inject the enriched value without changing findMatchingRule's signature.
+  const synthetic: ClassifiableTx = {
+    // enriched_merchant at position 0 in the internal haystack
+    descriptionClean: tx.enrichedMerchant,
+    merchant: tx.merchant,
+    descriptionRaw: tx.descriptionRaw,
+  };
+
+  // Cast to DB: findMatchingRule accepts DB (top-level drizzle) but we may
+  // hold a PgTransaction (structurally compatible for all query ops, just
+  // missing the `$client` field which findMatchingRule never uses).
+  const rule = await findMatchingRule(userId, synthetic, database as DB);
+
+  if (!rule) {
+    log.info(
+      { userId, txId, event: "reclassify_no_rule_match" },
+      "no rule matched after enrichment; classification unchanged",
+    );
+    return;
+  }
+
+  await database
+    .update(transactions)
+    .set({
+      categorySlug: rule.categorySlug,
+      classificationMethod: "rule_retroactive",
+      classificationConfidence: 100,
+      classificationReason: `rule_retroactive: matched rule #${rule.id} via enriched_merchant`,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(transactions.id, txId), eq(transactions.userId, userId)));
+
+  log.info(
+    {
+      userId,
+      txId,
+      ruleId: rule.id,
+      categorySlug: rule.categorySlug,
+      event: "reclassify_applied",
+    },
+    "reclassified transaction via enriched_merchant rule match",
+  );
+}

--- a/src/lib/gmail/enrich-pull.test.ts
+++ b/src/lib/gmail/enrich-pull.test.ts
@@ -238,24 +238,58 @@ describe("processPendingEnrichReceipts (via pullForUser)", () => {
     expect(receipt.matchStatus).toBe("pending");
   });
 
-  it("unmatched receipt gets status=unmatched and is eligible for re-attempt", async () => {
+  it("unmatched receipt gets status=unmatched and is re-attempted on the next pull", async () => {
     const DATE = new Date("2026-04-19T10:00:00Z");
-    // No corresponding tx — should result in unmatched.
+    const AMOUNT = BigInt(99999);
+
+    // First pull: no corresponding tx exists → receipt becomes unmatched.
     const receiptId = await seedReceipt({
       gateway: "mercado_pago",
-      amountCents: BigInt(99999),
+      amountCents: AMOUNT,
       occurredAt: DATE,
-      merchant: "NoMatchMerchant",
+      merchant: "RetryMerchant",
     });
 
     await pullForUser(userId, {}, { getClient: async () => makeNoopClient() });
 
-    const [receipt] = await db
+    const [afterFirst] = await db
       .select({ matchStatus: emailReceipts.matchStatus })
       .from(emailReceipts)
       .where(eq(emailReceipts.id, receiptId));
 
-    expect(receipt.matchStatus).toBe("unmatched");
+    expect(afterFirst.matchStatus).toBe("unmatched");
+
+    // Bank tx arrives later (e.g. via SMS ingestion). Seed it now.
+    const txId = await seedTx({
+      descriptionRaw: "MERCADOPAGO COLOMBIA retry-test",
+      amountCents: -AMOUNT,
+      occurredAt: DATE,
+    });
+
+    // Second pull: the unmatched receipt is re-selected and matched this time.
+    await pullForUser(userId, {}, { getClient: async () => makeNoopClient() });
+
+    const [afterSecond] = await db
+      .select({
+        matchStatus: emailReceipts.matchStatus,
+        matchedTransactionId: emailReceipts.matchedTransactionId,
+      })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.id, receiptId));
+
+    expect(afterSecond.matchStatus).toBe("matched");
+    expect(afterSecond.matchedTransactionId).toBe(txId);
+
+    const [tx] = await db
+      .select({
+        enrichedMerchant: transactions.enrichedMerchant,
+        enrichmentSource: transactions.enrichmentSource,
+      })
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+
+    expect(tx.enrichedMerchant).toBe("RetryMerchant");
+    expect(tx.enrichmentSource).toBe("gmail");
   });
 
   it("ambiguous receipt gets status=ambiguous with matchCandidates populated", async () => {

--- a/src/lib/gmail/enrich-pull.test.ts
+++ b/src/lib/gmail/enrich-pull.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Pull-engine integration tests for the enrich-mode receipt flow (#454).
+ * Covers the processPendingEnrichReceipts path wired into pullForUser.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  categories,
+  classificationRules,
+  emailReceipts,
+  gmailConnections,
+  transactions,
+  users,
+} from "@/lib/db/schema";
+import { gmailCipher } from "@/lib/crypto/gmail-cipher";
+import type { AuthedGmailClient } from "./client";
+import { pullForUser } from "./pull";
+import { GATEWAYS } from "./registry";
+
+const TAG = "VITEST_ENRICH_PULL_";
+const GMAIL_KEY_ENV = "GMAIL_TOKEN_ENCRYPTION_KEY";
+const ORIGINAL_KEY = process.env[GMAIL_KEY_ENV];
+
+let userId: number;
+let accountId: number;
+let connId: number;
+
+async function cleanup(): Promise<void> {
+  await db.execute(sql`DELETE FROM classification_rules WHERE user_id = ${userId}`);
+  await db.execute(sql`DELETE FROM email_receipts WHERE user_id = ${userId}`);
+  await db.execute(sql`DELETE FROM transactions WHERE account_id = ${accountId}`);
+}
+
+async function seedTx(opts: {
+  descriptionRaw: string;
+  amountCents: bigint;
+  occurredAt: Date;
+}): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: opts.occurredAt,
+      amountCents: opts.amountCents,
+      currency: "COP",
+      descriptionRaw: opts.descriptionRaw,
+      classificationMethod: "unclassified",
+      source: "sms",
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function seedReceipt(opts: {
+  gateway: "mercado_pago" | "payu" | "wompi" | "apple" | "paypal";
+  amountCents: bigint;
+  occurredAt: Date;
+  merchant: string;
+  matchStatus?: "pending" | "matched" | "ambiguous" | "unmatched";
+}): Promise<number> {
+  const [row] = await db
+    .insert(emailReceipts)
+    .values({
+      userId,
+      gmailConnectionId: connId,
+      gmailMsgId: `${TAG}${Date.now()}-${Math.random()}`,
+      gateway: opts.gateway,
+      amountCents: opts.amountCents,
+      occurredAt: opts.occurredAt,
+      merchant: opts.merchant,
+      rawHtml: "<html>receipt</html>",
+      matchStatus: opts.matchStatus ?? "pending",
+    })
+    .returning({ id: emailReceipts.id });
+  return row.id;
+}
+
+/**
+ * A fake authed client that returns no new Gmail messages — we only care
+ * about the post-pull processing of pre-seeded receipts.
+ */
+function makeNoopClient(): AuthedGmailClient {
+  return {
+    oauth: {} as unknown,
+    gmail: {
+      users: {
+        messages: {
+          async list() {
+            return { data: { messages: [], nextPageToken: undefined } };
+          },
+          async get() {
+            return { data: {} };
+          },
+        },
+      },
+    },
+    connection: {
+      id: connId,
+      gmailEmail: `${TAG}${userId}@example.com`,
+      accessTokenStale: false,
+    },
+  } as unknown as AuthedGmailClient;
+}
+
+beforeAll(async () => {
+  process.env[GMAIL_KEY_ENV] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+  const [u] = await db
+    .insert(users)
+    .values({ email: `${TAG}user@test.local`, name: `${TAG}user` })
+    .returning({ id: users.id });
+  userId = u.id;
+
+  const [a] = await db
+    .insert(accounts)
+    .values({ userId, name: `${TAG}acct`, institution: "Test", type: "savings", currency: "COP" })
+    .returning({ id: accounts.id });
+  accountId = a.id;
+
+  // Seed categories required by FK constraints.
+  await db
+    .insert(categories)
+    .values([
+      { userId, slug: "delivery", name: "Delivery", icon: "truck", color: "#3b82f6", sortOrder: 1 },
+    ]);
+
+  const [c] = await db
+    .insert(gmailConnections)
+    .values({
+      userId,
+      gmailEmail: `${TAG}${userId}@example.com`,
+      accessTokenEnc: gmailCipher.encrypt("dummy-access"),
+      refreshTokenEnc: gmailCipher.encrypt("dummy-refresh"),
+      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  connId = c.id;
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM gmail_connections WHERE id = ${connId}`);
+  await db.execute(sql`DELETE FROM categories WHERE user_id = ${userId}`);
+  await db.execute(sql`DELETE FROM accounts WHERE id = ${accountId}`);
+  await db.execute(sql`DELETE FROM users WHERE id = ${userId}`);
+  if (ORIGINAL_KEY === undefined) delete process.env[GMAIL_KEY_ENV];
+  else process.env[GMAIL_KEY_ENV] = ORIGINAL_KEY;
+});
+
+describe("processPendingEnrichReceipts (via pullForUser)", () => {
+  it("end-to-end: matched receipt enriches and reclassifies the transaction", async () => {
+    const DATE = new Date("2026-04-19T10:00:00Z");
+    const AMOUNT = BigInt(65990);
+
+    const txId = await seedTx({
+      descriptionRaw: "MERCADOPAGO COLOMBIA e2e-test",
+      amountCents: -AMOUNT,
+      occurredAt: DATE,
+    });
+    const receiptId = await seedReceipt({
+      gateway: "mercado_pago",
+      amountCents: AMOUNT,
+      occurredAt: DATE,
+      merchant: "Rappi",
+    });
+
+    // Insert a rule that matches "Rappi" so reclassify also fires.
+    await db.insert(classificationRules).values({
+      userId,
+      pattern: "%Rappi%",
+      categorySlug: "delivery",
+      priority: 5,
+      active: true,
+    });
+
+    await pullForUser(userId, {}, { getClient: async () => makeNoopClient() });
+
+    const [tx] = await db
+      .select({
+        enrichedMerchant: transactions.enrichedMerchant,
+        enrichmentSource: transactions.enrichmentSource,
+        categorySlug: transactions.categorySlug,
+        classificationMethod: transactions.classificationMethod,
+      })
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+
+    expect(tx.enrichedMerchant).toBe("Rappi");
+    expect(tx.enrichmentSource).toBe("gmail");
+    expect(tx.categorySlug).toBe("delivery");
+    expect(tx.classificationMethod).toBe("rule_retroactive");
+
+    const [receipt] = await db
+      .select({ matchStatus: emailReceipts.matchStatus })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.id, receiptId));
+    expect(receipt.matchStatus).toBe("matched");
+  });
+
+  it("ingest-mode gateway (bancolombia) is NOT processed by the enrich loop", async () => {
+    // Insert a bancolombia receipt — it should stay pending (not routed through
+    // the enrich loop which only touches mode=enrich gateways).
+    const receiptId = await db
+      .insert(emailReceipts)
+      .values({
+        userId,
+        gmailConnectionId: connId,
+        gmailMsgId: `${TAG}banc-${Date.now()}`,
+        gateway: "bancolombia",
+        rawHtml: "<html>banc</html>",
+        matchStatus: "pending",
+      })
+      .returning({ id: emailReceipts.id })
+      .then(([r]) => r.id);
+
+    // The enrich loop uses GATEWAYS.filter(g => g.mode === "enrich") so
+    // bancolombia should never be processed. Pull with just mercado_pago
+    // selected to avoid triggering the bancolombia ingest path.
+    await pullForUser(
+      userId,
+      { gateways: ["mercado_pago"] },
+      { getClient: async () => makeNoopClient() },
+    );
+
+    const [receipt] = await db
+      .select({ matchStatus: emailReceipts.matchStatus })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.id, receiptId));
+
+    // Receipt must remain pending (bancolombia ingest path not triggered here,
+    // enrich path correctly excluded it).
+    expect(receipt.matchStatus).toBe("pending");
+  });
+
+  it("unmatched receipt gets status=unmatched and is eligible for re-attempt", async () => {
+    const DATE = new Date("2026-04-19T10:00:00Z");
+    // No corresponding tx — should result in unmatched.
+    const receiptId = await seedReceipt({
+      gateway: "mercado_pago",
+      amountCents: BigInt(99999),
+      occurredAt: DATE,
+      merchant: "NoMatchMerchant",
+    });
+
+    await pullForUser(userId, {}, { getClient: async () => makeNoopClient() });
+
+    const [receipt] = await db
+      .select({ matchStatus: emailReceipts.matchStatus })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.id, receiptId));
+
+    expect(receipt.matchStatus).toBe("unmatched");
+  });
+
+  it("ambiguous receipt gets status=ambiguous with matchCandidates populated", async () => {
+    const DATE = new Date("2026-04-18T10:00:00Z");
+    const AMOUNT = BigInt(12345);
+
+    // Two txs in the window — should cause ambiguous.
+    await seedTx({
+      descriptionRaw: "MERCADOPAGO COLOMBIA amb-1",
+      amountCents: -AMOUNT,
+      occurredAt: DATE,
+    });
+    await seedTx({
+      descriptionRaw: "MERCADOPAGO COLOMBIA amb-2",
+      amountCents: -AMOUNT,
+      occurredAt: new Date(DATE.getTime() + 30_000),
+    });
+    const receiptId = await seedReceipt({
+      gateway: "mercado_pago",
+      amountCents: AMOUNT,
+      occurredAt: DATE,
+      merchant: "AmbiguousMerchant",
+    });
+
+    await pullForUser(userId, {}, { getClient: async () => makeNoopClient() });
+
+    const [receipt] = await db
+      .select({
+        matchStatus: emailReceipts.matchStatus,
+        matchCandidates: emailReceipts.matchCandidates,
+      })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.id, receiptId));
+
+    expect(receipt.matchStatus).toBe("ambiguous");
+    expect(Array.isArray(receipt.matchCandidates)).toBe(true);
+    expect((receipt.matchCandidates as number[]).length).toBe(2);
+  });
+
+  it("all enrich gateways in GATEWAYS registry have mode=enrich (registry coverage)", () => {
+    const enrichGateways = GATEWAYS.filter((g) => g.mode === "enrich");
+    const ingestGateways = GATEWAYS.filter((g) => g.mode === "ingest");
+
+    // All enrich gateways must have a bankDescriptionRegex.
+    for (const g of enrichGateways) {
+      expect(g.bankDescriptionRegex).not.toBeNull();
+    }
+    // All ingest gateways must NOT have a bankDescriptionRegex.
+    for (const g of ingestGateways) {
+      expect(g.bankDescriptionRegex).toBeNull();
+    }
+  });
+});

--- a/src/lib/gmail/enrich.test.ts
+++ b/src/lib/gmail/enrich.test.ts
@@ -1,0 +1,285 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  categories,
+  classificationRules,
+  emailReceipts,
+  gmailConnections,
+  transactions,
+  users,
+} from "@/lib/db/schema";
+import { gmailCipher } from "@/lib/crypto/gmail-cipher";
+import { applyEnrichment } from "./enrich";
+
+const TAG = "VITEST_ENRICH_";
+const GMAIL_KEY_ENV = "GMAIL_TOKEN_ENCRYPTION_KEY";
+const ORIGINAL_KEY = process.env[GMAIL_KEY_ENV];
+
+let userA: number;
+let userB: number;
+let accountA: number;
+let accountB: number;
+let connA: number;
+let connB: number;
+
+async function cleanup(): Promise<void> {
+  await db.execute(sql`DELETE FROM classification_rules WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM email_receipts WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM transactions WHERE account_id IN (${accountA}, ${accountB})`);
+}
+
+async function createUser(suffix: string): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `${TAG}${suffix}@test.local`, name: `${TAG}${suffix}` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function createAccount(userId: number, suffix: string): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG}${suffix}`,
+      institution: "Test",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createConnection(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(gmailConnections)
+    .values({
+      userId,
+      gmailEmail: `${TAG}${userId}@example.com`,
+      accessTokenEnc: gmailCipher.encrypt("dummy-access"),
+      refreshTokenEnc: gmailCipher.encrypt("dummy-refresh"),
+      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  return row.id;
+}
+
+async function createTx(userId: number, acctId: number, descriptionRaw: string): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId: acctId,
+      occurredAt: new Date("2026-04-19T10:00:00Z"),
+      amountCents: BigInt(-65990),
+      currency: "COP",
+      descriptionRaw,
+      classificationMethod: "unclassified",
+      source: "sms",
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function createReceipt(
+  userId: number,
+  connId: number,
+  merchant: string,
+  msgSuffix?: string,
+): Promise<number> {
+  const [row] = await db
+    .insert(emailReceipts)
+    .values({
+      userId,
+      gmailConnectionId: connId,
+      gmailMsgId: `${TAG}receipt-${msgSuffix ?? Date.now()}-${Math.random()}`,
+      gateway: "mercado_pago",
+      amountCents: BigInt(65990),
+      occurredAt: new Date("2026-04-19T10:00:00Z"),
+      merchant,
+      rawHtml: "<html>test</html>",
+      matchStatus: "pending",
+    })
+    .returning({ id: emailReceipts.id });
+  return row.id;
+}
+
+async function getTxState(id: number) {
+  const [row] = await db
+    .select({
+      descriptionRaw: transactions.descriptionRaw,
+      enrichedMerchant: transactions.enrichedMerchant,
+      enrichmentSource: transactions.enrichmentSource,
+      categorySlug: transactions.categorySlug,
+      classificationMethod: transactions.classificationMethod,
+    })
+    .from(transactions)
+    .where(eq(transactions.id, id));
+  return row;
+}
+
+async function getReceiptState(id: number) {
+  const [row] = await db
+    .select({
+      matchStatus: emailReceipts.matchStatus,
+      matchedTransactionId: emailReceipts.matchedTransactionId,
+    })
+    .from(emailReceipts)
+    .where(eq(emailReceipts.id, id));
+  return row;
+}
+
+beforeAll(async () => {
+  process.env[GMAIL_KEY_ENV] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  userA = await createUser("A");
+  userB = await createUser("B");
+  accountA = await createAccount(userA, "A");
+  accountB = await createAccount(userB, "B");
+  connA = await createConnection(userA);
+  connB = await createConnection(userB);
+
+  // Seed categories required by FK constraints.
+  await db.insert(categories).values([
+    {
+      userId: userA,
+      slug: "delivery",
+      name: "Delivery",
+      icon: "truck",
+      color: "#3b82f6",
+      sortOrder: 1,
+    },
+    {
+      userId: userB,
+      slug: "delivery",
+      name: "Delivery",
+      icon: "truck",
+      color: "#3b82f6",
+      sortOrder: 1,
+    },
+  ]);
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM gmail_connections WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM categories WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM accounts WHERE id IN (${accountA}, ${accountB})`);
+  await db.execute(sql`DELETE FROM users WHERE id IN (${userA}, ${userB})`);
+  if (ORIGINAL_KEY === undefined) delete process.env[GMAIL_KEY_ENV];
+  else process.env[GMAIL_KEY_ENV] = ORIGINAL_KEY;
+});
+
+describe("applyEnrichment — multi-tenant isolation", () => {
+  it("throws cross-tenant error when receipt belongs to a different user", async () => {
+    const txId = await createTx(userA, accountA, "MERCADOPAGO COLOMBIA A");
+    const receiptId = await createReceipt(userB, connB, "Rappi", "cross");
+
+    await expect(applyEnrichment(userA, txId, receiptId)).rejects.toThrow(/cross-tenant/);
+  });
+
+  it("throws cross-tenant error when transaction belongs to a different user", async () => {
+    const txId = await createTx(userA, accountA, "MERCADOPAGO COLOMBIA B");
+    const receiptId = await createReceipt(userB, connB, "Rappi", "cross2");
+
+    // userB tries to enrich userA's tx with their own receipt
+    await expect(applyEnrichment(userB, txId, receiptId)).rejects.toThrow(/cross-tenant/);
+  });
+});
+
+describe("applyEnrichment — functional", () => {
+  it("sets enrichedMerchant and enrichmentSource on the transaction", async () => {
+    const txId = await createTx(userA, accountA, "MERCADOPAGO COLOMBIA 001");
+    const receiptId = await createReceipt(userA, connA, "Rappi");
+
+    await applyEnrichment(userA, txId, receiptId);
+
+    const tx = await getTxState(txId);
+    expect(tx.enrichedMerchant).toBe("Rappi");
+    expect(tx.enrichmentSource).toBe("gmail");
+  });
+
+  it("sets matchStatus=matched and matchedTransactionId on the receipt", async () => {
+    const txId = await createTx(userA, accountA, "MERCADOPAGO COLOMBIA 002");
+    const receiptId = await createReceipt(userA, connA, "Rappi");
+
+    await applyEnrichment(userA, txId, receiptId);
+
+    const receipt = await getReceiptState(receiptId);
+    expect(receipt.matchStatus).toBe("matched");
+    expect(receipt.matchedTransactionId).toBe(txId);
+  });
+
+  it("preserves descriptionRaw (audit trail is immutable)", async () => {
+    const original = "MERCADOPAGO COLOMBIA audit-check";
+    const txId = await createTx(userA, accountA, original);
+    const receiptId = await createReceipt(userA, connA, "Rappi");
+
+    await applyEnrichment(userA, txId, receiptId);
+
+    const tx = await getTxState(txId);
+    expect(tx.descriptionRaw).toBe(original);
+  });
+
+  it("applies rule_retroactive classification when a matching rule exists", async () => {
+    const txId = await createTx(userA, accountA, "MERCADOPAGO COLOMBIA classify");
+    const receiptId = await createReceipt(userA, connA, "Rappi");
+
+    await db.insert(classificationRules).values({
+      userId: userA,
+      pattern: "%Rappi%",
+      categorySlug: "delivery",
+      priority: 5,
+      active: true,
+    });
+
+    await applyEnrichment(userA, txId, receiptId);
+
+    const tx = await getTxState(txId);
+    expect(tx.categorySlug).toBe("delivery");
+    expect(tx.classificationMethod).toBe("rule_retroactive");
+  });
+
+  it("is atomic: if reclassify step fails, neither tx nor receipt is modified", async () => {
+    // We simulate atomicity by verifying a failing classification rule
+    // insertion doesn't corrupt the row states. However, testing a true
+    // mid-transaction failure requires injecting a mock. Here we test the
+    // observable guarantee: without a failure, both writes land or neither
+    // does. We verify via a cross-tenant throw that rolls back both writes.
+    const txId = await createTx(userA, accountA, "MERCADOPAGO COLOMBIA atomic");
+    const receiptIdWrong = await createReceipt(userB, connB, "Rappi", "atomic-wrong");
+
+    await expect(applyEnrichment(userA, txId, receiptIdWrong)).rejects.toThrow(/cross-tenant/);
+
+    // Neither row should be modified.
+    const tx = await getTxState(txId);
+    expect(tx.enrichedMerchant).toBeNull();
+
+    const receipt = await getReceiptState(receiptIdWrong);
+    expect(receipt.matchStatus).toBe("pending");
+  });
+});
+
+describe("applyEnrichment — idempotency", () => {
+  it("calling twice with same args produces identical state", async () => {
+    const txId = await createTx(userA, accountA, "MERCADOPAGO COLOMBIA idem");
+    const receiptId = await createReceipt(userA, connA, "Rappi");
+
+    await applyEnrichment(userA, txId, receiptId);
+    const tx1 = await getTxState(txId);
+    const receipt1 = await getReceiptState(receiptId);
+
+    // Second call: receipt is already matched=matched, tx is already enriched.
+    // The cross-tenant check still passes since both rows belong to userA.
+    await applyEnrichment(userA, txId, receiptId);
+    const tx2 = await getTxState(txId);
+    const receipt2 = await getReceiptState(receiptId);
+
+    expect(tx1).toEqual(tx2);
+    expect(receipt1).toEqual(receipt2);
+  });
+});

--- a/src/lib/gmail/enrich.test.ts
+++ b/src/lib/gmail/enrich.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
@@ -12,6 +12,29 @@ import {
 } from "@/lib/db/schema";
 import { gmailCipher } from "@/lib/crypto/gmail-cipher";
 import { applyEnrichment } from "./enrich";
+
+// Controls whether reclassifyTransaction should throw. Shared via vi.hoisted
+// so the factory inside vi.mock() can read it before top-level consts are set.
+const { shouldReclassifyThrow } = vi.hoisted(() => ({ shouldReclassifyThrow: { value: false } }));
+
+vi.mock("@/lib/classification/reclassify", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/classification/reclassify")>();
+  return {
+    ...original,
+    reclassifyTransaction: vi.fn(
+      async (
+        userId: number,
+        txId: number,
+        database?: import("@/lib/classification/reclassify").ReclassifyDb,
+      ) => {
+        if (shouldReclassifyThrow.value) {
+          throw new Error("injected reclassify failure for rollback test");
+        }
+        return original.reclassifyTransaction(userId, txId, database);
+      },
+    ),
+  };
+});
 
 const TAG = "VITEST_ENRICH_";
 const GMAIL_KEY_ENV = "GMAIL_TOKEN_ENCRYPTION_KEY";
@@ -244,23 +267,47 @@ describe("applyEnrichment — functional", () => {
     expect(tx.classificationMethod).toBe("rule_retroactive");
   });
 
-  it("is atomic: if reclassify step fails, neither tx nor receipt is modified", async () => {
-    // We simulate atomicity by verifying a failing classification rule
-    // insertion doesn't corrupt the row states. However, testing a true
-    // mid-transaction failure requires injecting a mock. Here we test the
-    // observable guarantee: without a failure, both writes land or neither
-    // does. We verify via a cross-tenant throw that rolls back both writes.
+  it("throws on cross-tenant attempt before issuing any write", async () => {
+    // The cross-tenant check in enrich.ts runs before the first UPDATE, so the
+    // throw happens before any write — this test validates the guard, NOT rollback.
     const txId = await createTx(userA, accountA, "MERCADOPAGO COLOMBIA atomic");
     const receiptIdWrong = await createReceipt(userB, connB, "Rappi", "atomic-wrong");
 
     await expect(applyEnrichment(userA, txId, receiptIdWrong)).rejects.toThrow(/cross-tenant/);
 
-    // Neither row should be modified.
+    // Neither row should be modified (no write was ever issued).
     const tx = await getTxState(txId);
     expect(tx.enrichedMerchant).toBeNull();
 
     const receipt = await getReceiptState(receiptIdWrong);
     expect(receipt.matchStatus).toBe("pending");
+  });
+
+  it("rolls back tx update if reclassify step fails mid-transaction", async () => {
+    // Both updates (transactions + email_receipts) execute inside db.transaction
+    // before reclassifyTransaction is called. Injecting a failure in reclassify
+    // proves Drizzle rolls back both — if the transaction were absent, both UPDATEs
+    // would persist.
+    const txId = await createTx(userA, accountA, "MERCADOPAGO COLOMBIA rollback");
+    const receiptId = await createReceipt(userA, connA, "Rappi", "rollback");
+
+    shouldReclassifyThrow.value = true;
+    try {
+      await expect(applyEnrichment(userA, txId, receiptId)).rejects.toThrow(
+        /injected reclassify failure/,
+      );
+    } finally {
+      shouldReclassifyThrow.value = false;
+    }
+
+    // Re-query outside the failed transaction scope — both rows must be pristine.
+    const tx = await getTxState(txId);
+    expect(tx.enrichedMerchant).toBeNull();
+    expect(tx.enrichmentSource).toBeNull();
+
+    const receipt = await getReceiptState(receiptId);
+    expect(receipt.matchStatus).toBe("pending");
+    expect(receipt.matchedTransactionId).toBeNull();
   });
 });
 

--- a/src/lib/gmail/enrich.ts
+++ b/src/lib/gmail/enrich.ts
@@ -1,0 +1,85 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { emailReceipts, transactions } from "@/lib/db/schema";
+import { createLogger } from "@/lib/logger";
+import { reclassifyTransaction, type ReclassifyDb } from "@/lib/classification/reclassify";
+
+const log = createLogger({ module: "gmail/enrich" });
+
+/**
+ * Apply enrichment from a matched email receipt to the corresponding
+ * bank transaction, then trigger retroactive reclassification.
+ *
+ * Everything runs inside a single Drizzle transaction so a mid-way failure
+ * rolls back both the transactions update and the email_receipts update.
+ *
+ * Tenant isolation: both rows are verified to belong to `userId` before any
+ * mutation. A mismatch throws `Error("cross-tenant attempt")` — the error
+ * message is intentionally stable so callers can match on it in tests.
+ */
+export async function applyEnrichment(
+  userId: number,
+  txId: number,
+  receiptId: number,
+): Promise<void> {
+  await db.transaction(async (trx) => {
+    // Verify the transaction belongs to this user.
+    const [tx] = await trx
+      .select({
+        id: transactions.id,
+        userId: transactions.userId,
+        descriptionRaw: transactions.descriptionRaw,
+      })
+      .from(transactions)
+      .where(and(eq(transactions.id, txId), eq(transactions.userId, userId)));
+
+    if (!tx) {
+      throw new Error("cross-tenant attempt: transaction does not belong to user");
+    }
+
+    // Verify the receipt belongs to this user.
+    const [receipt] = await trx
+      .select({
+        id: emailReceipts.id,
+        userId: emailReceipts.userId,
+        merchant: emailReceipts.merchant,
+      })
+      .from(emailReceipts)
+      .where(and(eq(emailReceipts.id, receiptId), eq(emailReceipts.userId, userId)));
+
+    if (!receipt) {
+      throw new Error("cross-tenant attempt: receipt does not belong to user");
+    }
+
+    // Update the transaction with enriched merchant data.
+    // NEVER modify descriptionRaw — it is the immutable audit field.
+    await trx
+      .update(transactions)
+      .set({
+        enrichedMerchant: receipt.merchant,
+        enrichmentSource: "gmail",
+        updatedAt: new Date(),
+      })
+      .where(and(eq(transactions.id, txId), eq(transactions.userId, userId)));
+
+    // Update the receipt to reflect the match.
+    await trx
+      .update(emailReceipts)
+      .set({
+        matchedTransactionId: txId,
+        matchStatus: "matched",
+        updatedAt: new Date(),
+      })
+      .where(and(eq(emailReceipts.id, receiptId), eq(emailReceipts.userId, userId)));
+
+    // Trigger retroactive reclassification inside the same DB transaction
+    // so rule updates and enrichment are atomic. Cast trx to ReclassifyDb
+    // (the PgTransaction union type) which is structurally compatible.
+    await reclassifyTransaction(userId, txId, trx as ReclassifyDb);
+  });
+
+  log.info(
+    { userId, txId, receiptId, event: "gmail_enrichment_applied" },
+    "gmail enrichment applied",
+  );
+}

--- a/src/lib/gmail/matcher.test.ts
+++ b/src/lib/gmail/matcher.test.ts
@@ -1,0 +1,307 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, emailReceipts, gmailConnections, transactions, users } from "@/lib/db/schema";
+import { gmailCipher } from "@/lib/crypto/gmail-cipher";
+import { matchReceipt } from "./matcher";
+
+const TAG = "VITEST_MATCHER_";
+const GMAIL_KEY_ENV = "GMAIL_TOKEN_ENCRYPTION_KEY";
+const ORIGINAL_KEY = process.env[GMAIL_KEY_ENV];
+
+let userA: number;
+let userB: number;
+let accountA: number;
+let accountB: number;
+let connA: number;
+let connB: number;
+
+async function cleanup(): Promise<void> {
+  await db.execute(sql`DELETE FROM email_receipts WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM transactions WHERE account_id IN (${accountA}, ${accountB})`);
+}
+
+async function createUser(suffix: string): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `${TAG}${suffix}@test.local`, name: `${TAG}${suffix}` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function createAccount(userId: number, suffix: string): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG}${suffix}`,
+      institution: "Test",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createConnection(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(gmailConnections)
+    .values({
+      userId,
+      gmailEmail: `${TAG}${userId}@example.com`,
+      accessTokenEnc: gmailCipher.encrypt("dummy-access"),
+      refreshTokenEnc: gmailCipher.encrypt("dummy-refresh"),
+      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  return row.id;
+}
+
+async function createTx(opts: {
+  userId: number;
+  accountId: number;
+  amountCents: bigint;
+  occurredAt: Date;
+  descriptionRaw: string;
+  enrichedMerchant?: string | null;
+  deletedAt?: Date | null;
+}): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId: opts.userId,
+      accountId: opts.accountId,
+      occurredAt: opts.occurredAt,
+      amountCents: opts.amountCents,
+      currency: "COP",
+      descriptionRaw: opts.descriptionRaw,
+      enrichedMerchant: opts.enrichedMerchant ?? null,
+      deletedAt: opts.deletedAt ?? null,
+      classificationMethod: "unclassified",
+      source: "sms",
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function createReceipt(opts: {
+  userId: number;
+  connId: number;
+  gateway: "mercado_pago" | "payu" | "wompi" | "apple" | "paypal";
+  amountCents: bigint;
+  occurredAt: Date;
+  merchant?: string;
+  msgId?: string;
+}): Promise<number> {
+  const [row] = await db
+    .insert(emailReceipts)
+    .values({
+      userId: opts.userId,
+      gmailConnectionId: opts.connId,
+      gmailMsgId: opts.msgId ?? `${TAG}${Date.now()}-${Math.random()}`,
+      gateway: opts.gateway,
+      amountCents: opts.amountCents,
+      occurredAt: opts.occurredAt,
+      merchant: opts.merchant ?? "TestMerchant",
+      rawHtml: "<html>test</html>",
+      matchStatus: "pending",
+    })
+    .returning({ id: emailReceipts.id });
+  return row.id;
+}
+
+beforeAll(async () => {
+  process.env[GMAIL_KEY_ENV] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  userA = await createUser("A");
+  userB = await createUser("B");
+  accountA = await createAccount(userA, "A");
+  accountB = await createAccount(userB, "B");
+  connA = await createConnection(userA);
+  connB = await createConnection(userB);
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM gmail_connections WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM accounts WHERE id IN (${accountA}, ${accountB})`);
+  await db.execute(sql`DELETE FROM users WHERE id IN (${userA}, ${userB})`);
+  if (ORIGINAL_KEY === undefined) delete process.env[GMAIL_KEY_ENV];
+  else process.env[GMAIL_KEY_ENV] = ORIGINAL_KEY;
+});
+
+const AMOUNT = BigInt(65990);
+const DATE = new Date("2026-04-19T10:00:00Z");
+
+describe("matchReceipt — multi-tenant isolation", () => {
+  it("does NOT match userA tx when receipt belongs to userB (cross-tenant guard)", async () => {
+    // UserA has a tx that looks like a MercadoPago payment.
+    await createTx({
+      userId: userA,
+      accountId: accountA,
+      amountCents: -AMOUNT,
+      occurredAt: DATE,
+      descriptionRaw: "MERCADOPAGO COLOMBIA 999",
+    });
+    // UserB has a receipt for the same amount/date but different userId.
+    const receiptId = await createReceipt({
+      userId: userB,
+      connId: connB,
+      gateway: "mercado_pago",
+      amountCents: AMOUNT,
+      occurredAt: DATE,
+    });
+
+    const result = await matchReceipt(userB, receiptId);
+    // Must NOT return the tx that belongs to userA.
+    expect(result.status).toBe("unmatched");
+  });
+
+  it("throws when receipt id does not belong to caller userId", async () => {
+    const receiptId = await createReceipt({
+      userId: userA,
+      connId: connA,
+      gateway: "mercado_pago",
+      amountCents: AMOUNT,
+      occurredAt: DATE,
+    });
+    // UserB tries to access userA's receipt.
+    await expect(matchReceipt(userB, receiptId)).rejects.toThrow(/receipt.*not found/);
+  });
+});
+
+describe("matchReceipt — functional", () => {
+  it("returns matched when exactly one tx is in the window", async () => {
+    const txId = await createTx({
+      userId: userA,
+      accountId: accountA,
+      amountCents: -AMOUNT,
+      occurredAt: DATE,
+      descriptionRaw: "MERCADOPAGO COLOMBIA 001",
+    });
+    const receiptId = await createReceipt({
+      userId: userA,
+      connId: connA,
+      gateway: "mercado_pago",
+      amountCents: AMOUNT,
+      occurredAt: DATE,
+    });
+
+    const result = await matchReceipt(userA, receiptId);
+    expect(result.status).toBe("matched");
+    if (result.status === "matched") {
+      expect(result.transactionId).toBe(txId);
+    }
+  });
+
+  it("returns ambiguous with candidateIds when 2 txs are in the window", async () => {
+    const tx1 = await createTx({
+      userId: userA,
+      accountId: accountA,
+      amountCents: -AMOUNT,
+      occurredAt: DATE,
+      descriptionRaw: "MERCADOPAGO COLOMBIA 002",
+    });
+    const tx2 = await createTx({
+      userId: userA,
+      accountId: accountA,
+      amountCents: -AMOUNT,
+      occurredAt: new Date(DATE.getTime() + 60_000), // 1 min later
+      descriptionRaw: "MERCADOPAGO COLOMBIA 003",
+    });
+    const receiptId = await createReceipt({
+      userId: userA,
+      connId: connA,
+      gateway: "mercado_pago",
+      amountCents: AMOUNT,
+      occurredAt: DATE,
+    });
+
+    const result = await matchReceipt(userA, receiptId);
+    expect(result.status).toBe("ambiguous");
+    if (result.status === "ambiguous") {
+      expect(result.candidateIds).toHaveLength(2);
+      expect(result.candidateIds).toContain(tx1);
+      expect(result.candidateIds).toContain(tx2);
+    }
+  });
+
+  it("returns unmatched when no tx exists in the window", async () => {
+    const receiptId = await createReceipt({
+      userId: userA,
+      connId: connA,
+      gateway: "mercado_pago",
+      amountCents: AMOUNT,
+      occurredAt: DATE,
+    });
+
+    const result = await matchReceipt(userA, receiptId);
+    expect(result.status).toBe("unmatched");
+  });
+
+  it("excludes already-enriched transactions from candidates", async () => {
+    // This tx already has enriched_merchant set — should be excluded.
+    await createTx({
+      userId: userA,
+      accountId: accountA,
+      amountCents: -AMOUNT,
+      occurredAt: DATE,
+      descriptionRaw: "MERCADOPAGO COLOMBIA 004",
+      enrichedMerchant: "SomePreviousMerchant",
+    });
+    const receiptId = await createReceipt({
+      userId: userA,
+      connId: connA,
+      gateway: "mercado_pago",
+      amountCents: AMOUNT,
+      occurredAt: DATE,
+    });
+
+    const result = await matchReceipt(userA, receiptId);
+    expect(result.status).toBe("unmatched");
+  });
+
+  it("excludes soft-deleted transactions from candidates", async () => {
+    await createTx({
+      userId: userA,
+      accountId: accountA,
+      amountCents: -AMOUNT,
+      occurredAt: DATE,
+      descriptionRaw: "MERCADOPAGO COLOMBIA 005",
+      deletedAt: new Date(), // soft-deleted
+    });
+    const receiptId = await createReceipt({
+      userId: userA,
+      connId: connA,
+      gateway: "mercado_pago",
+      amountCents: AMOUNT,
+      occurredAt: DATE,
+    });
+
+    const result = await matchReceipt(userA, receiptId);
+    expect(result.status).toBe("unmatched");
+  });
+
+  it("throws for ingest-mode gateway (bancolombia)", async () => {
+    // Bancolombia receipts should never reach the matcher — this is a
+    // defense-in-depth guard in case the pull engine filter ever breaks.
+    const receiptId = await db
+      .insert(emailReceipts)
+      .values({
+        userId: userA,
+        gmailConnectionId: connA,
+        gmailMsgId: `${TAG}bancolombia-${Date.now()}`,
+        gateway: "bancolombia",
+        amountCents: AMOUNT,
+        occurredAt: DATE,
+        rawHtml: "<html>test</html>",
+        matchStatus: "pending",
+      })
+      .returning({ id: emailReceipts.id })
+      .then(([r]) => r.id);
+
+    await expect(matchReceipt(userA, receiptId)).rejects.toThrow(/ingest-mode/);
+  });
+});

--- a/src/lib/gmail/matcher.ts
+++ b/src/lib/gmail/matcher.ts
@@ -1,0 +1,116 @@
+import { and, eq, gte, isNull, lte, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { emailReceipts, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { createLogger } from "@/lib/logger";
+import { getGatewayById } from "@/lib/gmail/registry";
+
+const log = createLogger({ module: "gmail/matcher" });
+
+// ±2 days expressed in milliseconds.
+const MATCH_WINDOW_MS = 2 * 24 * 60 * 60 * 1000;
+
+export type MatchResult =
+  | { status: "matched"; transactionId: number }
+  | { status: "ambiguous"; candidateIds: number[] }
+  | { status: "unmatched" };
+
+/**
+ * Find the bank transaction that corresponds to an email receipt.
+ *
+ * Tenant isolation: both the receipt load and the transactions JOIN are
+ * scoped by `userId`. The function throws if the receipt is not found under
+ * the given userId (cross-tenant attempt or stale id).
+ *
+ * Only runs on enrich-mode gateways. If called on an ingest-mode gateway
+ * (e.g. bancolombia) it throws — the pull engine should never route those
+ * receipts here, but this is a defense-in-depth guard.
+ */
+export async function matchReceipt(userId: number, receiptId: number): Promise<MatchResult> {
+  // Load receipt scoped by (id, userId) — throw on mismatch to prevent
+  // cross-tenant data exposure.
+  const [receipt] = await db
+    .select({
+      id: emailReceipts.id,
+      userId: emailReceipts.userId,
+      gateway: emailReceipts.gateway,
+      amountCents: emailReceipts.amountCents,
+      occurredAt: emailReceipts.occurredAt,
+    })
+    .from(emailReceipts)
+    .where(and(eq(emailReceipts.id, receiptId), eq(emailReceipts.userId, userId)));
+
+  if (!receipt) {
+    throw new Error(`[gmail/matcher] receipt ${receiptId} not found for user ${userId}`);
+  }
+
+  if (!receipt.amountCents || !receipt.occurredAt) {
+    log.info(
+      { userId, receiptId, event: "matcher_receipt_unparsed" },
+      "receipt has no amountCents or occurredAt; unmatched",
+    );
+    return { status: "unmatched" };
+  }
+
+  // Defense-in-depth: matcher must never run on ingest-mode gateways.
+  const gateway = getGatewayById(receipt.gateway);
+  if (!gateway.bankDescriptionRegex) {
+    throw new Error(
+      `[gmail/matcher] gateway ${receipt.gateway} is ingest-mode (bankDescriptionRegex is null); matcher must not run on it`,
+    );
+  }
+
+  // Adapt the JS regex source for PostgreSQL POSIX (`~*`).
+  // `\b` is a word-boundary in JS regex but a literal backspace (ASCII 8) in
+  // POSIX ERE — strip it so the pattern degrades gracefully to a substring
+  // match (still accurate enough for bank description tokens like MERCADOPAGO,
+  // PAYPAL, WOMPI which are unlikely to appear as sub-tokens in other words).
+  const posixPattern = gateway.bankDescriptionRegex.source.replace(/\\b/g, "");
+
+  const windowStart = new Date(receipt.occurredAt.getTime() - MATCH_WINDOW_MS);
+  const windowEnd = new Date(receipt.occurredAt.getTime() + MATCH_WINDOW_MS);
+
+  // Receipts store the amount as a positive value (what the user paid), but
+  // bank transactions store expenses as negative. Match both signs so a
+  // receipt for 65990 matches a transaction with -65990 (purchase) or +65990
+  // (unusual but covers manual/CSV imports with inverted sign conventions).
+  const positiveAmount =
+    receipt.amountCents < BigInt(0) ? -receipt.amountCents : receipt.amountCents;
+  const negativeAmount = -positiveAmount;
+
+  const candidates = await db
+    .select({ id: transactions.id })
+    .from(transactions)
+    .where(
+      and(
+        // Tenant safety: every constraint includes userId as a top-level guard.
+        eq(transactions.userId, userId),
+        sql`(${transactions.amountCents} = ${positiveAmount} OR ${transactions.amountCents} = ${negativeAmount})`,
+        gte(transactions.occurredAt, windowStart),
+        lte(transactions.occurredAt, windowEnd),
+        // Gateway regex match — case-insensitive POSIX (~*). Uses posixPattern
+        // (not the raw .source) because \b is a backspace in POSIX ERE, not a
+        // word boundary — see the adaptation comment above.
+        sql`${transactions.descriptionRaw} ~* ${posixPattern}`,
+        // Exclude already-enriched transactions (another receipt already claimed them).
+        isNull(transactions.enrichedMerchant),
+        // Exclude soft-deleted transactions.
+        notDeleted(transactions.deletedAt),
+      ),
+    );
+
+  log.info(
+    {
+      userId,
+      receiptId,
+      candidateCount: candidates.length,
+      gateway: receipt.gateway,
+      event: "matcher_candidates",
+    },
+    "matcher found candidates",
+  );
+
+  if (candidates.length === 0) return { status: "unmatched" };
+  if (candidates.length === 1) return { status: "matched", transactionId: candidates[0].id };
+  return { status: "ambiguous", candidateIds: candidates.map((c) => c.id) };
+}

--- a/src/lib/gmail/matcher.ts
+++ b/src/lib/gmail/matcher.ts
@@ -65,6 +65,9 @@ export async function matchReceipt(userId: number, receiptId: number): Promise<M
   // POSIX ERE — strip it so the pattern degrades gracefully to a substring
   // match (still accurate enough for bank description tokens like MERCADOPAGO,
   // PAYPAL, WOMPI which are unlikely to appear as sub-tokens in other words).
+  // PostgreSQL POSIX `~*` does not support `\b` as a word boundary (it means
+  // backspace). Strip `\b` from regex.source — assumes `\b` only appears as an
+  // anchor, never inside a character class (e.g. `[\b]` would break differently).
   const posixPattern = gateway.bankDescriptionRegex.source.replace(/\\b/g, "");
 
   const windowStart = new Date(receipt.occurredAt.getTime() - MATCH_WINDOW_MS);

--- a/src/lib/gmail/pull.ts
+++ b/src/lib/gmail/pull.ts
@@ -20,6 +20,8 @@ import {
 } from "@/lib/gmail/registry";
 import { parseBancolombiaEmail } from "@/lib/gmail/parsers/bancolombia";
 import { ingestParsedEmail } from "@/lib/ingestion/email-bancolombia";
+import { matchReceipt } from "@/lib/gmail/matcher";
+import { applyEnrichment } from "@/lib/gmail/enrich";
 
 const log = createLogger({ module: "gmail/pull" });
 
@@ -348,6 +350,83 @@ async function processPendingBancolombiaReceipts(userId: number): Promise<void> 
 }
 
 /**
+ * Match and enrich every pending receipt for an enrich-mode gateway. Called
+ * at the tail of `pullForUser` so freshly-inserted receipts are processed in
+ * the same cron tick AND stale pending rows from a previously-failed match are
+ * retried on every subsequent cron — no need for a separate reaper.
+ *
+ * Per-receipt errors are logged and do NOT interrupt the loop; the receipt
+ * stays pending for the next tick to retry.
+ *
+ * Unmatched receipts are persisted with match_status='unmatched' but are
+ * re-attempted on future pulls (the corresponding bank tx may not have arrived
+ * via SMS yet at the time of the first pull).
+ */
+async function processPendingEnrichReceipts(userId: number, gatewayId: GatewayId): Promise<void> {
+  const pending = await db
+    .select({ id: emailReceipts.id })
+    .from(emailReceipts)
+    .where(
+      and(
+        eq(emailReceipts.userId, userId),
+        eq(emailReceipts.gateway, gatewayId),
+        eq(emailReceipts.matchStatus, "pending"),
+        notDeleted(emailReceipts.deletedAt),
+      ),
+    );
+
+  for (const receipt of pending) {
+    try {
+      const result = await matchReceipt(userId, receipt.id);
+
+      if (result.status === "matched") {
+        await applyEnrichment(userId, result.transactionId, receipt.id);
+      } else if (result.status === "ambiguous") {
+        await db
+          .update(emailReceipts)
+          .set({
+            matchStatus: "ambiguous",
+            matchCandidates: result.candidateIds,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(emailReceipts.id, receipt.id), eq(emailReceipts.userId, userId)));
+        log.info(
+          {
+            userId,
+            receiptId: receipt.id,
+            candidateIds: result.candidateIds,
+            event: "gmail_enrich_ambiguous",
+          },
+          "receipt has ambiguous tx candidates; persisted for user disambiguation",
+        );
+      } else {
+        // unmatched: persist the status so it's queryable, but leave it
+        // eligible for re-attempt on future pulls.
+        await db
+          .update(emailReceipts)
+          .set({ matchStatus: "unmatched", updatedAt: new Date() })
+          .where(and(eq(emailReceipts.id, receipt.id), eq(emailReceipts.userId, userId)));
+        log.info(
+          { userId, receiptId: receipt.id, gateway: gatewayId, event: "gmail_enrich_unmatched" },
+          "no tx candidate found for receipt; will retry on next pull",
+        );
+      }
+    } catch (err) {
+      log.error(
+        {
+          err,
+          userId,
+          receiptId: receipt.id,
+          gateway: gatewayId,
+          event: "gmail_enrich_receipt_failed",
+        },
+        "failed to match/enrich receipt; leaving as pending for retry",
+      );
+    }
+  }
+}
+
+/**
  * Pull new Gmail messages for one user, store them in `email_receipts`, and
  * update the connection's `last_pull_at` watermark.
  *
@@ -458,6 +537,14 @@ export async function pullForUser(
     if (g.id === "bancolombia") {
       await processPendingBancolombiaReceipts(userId);
     }
+  }
+
+  // Process enrich-mode receipts (#454 — mercado_pago, payu, wompi, apple,
+  // paypal). Stale pending receipts are retried on every pull — the bank tx
+  // may not have arrived via SMS yet on the first attempt.
+  const enrichGatewaysSelected = selectedGateways.filter((g) => g.mode === "enrich");
+  for (const g of enrichGatewaysSelected) {
+    await processPendingEnrichReceipts(userId, g.id);
   }
 
   // Only advance the watermark on fully successful pulls — partial failures

--- a/src/lib/gmail/pull.ts
+++ b/src/lib/gmail/pull.ts
@@ -370,7 +370,7 @@ async function processPendingEnrichReceipts(userId: number, gatewayId: GatewayId
       and(
         eq(emailReceipts.userId, userId),
         eq(emailReceipts.gateway, gatewayId),
-        eq(emailReceipts.matchStatus, "pending"),
+        inArray(emailReceipts.matchStatus, ["pending", "unmatched"]),
         notDeleted(emailReceipts.deletedAt),
       ),
     );


### PR DESCRIPTION
## Summary

- Adds tenant-safe Gmail-receipt → transaction matcher with `matched`/`ambiguous`/`unmatched` discriminated result
- Wires atomic enrichment + retroactive rule reclassification (single drizzle transaction)
- Integrates into the existing pull engine; unmatched receipts are retried on future pulls

Closes #454
Part of Epic G (#459)

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` — 1247 tests passing (101 test files)
- [x] Multi-tenant test verifies #338-style cross-tenant leak does NOT regress (matcher must not return another user's tx)
- [x] Atomicity test injects mid-transaction failure, verifies both writes roll back
- [x] Re-attempt test runs `pullForUser` twice; first call → unmatched, second call after bank tx arrives → matched

## Notes

- No schema migration needed — all required columns landed in #450.
- No UI changes — Web/`needs_review` UX is #455, bot disambiguation is #456.
- POSIX regex `\b` gotcha documented in `matcher.ts` (PG `~*` treats `\b` as backspace, not word-boundary).