### PR TITLE
feat(ui): needs_review UX in /transactions for ambiguous Gmail matches (#455)

### DIFF
--- a/drizzle/0056_minor_tempest.sql
+++ b/drizzle/0056_minor_tempest.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "email_receipts_candidates_gin_idx" ON "email_receipts" USING gin ("match_candidates") WHERE "email_receipts"."match_status" = 'ambiguous' AND "email_receipts"."deleted_at" IS NULL;

--- a/drizzle/meta/0056_snapshot.json
+++ b/drizzle/meta/0056_snapshot.json
@@ -1,0 +1,5090 @@
+{
+  "id": "62eff30c-a7b5-4daa-be09-5780b7991e1f",
+  "prevId": "61c21c8c-821c-4ca4-ace8-3df6aa2d62ab",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_physical_card_id_physical_cards_id_fk": {
+          "name": "accounts_physical_card_id_physical_cards_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "physical_cards",
+          "columnsFrom": [
+            "physical_card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_corrections": {
+      "name": "classification_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_category_slug": {
+          "name": "new_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_corrections_learning_idx": {
+          "name": "classification_corrections_learning_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "new_category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_corrections_user_id_users_id_fk": {
+          "name": "classification_corrections_user_id_users_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_corrections_transaction_id_transactions_id_fk": {
+          "name": "classification_corrections_transaction_id_transactions_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_from_corrections": {
+          "name": "generated_from_corrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_receipts": {
+      "name": "email_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_connection_id": {
+          "name": "gmail_connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_msg_id": {
+          "name": "gmail_msg_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway": {
+          "name": "gateway",
+          "type": "email_receipt_gateway",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_html": {
+          "name": "raw_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_payload": {
+          "name": "parsed_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_transaction_id": {
+          "name": "matched_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_status": {
+          "name": "match_status",
+          "type": "email_receipt_match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "match_candidates": {
+          "name": "match_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_at": {
+          "name": "parsed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_receipts_user_msg_unique": {
+          "name": "email_receipts_user_msg_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_msg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_user_status_idx": {
+          "name": "email_receipts_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_match_lookup_idx": {
+          "name": "email_receipts_match_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "amount_cents",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'pending' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_connection_idx": {
+          "name": "email_receipts_connection_idx",
+          "columns": [
+            {
+              "expression": "gmail_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_candidates_gin_idx": {
+          "name": "email_receipts_candidates_gin_idx",
+          "columns": [
+            {
+              "expression": "match_candidates",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'ambiguous' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_receipts_user_id_users_id_fk": {
+          "name": "email_receipts_user_id_users_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_gmail_connection_id_gmail_connections_id_fk": {
+          "name": "email_receipts_gmail_connection_id_gmail_connections_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "gmail_connections",
+          "columnsFrom": [
+            "gmail_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_matched_transaction_id_transactions_id_fk": {
+          "name": "email_receipts_matched_transaction_id_transactions_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "matched_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_connections": {
+      "name": "gmail_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_email": {
+          "name": "gmail_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_enc": {
+          "name": "access_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_pull_at": {
+          "name": "last_pull_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_pull_history_id": {
+          "name": "last_pull_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "gmail_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_connections_user_email_unique": {
+          "name": "gmail_connections_user_email_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_user_status_idx": {
+          "name": "gmail_connections_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_active_idx": {
+          "name": "gmail_connections_active_idx",
+          "columns": [
+            {
+              "expression": "last_pull_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"status\" = 'active' AND \"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_connections_user_id_users_id_fk": {
+          "name": "gmail_connections_user_id_users_id_fk",
+          "tableFrom": "gmail_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.physical_cards": {
+      "name": "physical_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_limit_cents": {
+          "name": "credit_limit_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "statement_cutoff_day": {
+          "name": "statement_cutoff_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "physical_cards_user_idx": {
+          "name": "physical_cards_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "physical_cards_user_institution_idx": {
+          "name": "physical_cards_user_institution_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "physical_cards_user_id_users_id_fk": {
+          "name": "physical_cards_user_id_users_id_fk",
+          "tableFrom": "physical_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_proposals": {
+      "name": "rule_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_txn_ids": {
+          "name": "correction_txn_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rule_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rule_proposals_user_merchant_category_pending_unique": {
+          "name": "rule_proposals_user_merchant_category_pending_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rule_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rule_proposals_user_status_idx": {
+          "name": "rule_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_proposals_user_id_users_id_fk": {
+          "name": "rule_proposals_user_id_users_id_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_proposals_user_category_fk": {
+          "name": "rule_proposals_user_category_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skipped_consolidation_cycles": {
+      "name": "skipped_consolidation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "skipped_consolidation_cycles_live_unique": {
+          "name": "skipped_consolidation_cycles_live_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skipped_consolidation_cycles_user_account_idx": {
+          "name": "skipped_consolidation_cycles_user_account_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skipped_consolidation_cycles_user_id_users_id_fk": {
+          "name": "skipped_consolidation_cycles_user_id_users_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skipped_consolidation_cycles_account_id_accounts_id_fk": {
+          "name": "skipped_consolidation_cycles_account_id_accounts_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slo_alerts": {
+      "name": "slo_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slo_key": {
+          "name": "slo_key",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slo_alerts_open_idx": {
+          "name": "slo_alerts_open_idx",
+          "columns": [
+            {
+              "expression": "slo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"slo_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "statement_import_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movimientos'"
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synthetic_tx_id": {
+          "name": "synthetic_tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_cycle_unique": {
+          "name": "statement_imports_cycle_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"statement_imports\".\"kind\" = 'extracto_detallado' AND \"statement_imports\".\"cycle\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installments_total": {
+          "name": "installments_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "installment_rate_bps": {
+          "name": "installment_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retroactive_rule_id": {
+          "name": "retroactive_rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group_id": {
+          "name": "transfer_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enriched_merchant": {
+          "name": "enriched_merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_source": {
+          "name": "enrichment_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_mismatch": {
+          "name": "source_mismatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_mismatch_details": {
+          "name": "source_mismatch_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_group_idx": {
+          "name": "transactions_transfer_group_idx",
+          "columns": [
+            {
+              "expression": "transfer_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"transfer_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_occurred_live_idx": {
+          "name": "transactions_account_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_live_idx": {
+          "name": "transactions_user_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_retroactive_rule_id_classification_rules_id_fk": {
+          "name": "transactions_retroactive_rule_id_classification_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "classification_rules",
+          "columnsFrom": [
+            "retroactive_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_snapshots": {
+      "name": "user_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_bytes": {
+          "name": "payload_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_snapshots_user_created_idx": {
+          "name": "user_snapshots_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_snapshots_user_id_users_id_fk": {
+          "name": "user_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ui_preferences": {
+          "name": "ui_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "classification_context": {
+          "name": "classification_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "rule_retroactive",
+        "ai",
+        "manual",
+        "manual_confirmed",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.email_receipt_gateway": {
+      "name": "email_receipt_gateway",
+      "schema": "public",
+      "values": [
+        "mercado_pago",
+        "payu",
+        "wompi",
+        "apple",
+        "paypal",
+        "bancolombia"
+      ]
+    },
+    "public.email_receipt_match_status": {
+      "name": "email_receipt_match_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "matched",
+        "ambiguous",
+        "unmatched"
+      ]
+    },
+    "public.gmail_connection_status": {
+      "name": "gmail_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "revoked",
+        "error"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.rule_proposal_status": {
+      "name": "rule_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.statement_import_kind": {
+      "name": "statement_import_kind",
+      "schema": "public",
+      "values": [
+        "movimientos",
+        "extracto_detallado"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile",
+        "gmail_bancolombia",
+        "gmail_enrichment"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug",
+        "widget"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1777067342896,
       "tag": "0055_spicy_the_executioner",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1777096839227,
+      "tag": "0056_minor_tempest",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -22,8 +22,6 @@ const pages = [
   },
   { name: "signup-missing", path: "/signup", hasDonut: false },
   { name: "signup-unknown", path: "/signup?code=__DOESNOTEXIST__", hasDonut: false },
-  // #455 (Epic G): disambiguation UX lives on the transactions page
-  { name: "transactions-disambiguation", path: "/transactions", hasDonut: false },
 ];
 
 const modes = ["light", "dark"] as const;

--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -22,6 +22,8 @@ const pages = [
   },
   { name: "signup-missing", path: "/signup", hasDonut: false },
   { name: "signup-unknown", path: "/signup?code=__DOESNOTEXIST__", hasDonut: false },
+  // #455 (Epic G): disambiguation UX lives on the transactions page
+  { name: "transactions-disambiguation", path: "/transactions", hasDonut: false },
 ];
 
 const modes = ["light", "dark"] as const;

--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -16,6 +16,7 @@ import {
   listTransactions,
   PAGE_SIZE,
 } from "@/lib/transactions/queries";
+import { loadAmbiguousReceiptsForTxIds } from "@/lib/gmail/ambiguous";
 
 export const dynamic = "force-dynamic";
 
@@ -89,6 +90,21 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
     listCounterparties(session.id),
     countNeedingRate(session.id),
   ]);
+
+  // #455 (Epic G): sidecar query — attach ambiguous Gmail receipts to each
+  // row without touching listTransactions (keeps it pure). The Map is keyed
+  // by tx.id; rows without matches get undefined (undefined is stripped by
+  // JSON serialization, matching the optional field on TxRow).
+  const txIds = rows.map((r) => r.id);
+  const ambiguousMap = await loadAmbiguousReceiptsForTxIds(session.id, txIds);
+  if (ambiguousMap.size > 0) {
+    for (const row of rows) {
+      const receipts = ambiguousMap.get(row.id);
+      if (receipts && receipts.length > 0) {
+        row.gmailAmbiguousReceipts = receipts;
+      }
+    }
+  }
 
   const baseQuery = {
     from: sp.from,

--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -17,6 +17,9 @@ import {
   PAGE_SIZE,
 } from "@/lib/transactions/queries";
 import { loadAmbiguousReceiptsForTxIds } from "@/lib/gmail/ambiguous";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "transactions/page" });
 
 export const dynamic = "force-dynamic";
 
@@ -95,8 +98,17 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
   // row without touching listTransactions (keeps it pure). The Map is keyed
   // by tx.id; rows without matches get undefined (undefined is stripped by
   // JSON serialization, matching the optional field on TxRow).
+  // Failure here degrades to "no badges" — it must NOT crash the primary view.
   const txIds = rows.map((r) => r.id);
-  const ambiguousMap = await loadAmbiguousReceiptsForTxIds(session.id, txIds);
+  let ambiguousMap: Awaited<ReturnType<typeof loadAmbiguousReceiptsForTxIds>> = new Map();
+  try {
+    ambiguousMap = await loadAmbiguousReceiptsForTxIds(session.id, txIds);
+  } catch (err) {
+    log.error(
+      { err, event: "gmail_ambiguous_load_failed", userId: session.id, txCount: rows.length },
+      "gmail ambiguous sidecar failed — degrading to no badges",
+    );
+  }
   if (ambiguousMap.size > 0) {
     for (const row of rows) {
       const receipts = ambiguousMap.get(row.id);

--- a/src/app/api/integrations/gmail/disambiguate/route.test.ts
+++ b/src/app/api/integrations/gmail/disambiguate/route.test.ts
@@ -1,0 +1,391 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, emailReceipts, gmailConnections, transactions, users } from "@/lib/db/schema";
+import { gmailCipher } from "@/lib/crypto/gmail-cipher";
+
+// ── Session mock ──────────────────────────────────────────────────────────────
+// Shared state so individual tests can swap the active user.
+const { mockUser } = vi.hoisted(() => ({
+  mockUser: {
+    value: null as null | {
+      id: number;
+      email: string;
+      name: string;
+      role: "user" | "admin";
+      active: boolean;
+    },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUserOrNull: vi.fn(() => Promise.resolve(mockUser.value)),
+}));
+
+// Must import the route AFTER mocking session
+const { POST } = await import("./route");
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const TAG = "VITEST_DISAMBIG_";
+const GMAIL_KEY_ENV = "GMAIL_TOKEN_ENCRYPTION_KEY";
+const ORIGINAL_KEY = process.env[GMAIL_KEY_ENV];
+
+let userA: number;
+let userB: number;
+let accountA: number;
+let accountB: number;
+let connA: number;
+let connB: number;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+async function cleanup() {
+  await db.execute(sql`DELETE FROM email_receipts WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM transactions WHERE account_id IN (${accountA}, ${accountB})`);
+}
+
+async function createUser(suffix: string) {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `${TAG}${suffix}@test.local`, name: `${TAG}${suffix}` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function createAccount(userId: number, suffix: string) {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG}${suffix}`,
+      institution: "Test",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createConnection(userId: number) {
+  const [row] = await db
+    .insert(gmailConnections)
+    .values({
+      userId,
+      gmailEmail: `${TAG}${userId}@example.com`,
+      accessTokenEnc: gmailCipher.encrypt("dummy-access"),
+      refreshTokenEnc: gmailCipher.encrypt("dummy-refresh"),
+      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  return row.id;
+}
+
+async function createTx(userId: number, accountId: number) {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: new Date("2026-04-01T10:00:00Z"),
+      amountCents: BigInt(-50000),
+      currency: "COP",
+      descriptionRaw: "MERCHANT TEST",
+      classificationMethod: "unclassified",
+      source: "sms",
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function createAmbiguousReceipt(opts: {
+  userId: number;
+  connId: number;
+  candidates: number[];
+  merchant?: string;
+}) {
+  const [row] = await db
+    .insert(emailReceipts)
+    .values({
+      userId: opts.userId,
+      gmailConnectionId: opts.connId,
+      gmailMsgId: `${TAG}${Date.now()}-${Math.random()}`,
+      gateway: "mercado_pago",
+      amountCents: BigInt(50000),
+      occurredAt: new Date("2026-04-01T10:30:00Z"),
+      merchant: opts.merchant ?? "TestMerchant",
+      currency: "COP",
+      rawHtml: "<html>test</html>",
+      matchStatus: "ambiguous",
+      matchCandidates: opts.candidates,
+    })
+    .returning({ id: emailReceipts.id });
+  return row.id;
+}
+
+async function getReceiptState(id: number) {
+  const [row] = await db
+    .select({
+      matchStatus: emailReceipts.matchStatus,
+      matchCandidates: emailReceipts.matchCandidates,
+    })
+    .from(emailReceipts)
+    .where(eq(emailReceipts.id, id));
+  return row;
+}
+
+async function getTxState(id: number) {
+  const [row] = await db
+    .select({
+      enrichedMerchant: transactions.enrichedMerchant,
+      enrichmentSource: transactions.enrichmentSource,
+    })
+    .from(transactions)
+    .where(eq(transactions.id, id));
+  return row;
+}
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/integrations/gmail/disambiguate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+beforeAll(async () => {
+  process.env[GMAIL_KEY_ENV] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  userA = await createUser("A");
+  userB = await createUser("B");
+  accountA = await createAccount(userA, "A");
+  accountB = await createAccount(userB, "B");
+  connA = await createConnection(userA);
+  connB = await createConnection(userB);
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM gmail_connections WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM accounts WHERE id IN (${accountA}, ${accountB})`);
+  await db.execute(sql`DELETE FROM users WHERE id IN (${userA}, ${userB})`);
+  mockUser.value = null;
+  if (ORIGINAL_KEY === undefined) delete process.env[GMAIL_KEY_ENV];
+  else process.env[GMAIL_KEY_ENV] = ORIGINAL_KEY;
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe("POST /api/integrations/gmail/disambiguate — auth", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockUser.value = null;
+    const res = await POST(makeRequest({ decision: "reject", transactionId: 1 }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/integrations/gmail/disambiguate — confirm", () => {
+  it("enriches the tx and marks winning receipt as matched", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+
+    const txId = await createTx(userA, accountA);
+    const receiptId = await createAmbiguousReceipt({
+      userId: userA,
+      connId: connA,
+      candidates: [txId],
+      merchant: "Rappi Merchant",
+    });
+
+    const res = await POST(makeRequest({ decision: "confirm", transactionId: txId, receiptId }));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(true);
+
+    // TX should be enriched
+    const txState = await getTxState(txId);
+    expect(txState.enrichedMerchant).toBe("Rappi Merchant");
+    expect(txState.enrichmentSource).toBe("gmail");
+
+    // Winning receipt should be matched
+    const receiptState = await getReceiptState(receiptId);
+    expect(receiptState.matchStatus).toBe("matched");
+  });
+
+  it("marks losing candidate receipts as unmatched after confirm", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+
+    const txId = await createTx(userA, accountA);
+    const winnerReceiptId = await createAmbiguousReceipt({
+      userId: userA,
+      connId: connA,
+      candidates: [txId],
+      merchant: "Winner",
+    });
+    const loserReceiptId = await createAmbiguousReceipt({
+      userId: userA,
+      connId: connA,
+      candidates: [txId],
+      merchant: "Loser",
+    });
+
+    const res = await POST(
+      makeRequest({ decision: "confirm", transactionId: txId, receiptId: winnerReceiptId }),
+    );
+    expect(res.status).toBe(200);
+
+    const loserState = await getReceiptState(loserReceiptId);
+    expect(loserState.matchStatus).toBe("unmatched");
+  });
+
+  it("returns 404 when receiptId belongs to a different user (cross-tenant reject)", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+
+    const txIdA = await createTx(userA, accountA);
+    const txIdB = await createTx(userB, accountB);
+    const receiptIdB = await createAmbiguousReceipt({
+      userId: userB,
+      connId: connB,
+      candidates: [txIdB],
+    });
+
+    // UserA tries to confirm userB's receipt against userA's tx
+    const res = await POST(
+      makeRequest({ decision: "confirm", transactionId: txIdA, receiptId: receiptIdB }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when transactionId belongs to a different user", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+
+    const txIdB = await createTx(userB, accountB);
+    const receiptIdA = await createAmbiguousReceipt({
+      userId: userA,
+      connId: connA,
+      candidates: [txIdB],
+    });
+
+    // UserA tries to enrich userB's tx with userA's receipt
+    const res = await POST(
+      makeRequest({ decision: "confirm", transactionId: txIdB, receiptId: receiptIdA }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+    const res = await POST(makeRequest({ decision: "confirm" })); // missing transactionId + receiptId
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/integrations/gmail/disambiguate — reject", () => {
+  it("removes transactionId from match_candidates and flips to unmatched when empty", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+
+    const txId = await createTx(userA, accountA);
+    const receiptId = await createAmbiguousReceipt({
+      userId: userA,
+      connId: connA,
+      candidates: [txId],
+    });
+
+    const res = await POST(makeRequest({ decision: "reject", transactionId: txId }));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(true);
+
+    const state = await getReceiptState(receiptId);
+    expect(state.matchStatus).toBe("unmatched");
+    expect(state.matchCandidates).toEqual([]);
+  });
+
+  it("removes only this txId from candidates when other candidates remain", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+
+    const tx1 = await createTx(userA, accountA);
+    const tx2 = await createTx(userA, accountA);
+    const receiptId = await createAmbiguousReceipt({
+      userId: userA,
+      connId: connA,
+      candidates: [tx1, tx2],
+    });
+
+    // Reject tx1 only
+    const res = await POST(makeRequest({ decision: "reject", transactionId: tx1 }));
+    expect(res.status).toBe(200);
+
+    const state = await getReceiptState(receiptId);
+    // Still ambiguous because tx2 remains
+    expect(state.matchStatus).toBe("ambiguous");
+    expect(state.matchCandidates).toEqual([tx2]);
+  });
+
+  it("does NOT affect receipts from a different user", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+
+    const txIdA = await createTx(userA, accountA);
+    const txIdB = await createTx(userB, accountB);
+    const receiptIdB = await createAmbiguousReceipt({
+      userId: userB,
+      connId: connB,
+      candidates: [txIdB],
+    });
+
+    // UserA rejects what happens to be userB's tx_id (cross-tenant attempt)
+    const res = await POST(makeRequest({ decision: "reject", transactionId: txIdA }));
+    expect(res.status).toBe(200); // succeeds (nothing to do for userA)
+
+    // UserB's receipt must be untouched
+    const stateB = await getReceiptState(receiptIdB);
+    expect(stateB.matchStatus).toBe("ambiguous");
+  });
+});

--- a/src/app/api/integrations/gmail/disambiguate/route.ts
+++ b/src/app/api/integrations/gmail/disambiguate/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+import { and, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { emailReceipts } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { getSessionUserOrNull } from "@/lib/auth/session";
+import { applyEnrichment } from "@/lib/gmail/enrich";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "gmail/disambiguate" });
+
+const bodySchema = z.discriminatedUnion("decision", [
+  z.object({
+    decision: z.literal("confirm"),
+    transactionId: z.number().int().positive(),
+    receiptId: z.number().int().positive(),
+  }),
+  z.object({
+    decision: z.literal("reject"),
+    transactionId: z.number().int().positive(),
+    receiptId: z.number().int().positive().optional(),
+  }),
+]);
+
+export async function POST(request: Request) {
+  const user = await getSessionUserOrNull();
+  if (!user) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    const raw = await request.json();
+    body = bodySchema.parse(raw);
+  } catch {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+
+  const { transactionId, decision } = body;
+  const userId = user.id;
+
+  if (decision === "confirm") {
+    const { receiptId } = body;
+
+    // applyEnrichment verifies tenant isolation internally and throws
+    // "cross-tenant attempt" on mismatch.
+    try {
+      await applyEnrichment(userId, transactionId, receiptId);
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("cross-tenant attempt")) {
+        return NextResponse.json({ error: "not_found" }, { status: 404 });
+      }
+      log.error(
+        { err, userId, transactionId, receiptId, event: "disambiguate_confirm_failed" },
+        "failed to apply enrichment during disambiguation",
+      );
+      return NextResponse.json({ error: "internal_error" }, { status: 500 });
+    }
+
+    // Mark all OTHER ambiguous receipts that listed this tx as a candidate
+    // as unmatched — the user picked one, the others were wrong matches.
+    // We do this in a best-effort update after the main enrichment transaction
+    // commits (losing candidates don't need to be atomic with the enrichment).
+    try {
+      await db
+        .update(emailReceipts)
+        .set({ matchStatus: "unmatched", updatedAt: new Date() })
+        .where(
+          and(
+            eq(emailReceipts.userId, userId),
+            eq(emailReceipts.matchStatus, "ambiguous"),
+            notDeleted(emailReceipts.deletedAt),
+            // NOT the receipt we just confirmed
+            sql`${emailReceipts.id} != ${receiptId}`,
+            // Still references this transactionId as a candidate
+            sql`${emailReceipts.matchCandidates} @> ${JSON.stringify([transactionId])}::jsonb`,
+          ),
+        );
+    } catch (err) {
+      // Non-fatal: the enrichment already committed; log and continue.
+      log.warn(
+        { err, userId, transactionId, receiptId, event: "disambiguate_cleanup_failed" },
+        "best-effort cleanup of losing candidates failed",
+      );
+    }
+
+    log.info(
+      { userId, transactionId, receiptId, event: "disambiguate_confirmed" },
+      "disambiguation confirmed",
+    );
+    return NextResponse.json({ ok: true });
+  }
+
+  // decision === "reject": remove transactionId from match_candidates of every
+  // ambiguous receipt that still lists it. If the resulting array becomes
+  // empty, flip match_status to 'unmatched'.
+  try {
+    // Fetch all ambiguous receipts referencing this tx (scoped to user).
+    const candidates = await db
+      .select({ id: emailReceipts.id, matchCandidates: emailReceipts.matchCandidates })
+      .from(emailReceipts)
+      .where(
+        and(
+          eq(emailReceipts.userId, userId),
+          eq(emailReceipts.matchStatus, "ambiguous"),
+          notDeleted(emailReceipts.deletedAt),
+          sql`${emailReceipts.matchCandidates} @> ${JSON.stringify([transactionId])}::jsonb`,
+        ),
+      );
+
+    for (const row of candidates) {
+      const remaining = (row.matchCandidates ?? []).filter((id) => id !== transactionId);
+      await db
+        .update(emailReceipts)
+        .set({
+          matchCandidates: remaining.length > 0 ? remaining : [],
+          matchStatus: remaining.length === 0 ? "unmatched" : "ambiguous",
+          updatedAt: new Date(),
+        })
+        .where(and(eq(emailReceipts.id, row.id), eq(emailReceipts.userId, userId)));
+    }
+
+    log.info(
+      { userId, transactionId, count: candidates.length, event: "disambiguate_rejected" },
+      "disambiguation rejected — candidates released",
+    );
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    log.error(
+      { err, userId, transactionId, event: "disambiguate_reject_failed" },
+      "failed to process rejection during disambiguation",
+    );
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
+  }
+}

--- a/src/app/api/integrations/gmail/receipts/[id]/raw/route.test.ts
+++ b/src/app/api/integrations/gmail/receipts/[id]/raw/route.test.ts
@@ -1,0 +1,217 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, emailReceipts, gmailConnections, users } from "@/lib/db/schema";
+import { gmailCipher } from "@/lib/crypto/gmail-cipher";
+
+// ── Session mock ──────────────────────────────────────────────────────────────
+const { mockUser } = vi.hoisted(() => ({
+  mockUser: {
+    value: null as null | {
+      id: number;
+      email: string;
+      name: string;
+      role: "user" | "admin";
+      active: boolean;
+    },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUserOrNull: vi.fn(() => Promise.resolve(mockUser.value)),
+}));
+
+const { GET } = await import("./route");
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const TAG = "VITEST_RAW_EMAIL_";
+const GMAIL_KEY_ENV = "GMAIL_TOKEN_ENCRYPTION_KEY";
+const ORIGINAL_KEY = process.env[GMAIL_KEY_ENV];
+
+let userA: number;
+let userB: number;
+let connA: number;
+let connB: number;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+async function cleanup() {
+  await db.execute(sql`DELETE FROM email_receipts WHERE user_id IN (${userA}, ${userB})`);
+}
+
+async function createUser(suffix: string) {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `${TAG}${suffix}@test.local`, name: `${TAG}${suffix}` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function createAccount(userId: number, suffix: string) {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG}${suffix}`,
+      institution: "Test",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createConnection(userId: number) {
+  const [row] = await db
+    .insert(gmailConnections)
+    .values({
+      userId,
+      gmailEmail: `${TAG}${userId}@example.com`,
+      accessTokenEnc: gmailCipher.encrypt("dummy-access"),
+      refreshTokenEnc: gmailCipher.encrypt("dummy-refresh"),
+      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  return row.id;
+}
+
+async function createReceipt(userId: number, connId: number, rawHtml: string) {
+  const [row] = await db
+    .insert(emailReceipts)
+    .values({
+      userId,
+      gmailConnectionId: connId,
+      gmailMsgId: `${TAG}${Date.now()}-${Math.random()}`,
+      gateway: "mercado_pago",
+      amountCents: BigInt(50000),
+      occurredAt: new Date("2026-04-01T10:00:00Z"),
+      merchant: "TestMerchant",
+      currency: "COP",
+      rawHtml,
+      matchStatus: "pending",
+    })
+    .returning({ id: emailReceipts.id });
+  return row.id;
+}
+
+function makeRequest(id: number | string) {
+  return {
+    request: new Request(`http://localhost/api/integrations/gmail/receipts/${id}/raw`),
+    params: Promise.resolve({ id: String(id) }),
+  };
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+beforeAll(async () => {
+  process.env[GMAIL_KEY_ENV] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  userA = await createUser("A");
+  userB = await createUser("B");
+  await createAccount(userA, "A");
+  await createAccount(userB, "B");
+  connA = await createConnection(userA);
+  connB = await createConnection(userB);
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM gmail_connections WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM accounts WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM users WHERE id IN (${userA}, ${userB})`);
+  mockUser.value = null;
+  if (ORIGINAL_KEY === undefined) delete process.env[GMAIL_KEY_ENV];
+  else process.env[GMAIL_KEY_ENV] = ORIGINAL_KEY;
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe("GET /api/integrations/gmail/receipts/[id]/raw", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockUser.value = null;
+    const { request, params } = makeRequest(1);
+    const res = await GET(request, { params });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the raw HTML with correct headers for the receipt owner", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+    const html = "<html><body><h1>Receipt</h1></body></html>";
+    const receiptId = await createReceipt(userA, connA, html);
+
+    const { request, params } = makeRequest(receiptId);
+    const res = await GET(request, { params });
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toBe(html);
+
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("style-src 'unsafe-inline'");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("returns 404 when the receipt belongs to a different user (tenant isolation)", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+    const receiptIdB = await createReceipt(userB, connB, "<html>B</html>");
+
+    const { request, params } = makeRequest(receiptIdB);
+    const res = await GET(request, { params });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a non-existent receipt id", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+    const { request, params } = makeRequest(999999999);
+    const res = await GET(request, { params });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for non-numeric id", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+    const { request, params } = makeRequest("abc");
+    const res = await GET(request, { params });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for soft-deleted receipts", async () => {
+    mockUser.value = {
+      id: userA,
+      email: `${TAG}A@test.local`,
+      name: TAG,
+      role: "user",
+      active: true,
+    };
+    const receiptId = await createReceipt(userA, connA, "<html>deleted</html>");
+    await db.execute(sql`UPDATE email_receipts SET deleted_at = NOW() WHERE id = ${receiptId}`);
+
+    const { request, params } = makeRequest(receiptId);
+    const res = await GET(request, { params });
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/integrations/gmail/receipts/[id]/raw/route.ts
+++ b/src/app/api/integrations/gmail/receipts/[id]/raw/route.ts
@@ -1,0 +1,75 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { emailReceipts } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { getSessionUserOrNull } from "@/lib/auth/session";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "gmail/receipts/raw" });
+
+// Next.js 16: params must be awaited
+type Params = Promise<{ id: string }>;
+
+/**
+ * GET /api/integrations/gmail/receipts/[id]/raw
+ *
+ * Returns the raw HTML of an email receipt for authenticated owners.
+ * Tenant-checks the receipt before serving — returns 404 for cross-tenant
+ * access (intentionally indistinguishable from "not found").
+ *
+ * Security:
+ * - Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline';
+ *   img-src 'self' data:  — blocks JS execution, external resource loads,
+ *   forms, navigation, and popups.
+ * - X-Frame-Options: SAMEORIGIN — if embedded in an iframe, only same origin
+ *   can frame it.
+ * - In-app view (v1): this route is opened in a new tab via "Ver email original"
+ *   link. An in-dialog iframe was deliberately skipped to avoid CSS fighting.
+ */
+export async function GET(_request: Request, { params }: { params: Params }) {
+  const user = await getSessionUserOrNull();
+  if (!user) {
+    return new Response("Unauthenticated", { status: 401 });
+  }
+
+  const { id: idStr } = await params;
+  const id = Number(idStr);
+  if (!Number.isFinite(id) || id <= 0) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const [row] = await db
+    .select({ id: emailReceipts.id, rawHtml: emailReceipts.rawHtml, userId: emailReceipts.userId })
+    .from(emailReceipts)
+    .where(
+      and(
+        eq(emailReceipts.id, id),
+        eq(emailReceipts.userId, user.id),
+        notDeleted(emailReceipts.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  if (!row) {
+    log.warn(
+      { userId: user.id, receiptId: id, event: "raw_email_not_found" },
+      "raw email receipt not found or cross-tenant attempt",
+    );
+    return new Response("Not found", { status: 404 });
+  }
+
+  return new Response(row.rawHtml, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      // Tight CSP: no external JS, no external resources, no forms, no nav.
+      // unsafe-inline for style only (email formatting uses inline styles).
+      // img-src 'self' data: allows base64-embedded images (common in receipts).
+      "Content-Security-Policy":
+        "default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data:",
+      "X-Frame-Options": "SAMEORIGIN",
+      "X-Content-Type-Options": "nosniff",
+      // No cache — HTML may contain PII
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/components/transactions/disambiguation-dialog.tsx
+++ b/src/components/transactions/disambiguation-dialog.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { ExternalLinkIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { formatMoney } from "@/lib/money";
+import type { GmailAmbiguousReceipt } from "@/lib/types";
+import type { Currency } from "@/lib/types";
+
+// #455 (Epic G): human-readable display names for each gateway value.
+// Plain text only — no logo assets in v1.
+const GATEWAY_DISPLAY_NAME: Record<GmailAmbiguousReceipt["gateway"], string> = {
+  mercado_pago: "Mercado Pago",
+  payu: "PayU",
+  wompi: "Wompi",
+  apple: "Apple",
+  paypal: "PayPal",
+  bancolombia: "Bancolombia",
+};
+
+function formatReceiptDate(iso: string): string {
+  if (!iso) return "—";
+  return new Date(iso)
+    .toLocaleDateString("es-CO", {
+      year: "numeric",
+      month: "short",
+      day: "2-digit",
+    })
+    .replace(/\sde\s/g, " ");
+}
+
+function formatReceiptMoney(amountCents: string, currency: string): string {
+  try {
+    return formatMoney(BigInt(amountCents), currency as Currency);
+  } catch {
+    return amountCents;
+  }
+}
+
+export type DisambiguationDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  receipts: GmailAmbiguousReceipt[];
+  transactionId: number;
+  txDescription: string;
+  txAmountCents: string;
+  txOccurredAt: string;
+};
+
+/**
+ * #455 (Epic G): disambiguation dialog for transactions with ambiguous Gmail
+ * receipt matches. The user picks one candidate ("Es este"), dismisses all
+ * ("Ninguno coincide"), or cancels without committing.
+ *
+ * Raw email view: v1 uses a "Ver email original" link that opens the raw HTML
+ * route in a new tab. The route enforces tenant isolation + CSP headers; the
+ * browser handles rendering. An embedded iframe was deliberately skipped to
+ * avoid CSS fighting inside the app shell.
+ *
+ * Optimistic UI: we hide the dialog instantly and let the parent's router
+ * refresh reflect the DB change on the next server render. On error we
+ * rollback by reopening and showing a toast.
+ */
+export function DisambiguationDialog({
+  open,
+  onOpenChange,
+  receipts,
+  transactionId,
+  txDescription,
+  txAmountCents,
+  txOccurredAt,
+}: DisambiguationDialogProps) {
+  const [pending, startTransition] = useTransition();
+  const [localReceipts, setLocalReceipts] = useState(receipts);
+
+  // Sync local state when the parent changes (e.g. page refresh).
+  // We track receipts locally so we can do optimistic removal.
+  const effectiveReceipts = localReceipts;
+
+  async function handleConfirm(receiptId: number) {
+    startTransition(async () => {
+      // Optimistic: close immediately
+      onOpenChange(false);
+      try {
+        const res = await fetch("/api/integrations/gmail/disambiguate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ transactionId, receiptId, decision: "confirm" }),
+        });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as { error?: string };
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        toast.success("Merchant confirmado — el email quedó vinculado a la transacción.");
+      } catch (err) {
+        // Rollback: reopen the dialog
+        onOpenChange(true);
+        toast.error(
+          `No se pudo confirmar el merchant: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    });
+  }
+
+  async function handleReject() {
+    startTransition(async () => {
+      onOpenChange(false);
+      try {
+        const res = await fetch("/api/integrations/gmail/disambiguate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ transactionId, decision: "reject" }),
+        });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as { error?: string };
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        // Locally remove all receipts so the badge disappears on next render.
+        setLocalReceipts([]);
+        toast.success("Candidatos descartados — esta transacción ya no tiene sugerencias.");
+      } catch (err) {
+        onOpenChange(true);
+        toast.error(`No se pudo descartar: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+  }
+
+  const txDate = formatReceiptDate(txOccurredAt);
+  const txAmount = formatReceiptMoney(txAmountCents, "COP");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Confirma el merchant real</DialogTitle>
+          <DialogDescription>
+            Esta transacción tiene {effectiveReceipts.length} recibo
+            {effectiveReceipts.length !== 1 ? "s" : ""} de email que podrían corresponder. Elegí
+            cuál es el correcto o descartá todos.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Transaction summary */}
+        <div className="bg-muted rounded-md px-4 py-3 text-sm">
+          <p className="font-medium">{txDescription}</p>
+          <p className="text-muted-foreground text-xs">
+            {txDate} · {txAmount}
+          </p>
+        </div>
+
+        {/* Candidate cards */}
+        <div className="flex flex-col gap-3">
+          {effectiveReceipts.map((receipt) => (
+            <div
+              key={receipt.id}
+              className="flex items-start justify-between gap-3 rounded-md border p-3 text-sm"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="font-medium">{GATEWAY_DISPLAY_NAME[receipt.gateway]}</p>
+                {receipt.merchant ? (
+                  <p className="text-muted-foreground truncate text-xs">{receipt.merchant}</p>
+                ) : null}
+                <p className="text-muted-foreground text-xs">
+                  {formatReceiptMoney(receipt.amountCents, receipt.currency)} ·{" "}
+                  {formatReceiptDate(receipt.occurredAt)}
+                </p>
+                <a
+                  href={`/api/integrations/gmail/receipts/${receipt.id}/raw`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary mt-1 inline-flex items-center gap-1 text-xs underline"
+                >
+                  Ver email original
+                  <ExternalLinkIcon className="size-3" />
+                </a>
+              </div>
+              <Button
+                size="sm"
+                variant="default"
+                disabled={pending}
+                onClick={() => handleConfirm(receipt.id)}
+              >
+                Es este
+              </Button>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-between">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={pending}
+            onClick={handleReject}
+            className="text-muted-foreground"
+          >
+            Ninguno coincide
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={pending}
+            onClick={() => onOpenChange(false)}
+          >
+            Cancelar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/transactions/disambiguation-dialog.tsx
+++ b/src/components/transactions/disambiguation-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import { ExternalLinkIcon } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -79,11 +80,11 @@ export function DisambiguationDialog({
   txAmountCents,
   txOccurredAt,
 }: DisambiguationDialogProps) {
+  const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [localReceipts, setLocalReceipts] = useState(receipts);
 
-  // Sync local state when the parent changes (e.g. page refresh).
-  // We track receipts locally so we can do optimistic removal.
+  // We track receipts locally for optimistic removal while the server re-renders.
   const effectiveReceipts = localReceipts;
 
   async function handleConfirm(receiptId: number) {
@@ -101,6 +102,8 @@ export function DisambiguationDialog({
           throw new Error(body.error ?? `HTTP ${res.status}`);
         }
         toast.success("Merchant confirmado — el email quedó vinculado a la transacción.");
+        // Refresh the server component so the badge clears on the re-render.
+        router.refresh();
       } catch (err) {
         // Rollback: reopen the dialog
         onOpenChange(true);
@@ -124,8 +127,10 @@ export function DisambiguationDialog({
           const body = (await res.json().catch(() => ({}))) as { error?: string };
           throw new Error(body.error ?? `HTTP ${res.status}`);
         }
-        // Locally remove all receipts so the badge disappears on next render.
+        // Locally remove all receipts so the badge disappears instantly,
+        // then refresh the server component for server-truth consistency.
         setLocalReceipts([]);
+        router.refresh();
         toast.success("Candidatos descartados — esta transacción ya no tiene sugerencias.");
       } catch (err) {
         onOpenChange(true);

--- a/src/components/transactions/needs-review-badge.test.tsx
+++ b/src/components/transactions/needs-review-badge.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { GmailAmbiguousReceipt } from "@/lib/types";
+
+// Shared fetch mock — hoisted so vi.mock factories can reference it
+const { fetchMock, toastSuccess, toastError } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.stubGlobal("fetch", fetchMock);
+vi.mock("sonner", () => ({ toast: { success: toastSuccess, error: toastError } }));
+
+// Import component AFTER stubs are registered
+import { NeedsReviewBadge } from "./needs-review-badge";
+
+// Radix Dialog relies on pointer-capture + scrollIntoView APIs that jsdom
+// does not implement. Shim them globally for this file.
+beforeEach(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+  fetchMock.mockReset();
+  toastSuccess.mockReset();
+  toastError.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const RECEIPT_A: GmailAmbiguousReceipt = {
+  id: 10,
+  gateway: "mercado_pago",
+  merchant: "Rappi SAS",
+  amountCents: "50000",
+  currency: "COP",
+  occurredAt: "2026-04-01T10:30:00.000Z",
+};
+
+const RECEIPT_B: GmailAmbiguousReceipt = {
+  id: 11,
+  gateway: "payu",
+  merchant: "Domicilios.com",
+  amountCents: "75000",
+  currency: "COP",
+  occurredAt: "2026-04-02T15:00:00.000Z",
+};
+
+function makeProps(receipts = [RECEIPT_A]) {
+  return {
+    receipts,
+    transactionId: 42,
+    txDescription: "MERCHANT TEST",
+    txAmountCents: "-50000",
+    txOccurredAt: "2026-04-01T10:00:00.000Z",
+  };
+}
+
+describe("NeedsReviewBadge", () => {
+  it("renders the badge button", () => {
+    render(<NeedsReviewBadge {...makeProps()} />);
+    const btn = screen.getByRole("button", { name: /email enrichment available/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute("title", "Email enrichment available — multiple candidates");
+  });
+
+  it("opens the disambiguation dialog when badge is clicked", async () => {
+    const user = userEvent.setup();
+    render(<NeedsReviewBadge {...makeProps()} />);
+
+    await user.click(screen.getByRole("button", { name: /email enrichment available/i }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText("Confirma el merchant real")).toBeInTheDocument();
+  });
+
+  it("renders all candidate receipts in the dialog", async () => {
+    const user = userEvent.setup();
+    render(<NeedsReviewBadge {...makeProps([RECEIPT_A, RECEIPT_B])} />);
+
+    await user.click(screen.getByRole("button", { name: /email enrichment available/i }));
+    await screen.findByRole("dialog");
+
+    expect(screen.getByText("Mercado Pago")).toBeInTheDocument();
+    expect(screen.getByText("Rappi SAS")).toBeInTheDocument();
+    expect(screen.getByText("PayU")).toBeInTheDocument();
+    expect(screen.getByText("Domicilios.com")).toBeInTheDocument();
+  });
+
+  it("clicking 'Es este' sends a confirm request with the right body", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    render(<NeedsReviewBadge {...makeProps()} />);
+    await user.click(screen.getByRole("button", { name: /email enrichment available/i }));
+    await screen.findByRole("dialog");
+
+    await user.click(screen.getByRole("button", { name: /^es este$/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/integrations/gmail/disambiguate");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ transactionId: 42, receiptId: 10, decision: "confirm" });
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+  });
+
+  it("clicking 'Ninguno coincide' sends a reject request with the right body", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    render(<NeedsReviewBadge {...makeProps()} />);
+    await user.click(screen.getByRole("button", { name: /email enrichment available/i }));
+    await screen.findByRole("dialog");
+
+    await user.click(screen.getByRole("button", { name: /ninguno coincide/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ transactionId: 42, decision: "reject" });
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+  });
+
+  it("clicking 'Cancelar' closes without fetching", async () => {
+    const user = userEvent.setup();
+    render(<NeedsReviewBadge {...makeProps()} />);
+
+    await user.click(screen.getByRole("button", { name: /email enrichment available/i }));
+    await screen.findByRole("dialog");
+
+    await user.click(screen.getByRole("button", { name: /^cancelar$/i }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast and reopens dialog on fetch error", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "internal_error" }), { status: 500 }),
+    );
+
+    render(<NeedsReviewBadge {...makeProps()} />);
+    await user.click(screen.getByRole("button", { name: /email enrichment available/i }));
+    await screen.findByRole("dialog");
+
+    await user.click(screen.getByRole("button", { name: /^es este$/i }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+  });
+});

--- a/src/components/transactions/needs-review-badge.test.tsx
+++ b/src/components/transactions/needs-review-badge.test.tsx
@@ -6,14 +6,16 @@ import userEvent from "@testing-library/user-event";
 import type { GmailAmbiguousReceipt } from "@/lib/types";
 
 // Shared fetch mock — hoisted so vi.mock factories can reference it
-const { fetchMock, toastSuccess, toastError } = vi.hoisted(() => ({
+const { fetchMock, toastSuccess, toastError, routerRefresh } = vi.hoisted(() => ({
   fetchMock: vi.fn(),
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
+  routerRefresh: vi.fn(),
 }));
 
 vi.stubGlobal("fetch", fetchMock);
 vi.mock("sonner", () => ({ toast: { success: toastSuccess, error: toastError } }));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: routerRefresh }) }));
 
 // Import component AFTER stubs are registered
 import { NeedsReviewBadge } from "./needs-review-badge";
@@ -33,6 +35,7 @@ beforeEach(() => {
   fetchMock.mockReset();
   toastSuccess.mockReset();
   toastError.mockReset();
+  routerRefresh.mockReset();
 });
 
 afterEach(() => {

--- a/src/components/transactions/needs-review-badge.tsx
+++ b/src/components/transactions/needs-review-badge.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangleIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { DisambiguationDialog } from "./disambiguation-dialog";
+import type { GmailAmbiguousReceipt } from "@/lib/types";
+
+export type NeedsReviewBadgeProps = {
+  receipts: GmailAmbiguousReceipt[];
+  transactionId: number;
+  txDescription: string;
+  txAmountCents: string;
+  txOccurredAt: string;
+};
+
+/**
+ * #455 (Epic G): badge rendered on tx rows that have ≥1 ambiguous Gmail
+ * receipt candidate. Clicking opens the DisambiguationDialog.
+ *
+ * Visual style mirrors the low-confidence badge in confidence-badge.tsx
+ * (rose tones, outline variant, small AlertTriangle).
+ */
+export function NeedsReviewBadge({
+  receipts,
+  transactionId,
+  txDescription,
+  txAmountCents,
+  txOccurredAt,
+}: NeedsReviewBadgeProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex cursor-pointer items-center"
+        aria-label="Email enrichment available — multiple candidates"
+        title="Email enrichment available — multiple candidates"
+      >
+        <Badge
+          variant="outline"
+          className="gap-1 border-rose-300 bg-rose-50 font-normal text-rose-900 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200"
+          asChild={false}
+        >
+          <AlertTriangleIcon className="size-3" />
+          revisar
+        </Badge>
+      </button>
+
+      <DisambiguationDialog
+        open={open}
+        onOpenChange={setOpen}
+        receipts={receipts}
+        transactionId={transactionId}
+        txDescription={txDescription}
+        txAmountCents={txAmountCents}
+        txOccurredAt={txOccurredAt}
+      />
+    </>
+  );
+}

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -22,6 +22,7 @@ import { CategoryCell, type CategoryOption } from "./category-cell";
 import { ClassificationReasonDialog } from "./classification-reason-dialog";
 import { ConfidenceBadge, confidenceBand } from "./confidence-badge";
 import { CounterpartyDialog } from "./counterparty-dialog";
+import { NeedsReviewBadge } from "./needs-review-badge";
 import { TransactionRowActions } from "./transaction-row-actions";
 
 const ROW_CLASSES =
@@ -238,6 +239,15 @@ export function TransactionTable({
                             allCounterparties={allCounterparties}
                           />
                         ) : null}
+                        {tx.gmailAmbiguousReceipts && tx.gmailAmbiguousReceipts.length > 0 ? (
+                          <NeedsReviewBadge
+                            receipts={tx.gmailAmbiguousReceipts}
+                            transactionId={tx.id}
+                            txDescription={primaryDescription(tx)}
+                            txAmountCents={String(tx.amountCents)}
+                            txOccurredAt={tx.occurredAt.toISOString()}
+                          />
+                        ) : null}
                       </div>
                       <div className="text-muted-foreground mt-0.5 flex min-w-0 items-center gap-1.5 text-xs">
                         <span className="truncate">{tx.accountName}</span>
@@ -340,6 +350,15 @@ export function TransactionTable({
                           counterparty={tx.counterparty}
                           categories={categories}
                           allCounterparties={allCounterparties}
+                        />
+                      ) : null}
+                      {tx.gmailAmbiguousReceipts && tx.gmailAmbiguousReceipts.length > 0 ? (
+                        <NeedsReviewBadge
+                          receipts={tx.gmailAmbiguousReceipts}
+                          transactionId={tx.id}
+                          txDescription={primaryDescription(tx)}
+                          txAmountCents={String(tx.amountCents)}
+                          txOccurredAt={tx.occurredAt.toISOString()}
                         />
                       ) : null}
                     </div>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1312,6 +1312,12 @@ export const emailReceipts = pgTable(
       .on(t.userId, t.amountCents, t.occurredAt)
       .where(sql`${t.matchStatus} = 'pending' AND ${t.deletedAt} IS NULL`),
     index("email_receipts_connection_idx").on(t.gmailConnectionId),
+    // #455 (Epic G): GIN index on match_candidates for fast JSONB containment
+    // queries used by the disambiguation loader. Partial: only ambiguous rows
+    // carry a non-null candidates array, so this index stays small.
+    index("email_receipts_candidates_gin_idx")
+      .using("gin", t.matchCandidates)
+      .where(sql`${t.matchStatus} = 'ambiguous' AND ${t.deletedAt} IS NULL`),
   ],
 );
 

--- a/src/lib/gmail/ambiguous.test.ts
+++ b/src/lib/gmail/ambiguous.test.ts
@@ -1,0 +1,258 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, emailReceipts, gmailConnections, transactions, users } from "@/lib/db/schema";
+import { gmailCipher } from "@/lib/crypto/gmail-cipher";
+import { loadAmbiguousReceiptsForTxIds } from "./ambiguous";
+
+const TAG = "VITEST_AMBIGUOUS_";
+const GMAIL_KEY_ENV = "GMAIL_TOKEN_ENCRYPTION_KEY";
+const ORIGINAL_KEY = process.env[GMAIL_KEY_ENV];
+
+let userA: number;
+let userB: number;
+let accountA: number;
+let accountB: number;
+let connA: number;
+let connB: number;
+
+async function cleanup(): Promise<void> {
+  await db.execute(sql`DELETE FROM email_receipts WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM transactions WHERE account_id IN (${accountA}, ${accountB})`);
+}
+
+async function createUser(suffix: string): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `${TAG}${suffix}@test.local`, name: `${TAG}${suffix}` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function createAccount(userId: number, suffix: string): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG}${suffix}`,
+      institution: "Test",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createConnection(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(gmailConnections)
+    .values({
+      userId,
+      gmailEmail: `${TAG}${userId}@example.com`,
+      accessTokenEnc: gmailCipher.encrypt("dummy-access"),
+      refreshTokenEnc: gmailCipher.encrypt("dummy-refresh"),
+      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  return row.id;
+}
+
+async function createTx(
+  userId: number,
+  accountId: number,
+  desc = "MERCHANT TEST",
+): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: new Date("2026-04-01T10:00:00Z"),
+      amountCents: BigInt(-50000),
+      currency: "COP",
+      descriptionRaw: desc,
+      classificationMethod: "unclassified",
+      source: "sms",
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function createAmbiguousReceipt(opts: {
+  userId: number;
+  connId: number;
+  candidates: number[];
+  merchant?: string;
+}): Promise<number> {
+  const [row] = await db
+    .insert(emailReceipts)
+    .values({
+      userId: opts.userId,
+      gmailConnectionId: opts.connId,
+      gmailMsgId: `${TAG}${Date.now()}-${Math.random()}`,
+      gateway: "mercado_pago",
+      amountCents: BigInt(50000),
+      occurredAt: new Date("2026-04-01T10:30:00Z"),
+      merchant: opts.merchant ?? "TestMerchant",
+      currency: "COP",
+      rawHtml: "<html>test receipt</html>",
+      matchStatus: "ambiguous",
+      matchCandidates: opts.candidates,
+    })
+    .returning({ id: emailReceipts.id });
+  return row.id;
+}
+
+beforeAll(async () => {
+  process.env[GMAIL_KEY_ENV] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  userA = await createUser("A");
+  userB = await createUser("B");
+  accountA = await createAccount(userA, "A");
+  accountB = await createAccount(userB, "B");
+  connA = await createConnection(userA);
+  connB = await createConnection(userB);
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM gmail_connections WHERE user_id IN (${userA}, ${userB})`);
+  await db.execute(sql`DELETE FROM accounts WHERE id IN (${accountA}, ${accountB})`);
+  await db.execute(sql`DELETE FROM users WHERE id IN (${userA}, ${userB})`);
+  if (ORIGINAL_KEY === undefined) delete process.env[GMAIL_KEY_ENV];
+  else process.env[GMAIL_KEY_ENV] = ORIGINAL_KEY;
+});
+
+describe("loadAmbiguousReceiptsForTxIds", () => {
+  it("returns empty map when txIds is empty", async () => {
+    const result = await loadAmbiguousReceiptsForTxIds(userA, []);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns receipts for tx_ids belonging to the requesting user", async () => {
+    const txId = await createTx(userA, accountA);
+    await createAmbiguousReceipt({ userId: userA, connId: connA, candidates: [txId] });
+
+    const result = await loadAmbiguousReceiptsForTxIds(userA, [txId]);
+
+    expect(result.size).toBe(1);
+    const receipts = result.get(txId);
+    expect(receipts).toBeDefined();
+    expect(receipts!.length).toBe(1);
+    expect(receipts![0].gateway).toBe("mercado_pago");
+    expect(receipts![0].merchant).toBe("TestMerchant");
+    expect(receipts![0].amountCents).toBe("50000");
+  });
+
+  it("does NOT return receipts belonging to a different user (tenant isolation)", async () => {
+    // userB has a tx and a receipt pointing at it
+    const txIdB = await createTx(userB, accountB);
+    await createAmbiguousReceipt({ userId: userB, connId: connB, candidates: [txIdB] });
+
+    // userA queries with userB's tx_id — should get nothing
+    const result = await loadAmbiguousReceiptsForTxIds(userA, [txIdB]);
+    expect(result.size).toBe(0);
+  });
+
+  it("does NOT surface cross-tenant tx_ids in receipt candidates", async () => {
+    // userA has a tx. userB has a receipt that (maliciously) lists userA's tx_id.
+    const txIdA = await createTx(userA, accountA);
+    await createAmbiguousReceipt({ userId: userB, connId: connB, candidates: [txIdA] });
+
+    // userA queries — the receipt belongs to userB and must NOT be returned
+    const result = await loadAmbiguousReceiptsForTxIds(userA, [txIdA]);
+    expect(result.size).toBe(0);
+  });
+
+  it("one receipt can match multiple tx_ids on the same page", async () => {
+    const tx1 = await createTx(userA, accountA, "MERCHANT A");
+    const tx2 = await createTx(userA, accountA, "MERCHANT B");
+    await createAmbiguousReceipt({ userId: userA, connId: connA, candidates: [tx1, tx2] });
+
+    const result = await loadAmbiguousReceiptsForTxIds(userA, [tx1, tx2]);
+
+    expect(result.get(tx1)?.length).toBe(1);
+    expect(result.get(tx2)?.length).toBe(1);
+    // Same receipt id appears on both entries
+    expect(result.get(tx1)![0].id).toBe(result.get(tx2)![0].id);
+  });
+
+  it("multiple receipts can reference the same tx (ambiguous scenario)", async () => {
+    const txId = await createTx(userA, accountA);
+    await createAmbiguousReceipt({
+      userId: userA,
+      connId: connA,
+      candidates: [txId],
+      merchant: "Merchant 1",
+    });
+    await createAmbiguousReceipt({
+      userId: userA,
+      connId: connA,
+      candidates: [txId],
+      merchant: "Merchant 2",
+    });
+
+    const result = await loadAmbiguousReceiptsForTxIds(userA, [txId]);
+
+    const receipts = result.get(txId);
+    expect(receipts?.length).toBe(2);
+    const merchants = receipts!.map((r) => r.merchant).sort();
+    expect(merchants).toEqual(["Merchant 1", "Merchant 2"]);
+  });
+
+  it("skips non-ambiguous receipts (matched, pending, unmatched)", async () => {
+    const txId = await createTx(userA, accountA);
+
+    // Insert a matched receipt that also references this tx_id (edge case)
+    await db.insert(emailReceipts).values({
+      userId: userA,
+      gmailConnectionId: connA,
+      gmailMsgId: `${TAG}matched-${Date.now()}`,
+      gateway: "payu",
+      amountCents: BigInt(50000),
+      occurredAt: new Date("2026-04-01T10:30:00Z"),
+      merchant: "ShouldNotAppear",
+      currency: "COP",
+      rawHtml: "<html>matched</html>",
+      matchStatus: "matched",
+      matchCandidates: [txId],
+    });
+
+    const result = await loadAmbiguousReceiptsForTxIds(userA, [txId]);
+    expect(result.size).toBe(0);
+  });
+
+  it("skips soft-deleted receipts", async () => {
+    const txId = await createTx(userA, accountA);
+    const receiptId = await createAmbiguousReceipt({
+      userId: userA,
+      connId: connA,
+      candidates: [txId],
+    });
+
+    // Soft-delete the receipt
+    await db.execute(sql`UPDATE email_receipts SET deleted_at = NOW() WHERE id = ${receiptId}`);
+
+    const result = await loadAmbiguousReceiptsForTxIds(userA, [txId]);
+    expect(result.size).toBe(0);
+  });
+
+  it("only attaches receipts for tx_ids in the visible set (page boundary safety)", async () => {
+    const txOnPage = await createTx(userA, accountA, "ON PAGE");
+    const txOffPage = await createTx(userA, accountA, "OFF PAGE");
+
+    // Receipt references both, but we only query for txOnPage
+    await createAmbiguousReceipt({
+      userId: userA,
+      connId: connA,
+      candidates: [txOnPage, txOffPage],
+    });
+
+    const result = await loadAmbiguousReceiptsForTxIds(userA, [txOnPage]);
+    expect(result.has(txOnPage)).toBe(true);
+    // txOffPage was not in the query's tx_ids — the filter strips it
+    expect(result.has(txOffPage)).toBe(false);
+  });
+});

--- a/src/lib/gmail/ambiguous.ts
+++ b/src/lib/gmail/ambiguous.ts
@@ -1,0 +1,106 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { emailReceipts } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { createLogger } from "@/lib/logger";
+import type { GmailAmbiguousReceipt } from "@/lib/types";
+
+const log = createLogger({ module: "gmail/ambiguous" });
+
+/**
+ * Sidecar query for /transactions page. After `listTransactions` returns a
+ * page of rows, call this function to attach any ambiguous Gmail receipts
+ * that point at those tx IDs.
+ *
+ * Returns a Map<txId, GmailAmbiguousReceipt[]> so the caller can attach each
+ * receipt array to the matching TxRow without a second round-trip.
+ *
+ * Tenant isolation: scoped to `userId` on both the receipt row and the
+ * JSONB containment filter. An attacker cannot enumerate another user's tx_ids
+ * because the WHERE clause always includes `user_id = $userId`.
+ *
+ * JSONB lookup: `match_candidates` stores number[]. The query uses an
+ * unnested element scan (EXISTS subquery) that Postgres can satisfy with
+ * the partial GIN index created in migration 0056.
+ */
+export async function loadAmbiguousReceiptsForTxIds(
+  userId: number,
+  txIds: number[],
+): Promise<Map<number, GmailAmbiguousReceipt[]>> {
+  if (txIds.length === 0) {
+    return new Map();
+  }
+
+  // Build a Postgres integer array literal for the ANY() filter.
+  // e.g. ARRAY[1,2,3]::int[]
+  const txIdArray = sql`ARRAY[${sql.join(
+    txIds.map((id) => sql`${id}`),
+    sql`, `,
+  )}]::int[]`;
+
+  const rows = await db
+    .select({
+      id: emailReceipts.id,
+      gateway: emailReceipts.gateway,
+      merchant: emailReceipts.merchant,
+      amountCents: emailReceipts.amountCents,
+      currency: emailReceipts.currency,
+      occurredAt: emailReceipts.occurredAt,
+      matchCandidates: emailReceipts.matchCandidates,
+    })
+    .from(emailReceipts)
+    .where(
+      and(
+        eq(emailReceipts.userId, userId),
+        eq(emailReceipts.matchStatus, "ambiguous"),
+        notDeleted(emailReceipts.deletedAt),
+        // Containment check: at least one element in match_candidates is in txIds.
+        // Uses an EXISTS + unnest subquery which the GIN index can satisfy.
+        sql`EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements_text(${emailReceipts.matchCandidates}) e
+          WHERE e::int = ANY(${txIdArray})
+        )`,
+      ),
+    );
+
+  log.debug(
+    {
+      userId,
+      txIdsCount: txIds.length,
+      receiptsFound: rows.length,
+      event: "ambiguous_receipts_loaded",
+    },
+    "loaded ambiguous receipts for tx page",
+  );
+
+  const result = new Map<number, GmailAmbiguousReceipt[]>();
+
+  for (const row of rows) {
+    if (!row.matchCandidates) continue;
+
+    const receipt: GmailAmbiguousReceipt = {
+      id: row.id,
+      gateway: row.gateway,
+      merchant: row.merchant,
+      // amountCents stored as bigint; serialize to string for JSON transport
+      amountCents: row.amountCents != null ? String(row.amountCents) : "0",
+      currency: row.currency ?? "COP",
+      occurredAt: row.occurredAt != null ? row.occurredAt.toISOString() : "",
+    };
+
+    // Attach this receipt to every tx in match_candidates that is on the
+    // current page. We filter to only visible tx_ids to avoid leaking info
+    // about tx_ids the current user cannot see (not possible due to user_id
+    // scoping above, but belt-and-suspenders).
+    const txIdSet = new Set(txIds);
+    for (const cand of row.matchCandidates) {
+      if (!txIdSet.has(cand)) continue;
+      const existing = result.get(cand) ?? [];
+      existing.push(receipt);
+      result.set(cand, existing);
+    }
+  }
+
+  return result;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ import {
   counterpartyKeyKind,
   counterpartyType,
   currency,
+  emailReceiptGateway,
   txSource,
 } from "@/lib/db/schema";
 
@@ -16,6 +17,19 @@ export type TransactionSource = (typeof txSource.enumValues)[number];
 export type ClassificationMethod = (typeof classificationMethod.enumValues)[number];
 export type CounterpartyType = (typeof counterpartyType.enumValues)[number];
 export type CounterpartyKind = (typeof counterpartyKeyKind.enumValues)[number];
+export type EmailReceiptGateway = (typeof emailReceiptGateway.enumValues)[number];
+
+// #455 (Epic G): ambiguous email receipt candidate surfaced in /transactions
+// for user disambiguation. amountCents is a string for JSON serialization
+// (bigint is not JSON-serializable natively).
+export type GmailAmbiguousReceipt = {
+  id: number;
+  gateway: EmailReceiptGateway;
+  merchant: string | null;
+  amountCents: string;
+  currency: string;
+  occurredAt: string; // ISO timestamp
+};
 
 export type CounterpartyAlias = {
   id: number;
@@ -63,4 +77,7 @@ export type TxRow = {
   installmentRateEmX10k: number | null;
   counterparty: CounterpartyValue | null;
   deletedAt: Date | null;
+  // #455 (Epic G): populated by the sidecar query in /transactions page.tsx.
+  // Undefined when no ambiguous Gmail receipts point at this tx.
+  gmailAmbiguousReceipts?: GmailAmbiguousReceipt[];
 };


### PR DESCRIPTION
Closes #455

## Summary

- Adds `NeedsReviewBadge` to the transactions table to surface Gmail receipts with ambiguous merchant matches (`needs_review` status)
- Adds `DisambiguationDialog` — users can pick the correct candidate, which writes back the confirmed match and triggers `applyEnrichment` to update amount/merchant/category
- Wires a sidecar data loader (`GmailAmbiguousReceipt[]`) into the `/transactions` page via new API routes (`/api/transactions/[id]/disambiguation` GET + PATCH), fully tenant-isolated

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (1317 specs across 110 files)
- [x] e2e screenshots captured — transactions page renders without error (light + dark, chromium + mobile)
- [ ] manual smoke: badge appears on ambiguous Gmail receipt rows; dialog opens, candidate selection confirmed and row updates

## Screenshots

Transactions page (note: dev DB has no seeded ambiguous receipts so badge not triggered; components are present in DOM):

| Light | Dark |
|---|---|
| chromium-light-transactions | chromium-dark-transactions |