### PR TITLE
feat(ingestion): gateway parsers — MP, PayU, Wompi, Apple, PayPal (#453)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "next-auth": "^5.0.0-beta.31",
         "next-themes": "^0.4.6",
         "node-cron": "^4.2.1",
+        "node-html-parser": "^7.1.0",
         "pino": "^10.3.1",
         "postgres": "^3.4.9",
         "radix-ui": "^1.4.3",
@@ -820,6 +821,8 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
     "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -914,7 +917,11 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
@@ -997,6 +1004,14 @@
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
@@ -1239,6 +1254,8 @@
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
@@ -1612,9 +1629,13 @@
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
+    "node-html-parser": ["node-html-parser@7.1.0", "", { "dependencies": { "css-select": "^5.1.0", "he": "1.2.0" } }, "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ=="],
+
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "number-flow": ["number-flow@0.6.0", "", { "dependencies": { "esm-env": "^1.1.4" } }, "sha512-K8flNq2Wqus53vjp/btVo3qXFkagF8dIdYavreBfE7hlvFFG/b1HMGEH6nZL+mlrJ+4lbLP9OmPv3t2rmRkpSQ=="],
 
@@ -2205,6 +2226,8 @@
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,12 @@ const eslintConfig = defineConfig([
   {
     rules: {
       "no-console": "error",
+      // Align with the TypeScript convention: identifiers prefixed with "_" are
+      // intentionally unused (e.g. interface-satisfying params in stub parsers).
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
     },
   },
   // Override default ignores of eslint-config-next.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "next-auth": "^5.0.0-beta.31",
     "next-themes": "^0.4.6",
     "node-cron": "^4.2.1",
+    "node-html-parser": "^7.1.0",
     "pino": "^10.3.1",
     "postgres": "^3.4.9",
     "radix-ui": "^1.4.3",

--- a/src/lib/gmail/enrich-pull.test.ts
+++ b/src/lib/gmail/enrich-pull.test.ts
@@ -333,6 +333,60 @@ describe("processPendingEnrichReceipts (via pullForUser)", () => {
     expect((receipt.matchCandidates as number[]).length).toBe(2);
   });
 
+  it("skipped receipt (non-transactional) gets parsedAt set so it is not re-parsed on subsequent pulls", async () => {
+    // A non-transactional MP email: no "Pagaste" / "Le compraste a" → parser
+    // returns { kind: "skipped", reason: "non_transactional" }.
+    const promotionalHtml = `<!DOCTYPE html><html><body>
+      <p>Con Mercado Pago aprovecha 3 cuotas sin interes en muchas marcas.</p>
+      <p>#LoMejorEstaLlegando</p>
+    </body></html>`;
+
+    // Insert the receipt WITHOUT parsedAt so the pull engine enters the parse step.
+    const [receiptRow] = await db
+      .insert(emailReceipts)
+      .values({
+        userId,
+        gmailConnectionId: connId,
+        gmailMsgId: `${TAG}skipped-${Date.now()}`,
+        gateway: "mercado_pago",
+        rawHtml: promotionalHtml,
+        matchStatus: "pending",
+        // parsedAt intentionally omitted (null)
+      })
+      .returning({ id: emailReceipts.id });
+    const receiptId = receiptRow.id;
+
+    // First pull: parser sees the promo email, returns "skipped".
+    // Fix under test: parsedAt must be set alongside matchStatus="unmatched".
+    await pullForUser(userId, {}, { getClient: async () => makeNoopClient() });
+
+    const [afterFirst] = await db
+      .select({
+        matchStatus: emailReceipts.matchStatus,
+        parsedAt: emailReceipts.parsedAt,
+      })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.id, receiptId));
+
+    expect(afterFirst.matchStatus).toBe("unmatched");
+    expect(afterFirst.parsedAt).not.toBeNull();
+
+    const parsedAtAfterFirst = afterFirst.parsedAt!.getTime();
+
+    // Second pull: receipt is still in the WHERE clause (matchStatus="unmatched")
+    // but parsedAt is now set — so the parse step (and parseReceipt call) is
+    // skipped entirely. parsedAt must remain exactly the same value.
+    await pullForUser(userId, {}, { getClient: async () => makeNoopClient() });
+
+    const [afterSecond] = await db
+      .select({ parsedAt: emailReceipts.parsedAt })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.id, receiptId));
+
+    // parsedAt must not have been refreshed (i.e. parseReceipt was not called again).
+    expect(afterSecond.parsedAt!.getTime()).toBe(parsedAtAfterFirst);
+  });
+
   it("all enrich gateways in GATEWAYS registry have mode=enrich (registry coverage)", () => {
     const enrichGateways = GATEWAYS.filter((g) => g.mode === "enrich");
     const ingestGateways = GATEWAYS.filter((g) => g.mode === "ingest");

--- a/src/lib/gmail/enrich-pull.test.ts
+++ b/src/lib/gmail/enrich-pull.test.ts
@@ -61,6 +61,9 @@ async function seedReceipt(opts: {
   merchant: string;
   matchStatus?: "pending" | "matched" | "ambiguous" | "unmatched";
 }): Promise<number> {
+  // parsedAt is set so the pull engine skips the parse step and goes straight
+  // to matching. Integration tests care about the match/enrich path, not the
+  // parse step (which is unit-tested in parsers/*.test.ts).
   const [row] = await db
     .insert(emailReceipts)
     .values({
@@ -72,6 +75,7 @@ async function seedReceipt(opts: {
       occurredAt: opts.occurredAt,
       merchant: opts.merchant,
       rawHtml: "<html>receipt</html>",
+      parsedAt: new Date(),
       matchStatus: opts.matchStatus ?? "pending",
     })
     .returning({ id: emailReceipts.id });

--- a/src/lib/gmail/parsers/README.md
+++ b/src/lib/gmail/parsers/README.md
@@ -1,0 +1,20 @@
+# Gmail receipt parsers
+
+One parser per gateway. Each implements `GatewayParser.parse(html, opts?) → ParseResult`.
+
+The orchestrator (`index.ts`) dispatches based on `email_receipts.gateway`. Bancolombia has a separate ingest path and is NOT routed through here — see `bancolombia.ts` and `processPendingBancolombiaReceipts` in `pull.ts`.
+
+## Parsers
+
+- `mercado-pago.ts` — flat-prose receipts; period=thousands, comma=decimal; Spanish date format
+- `payu.ts` — labeled-table receipts; skip rejected + card-registration emails; Bogotá time (UTC-5)
+- `wompi.ts` — labeled receipt with `WC-` reference; comma=thousands separator; no in-body date
+- `apple.ts` — multiple email types from same sender; skip non-purchase variants; two invoice layouts
+- `paypal.ts` — STUB until prod samples available
+
+## Google Play / Google Pay
+
+Verified absent in alpha user inbox (2026-04-23). Charges that look like Google Pay
+(`DLO*DiDi Food CO Pay`) are actually **dLocal** (LATAM payment processor used by DiDi,
+Spotify, Netflix, etc.) — dLocal does not send receipts itself; the merchant does.
+**No parser added in MVP.** Reopen if Google Play receipts appear in any beta user's inbox.

--- a/src/lib/gmail/parsers/_text.ts
+++ b/src/lib/gmail/parsers/_text.ts
@@ -1,0 +1,118 @@
+// Shared HTML-to-visible-text helper for gateway email parsers.
+//
+// WHY THIS EXISTS
+// ---------------
+// CodeQL `js/double-escaping` was triggered in payu.ts by a cascading
+// named-entity replacement chain where &amp; was decoded AFTER other
+// replacements — creating a double-decode path:
+//   "&amp;amp;" → "&amp;" → "&"   (input that was meant to stay "&amp;")
+// The fix is a single-pass atomic lookup so each &NAME; is matched exactly
+// once and cannot cascade.
+//
+// Note: bancolombia.ts keeps its own private implementation (copied here from
+// the same pattern) to limit the blast radius of issue #453. That parser has
+// a different return type (BancolombiaParseResult) and extra helpers
+// (isolateTransactionalSentence) that make a shared import non-trivial to
+// wire safely. Unifying them is deferred.
+
+// Named HTML entities that appear in real gateway emails (PayU, Wompi,
+// MercadoPago, Apple). This is the union of all entity sets observed across
+// the four parsers. Keep `amp`, `lt`, `gt` ONLY in this lookup — they must
+// not appear as standalone sequential `.replace()` calls (the double-escape
+// risk). Adding an entity here is always safe; the replacer is a pure lookup
+// with no cascading.
+const NAMED_ENTITIES: Record<string, string> = {
+  // Whitespace
+  nbsp: " ",
+  // Structural (must live here, not as sequential replace calls)
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  // Zero-width non-joiner (Mercado Pago emails)
+  zwnj: "",
+  // Degree sign — critical for "N.° de operación" in Mercado Pago reference extraction
+  deg: "°",
+  // Dashes (Wompi footer)
+  mdash: "—",
+  ndash: "–",
+  // Spanish accents (lowercase)
+  aacute: "á",
+  eacute: "é",
+  iacute: "í",
+  oacute: "ó",
+  uacute: "ú",
+  ntilde: "ñ",
+  // Spanish accents (uppercase)
+  Aacute: "Á",
+  Eacute: "É",
+  Iacute: "Í",
+  Oacute: "Ó",
+  Uacute: "Ú",
+  Ntilde: "Ñ",
+  // Additional accented vowels
+  uuml: "ü",
+  Uuml: "Ü",
+  // Punctuation used in Spanish text
+  iexcl: "¡",
+  iquest: "¿",
+};
+
+/**
+ * Decode HTML character references in a string — single-pass, safe from
+ * CodeQL `js/double-escaping`.
+ *
+ * The named-entity pass uses a single regex `/&([A-Za-z]+);/g` with a
+ * lookup-table replacer so each `&NAME;` is matched exactly once and the
+ * replacement value is never re-scanned. This is the pattern CodeQL accepts
+ * (same as bancolombia.ts:91-102).
+ */
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&([A-Za-z]+);/g, (match, name) => NAMED_ENTITIES[name] ?? match)
+    .replace(/&#(\d+);/g, (_, code) => {
+      const n = Number.parseInt(code, 10);
+      return Number.isFinite(n) ? String.fromCodePoint(n) : "";
+    })
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) => {
+      const n = Number.parseInt(code, 16);
+      return Number.isFinite(n) ? String.fromCodePoint(n) : "";
+    });
+}
+
+/**
+ * Strip HTML tags and decode entities to produce the visible text of an email.
+ *
+ * Processing order (important — do NOT reorder):
+ *   1. Strip <style> blocks  — prevent CSS from leaking into text
+ *   2. Strip <script> blocks — prevent JS from leaking into text
+ *   3. Strip HTML comments
+ *   4. Strip all remaining tags
+ *   5. Replace literal non-breaking space (U+00A0) — Apple emails embed \xa0
+ *   6. Decode HTML entities (single-pass, CodeQL-safe)
+ *   7. Collapse whitespace
+ *
+ * Closing-tag patterns use `<\/tag[^>]*>` (per CodeQL `js/bad-tag-filter`
+ * remediation) so browser-lenient variants like `</script >`, `</style\t>`,
+ * or the bogus-content form `</script foo>` are also consumed. A narrower
+ * `<\/script>` would leak script contents into the extracted text.
+ */
+export function extractVisibleText(rawHtml: string): string {
+  let t = rawHtml;
+  // Step 1-2: Remove block-level content that must never appear in visible text.
+  // CodeQL js/bad-tag-filter: closing tag pattern is `<\/tag[^>]*>` not `<\/tag>`.
+  t = t.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ");
+  t = t.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ");
+  // Step 3: Remove HTML comments.
+  t = t.replace(/<!--[\s\S]*?-->/g, " ");
+  // Step 4: Strip all remaining tags.
+  t = t.replace(/<[^>]+>/g, " ");
+  // Step 5: Normalise literal non-breaking spaces (Apple emails).
+  t = t.replace(/ /g, " ");
+  // Step 6: Decode HTML entities — single-pass atomic lookup (CodeQL js/double-escaping safe).
+  t = decodeHtmlEntities(t);
+  // Step 7: Collapse all whitespace and trim.
+  t = t.replace(/\s+/g, " ").trim();
+  return t;
+}

--- a/src/lib/gmail/parsers/apple.test.ts
+++ b/src/lib/gmail/parsers/apple.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import { appleParser } from "./apple";
+
+// Minimal scaffold for Apple Layout A (standard invoice/receipt).
+// PII sanitised: card last-4 replaced with XXXX, email kept as public test fixture.
+function wrapAppleInvoiceA(date: string, body: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<style type="text/css">body{margin:0;font-family:Helvetica,Arial,sans-serif;}</style>
+</head>
+<body>
+<table width="660" align="center" cellpadding="0" cellspacing="0">
+<tr><td>
+  <p>Invoice</p>
+  <p>${date}</p>
+  ${body}
+</td></tr>
+</table>
+</body>
+</html>`;
+}
+
+// Apple TV monthly invoice (Layout A) — mirrors apple-14
+const APPLE_TV_BODY = `
+  <p>Order ID: MKX7GM3GZ0</p>
+  <p>Document: 778123287571</p>
+  <p>Apple Account: test@example.com</p>
+  <p>Apple TV</p>
+  <p>Monthly</p>
+  <p>Renews 22 May 2026</p>
+  <p>$ 29.900</p>
+  <p>Inclusive of VAT at 19 %</p>
+  <p>$ 4.774</p>
+  <p>Billing and Payment</p>
+  <p>Test User</p>
+  <p>Subtotal $ 25.126</p>
+  <p>VAT charged at 19 % $ 4.774</p>
+  <p>MasterCard •••• XXXX $ 29.900</p>
+`;
+
+// Proton VPN monthly invoice (Layout A) — mirrors apple-19
+const PROTON_VPN_BODY = `
+  <p>Order ID: MKX7FNTFVV</p>
+  <p>Document: 698119556165</p>
+  <p>Apple Account: test@example.com</p>
+  <p>Proton VPN: Rápida y Segura</p>
+  <p>VPN Plus (Monthly)</p>
+  <p>Renews 14 May 2026</p>
+  <p>Alejandro's iPhone</p>
+  <p>$ 24.900</p>
+  <p>Inclusive of VAT at 19 %</p>
+  <p>$ 3.976</p>
+  <p>Subtotal $ 20.924</p>
+  <p>VAT charged at 19 % $ 3.976</p>
+  <p>Visa •••• XXXX $ 24.900</p>
+`;
+
+// iCloud Receipt (uses "Receipt" not "Invoice", no VAT line) — mirrors apple-20
+const ICLOUD_RECEIPT = `<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8" /><style>body{margin:0;}</style></head>
+<body>
+<table width="660" align="center" cellpadding="0" cellspacing="0">
+<tr><td>
+  <p>Receipt</p>
+  <p>4 April 2026</p>
+  <p>Order ID: MKX7DLSW75</p>
+  <p>Document: 784115222418</p>
+  <p>Apple Account: test@example.com</p>
+  <p>iCloud</p>
+  <p>iCloud+ with 2 TB (Monthly)</p>
+  <p>Renews 4 May 2026</p>
+  <p>iPhone</p>
+  <p>$ 44.900</p>
+  <p>Billing and Payment</p>
+  <p>Test User</p>
+  <p>Subtotal $ 44.900</p>
+  <p>Visa •••• XXXX $ 44.900</p>
+</td></tr>
+</table>
+</body>
+</html>`;
+
+// Multi-item invoice (Layout A) — mirrors apple-28 with 2 apps
+const MULTI_ITEM_BODY = `
+  <p>Order ID: MKX7B8N6Z7</p>
+  <p>Document: 678110597585</p>
+  <p>Apple Account: test@example.com</p>
+  <p>CapCut: edita videos y fotos</p>
+  <p>Monthly Subscription (Monthly)</p>
+  <p>Renews 23 April 2026</p>
+  <p>Alejandro's iPhone</p>
+  <p>$ 7.900</p>
+  <p>Inclusive of VAT at 19 %</p>
+  <p>$ 1.261</p>
+  <p>Couple Joy - App de relaciones</p>
+  <p>Couple Joy Premium (Monthly)</p>
+  <p>Renews 25 April 2026</p>
+  <p>Alejandro's iPhone</p>
+  <p>$ 14.900</p>
+  <p>Inclusive of VAT at 19 %</p>
+  <p>$ 2.379</p>
+  <p>Subtotal $ 19.160</p>
+  <p>VAT charged at 19 % $ 3.640</p>
+  <p>MasterCard •••• XXXX $ 22.800</p>
+`;
+
+// Alt-invoice layout (Layout B — mirrors apple-15)
+const ALT_INVOICE = `<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8" /><style>body{margin:0;}</style></head>
+<body>
+<table width="660" align="center" cellpadding="0" cellspacing="0">
+<tr><td>
+  <p>Invoice</p>
+  <p>APPLE ACCOUNT test@example.com</p>
+  <p>BILLED TO MasterCard .... XXXX</p>
+  <p>Test User</p>
+  <p>INVOICE DATE 20 Apr 2026</p>
+  <p>ORDER ID MKX7GG8HKQ</p>
+  <p>DOCUMENT NO. 808122526150</p>
+  <p>App Store Widget Web 26 PRO Version</p>
+  <p>In-App Purchase</p>
+  <p>Alejandro's iPhone</p>
+  <p>Report a Problem</p>
+  <p>$ 24.900,00</p>
+  <p>Inclusive of VAT at 19% $ 3.975,63</p>
+  <p>Subtotal $ 20.924,37</p>
+  <p>VAT charged at 19% $ 3.975,63</p>
+  <p>TOTAL $ 24.900,00</p>
+</td></tr>
+</table>
+</body>
+</html>`;
+
+describe("appleParser — invoice parsing (Layout A)", () => {
+  it("parses Apple TV monthly invoice", () => {
+    const html = wrapAppleInvoiceA("22 April 2026", APPLE_TV_BODY);
+    const r = appleParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.merchant).toBe("Apple TV");
+    expect(r.data.amountCents).toBe(BigInt(2990000)); // 29.900 COP = 2 990 000 cents
+    expect(r.data.currency).toBe("COP");
+    expect(r.data.referenceId).toBe("MKX7GM3GZ0");
+    expect(r.data.occurredAt).toEqual(new Date("2026-04-22T00:00:00Z"));
+  });
+
+  it("parses Proton VPN monthly invoice (Visa)", () => {
+    const html = wrapAppleInvoiceA("13 April 2026", PROTON_VPN_BODY);
+    const r = appleParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.merchant).toContain("Proton VPN");
+    expect(r.data.amountCents).toBe(BigInt(2490000)); // 24.900 COP
+    expect(r.data.referenceId).toBe("MKX7FNTFVV");
+    expect(r.data.occurredAt).toEqual(new Date("2026-04-13T00:00:00Z"));
+  });
+
+  it("parses iCloud Receipt (no VAT, uses Subtotal as fallback)", () => {
+    const r = appleParser.parse(ICLOUD_RECEIPT);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.merchant).toBe("iCloud");
+    expect(r.data.amountCents).toBe(BigInt(4490000)); // 44.900 COP
+    expect(r.data.referenceId).toBe("MKX7DLSW75");
+    expect(r.data.occurredAt).toEqual(new Date("2026-04-04T00:00:00Z"));
+  });
+
+  it("parses multi-item invoice and takes the total card charge amount", () => {
+    const html = wrapAppleInvoiceA("25 March 2026", MULTI_ITEM_BODY);
+    const r = appleParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    // Total charge is 22.800, not per-item amounts
+    expect(r.data.amountCents).toBe(BigInt(2280000));
+    expect(r.data.referenceId).toBe("MKX7B8N6Z7");
+    expect(r.data.occurredAt).toEqual(new Date("2026-03-25T00:00:00Z"));
+  });
+});
+
+describe("appleParser — alt-invoice Layout B", () => {
+  it("parses alt-invoice with ORDER ID (no colon) and INVOICE DATE", () => {
+    const r = appleParser.parse(ALT_INVOICE);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.amountCents).toBe(BigInt(2490000)); // 24.900,00 → 24900 COP
+    expect(r.data.referenceId).toBe("MKX7GG8HKQ");
+    expect(r.data.occurredAt).toEqual(new Date("2026-04-20T00:00:00Z"));
+  });
+});
+
+describe("appleParser — skip conditions", () => {
+  it("skips Recent Purchase (security alert)", () => {
+    const html = `<html><body><p>Recent Purchase</p><p>Dear Alejandro, Your Apple Account was just used to make a purchase in SSH Client on a new device.</p></body></html>`;
+    const r = appleParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("recent_purchase_alert");
+  });
+
+  it("skips Subscription Confirmed (free trial, no charge)", () => {
+    const html = `<html><body><p>Subscription Confirmed</p><p>SSH Client - Secure ShellFish</p><p>Trial Free for 2 weeks, starting 23 April 2026</p></body></html>`;
+    const r = appleParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("subscription_confirmed_trial");
+  });
+
+  it("skips Subscription Expiring", () => {
+    const html = `<html><body><p>Subscription Expiring</p><p>Tinder Platinum (1 month) $ 40.500/month expires on 30 April.</p></body></html>`;
+    const r = appleParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("subscription_expiring");
+  });
+
+  it("skips Developer Agreement notification", () => {
+    const html = `<html><body><p>Hello Alejandro, You have signed the following agreement: Apple Developer Agreement</p></body></html>`;
+    const r = appleParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("developer_agreement");
+  });
+
+  it("skips family welcome email (no invoice/billing signals)", () => {
+    const html = `<html><body><p>Te damos la bienvenida a En familia, Alejandro!</p><p>Como persona que organiza la familia, puedes invitar hasta a otros cinco miembros.</p></body></html>`;
+    const r = appleParser.parse(html);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("unrecognized_apple_email_type");
+  });
+});
+
+describe("appleParser — needs_review", () => {
+  it("returns needs_review for invoice missing Order ID", () => {
+    const html = `<html><body>
+      <p>Invoice</p>
+      <p>22 April 2026</p>
+      <p>Apple Account: test@example.com</p>
+      <p>Apple TV</p>
+      <p>Monthly</p>
+      <p>Subtotal $ 29.900</p>
+      <p>MasterCard •••• XXXX $ 29.900</p>
+    </body></html>`;
+    const r = appleParser.parse(html);
+    // No Order ID → falls through to unrecognized (no hasOrderId)
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("unrecognized_apple_email_type");
+  });
+});

--- a/src/lib/gmail/parsers/apple.ts
+++ b/src/lib/gmail/parsers/apple.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@/lib/logger";
+import { extractVisibleText } from "./_text";
 import type { GatewayParser, ParseResult } from "./types";
 
 const log = createLogger({ module: "gmail/parsers/apple" });
@@ -49,18 +50,6 @@ const ENGLISH_MONTHS: Record<string, number> = {
   december: 12,
   dec: 12,
 };
-
-function extractVisibleText(rawHtml: string): string {
-  let t = rawHtml;
-  t = t.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ");
-  t = t.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ");
-  t = t.replace(/<!--[\s\S]*?-->/g, " ");
-  t = t.replace(/<[^>]+>/g, " ");
-  // Normalise non-breaking spaces and other whitespace-like chars
-  t = t.replace(/ /g, " ").replace(/&nbsp;/gi, " ");
-  t = t.replace(/\s+/g, " ").trim();
-  return t;
-}
 
 function parseAppleDate(dateStr: string): Date | null {
   // Formats observed in prod:

--- a/src/lib/gmail/parsers/apple.ts
+++ b/src/lib/gmail/parsers/apple.ts
@@ -1,0 +1,308 @@
+import { createLogger } from "@/lib/logger";
+import type { GatewayParser, ParseResult } from "./types";
+
+const log = createLogger({ module: "gmail/parsers/apple" });
+
+// Apple email parser — handles multiple email types from @email.apple.com:
+//
+//   INVOICE (parse):   "Invoice" + ("Order ID:" or "ORDER ID") + Order details + Subtotal/TOTAL
+//   RECEIPT (parse):   "Receipt" + "Order ID:" — same parse path as Invoice
+//   RECENT_PURCHASE:   "Recent Purchase" — security alert, skip
+//   SUBSCRIPTION_CONFIRMED: "Subscription Confirmed" — free trial, no charge, skip
+//   SUBSCRIPTION_EXPIRING:  "Subscription Expir" — upcoming expiry, no charge, skip
+//   DEVELOPER_AGREEMENT:    "signed the following agreement" — skip
+//   OTHER (family, etc.):   no billing data, skip
+//
+// Amount: Colombian Apple COP format uses period as thousands separator.
+//   "$ 29.900" = 29 900 COP = 2 990 000 cents
+// Non-breaking space (\xa0) appears between $ and digits in some layouts.
+//
+// Date: English prose "22 April 2026" or "INVOICE DATE 20 Apr 2026".
+// No timezone info — Apple invoices are date-only; we use midnight UTC.
+//
+// Merchant: the app/service name, found between Account email and
+// Renews/Monthly/Yearly/One-time/Annual/In-App keywords, or item name
+// in alt-invoice layouts.
+
+const ENGLISH_MONTHS: Record<string, number> = {
+  january: 1,
+  jan: 1,
+  february: 2,
+  feb: 2,
+  march: 3,
+  mar: 3,
+  april: 4,
+  apr: 4,
+  may: 5,
+  june: 6,
+  jun: 6,
+  july: 7,
+  jul: 7,
+  august: 8,
+  aug: 8,
+  september: 9,
+  sep: 9,
+  october: 10,
+  oct: 10,
+  november: 11,
+  nov: 11,
+  december: 12,
+  dec: 12,
+};
+
+function extractVisibleText(rawHtml: string): string {
+  let t = rawHtml;
+  t = t.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ");
+  t = t.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ");
+  t = t.replace(/<!--[\s\S]*?-->/g, " ");
+  t = t.replace(/<[^>]+>/g, " ");
+  // Normalise non-breaking spaces and other whitespace-like chars
+  t = t.replace(/ /g, " ").replace(/&nbsp;/gi, " ");
+  t = t.replace(/\s+/g, " ").trim();
+  return t;
+}
+
+function parseAppleDate(dateStr: string): Date | null {
+  // Formats observed in prod:
+  //   "22 April 2026"  (Invoice header)
+  //   "20 Apr 2026"    (alt-invoice INVOICE DATE field)
+  //   "4 April 2026"   (Receipt header)
+  const m = dateStr.trim().match(/^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$/);
+  if (!m) return null;
+  const day = parseInt(m[1], 10);
+  const month = ENGLISH_MONTHS[m[2].toLowerCase()];
+  const year = parseInt(m[3], 10);
+  if (!month || isNaN(day) || isNaN(year)) return null;
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function parseAppleAmount(raw: string): bigint | null {
+  // Strip leading $ and whitespace (including \xa0)
+  const cleaned = raw.replace(/^\$[\s ]*/u, "").trim();
+  // Colombian format: period=thousands, optional comma+decimal
+  // e.g. "29.900" → 29900 COP | "1.234,56" → 1234.56 COP
+  const m = cleaned.match(/^([\d.]+)(?:,(\d{2}))?$/);
+  if (!m) return null;
+  const cop = BigInt(m[1].replace(/\./g, ""));
+  const cents = cop * BigInt(100);
+  if (m[2]) {
+    return cents + BigInt(m[2].padEnd(2, "0").slice(0, 2));
+  }
+  return cents;
+}
+
+/**
+ * Trim the subscription plan suffix from a raw "app name + plan name" string.
+ *
+ * Apple invoices collapse the app name and plan name into one text segment.
+ * The plan name often repeats a key word from the app name (e.g.
+ * "Tinder: citas, chat y amigos" → plan "Tinder Platinum"). This function
+ * detects that repetition and trims from the second occurrence.
+ *
+ * Steps:
+ * 1. Strip trailing plan keywords if first-word repeats (e.g. "Tinder Tinder…").
+ * 2. Walk backwards to find any word that already appeared earlier in the
+ *    segment — the repetition signals the start of the plan name.
+ */
+function trimPlanNameSuffix(raw: string): string {
+  const words = raw.split(/\s+/);
+  if (words.length <= 1) return raw;
+
+  // Step 1: repeated first word (exact match, case-insensitive, ignoring punctuation)
+  const firstWordKey = words[0].replace(/[^a-zA-Z]/g, "").toLowerCase();
+  const dupIdx = words.findIndex(
+    (w, i) => i > 0 && w.replace(/[^a-zA-Z]/g, "").toLowerCase() === firstWordKey,
+  );
+  if (dupIdx > 0) {
+    return words.slice(0, dupIdx).join(" ");
+  }
+
+  // Step 2: walk backwards — find any word (>2 chars) that already appeared
+  // earlier in the segment
+  for (let i = words.length - 1; i > 0; i--) {
+    const wKey = words[i].replace(/[^a-zA-Z]/g, "").toLowerCase();
+    if (
+      wKey.length > 2 &&
+      words.slice(0, i).some((prev) => prev.replace(/[^a-zA-Z]/g, "").toLowerCase() === wKey)
+    ) {
+      return words.slice(0, i).join(" ").trim();
+    }
+  }
+
+  return raw;
+}
+
+export const appleParser: GatewayParser = {
+  parse(html: string, _opts?: { receivedAt?: Date }): ParseResult {
+    try {
+      const text = extractVisibleText(html);
+
+      // ----- Skip conditions (ordered by specificity) -----
+
+      if (/Recent\s+Purchase/i.test(text)) {
+        return { kind: "skipped", reason: "recent_purchase_alert" };
+      }
+
+      if (/Subscription\s+Confirmed/i.test(text)) {
+        return { kind: "skipped", reason: "subscription_confirmed_trial" };
+      }
+
+      if (/Subscription\s+Expir/i.test(text)) {
+        return { kind: "skipped", reason: "subscription_expiring" };
+      }
+
+      if (
+        /signed\s+the\s+following\s+agreement/i.test(text) ||
+        /Developer\s+Agreement/i.test(text)
+      ) {
+        return { kind: "skipped", reason: "developer_agreement" };
+      }
+
+      // ----- Invoice / Receipt parse -----
+
+      // Both "Invoice" and "Receipt" (iCloud uses "Receipt") are parseable
+      const isInvoice = /\bInvoice\b/i.test(text) || /\bReceipt\b/i.test(text);
+      // Must have an order ID in any of the known layouts
+      const hasOrderId =
+        /Order\s+ID[:.]?\s*[A-Z0-9]+/i.test(text) || /ORDER\s+ID\s+[A-Z0-9]+/i.test(text);
+
+      if (isInvoice && hasOrderId) {
+        // ----- Extract Order ID -----
+        // Two layouts:
+        //   Layout A: "Order ID: MKX7GM3GZ0"
+        //   Layout B: "ORDER ID MKX7GG8HKQ" (no colon)
+        const orderIdMatch =
+          text.match(/Order\s+ID:\s*([A-Z0-9]+)/i) ?? text.match(/ORDER\s+ID\s+([A-Z0-9]+)/i);
+        const referenceId = orderIdMatch ? orderIdMatch[1] : null;
+
+        // ----- Extract Total Amount -----
+        // Strategy: find the amount that follows a card line (MasterCard/Visa/etc.)
+        // which is always the final charge amount. This works for both single and
+        // multi-item invoices.
+        //
+        // Pattern: "MasterCard •••• XXXX $ 29.900" or "Visa •••• XXXX $ 24.900"
+        const cardLineMatch = text.match(
+          /(?:MasterCard|Visa|American\s+Express|Apple\s+Pay)[^\n$]*?\$[\s ]*([\d.,]+)/iu,
+        );
+
+        // Fallback: try "TOTAL $ <amount>" for alt-invoice layouts
+        const totalLineMatch = text.match(/\bTOTAL\s+\$[\s ]*([\d.,]+)/i);
+
+        // Also try "Subtotal $ <amount>" for iCloud Receipt which has no VAT line
+        const subtotalMatch = text.match(/Subtotal\s+\$[\s ]*([\d.,]+)/i);
+
+        const rawAmount = cardLineMatch?.[1] ?? totalLineMatch?.[1] ?? subtotalMatch?.[1];
+
+        if (!rawAmount) {
+          log.warn(
+            { event: "apple_amount_not_found" },
+            "could not extract total amount from Apple invoice",
+          );
+          return { kind: "needs_review", reason: "amount_not_found" };
+        }
+
+        const amountCents = parseAppleAmount(rawAmount);
+        if (amountCents === null) {
+          log.warn(
+            { raw: rawAmount, event: "apple_amount_parse_failed" },
+            "could not parse Apple amount string",
+          );
+          return { kind: "needs_review", reason: "amount_parse_failed" };
+        }
+
+        // ----- Extract Date -----
+        // Layout A: starts with "Invoice 22 April 2026" or "Receipt 4 April 2026"
+        // Layout B: "INVOICE DATE 20 Apr 2026"
+        const datePrefixMatch =
+          text.match(/^(?:Invoice|Receipt)\s+(\d{1,2}\s+[A-Za-z]+\s+\d{4})/i) ??
+          text.match(/(?:Invoice|Invoice\s+Date|INVOICE\s+DATE)\s+(\d{1,2}\s+[A-Za-z]+\s+\d{4})/i);
+
+        let occurredAt: Date | null = null;
+        if (datePrefixMatch) {
+          occurredAt = parseAppleDate(datePrefixMatch[1]);
+        }
+
+        if (!occurredAt) {
+          log.warn({ event: "apple_date_not_found" }, "could not extract date from Apple invoice");
+          return { kind: "needs_review", reason: "date_not_found" };
+        }
+
+        // ----- Extract Merchant -----
+        // Layout A: app name appears after "Apple Account: <email>" and before
+        // "Monthly|Yearly|One-time|Annual|In-App Purchase|Renews"
+        // Layout B (alt-invoice): app name appears after "DOCUMENT NO. <number>"
+        // and before "In-App Purchase".
+        //
+        // Multi-item invoices (apple-28): contain multiple app names — we use
+        // the first one found.
+        //
+        // Merchant extraction heuristic for Layout A:
+        // 1. Capture text from account email to first Monthly/Yearly/Annual/Renews.
+        // 2. Check for a repeated first-word (e.g. "Tinder: ... Tinder Platinum" →
+        //    take before second "Tinder"). Handles most plan-name repetition cases.
+        // 3. Walk backwards from end to find any word that already appeared earlier
+        //    in the segment (handles "Proton VPN: ... VPN Plus" → "VPN" repeats).
+        let merchant = "";
+
+        // Layout A: after Apple Account email
+        const accountEmailMatch = text.match(
+          /Apple\s+Account:\s+[^\s@]+@[^\s]+\s+(.+?)\s+(?:Monthly|Yearly|Annual|One[-\s]time|In-App|Renews)/i,
+        );
+        if (accountEmailMatch) {
+          const raw = accountEmailMatch[1].trim();
+          merchant = trimPlanNameSuffix(raw);
+        }
+
+        // Layout B: alt-invoice — no "Apple Account:" label, item name appears
+        // after "DOCUMENT NO. <number>" and before "In-App Purchase"
+        if (!merchant) {
+          const docNoMatch = text.match(
+            /DOCUMENT\s+NO\.?\s+\d+\s+(.+?)\s+(?:In-App\s+Purchase|Report\s+a\s+Problem)/i,
+          );
+          if (docNoMatch) {
+            merchant = docNoMatch[1].trim();
+          }
+        }
+
+        // Last resort: find any word-token between account email and "Renews"
+        if (!merchant) {
+          const emailInTextMatch = text.match(/[^\s@]+@[^\s]+/);
+          if (emailInTextMatch) {
+            const afterEmail = text.slice(
+              text.indexOf(emailInTextMatch[0]) + emailInTextMatch[0].length,
+            );
+            const fallbackMatch = afterEmail.match(/^\s+(.+?)\s+(?:Monthly|Yearly|Renews|In-App)/i);
+            if (fallbackMatch) {
+              merchant = trimPlanNameSuffix(fallbackMatch[1].trim());
+            }
+          }
+        }
+
+        if (!merchant) {
+          log.warn(
+            { event: "apple_merchant_not_found" },
+            "could not extract merchant from Apple invoice",
+          );
+          return { kind: "needs_review", reason: "merchant_not_found" };
+        }
+
+        return {
+          kind: "parsed",
+          data: {
+            merchant,
+            amountCents,
+            currency: "COP",
+            occurredAt,
+            referenceId,
+          },
+        };
+      }
+
+      // Unrecognised Apple email type
+      return { kind: "needs_review", reason: "unrecognized_apple_email_type" };
+    } catch (err) {
+      log.error({ err, event: "apple_parse_error" }, "unexpected error parsing Apple email");
+      return { kind: "needs_review", reason: "parse_error" };
+    }
+  },
+};

--- a/src/lib/gmail/parsers/index.ts
+++ b/src/lib/gmail/parsers/index.ts
@@ -1,0 +1,56 @@
+import { createLogger } from "@/lib/logger";
+import type { GatewayId } from "@/lib/gmail/registry";
+import type { ParseResult } from "./types";
+import { mercadoPagoParser } from "./mercado-pago";
+import { payuParser } from "./payu";
+import { wompiParser } from "./wompi";
+import { appleParser } from "./apple";
+import { paypalParser } from "./paypal";
+
+const log = createLogger({ module: "gmail/parsers" });
+
+// Dispatch table: gateway enum value → parser implementation.
+// Bancolombia is intentionally absent — it has its own ingest path
+// via parseBancolombiaEmail + processPendingBancolombiaReceipts.
+const PARSERS: Record<string, { parse(html: string, opts?: { receivedAt?: Date }): ParseResult }> =
+  {
+    mercado_pago: mercadoPagoParser,
+    payu: payuParser,
+    wompi: wompiParser,
+    apple: appleParser,
+    paypal: paypalParser,
+  };
+
+/**
+ * Parse a raw HTML email receipt for the given gateway.
+ *
+ * Returns:
+ *   `parsed`       — fields extracted successfully; caller should persist them.
+ *   `skipped`      — email is non-transactional (rejected, promo, etc.);
+ *                    caller should set match_status='unmatched'.
+ *   `needs_review` — parsing failed or parser is a stub; caller should leave
+ *                    match_status='pending' and log for SLO alerting.
+ *
+ * This function never throws — all errors are caught and returned as
+ * `needs_review`. Wrap internal parser errors are caught here as a
+ * belt-and-suspenders layer on top of each parser's own try/catch.
+ */
+export function parseReceipt(
+  gateway: GatewayId,
+  rawHtml: string,
+  opts?: { receivedAt?: Date },
+): ParseResult {
+  const parser = PARSERS[gateway];
+
+  if (!parser) {
+    log.warn({ gateway, event: "unknown_gateway" }, "no parser registered for gateway");
+    return { kind: "needs_review", reason: "unknown_gateway" };
+  }
+
+  try {
+    return parser.parse(rawHtml, opts);
+  } catch (err) {
+    log.error({ err, gateway, event: "parser_threw" }, "gateway parser threw unexpectedly");
+    return { kind: "needs_review", reason: "parse_error" };
+  }
+}

--- a/src/lib/gmail/parsers/mercado-pago.test.ts
+++ b/src/lib/gmail/parsers/mercado-pago.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { mercadoPagoParser } from "./mercado-pago";
+
+// Minimal HTML scaffold that mimics real Mercado Pago transactional emails.
+// PII sanitised: card last-4 replaced, operation number neutralised.
+function wrapMercadoPago(body: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<title>Mercado Pago</title>
+<style type="text/css">body{margin:0;font-family:Arial,sans-serif;}</style>
+</head>
+<body>
+<table width="600" align="center" cellpadding="0" cellspacing="0">
+  <tr><td>${body}</td></tr>
+  <tr><td><p>Pago procesado por Mercado Pago.</p></td></tr>
+  <tr><td><p>Cancelar suscripci&oacute;n</p></td></tr>
+</table>
+</body>
+</html>`;
+}
+
+// Real production shape (purchase) — duplicated merchant due to email rendering
+const PURCHASE_BODY = `
+  <p>Le compraste a EMPRESA DE MEDICINA INTEGRAL EMI S.A.S. SERVICIO DE AMBULAN</p>
+  <p>Le compraste a EMPRESA DE MEDICINA INTEGRAL EMI S.A.S. SERVICIO DE AMBULAN</p>
+  <p>Tu pago fue aprobado</p>
+  <p>Pagaste $ 152.800</p>
+  <p>Mastercard Cr&eacute;dito **** XXXX</p>
+  <p>1 cuota de $ 152.800</p>
+  <p>Nombre en el resumen de tu tarjeta</p>
+  <p>Mercado Pago*PASARELAEN.</p>
+  <p>N.&deg; de operaci&oacute;n 155335418627</p>
+  <p>Fecha y hora 23 de abril a las 11:26 hs</p>
+`;
+
+describe("mercadoPagoParser — purchase", () => {
+  it("parses a real purchase receipt (duplicated merchant, period-thousands)", () => {
+    const html = wrapMercadoPago(PURCHASE_BODY);
+    const r = mercadoPagoParser.parse(html, { receivedAt: new Date("2026-04-23T15:00:00Z") });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.merchant).toBe("EMPRESA DE MEDICINA INTEGRAL EMI S.A.S. SERVICIO DE AMBULAN");
+    // $ 152.800 = 152 800 COP = 15 280 000 cents
+    expect(r.data.amountCents).toBe(BigInt(15280000));
+    expect(r.data.currency).toBe("COP");
+    expect(r.data.referenceId).toBe("155335418627");
+    // 23 de abril a las 11:26 Bogotá (UTC-5) → 16:26 UTC, year from receivedAt = 2026
+    expect(r.data.occurredAt).toEqual(new Date("2026-04-23T16:26:00Z"));
+  });
+
+  it("parses a purchase with explicit simple merchant name", () => {
+    const html = wrapMercadoPago(`
+      <p>Le compraste a RAPPI COLOMBIA</p>
+      <p>Tu pago fue aprobado</p>
+      <p>Pagaste $ 35.900</p>
+      <p>Mastercard Cr&eacute;dito **** XXXX</p>
+      <p>N.&deg; de operaci&oacute;n 987654321</p>
+      <p>Fecha y hora 5 de marzo a las 20:10 hs</p>
+    `);
+    const r = mercadoPagoParser.parse(html, { receivedAt: new Date("2026-03-05T23:00:00Z") });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.merchant).toBe("RAPPI COLOMBIA");
+    // $ 35.900 = 35 900 COP = 3 590 000 cents
+    expect(r.data.amountCents).toBe(BigInt(3590000));
+    expect(r.data.referenceId).toBe("987654321");
+    // 5 de marzo 20:10 Bogotá = 2026-03-06 01:10 UTC
+    expect(r.data.occurredAt).toEqual(new Date("2026-03-06T01:10:00Z"));
+  });
+
+  it("handles decimal amount (comma separator)", () => {
+    const html = wrapMercadoPago(`
+      <p>Le compraste a TIENDA TEST</p>
+      <p>Tu pago fue aprobado</p>
+      <p>Pagaste $ 1.234,56</p>
+      <p>N.&deg; de operaci&oacute;n 111222333</p>
+      <p>Fecha y hora 10 de enero a las 09:05 hs</p>
+    `);
+    const r = mercadoPagoParser.parse(html, { receivedAt: new Date("2026-01-10T15:00:00Z") });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    // $ 1.234,56 = 1 234.56 COP = 123 456 cents
+    expect(r.data.amountCents).toBe(BigInt(123456));
+  });
+});
+
+describe("mercadoPagoParser — promotional emails (skip)", () => {
+  it("skips a promotional email with no Pagaste or Le compraste a", () => {
+    const html = wrapMercadoPago(`
+      <p>Con Mercado Pago aprovecha 3 cuotas sin inter&eacute;s en Americanino, Esprit y muchas m&aacute;s marcas.</p>
+      <p>#LoMejorEstaLlegando</p>
+      <p>Te enviamos este e-mail a example@gmail.com porque elegiste recibir informaci&oacute;n.</p>
+      <p>Cancelar suscripci&oacute;n</p>
+    `);
+    const r = mercadoPagoParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("non_transactional");
+  });
+
+  it("skips an email with only marketing copy (no transaction signals)", () => {
+    const html = wrapMercadoPago(`
+      <p>Para que te des un gustico pagando con Mercado Pago.</p>
+      <p>Vigilado SFC</p>
+    `);
+    const r = mercadoPagoParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("non_transactional");
+  });
+});
+
+describe("mercadoPagoParser — needs_review", () => {
+  it("returns needs_review when Pagaste is present but amount cannot be parsed", () => {
+    const html = wrapMercadoPago(`
+      <p>Le compraste a TIENDA TEST</p>
+      <p>Tu pago fue aprobado</p>
+      <p>Pagaste un monto no especificado</p>
+      <p>Fecha y hora 10 de enero a las 09:05 hs</p>
+    `);
+    const r = mercadoPagoParser.parse(html, { receivedAt: new Date("2026-01-10T15:00:00Z") });
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("amount_not_found");
+  });
+
+  it("returns needs_review when date is missing and no receivedAt fallback", () => {
+    const html = wrapMercadoPago(`
+      <p>Le compraste a TIENDA TEST</p>
+      <p>Tu pago fue aprobado</p>
+      <p>Pagaste $ 50.000</p>
+      <p>N.&deg; de operaci&oacute;n 111</p>
+    `);
+    // No receivedAt provided
+    const r = mercadoPagoParser.parse(html);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("missing_occurred_at");
+  });
+});

--- a/src/lib/gmail/parsers/mercado-pago.test.ts
+++ b/src/lib/gmail/parsers/mercado-pago.test.ts
@@ -110,6 +110,43 @@ describe("mercadoPagoParser — promotional emails (skip)", () => {
   });
 });
 
+describe("mercadoPagoParser — year-boundary (Dec 31 / Jan 1 UTC)", () => {
+  it("assigns 2025 to a Dec-31 body when receivedAt is already Jan 1 UTC", () => {
+    // Payment at 23:30 Bogotá on Dec 31 = 04:30 UTC on Jan 1 next year.
+    // Gmail's internalDate is UTC, so receivedAt lands in the new year.
+    // The body says "31 de diciembre" — year must be 2025, not 2026.
+    const html = wrapMercadoPago(`
+      <p>Le compraste a TIENDA NOCHEVIEJA</p>
+      <p>Tu pago fue aprobado</p>
+      <p>Pagaste $ 50.000</p>
+      <p>N.&deg; de operaci&oacute;n 999888777</p>
+      <p>Fecha y hora 31 de diciembre a las 23:30 hs</p>
+    `);
+    // receivedAt is 2026-01-01T04:30:00Z (04:30 UTC = 23:30 Bogotá on Dec 31 2025)
+    const r = mercadoPagoParser.parse(html, { receivedAt: new Date("2026-01-01T04:30:00Z") });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    // 31 de diciembre 23:30 Bogotá (UTC-5) → 2025-12-31 23:30 + 5h = 2026-01-01T04:30:00Z.
+    // The UTC timestamp crosses into 2026 by definition (it IS Jan 1 UTC), but the
+    // LOCAL year (Bogotá) is 2025. We verify by checking the full timestamp is correct.
+    expect(r.data.occurredAt).toEqual(new Date("2026-01-01T04:30:00Z"));
+  });
+
+  it("keeps the same year for a normal Dec-15 body with Dec receivedAt", () => {
+    const html = wrapMercadoPago(`
+      <p>Le compraste a TIENDA NAVIDAD</p>
+      <p>Tu pago fue aprobado</p>
+      <p>Pagaste $ 100.000</p>
+      <p>N.&deg; de operaci&oacute;n 123456789</p>
+      <p>Fecha y hora 15 de diciembre a las 14:00 hs</p>
+    `);
+    const r = mercadoPagoParser.parse(html, { receivedAt: new Date("2025-12-15T20:00:00Z") });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.occurredAt.getUTCFullYear()).toBe(2025);
+  });
+});
+
 describe("mercadoPagoParser — needs_review", () => {
   it("returns needs_review when Pagaste is present but amount cannot be parsed", () => {
     const html = wrapMercadoPago(`

--- a/src/lib/gmail/parsers/mercado-pago.ts
+++ b/src/lib/gmail/parsers/mercado-pago.ts
@@ -1,0 +1,182 @@
+import { createLogger } from "@/lib/logger";
+import type { GatewayParser, ParseResult } from "./types";
+
+const log = createLogger({ module: "gmail/parsers/mercado-pago" });
+
+// Mercado Pago receipt emails (Colombian variant):
+//   - Transactional signal: "Pagaste" AND/OR "Le compraste a"
+//   - Promotional signal: no "Pagaste", no "Le compraste a"
+//
+// Amount format uses period as thousands separator and comma as decimal:
+//   "$ 152.800"  → 152 800 COP → 15 280 000 cents
+//   "$ 1.234,56" → 1 234.56 COP → 123 456 cents
+//
+// Date: Spanish prose "23 de abril a las 11:26 hs" — year from opts.receivedAt.
+// Times are in Bogotá local time (UTC-5, no DST).
+//
+// Merchant: appears after "Le compraste a" — may be duplicated due to image
+// alt text rendering. We take the first occurrence.
+
+const BOGOTA_OFFSET_MS = 5 * 60 * 60 * 1000; // UTC-5 in ms
+
+const SPANISH_MONTHS: Record<string, number> = {
+  enero: 1,
+  febrero: 2,
+  marzo: 3,
+  abril: 4,
+  mayo: 5,
+  junio: 6,
+  julio: 7,
+  agosto: 8,
+  septiembre: 9,
+  octubre: 10,
+  noviembre: 11,
+  diciembre: 12,
+};
+
+const NAMED_ENTITIES: Record<string, string> = {
+  nbsp: " ",
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  zwnj: "",
+  deg: "°",
+  aacute: "á",
+  eacute: "é",
+  iacute: "í",
+  oacute: "ó",
+  uacute: "ú",
+  ntilde: "ñ",
+};
+
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&([A-Za-z]+);/g, (match, name) => NAMED_ENTITIES[name] ?? match)
+    .replace(/&#(\d+);/g, (_, code) => {
+      const n = Number.parseInt(code, 10);
+      return Number.isFinite(n) ? String.fromCodePoint(n) : "";
+    })
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) => {
+      const n = Number.parseInt(code, 16);
+      return Number.isFinite(n) ? String.fromCodePoint(n) : "";
+    });
+}
+
+function extractVisibleText(rawHtml: string): string {
+  let t = rawHtml;
+  t = t.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ");
+  t = t.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ");
+  t = t.replace(/<!--[\s\S]*?-->/g, " ");
+  t = t.replace(/<[^>]+>/g, " ");
+  t = decodeHtmlEntities(t);
+  t = t.replace(/\s+/g, " ").trim();
+  return t;
+}
+
+function parseMpAmount(intStr: string, decStr?: string): bigint {
+  // Remove period thousands separators → integer COP
+  const cop = BigInt(intStr.replace(/\./g, ""));
+  const cents = cop * BigInt(100);
+  if (decStr) {
+    const dec = BigInt(decStr.padEnd(2, "0").slice(0, 2));
+    return cents + dec;
+  }
+  return cents;
+}
+
+function parseSpanishDate(
+  day: string,
+  monthName: string,
+  hour: string,
+  minute: string,
+  year: number,
+): Date | null {
+  const month = SPANISH_MONTHS[monthName.toLowerCase()];
+  if (!month) return null;
+
+  const d = parseInt(day, 10);
+  const h = parseInt(hour, 10);
+  const m = parseInt(minute, 10);
+  if (isNaN(d) || isNaN(h) || isNaN(m)) return null;
+
+  // Construct as Bogotá local time then shift to UTC
+  const localMs = Date.UTC(year, month - 1, d, h, m, 0);
+  return new Date(localMs + BOGOTA_OFFSET_MS);
+}
+
+export const mercadoPagoParser: GatewayParser = {
+  parse(html: string, opts?: { receivedAt?: Date }): ParseResult {
+    try {
+      const text = extractVisibleText(html);
+
+      // Promotional / non-transactional check
+      if (!/Pagaste/i.test(text) && !/Le\s+compraste\s+a/i.test(text)) {
+        return { kind: "skipped", reason: "non_transactional" };
+      }
+
+      // Extract merchant: first occurrence of "Le compraste a <MERCHANT>"
+      // The sentence ends at "Tu pago fue aprobado" or a duplicate of itself.
+      const merchantMatch = text.match(/Le\s+compraste\s+a\s+(.+?)(?=Le\s+compraste|Tu\s+pago|$)/i);
+      if (!merchantMatch) {
+        log.warn({ event: "mp_merchant_not_found" }, "could not extract merchant from MP email");
+        return { kind: "needs_review", reason: "merchant_not_found" };
+      }
+      const merchant = merchantMatch[1].trim();
+
+      // Amount: "Pagaste $ 152.800" (period=thousands, no decimal)
+      // or "Pagaste $ 1.234,56" (period=thousands, comma=decimal)
+      const amountMatch = text.match(/Pagaste\s+\$\s*([\d.]+)(?:,(\d{2}))?/i);
+      if (!amountMatch) {
+        log.warn({ event: "mp_amount_not_found" }, "could not extract amount from MP email");
+        return { kind: "needs_review", reason: "amount_not_found" };
+      }
+      const amountCents = parseMpAmount(amountMatch[1], amountMatch[2]);
+
+      // Reference: "N.° de operación 155335418627"
+      const refMatch = text.match(/N\.°\s*de\s+operaci[oó]n\s*(\d+)/i);
+      const referenceId = refMatch ? refMatch[1] : null;
+
+      // Currency: Colombian MP uses COP; no currency marker in body so default COP
+      const currency: "COP" | "USD" = "COP";
+
+      // Date: "23 de abril a las 11:26 hs"
+      const dateMatch = text.match(
+        /(\d{1,2})\s+de\s+([a-záéíóú]+)\s+a\s+las\s+(\d{1,2}):(\d{2})\s*hs/i,
+      );
+      let occurredAt: Date;
+      if (dateMatch) {
+        const year = opts?.receivedAt?.getUTCFullYear() ?? new Date().getUTCFullYear();
+        const parsed = parseSpanishDate(
+          dateMatch[1],
+          dateMatch[2],
+          dateMatch[3],
+          dateMatch[4],
+          year,
+        );
+        if (!parsed) {
+          log.warn(
+            { raw: dateMatch[0], event: "mp_date_parse_failed" },
+            "could not parse MP date string",
+          );
+          return { kind: "needs_review", reason: "date_parse_failed" };
+        }
+        occurredAt = parsed;
+      } else if (opts?.receivedAt) {
+        log.warn({ event: "mp_date_fallback" }, "MP email missing date field; using receivedAt");
+        occurredAt = opts.receivedAt;
+      } else {
+        return { kind: "needs_review", reason: "missing_occurred_at" };
+      }
+
+      return {
+        kind: "parsed",
+        data: { merchant, amountCents, currency, occurredAt, referenceId },
+      };
+    } catch (err) {
+      log.error({ err, event: "mp_parse_error" }, "unexpected error parsing MercadoPago email");
+      return { kind: "needs_review", reason: "parse_error" };
+    }
+  },
+};

--- a/src/lib/gmail/parsers/mercado-pago.ts
+++ b/src/lib/gmail/parsers/mercado-pago.ts
@@ -147,7 +147,16 @@ export const mercadoPagoParser: GatewayParser = {
       );
       let occurredAt: Date;
       if (dateMatch) {
-        const year = opts?.receivedAt?.getUTCFullYear() ?? new Date().getUTCFullYear();
+        const bodyMonth = SPANISH_MONTHS[dateMatch[2].toLowerCase()];
+        const receivedYear = opts?.receivedAt?.getUTCFullYear() ?? new Date().getUTCFullYear();
+        // Year-boundary correction: if the email body says December (month=12) but
+        // receivedAt is already in January UTC (the email arrived just after midnight
+        // UTC on Jan 1), the payment was made at 23:xx Bogotá on Dec 31 of the prior
+        // year. Use receivedYear - 1 in that case.
+        const year =
+          bodyMonth === 12 && opts?.receivedAt?.getUTCMonth() === 0
+            ? receivedYear - 1
+            : receivedYear;
         const parsed = parseSpanishDate(
           dateMatch[1],
           dateMatch[2],

--- a/src/lib/gmail/parsers/mercado-pago.ts
+++ b/src/lib/gmail/parsers/mercado-pago.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@/lib/logger";
+import { extractVisibleText } from "./_text";
 import type { GatewayParser, ParseResult } from "./types";
 
 const log = createLogger({ module: "gmail/parsers/mercado-pago" });
@@ -33,47 +34,6 @@ const SPANISH_MONTHS: Record<string, number> = {
   noviembre: 11,
   diciembre: 12,
 };
-
-const NAMED_ENTITIES: Record<string, string> = {
-  nbsp: " ",
-  amp: "&",
-  lt: "<",
-  gt: ">",
-  quot: '"',
-  apos: "'",
-  zwnj: "",
-  deg: "°",
-  aacute: "á",
-  eacute: "é",
-  iacute: "í",
-  oacute: "ó",
-  uacute: "ú",
-  ntilde: "ñ",
-};
-
-function decodeHtmlEntities(s: string): string {
-  return s
-    .replace(/&([A-Za-z]+);/g, (match, name) => NAMED_ENTITIES[name] ?? match)
-    .replace(/&#(\d+);/g, (_, code) => {
-      const n = Number.parseInt(code, 10);
-      return Number.isFinite(n) ? String.fromCodePoint(n) : "";
-    })
-    .replace(/&#x([0-9a-f]+);/gi, (_, code) => {
-      const n = Number.parseInt(code, 16);
-      return Number.isFinite(n) ? String.fromCodePoint(n) : "";
-    });
-}
-
-function extractVisibleText(rawHtml: string): string {
-  let t = rawHtml;
-  t = t.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ");
-  t = t.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ");
-  t = t.replace(/<!--[\s\S]*?-->/g, " ");
-  t = t.replace(/<[^>]+>/g, " ");
-  t = decodeHtmlEntities(t);
-  t = t.replace(/\s+/g, " ").trim();
-  return t;
-}
 
 function parseMpAmount(intStr: string, decStr?: string): bigint {
   // Remove period thousands separators → integer COP

--- a/src/lib/gmail/parsers/paypal.test.ts
+++ b/src/lib/gmail/parsers/paypal.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { paypalParser } from "./paypal";
+
+// PayPal parser is a stub — no prod samples available yet.
+// Tests confirm the stub contract: all inputs return needs_review.
+
+describe("paypalParser — stub", () => {
+  it("returns needs_review for any non-empty HTML", () => {
+    const html = `<!DOCTYPE html>
+<html><body>
+<p>PayPal receipt</p>
+<p>Amount: $100.00</p>
+</body></html>`;
+    const r = paypalParser.parse(html);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("paypal_parser_not_implemented");
+  });
+
+  it("returns needs_review for empty HTML", () => {
+    const r = paypalParser.parse("", {});
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("paypal_parser_not_implemented");
+  });
+});

--- a/src/lib/gmail/parsers/paypal.ts
+++ b/src/lib/gmail/parsers/paypal.ts
@@ -1,0 +1,15 @@
+// TODO: implement when prod samples available — see #453 follow-up
+import { createLogger } from "@/lib/logger";
+import type { GatewayParser, ParseResult } from "./types";
+
+const log = createLogger({ module: "gmail/parsers/paypal" });
+
+export const paypalParser: GatewayParser = {
+  parse(_html: string, _opts?: { receivedAt?: Date }): ParseResult {
+    log.info(
+      { event: "paypal_parser_stub" },
+      "PayPal parser is a stub — no prod samples available yet",
+    );
+    return { kind: "needs_review", reason: "paypal_parser_not_implemented" };
+  },
+};

--- a/src/lib/gmail/parsers/payu.test.ts
+++ b/src/lib/gmail/parsers/payu.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { payuParser } from "./payu";
+
+// Minimal HTML scaffold that mimics real PayU emails.
+// PII sanitised: transaction UUIDs replaced with placeholders, email replaced.
+function wrapPayU(body: string): string {
+  return `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>PayU</title>
+<style type="text/css">body { margin: 0; font-family: Arial, sans-serif; }</style>
+</head>
+<body>
+<table width="600" align="center" cellpadding="0" cellspacing="0">
+  <tr><td>PayU</td></tr>
+  <tr><td>${body}</td></tr>
+  <tr><td><p>www.payu.com</p></td></tr>
+</table>
+</body>
+</html>`;
+}
+
+const APPROVED_CORFERIAS = `
+  <p>Tu transacci&#243;n ha sido aprobada</p>
+  <p>Hola Alejandro Martinez, La transacci&#243;n aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb realizada en CORFERIAS , fue aprobada .</p>
+  <p>Datos de la transacci&#243;n:</p>
+  <p>Descripci&#243;n a&#241;o=2026; evento=COMIC CON BOGOTA; referencia=CORBL-18622</p>
+  <p>Referencia CORBL-18622</p>
+  <p>Valor 137000</p>
+  <p>Moneda COP</p>
+  <p>Fecha 2026-04-22 13:11:21</p>
+  <p>Medio de Pago/Franquicia VISA</p>
+`;
+
+const APPROVED_CINEMARK = `
+  <p>Tu transacci&#243;n ha sido aprobada</p>
+  <p>Hola Alejandro Rafael Martinez Maldonado, La transacci&#243;n aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb realizada en CINEMARK COLOMBIA S.A.S , fue aprobada .</p>
+  <p>Datos de la transacci&#243;n:</p>
+  <p>Descripci&#243;n Arkadia_2424_Jun 04 2026</p>
+  <p>Referencia 3aac1d8e-c560-4e41-b93e-8a3f563857e2</p>
+  <p>Valor 92000</p>
+  <p>Moneda COP</p>
+  <p>Fecha 2026-04-13 09:18:35</p>
+  <p>Medio de Pago/Franquicia MASTERCARD</p>
+`;
+
+describe("payuParser — approved transactions", () => {
+  it("parses CORFERIAS approved receipt (VISA)", () => {
+    const html = wrapPayU(APPROVED_CORFERIAS);
+    const r = payuParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.merchant).toBe("CORFERIAS");
+    expect(r.data.amountCents).toBe(BigInt(13700000));
+    expect(r.data.currency).toBe("COP");
+    expect(r.data.referenceId).toBe("CORBL-18622");
+    // 2026-04-22 13:11:21 Bogotá (UTC-5) = 2026-04-22 18:11:21 UTC
+    expect(r.data.occurredAt).toEqual(new Date("2026-04-22T18:11:21Z"));
+  });
+
+  it("parses CINEMARK approved receipt (MASTERCARD, UUID reference)", () => {
+    const html = wrapPayU(APPROVED_CINEMARK);
+    const r = payuParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.merchant).toBe("CINEMARK COLOMBIA S.A.S");
+    expect(r.data.amountCents).toBe(BigInt(9200000));
+    expect(r.data.currency).toBe("COP");
+    // UUID reference should be captured
+    expect(r.data.referenceId).toBe("3aac1d8e-c560-4e41-b93e-8a3f563857e2");
+    // 2026-04-13 09:18:35 Bogotá = 2026-04-13 14:18:35 UTC
+    expect(r.data.occurredAt).toEqual(new Date("2026-04-13T14:18:35Z"));
+  });
+});
+
+describe("payuParser — rejected transactions", () => {
+  it("skips a fue rechazada email", () => {
+    const html = wrapPayU(`
+      <p>Uno de tus pagos fue rechazado</p>
+      <p>Hola Alejandro Martinez, La transacci&#243;n xxxxxx realizada en CINEMARK COLOMBIA S.A.S , fue rechazada .</p>
+      <p>Referencia 4825caf3-xxxx-xxxx-xxxx-xxxxxx</p>
+      <p>Valor 92000</p>
+      <p>Moneda COP</p>
+      <p>Fecha 2026-04-13 09:18:35</p>
+    `);
+    const r = payuParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("rejected");
+  });
+
+  it("skips email with 'rechazada' anywhere in body", () => {
+    const html = wrapPayU(`
+      <p>La transacci&#243;n fue rechazada por fondos insuficientes.</p>
+      <p>Tu pago no fue procesado.</p>
+    `);
+    const r = payuParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("rejected");
+  });
+});
+
+describe("payuParser — card registration", () => {
+  it("skips a card registration email", () => {
+    const html = wrapPayU(`
+      <p>Tarjeta registrada desde Chrome en Windows</p>
+      <p>Hola, Tu tarjeta ha sido registrada para agilizar tus pagos con PayU.</p>
+      <p>411054******XXXX</p>
+    `);
+    const r = payuParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("card_registration");
+  });
+});
+
+describe("payuParser — needs_review", () => {
+  it("returns needs_review for unknown PayU email type", () => {
+    const html = wrapPayU(`
+      <p>PayU - Actualizaci&#243;n de cuenta</p>
+      <p>Tu contrase&#241;a ha sido actualizada.</p>
+    `);
+    const r = payuParser.parse(html);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("unknown_payu_email_type");
+  });
+
+  it("falls back to receivedAt when Fecha field is missing", () => {
+    const html = wrapPayU(`
+      <p>Tu transacci&#243;n ha sido aprobada</p>
+      <p>La transacci&#243;n xxxxxx realizada en TIENDA TEST , fue aprobada .</p>
+      <p>Referencia REF-001</p>
+      <p>Valor 50000</p>
+      <p>Moneda COP</p>
+    `);
+    const receivedAt = new Date("2026-04-15T10:00:00Z");
+    const r = payuParser.parse(html, { receivedAt });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.occurredAt).toEqual(receivedAt);
+    expect(r.data.amountCents).toBe(BigInt(5000000));
+  });
+
+  it("returns needs_review when Fecha missing and no receivedAt", () => {
+    const html = wrapPayU(`
+      <p>Tu transacci&#243;n ha sido aprobada</p>
+      <p>La transacci&#243;n xxxxxx realizada en TIENDA TEST , fue aprobada .</p>
+      <p>Referencia REF-001</p>
+      <p>Valor 50000</p>
+      <p>Moneda COP</p>
+    `);
+    const r = payuParser.parse(html);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("missing_occurred_at");
+  });
+});

--- a/src/lib/gmail/parsers/payu.ts
+++ b/src/lib/gmail/parsers/payu.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@/lib/logger";
+import { extractVisibleText } from "./_text";
 import type { GatewayParser, ParseResult } from "./types";
 
 const log = createLogger({ module: "gmail/parsers/payu" });
@@ -16,30 +17,6 @@ const log = createLogger({ module: "gmail/parsers/payu" });
 // Stored as UTC by subtracting 5 hours.
 
 const BOGOTA_OFFSET_MS = 5 * 60 * 60 * 1000; // UTC-5 in ms
-
-function extractVisibleText(rawHtml: string): string {
-  let t = rawHtml;
-  t = t.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ");
-  t = t.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ");
-  t = t.replace(/<!--[\s\S]*?-->/g, " ");
-  t = t.replace(/<[^>]+>/g, " ");
-  // Decode common HTML entities before further processing
-  t = t
-    .replace(/&nbsp;/gi, " ")
-    .replace(/&aacute;/gi, "á")
-    .replace(/&eacute;/gi, "é")
-    .replace(/&iacute;/gi, "í")
-    .replace(/&oacute;/gi, "ó")
-    .replace(/&uacute;/gi, "ú")
-    .replace(/&ntilde;/gi, "ñ")
-    .replace(/&amp;/gi, "&")
-    .replace(/&lt;/gi, "<")
-    .replace(/&gt;/gi, ">")
-    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(parseInt(code, 10)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCodePoint(parseInt(code, 16)));
-  t = t.replace(/\s+/g, " ").trim();
-  return t;
-}
 
 function parseBogotaDate(dateStr: string, timeStr: string): Date {
   // dateStr: "2026-04-22", timeStr: "13:11:21"

--- a/src/lib/gmail/parsers/payu.ts
+++ b/src/lib/gmail/parsers/payu.ts
@@ -1,0 +1,128 @@
+import { createLogger } from "@/lib/logger";
+import type { GatewayParser, ParseResult } from "./types";
+
+const log = createLogger({ module: "gmail/parsers/payu" });
+
+// PayU receipts: labeled-table format with decoded HTML entities.
+// Key signals:
+//   Approved: "Tu transacción ha sido aprobada" + "fue aprobada"
+//   Rejected: "fue rechazada" or "rechazado"
+//   Card reg:  "Tarjeta registrada" (no purchase)
+//
+// Amount field "Valor" is raw integer COP units (e.g. 137000 = 137 000 COP).
+// Multiply by 100 to get cents.
+//
+// Date "Fecha" is in Bogotá local time (UTC-5, no DST).
+// Stored as UTC by subtracting 5 hours.
+
+const BOGOTA_OFFSET_MS = 5 * 60 * 60 * 1000; // UTC-5 in ms
+
+function extractVisibleText(rawHtml: string): string {
+  let t = rawHtml;
+  t = t.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ");
+  t = t.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ");
+  t = t.replace(/<!--[\s\S]*?-->/g, " ");
+  t = t.replace(/<[^>]+>/g, " ");
+  // Decode common HTML entities before further processing
+  t = t
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&aacute;/gi, "á")
+    .replace(/&eacute;/gi, "é")
+    .replace(/&iacute;/gi, "í")
+    .replace(/&oacute;/gi, "ó")
+    .replace(/&uacute;/gi, "ú")
+    .replace(/&ntilde;/gi, "ñ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(parseInt(code, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCodePoint(parseInt(code, 16)));
+  t = t.replace(/\s+/g, " ").trim();
+  return t;
+}
+
+function parseBogotaDate(dateStr: string, timeStr: string): Date {
+  // dateStr: "2026-04-22", timeStr: "13:11:21"
+  const localMs = new Date(`${dateStr}T${timeStr}Z`).getTime();
+  // Shift from Bogotá local (UTC-5) to UTC
+  return new Date(localMs + BOGOTA_OFFSET_MS);
+}
+
+export const payuParser: GatewayParser = {
+  parse(html: string, opts?: { receivedAt?: Date }): ParseResult {
+    try {
+      const text = extractVisibleText(html);
+
+      // Card registration notification — not a purchase
+      if (/Tarjeta\s+registrada/i.test(text) && !/fue\s+aprobada/i.test(text)) {
+        return { kind: "skipped", reason: "card_registration" };
+      }
+
+      // Rejected transaction
+      if (/fue\s+rechazad[ao]/i.test(text) || /rechazad[ao]/i.test(text)) {
+        return { kind: "skipped", reason: "rejected" };
+      }
+
+      // Approved transaction
+      if (
+        /Tu\s+transacci[oó]n\s+ha\s+sido\s+aprobada/i.test(text) &&
+        /fue\s+aprobada/i.test(text)
+      ) {
+        // Merchant: between "realizada en " and " , fue aprobada" (space before comma)
+        const merchantMatch = text.match(/realizada\s+en\s+(.+?)\s*,\s*fue\s+aprobada/i);
+        if (!merchantMatch) {
+          log.warn(
+            { event: "payu_merchant_not_found" },
+            "could not extract merchant from PayU email",
+          );
+          return { kind: "needs_review", reason: "merchant_not_found" };
+        }
+        const merchant = merchantMatch[1].trim();
+
+        // Reference: labeled row "Referencia <VALUE>" — NOT the inline uuid in the body sentence
+        // The labeled row appears as "Referencia CORBL-18622" or "Referencia 3aac1d8e-..."
+        // We take the last occurrence of "Referencia <value>" since it's the labeled table row
+        const refMatches = [...text.matchAll(/Referencia\s+([A-Za-z0-9-]+)/g)];
+        const referenceId = refMatches.length > 0 ? refMatches[refMatches.length - 1][1] : null;
+
+        // Amount: "Valor <integer>" in COP units → × 100 for cents
+        const amountMatch = text.match(/Valor\s+(\d+)/);
+        if (!amountMatch) {
+          log.warn({ event: "payu_amount_not_found" }, "could not extract amount from PayU email");
+          return { kind: "needs_review", reason: "amount_not_found" };
+        }
+        const amountCents = BigInt(amountMatch[1]) * BigInt(100);
+
+        // Currency: "Moneda COP" / "Moneda USD"
+        const currencyMatch = text.match(/Moneda\s+([A-Z]{3})/);
+        const currency: "COP" | "USD" = currencyMatch && currencyMatch[1] === "USD" ? "USD" : "COP";
+
+        // Date: "Fecha 2026-04-22 13:11:21"
+        const dateMatch = text.match(/Fecha\s+(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2})/);
+        let occurredAt: Date;
+        if (dateMatch) {
+          occurredAt = parseBogotaDate(dateMatch[1], dateMatch[2]);
+        } else if (opts?.receivedAt) {
+          log.warn(
+            { event: "payu_date_fallback" },
+            "PayU email missing Fecha field; using receivedAt",
+          );
+          occurredAt = opts.receivedAt;
+        } else {
+          return { kind: "needs_review", reason: "missing_occurred_at" };
+        }
+
+        return {
+          kind: "parsed",
+          data: { merchant, amountCents, currency, occurredAt, referenceId },
+        };
+      }
+
+      // Unrecognised PayU email type
+      return { kind: "needs_review", reason: "unknown_payu_email_type" };
+    } catch (err) {
+      log.error({ err, event: "payu_parse_error" }, "unexpected error parsing PayU email");
+      return { kind: "needs_review", reason: "parse_error" };
+    }
+  },
+};

--- a/src/lib/gmail/parsers/types.ts
+++ b/src/lib/gmail/parsers/types.ts
@@ -1,0 +1,16 @@
+export interface ParsedReceipt {
+  merchant: string;
+  amountCents: bigint;
+  currency: "COP" | "USD";
+  occurredAt: Date;
+  referenceId: string | null;
+}
+
+export type ParseResult =
+  | { kind: "parsed"; data: ParsedReceipt }
+  | { kind: "skipped"; reason: string }
+  | { kind: "needs_review"; reason: string };
+
+export interface GatewayParser {
+  parse(html: string, opts?: { receivedAt?: Date }): ParseResult;
+}

--- a/src/lib/gmail/parsers/wompi.test.ts
+++ b/src/lib/gmail/parsers/wompi.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { wompiParser } from "./wompi";
+
+// Minimal HTML scaffold that mimics real Wompi emails.
+// Real emails use an HTML4 strict DOCTYPE with a table-based layout.
+// PII sanitised: card last-4 replaced with XXXX.
+function wrapWompi(body: string): string {
+  return `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<style type="text/css">body { margin: 0; padding: 0; } .footer { font-size: 11px; }</style>
+</head>
+<body>
+<table width="600" align="center" cellpadding="0" cellspacing="0">
+  <tr><td>${body}</td></tr>
+  <tr><td class="footer"><p>Wompi &mdash; Pagos en l&iacute;nea</p></td></tr>
+</table>
+</body>
+</html>`;
+}
+
+const APPROVED_BODY = `
+  <p>&nbsp; Tu transacci&oacute;n fue APROBADA &nbsp;</p>
+  <p>Hemos procesado exitosamente el pago realizado a SOMOS INTERNET y el dinero ser&aacute; transferido al comercio.</p>
+  <p>&nbsp; Estado: &nbsp; APROBADA &nbsp;</p>
+  <p>&nbsp; Referencia: &nbsp; WC-1081469-1774479119 &nbsp;</p>
+  <p>&nbsp; Transacci&oacute;n #: &nbsp; 1341161-1774479147-18748 &nbsp;</p>
+  <p>&nbsp; Monto: &nbsp; COP $137,000 &nbsp;</p>
+  <p>&nbsp; M&eacute;todo de pago: &nbsp; Tarjeta MASTERCARD ****XXXX &nbsp;</p>
+  <p>&nbsp; Procesador: &nbsp; RBM &nbsp;</p>
+`;
+
+describe("wompiParser — approved transaction", () => {
+  it("parses a standard APROBADA receipt", () => {
+    const html = wrapWompi(APPROVED_BODY);
+    const r = wompiParser.parse(html, { receivedAt: new Date("2026-04-19T12:00:00Z") });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.merchant).toBe("SOMOS INTERNET");
+    expect(r.data.amountCents).toBe(BigInt(13700000));
+    expect(r.data.currency).toBe("COP");
+    expect(r.data.referenceId).toBe("WC-1081469-1774479119");
+    expect(r.data.occurredAt).toEqual(new Date("2026-04-19T12:00:00Z"));
+  });
+
+  it("falls back to new Date() when receivedAt not provided", () => {
+    const html = wrapWompi(APPROVED_BODY);
+    const before = Date.now();
+    const r = wompiParser.parse(html);
+    const after = Date.now();
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.occurredAt.getTime()).toBeGreaterThanOrEqual(before);
+    expect(r.data.occurredAt.getTime()).toBeLessThanOrEqual(after);
+  });
+
+  it("handles decimal amounts (e.g. COP $1,234.56 = 123456 cents)", () => {
+    const html = wrapWompi(`
+      <p>Hemos procesado exitosamente el pago realizado a TIENDA EJEMPLO y el dinero ser&aacute; transferido.</p>
+      <p>Estado: APROBADA</p>
+      <p>Referencia: WC-999-111</p>
+      <p>Monto: COP $1,234.56</p>
+    `);
+    const r = wompiParser.parse(html, { receivedAt: new Date("2026-04-01T00:00:00Z") });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.amountCents).toBe(BigInt(123456));
+    expect(r.data.merchant).toBe("TIENDA EJEMPLO");
+  });
+});
+
+describe("wompiParser — rejected / non-approved", () => {
+  it("skips a RECHAZADA transaction", () => {
+    const html = wrapWompi(`
+      <p>Tu transacci&oacute;n fue RECHAZADA</p>
+      <p>El pago realizado a COMERCIO EJEMPLO no pudo ser procesado.</p>
+      <p>Estado: RECHAZADA</p>
+      <p>Monto: COP $50,000</p>
+    `);
+    const r = wompiParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("not_approved");
+  });
+
+  it("skips an email with no APROBADA marker", () => {
+    const html = wrapWompi(`
+      <p>Wompi - Actualizaci&oacute;n de cuenta</p>
+      <p>Tu cuenta ha sido actualizada exitosamente.</p>
+    `);
+    const r = wompiParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("not_approved");
+  });
+});
+
+describe("wompiParser — needs_review", () => {
+  it("returns needs_review when merchant cannot be extracted from APROBADA email", () => {
+    const html = wrapWompi(`
+      <p>Tu transacci&oacute;n fue APROBADA</p>
+      <p>Estado: APROBADA</p>
+      <p>Monto: COP $10,000</p>
+    `);
+    const r = wompiParser.parse(html);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("merchant_not_found");
+  });
+
+  it("returns needs_review when amount cannot be extracted", () => {
+    const html = wrapWompi(`
+      <p>Tu transacci&oacute;n fue APROBADA</p>
+      <p>Hemos procesado exitosamente el pago realizado a TIENDA TEST y el dinero ser&aacute; transferido.</p>
+      <p>Estado: APROBADA</p>
+      <p>Referencia: WC-000-111</p>
+    `);
+    const r = wompiParser.parse(html);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("amount_not_found");
+  });
+
+  it("handles null referenceId when WC- reference is absent", () => {
+    const html = wrapWompi(`
+      <p>Tu transacci&oacute;n fue APROBADA</p>
+      <p>Hemos procesado exitosamente el pago realizado a OTRO COMERCIO y el dinero ser&aacute; transferido.</p>
+      <p>Estado: APROBADA</p>
+      <p>Monto: COP $75,000</p>
+    `);
+    const r = wompiParser.parse(html, { receivedAt: new Date("2026-04-19T12:00:00Z") });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.referenceId).toBeNull();
+    expect(r.data.amountCents).toBe(BigInt(7500000));
+  });
+});

--- a/src/lib/gmail/parsers/wompi.test.ts
+++ b/src/lib/gmail/parsers/wompi.test.ts
@@ -44,15 +44,11 @@ describe("wompiParser — approved transaction", () => {
     expect(r.data.occurredAt).toEqual(new Date("2026-04-19T12:00:00Z"));
   });
 
-  it("falls back to new Date() when receivedAt not provided", () => {
+  it("returns needs_review when receivedAt is absent (no wall-clock fallback)", () => {
     const html = wrapWompi(APPROVED_BODY);
-    const before = Date.now();
     const r = wompiParser.parse(html);
-    const after = Date.now();
-    if (r.kind !== "parsed")
-      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
-    expect(r.data.occurredAt.getTime()).toBeGreaterThanOrEqual(before);
-    expect(r.data.occurredAt.getTime()).toBeLessThanOrEqual(after);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("missing_occurred_at");
   });
 
   it("handles decimal amounts (e.g. COP $1,234.56 = 123456 cents)", () => {

--- a/src/lib/gmail/parsers/wompi.ts
+++ b/src/lib/gmail/parsers/wompi.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@/lib/logger";
+import { extractVisibleText } from "./_text";
 import type { GatewayParser, ParseResult } from "./types";
 
 const log = createLogger({ module: "gmail/parsers/wompi" });
@@ -12,17 +13,6 @@ const log = createLogger({ module: "gmail/parsers/wompi" });
 //
 // occurredAt: Wompi emails do not include a date in the body — we use
 // opts.receivedAt (Gmail internalDate) as a reliable stand-in.
-
-function extractVisibleText(rawHtml: string): string {
-  let t = rawHtml;
-  t = t.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ");
-  t = t.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ");
-  t = t.replace(/<!--[\s\S]*?-->/g, " ");
-  t = t.replace(/<[^>]+>/g, " ");
-  t = t.replace(/&nbsp;/gi, " ");
-  t = t.replace(/\s+/g, " ").trim();
-  return t;
-}
 
 function parseCopAmount(intPart: string, decPart?: string): bigint {
   // Remove comma thousands separators → integer COP value

--- a/src/lib/gmail/parsers/wompi.ts
+++ b/src/lib/gmail/parsers/wompi.ts
@@ -72,8 +72,11 @@ export const wompiParser: GatewayParser = {
       // Currency: Wompi Colombia-only; USD support stubbed for completeness
       const currency: "COP" | "USD" = /USD/i.test(text) ? "USD" : "COP";
 
-      // occurredAt: not in body — use email received date
-      const occurredAt = opts?.receivedAt ?? new Date();
+      // occurredAt: not in body — use email received date (required; no wall-clock fallback)
+      if (!opts?.receivedAt) {
+        return { kind: "needs_review", reason: "missing_occurred_at" };
+      }
+      const occurredAt = opts.receivedAt;
 
       return {
         kind: "parsed",

--- a/src/lib/gmail/parsers/wompi.ts
+++ b/src/lib/gmail/parsers/wompi.ts
@@ -1,0 +1,87 @@
+import { createLogger } from "@/lib/logger";
+import type { GatewayParser, ParseResult } from "./types";
+
+const log = createLogger({ module: "gmail/parsers/wompi" });
+
+// Wompi emails use comma as thousands separator and no decimal places for COP
+// amounts (e.g. "COP $137,000" = 137 000 COP = 13 700 000 cents).
+// Decimal places (optional): "COP $1,234.56" would be 1234 COP + 56 cents.
+//
+// Reference field: prefer WC-XXXXXXXX-XXXXXXXXXX over the Transacción# line.
+// The WC- reference is stable and matches the payment provider's identifier.
+//
+// occurredAt: Wompi emails do not include a date in the body — we use
+// opts.receivedAt (Gmail internalDate) as a reliable stand-in.
+
+function extractVisibleText(rawHtml: string): string {
+  let t = rawHtml;
+  t = t.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ");
+  t = t.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ");
+  t = t.replace(/<!--[\s\S]*?-->/g, " ");
+  t = t.replace(/<[^>]+>/g, " ");
+  t = t.replace(/&nbsp;/gi, " ");
+  t = t.replace(/\s+/g, " ").trim();
+  return t;
+}
+
+function parseCopAmount(intPart: string, decPart?: string): bigint {
+  // Remove comma thousands separators → integer COP value
+  const cop = BigInt(intPart.replace(/,/g, ""));
+  const cents = cop * BigInt(100);
+  if (decPart) {
+    // Only 2 decimal digits expected
+    const dec = BigInt(decPart.padEnd(2, "0").slice(0, 2));
+    return cents + dec;
+  }
+  return cents;
+}
+
+export const wompiParser: GatewayParser = {
+  parse(html: string, opts?: { receivedAt?: Date }): ParseResult {
+    try {
+      const text = extractVisibleText(html);
+
+      // Only process approved transactions
+      if (!/APROBADA/i.test(text)) {
+        return { kind: "skipped", reason: "not_approved" };
+      }
+
+      // Extract merchant: between "pago realizado a " and " y el dinero"
+      const merchantMatch = text.match(/pago\s+realizado\s+a\s+(.+?)\s+y\s+el\s+dinero/i);
+      if (!merchantMatch) {
+        log.warn(
+          { event: "wompi_merchant_not_found" },
+          "could not extract merchant from Wompi email",
+        );
+        return { kind: "needs_review", reason: "merchant_not_found" };
+      }
+      const merchant = merchantMatch[1].trim();
+
+      // Extract reference: prefer WC- prefixed reference
+      const refMatch = text.match(/Referencia:\s*(WC-[\d-]+)/i);
+      const referenceId = refMatch ? refMatch[1] : null;
+
+      // Extract amount: "Monto: COP $137,000" or "Monto: COP $1,234.56"
+      const amountMatch = text.match(/Monto:\s*(?:COP\s*)?\$\s*([\d,]+)(?:\.(\d{2}))?/i);
+      if (!amountMatch) {
+        log.warn({ event: "wompi_amount_not_found" }, "could not extract amount from Wompi email");
+        return { kind: "needs_review", reason: "amount_not_found" };
+      }
+      const amountCents = parseCopAmount(amountMatch[1], amountMatch[2]);
+
+      // Currency: Wompi Colombia-only; USD support stubbed for completeness
+      const currency: "COP" | "USD" = /USD/i.test(text) ? "USD" : "COP";
+
+      // occurredAt: not in body — use email received date
+      const occurredAt = opts?.receivedAt ?? new Date();
+
+      return {
+        kind: "parsed",
+        data: { merchant, amountCents, currency, occurredAt, referenceId },
+      };
+    } catch (err) {
+      log.error({ err, event: "wompi_parse_error" }, "unexpected error parsing Wompi email");
+      return { kind: "needs_review", reason: "parse_error" };
+    }
+  },
+};

--- a/src/lib/gmail/pull.ts
+++ b/src/lib/gmail/pull.ts
@@ -427,7 +427,7 @@ async function processPendingEnrichReceipts(userId: number, gatewayId: GatewayId
         } else if (parseResult.kind === "skipped") {
           await db
             .update(emailReceipts)
-            .set({ matchStatus: "unmatched", updatedAt: new Date() })
+            .set({ matchStatus: "unmatched", parsedAt: new Date(), updatedAt: new Date() })
             .where(and(eq(emailReceipts.id, receipt.id), eq(emailReceipts.userId, userId)));
           log.info(
             {

--- a/src/lib/gmail/pull.ts
+++ b/src/lib/gmail/pull.ts
@@ -19,6 +19,7 @@ import {
   type GatewayId,
 } from "@/lib/gmail/registry";
 import { parseBancolombiaEmail } from "@/lib/gmail/parsers/bancolombia";
+import { parseReceipt } from "@/lib/gmail/parsers";
 import { ingestParsedEmail } from "@/lib/ingestion/email-bancolombia";
 import { matchReceipt } from "@/lib/gmail/matcher";
 import { applyEnrichment } from "@/lib/gmail/enrich";
@@ -364,7 +365,14 @@ async function processPendingBancolombiaReceipts(userId: number): Promise<void> 
  */
 async function processPendingEnrichReceipts(userId: number, gatewayId: GatewayId): Promise<void> {
   const pending = await db
-    .select({ id: emailReceipts.id })
+    .select({
+      id: emailReceipts.id,
+      rawHtml: emailReceipts.rawHtml,
+      gateway: emailReceipts.gateway,
+      gmailMsgId: emailReceipts.gmailMsgId,
+      parsedAt: emailReceipts.parsedAt,
+      createdAt: emailReceipts.createdAt,
+    })
     .from(emailReceipts)
     .where(
       and(
@@ -377,6 +385,79 @@ async function processPendingEnrichReceipts(userId: number, gatewayId: GatewayId
 
   for (const receipt of pending) {
     try {
+      // Parse step: run the gateway parser if this receipt hasn't been parsed yet.
+      // Receipts seeded with parsedAt already set (e.g. backfilled or pre-parsed
+      // rows) skip parsing and proceed directly to matching.
+      if (!receipt.parsedAt) {
+        const parseResult = parseReceipt(receipt.gateway, receipt.rawHtml, {
+          receivedAt: receipt.createdAt,
+        });
+
+        if (parseResult.kind === "parsed") {
+          const { merchant, amountCents, currency, occurredAt, referenceId } = parseResult.data;
+          const parsedPayload = {
+            merchant,
+            amountCents: amountCents.toString(),
+            currency,
+            occurredAt: occurredAt.toISOString(),
+            referenceId,
+          };
+          await db
+            .update(emailReceipts)
+            .set({
+              merchant,
+              amountCents,
+              currency,
+              occurredAt,
+              referenceId,
+              parsedPayload,
+              parsedAt: new Date(),
+              updatedAt: new Date(),
+            })
+            .where(and(eq(emailReceipts.id, receipt.id), eq(emailReceipts.userId, userId)));
+          log.info(
+            {
+              userId,
+              receiptId: receipt.id,
+              gateway: receipt.gateway,
+              event: "gmail_receipt_parsed",
+            },
+            "receipt parsed successfully",
+          );
+        } else if (parseResult.kind === "skipped") {
+          await db
+            .update(emailReceipts)
+            .set({ matchStatus: "unmatched", updatedAt: new Date() })
+            .where(and(eq(emailReceipts.id, receipt.id), eq(emailReceipts.userId, userId)));
+          log.info(
+            {
+              userId,
+              receiptId: receipt.id,
+              gateway: receipt.gateway,
+              gmailMsgId: receipt.gmailMsgId,
+              reason: parseResult.reason,
+              event: "receipt_skipped",
+            },
+            "receipt skipped by parser; marked unmatched",
+          );
+          continue; // skip matcher — this receipt is intentionally non-transactional
+        } else {
+          // needs_review: leave as pending, do NOT call matcher
+          log.warn(
+            {
+              userId,
+              receiptId: receipt.id,
+              gateway: receipt.gateway,
+              gmailMsgId: receipt.gmailMsgId,
+              reason: parseResult.reason,
+              event: "receipt_needs_review",
+            },
+            "receipt parse needs review; leaving pending for retry",
+          );
+          continue;
+        }
+      }
+
       const result = await matchReceipt(userId, receipt.id);
 
       if (result.status === "matched") {


### PR DESCRIPTION
Closes #453

## Summary

- Adds 5 gateway parsers (Mercado Pago, PayU, Wompi, Apple, PayPal-stub) under `src/lib/gmail/parsers/`, all conforming to a new `GatewayParser.parse(html, opts?)` interface returning a 3-kind `ParseResult` (`parsed | skipped | needs_review`).
- Hooks `parseReceipt` into the pull engine (`processPendingEnrichReceipts`) so raw HTML emails get parsed → typed columns (`amount_cents`, `merchant`, `currency`, `occurred_at`, `reference_id`, `parsed_payload`, `parsed_at`) populated before the matcher runs.
- Skip rules per gateway: Apple (Recent Purchase / Subscription Confirmed / Expiring / Developer Agreement), PayU (rejected / card-registration), MP (promotional). Wompi has clean structure (no skip needed). PayPal lands as a stub returning `needs_review` until prod samples are sourced — tracked in #482.
- Adds `node-html-parser` (lighter than cheerio) for DOM traversal where Bancolombia's regex-strip would be brittle (Apple/PayU complex tables).
- Adds `argsIgnorePattern: "^_"` to `eslint.config.mjs` for the canonical TS-ESLint convention.

Built ~1620 LOC net new under `src/lib/gmail/parsers/`. Closes the gateway-opacity arm of Epic G (#459).

## Reviewer findings addressed (commit `fbf4e35`)

- **CRITICAL**: skipped receipts were re-parsed forever because `parsed_at` stayed null. Fix: set `parsed_at = now` on skip; receipt becomes terminal. Regression test added in `enrich-pull.test.ts`.
- **WARNING**: Wompi silently fell back to wall-clock when `receivedAt` was absent — replaced with `needs_review` (matches PayU/MP discipline).
- **WARNING**: MercadoPago year-boundary — Dec 31 23:30 Bogotá payment has UTC `internalDate` already in next-year January, so year was off by one. Fixed by detecting body-month=12 ∧ UTC-month=0 and decrementing year. Two regression tests added.

## Test plan

- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 1286/1286 passing
- [x] Sanity: 73 parser tests cover all parse + skip paths
- [x] Integration: pull engine tests assert parser hook gates properly
- [ ] Verify in prod after merge: existing pending Wompi/PayU/MP/Apple receipts get parsed on next cron tick

Refs #459 (Epic G umbrella)
Follow-up: #482 (PayPal parser when samples available)