### PR TITLE
feat(infra): extend gmail-pull cron route with opts (#486)

### DIFF
--- a/src/app/api/cron/gmail-pull/route.test.ts
+++ b/src/app/api/cron/gmail-pull/route.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PullResult } from "@/lib/gmail/pull";
+
+// ── Shared mock state (hoisted above module-level const) ──────────────────────
+const mocks = vi.hoisted(() => ({
+  pullForUser: vi.fn<(userId: number, opts: Record<string, unknown>) => Promise<PullResult>>(),
+  pullAllActiveConnections:
+    vi.fn<
+      (deps: Record<string, unknown>, opts: Record<string, unknown>) => Promise<PullResult[]>
+    >(),
+  // DB connection lookup: null by default (no active connection found)
+  dbResult: null as { id: number } | null,
+}));
+
+vi.mock("@/lib/gmail/pull", () => ({
+  pullForUser: mocks.pullForUser,
+  pullAllActiveConnections: mocks.pullAllActiveConnections,
+}));
+
+// Mock the DB connection check. The route calls db.select().from().where().limit(1)
+// which returns a single row or undefined. We intercept via a chainable mock.
+vi.mock("@/lib/db", () => {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn(() => Promise.resolve(mocks.dbResult ? [mocks.dbResult] : [])),
+  };
+  return { db: chain };
+});
+
+// Import the route AFTER mocks are established.
+const { POST } = await import("./route");
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const VALID_TOKEN = "test-cron-token";
+
+function makeRequest(opts: { token?: string | null; body?: unknown }): Request {
+  const headers: Record<string, string> = {};
+  if (opts.token !== null) {
+    headers["authorization"] = `Bearer ${opts.token ?? VALID_TOKEN}`;
+  }
+  let bodyStr: string | undefined;
+  if (opts.body !== undefined) {
+    headers["content-type"] = "application/json";
+    bodyStr = JSON.stringify(opts.body);
+  }
+  return new Request("http://localhost/api/cron/gmail-pull", {
+    method: "POST",
+    headers,
+    body: bodyStr,
+  });
+}
+
+function makeEmptyPullResult(userId = 1): PullResult {
+  return {
+    userId,
+    pulled: 0,
+    skipped: 0,
+    byGateway: {
+      mercado_pago: { pulled: 0, skipped: 0 },
+      payu: { pulled: 0, skipped: 0 },
+      wompi: { pulled: 0, skipped: 0 },
+      apple: { pulled: 0, skipped: 0 },
+      paypal: { pulled: 0, skipped: 0 },
+      bancolombia: { pulled: 0, skipped: 0 },
+    },
+    errors: [],
+    connectionId: 42,
+  };
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  process.env.CRON_TOKEN = VALID_TOKEN;
+  mocks.dbResult = null;
+  vi.clearAllMocks();
+  mocks.pullAllActiveConnections.mockResolvedValue([makeEmptyPullResult(1)]);
+  mocks.pullForUser.mockResolvedValue(makeEmptyPullResult(1));
+});
+
+// ── Auth tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/cron/gmail-pull — auth", () => {
+  it("returns 401 when Authorization header is missing", async () => {
+    const res = await POST(makeRequest({ token: null }));
+    expect(res.status).toBe(401);
+    // Body parsing must NOT happen before auth
+    expect(mocks.pullAllActiveConnections).not.toHaveBeenCalled();
+    expect(mocks.pullForUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when CRON_TOKEN does not match", async () => {
+    const res = await POST(makeRequest({ token: "wrong-token" }));
+    expect(res.status).toBe(401);
+    expect(mocks.pullAllActiveConnections).not.toHaveBeenCalled();
+    expect(mocks.pullForUser).not.toHaveBeenCalled();
+  });
+});
+
+// ── Body validation tests ─────────────────────────────────────────────────────
+
+describe("POST /api/cron/gmail-pull — body validation", () => {
+  it("returns 400 when body is not valid JSON", async () => {
+    const req = new Request("http://localhost/api/cron/gmail-pull", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${VALID_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: "not-json{{{",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("Invalid JSON body");
+  });
+
+  it("returns 400 for unknown field (strict schema)", async () => {
+    const res = await POST(makeRequest({ body: { unknownField: true } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when userId is negative", async () => {
+    const res = await POST(makeRequest({ body: { userId: -1 } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when userId is zero", async () => {
+    const res = await POST(makeRequest({ body: { userId: 0 } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when sinceDays exceeds 3650", async () => {
+    const res = await POST(makeRequest({ body: { sinceDays: 3651 } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for unknown gateway id", async () => {
+    const res = await POST(makeRequest({ body: { gateways: ["wat"] } }));
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── No-body (regular cron tick) ───────────────────────────────────────────────
+
+describe("POST /api/cron/gmail-pull — empty body (regular tick)", () => {
+  it("calls pullAllActiveConnections with empty opts and returns ok", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(200);
+    expect(mocks.pullAllActiveConnections).toHaveBeenCalledOnce();
+    // First arg is deps ({}), second is opts (should be empty or no sinceDays/gateways)
+    const [deps, opts] = mocks.pullAllActiveConnections.mock.calls[0];
+    expect(deps).toEqual({});
+    expect(opts).toEqual({});
+    expect(mocks.pullForUser).not.toHaveBeenCalled();
+    const json = (await res.json()) as { ok: boolean; users: number };
+    expect(json.ok).toBe(true);
+    expect(json.users).toBe(1);
+  });
+});
+
+// ── userId single-user mode ───────────────────────────────────────────────────
+
+describe("POST /api/cron/gmail-pull — userId single-user mode", () => {
+  it("calls pullForUser(N, {}) and skips the all-users path", async () => {
+    mocks.dbResult = { id: 99 };
+    const res = await POST(makeRequest({ body: { userId: 5 } }));
+    expect(res.status).toBe(200);
+    expect(mocks.pullForUser).toHaveBeenCalledOnce();
+    expect(mocks.pullForUser).toHaveBeenCalledWith(5, {});
+    expect(mocks.pullAllActiveConnections).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when user has no active connection", async () => {
+    mocks.dbResult = null; // no active connection
+    const res = await POST(makeRequest({ body: { userId: 5 } }));
+    expect(res.status).toBe(404);
+    expect(mocks.pullForUser).not.toHaveBeenCalled();
+    expect(mocks.pullAllActiveConnections).not.toHaveBeenCalled();
+  });
+
+  it("wraps single-user result in array for consistent response shape", async () => {
+    mocks.dbResult = { id: 99 };
+    mocks.pullForUser.mockResolvedValue({
+      ...makeEmptyPullResult(5),
+      pulled: 12,
+      skipped: 3,
+    });
+    const res = await POST(makeRequest({ body: { userId: 5 } }));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      users: number;
+      pulled: number;
+      skipped: number;
+    };
+    expect(json.ok).toBe(true);
+    expect(json.users).toBe(1);
+    expect(json.pulled).toBe(12);
+    expect(json.skipped).toBe(3);
+  });
+});
+
+// ── Opts forwarding ───────────────────────────────────────────────────────────
+
+describe("POST /api/cron/gmail-pull — opts forwarding", () => {
+  it("passes sinceDays and gateways opts to pullAllActiveConnections", async () => {
+    const res = await POST(makeRequest({ body: { sinceDays: 365, gateways: ["paypal"] } }));
+    expect(res.status).toBe(200);
+    expect(mocks.pullAllActiveConnections).toHaveBeenCalledOnce();
+    const [, opts] = mocks.pullAllActiveConnections.mock.calls[0];
+    expect(opts).toEqual({ sinceDays: 365, gateways: ["paypal"] });
+  });
+
+  it("passes sinceDays and gateways to pullForUser when userId is set", async () => {
+    mocks.dbResult = { id: 99 };
+    const res = await POST(
+      makeRequest({ body: { userId: 7, sinceDays: 90, gateways: ["mercado_pago"] } }),
+    );
+    expect(res.status).toBe(200);
+    expect(mocks.pullForUser).toHaveBeenCalledWith(7, {
+      sinceDays: 90,
+      gateways: ["mercado_pago"],
+    });
+  });
+});
+
+// ── byGateway rollup ──────────────────────────────────────────────────────────
+
+describe("POST /api/cron/gmail-pull — response shape", () => {
+  it("includes byGateway rollup in response", async () => {
+    const result = makeEmptyPullResult(1);
+    result.byGateway.paypal = { pulled: 5, skipped: 2 };
+    mocks.pullAllActiveConnections.mockResolvedValue([result]);
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      byGateway: Record<string, { pulled: number; skipped: number }>;
+    };
+    expect(json.ok).toBe(true);
+    expect(json.byGateway.paypal).toEqual({ pulled: 5, skipped: 2 });
+  });
+});

--- a/src/app/api/cron/gmail-pull/route.ts
+++ b/src/app/api/cron/gmail-pull/route.ts
@@ -1,6 +1,12 @@
 import { timingSafeEqual } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
 import { NextResponse } from "next/server";
-import { pullAllActiveConnections } from "@/lib/gmail/pull";
+import { db } from "@/lib/db";
+import { gmailConnections } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { pullForUser, pullAllActiveConnections } from "@/lib/gmail/pull";
+import { GATEWAY_IDS } from "@/lib/gmail/registry";
 import { createLogger } from "@/lib/logger";
 
 export const runtime = "nodejs";
@@ -26,6 +32,18 @@ function resolveToken(req: Request): string | null {
   return header.slice(7).trim() || null;
 }
 
+// Optional body schema. Absent body = regular cron tick (all users, default
+// window). Present body must be a valid JSON object matching this shape.
+const PullOptsSchema = z
+  .object({
+    userId: z.number().int().positive().optional(),
+    sinceDays: z.number().int().positive().max(3650).optional(),
+    gateways: z.array(z.enum(GATEWAY_IDS)).optional(),
+  })
+  .strict();
+
+type ParsedOpts = z.infer<typeof PullOptsSchema>;
+
 export async function POST(req: Request) {
   const expected = process.env.CRON_TOKEN;
   if (!expected) {
@@ -36,16 +54,88 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const results = await pullAllActiveConnections();
+  // Parse optional body. An empty body is treated as "no opts" (regular tick).
+  let parsed: ParsedOpts = {};
+  const contentType = req.headers.get("content-type") ?? "";
+  const rawText = await req.text();
+  if (rawText.trim().length > 0) {
+    let bodyJson: unknown;
+    try {
+      bodyJson = JSON.parse(rawText);
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+    const validation = PullOptsSchema.safeParse(bodyJson);
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: "Invalid body", details: validation.error.flatten() },
+        { status: 400 },
+      );
+    }
+    parsed = validation.data;
+  }
+
+  void contentType; // not used for routing, only for future multipart support
+
+  const { userId, ...pullOpts } = parsed;
+
+  let results;
+
+  if (userId !== undefined) {
+    // Single-user mode — verify the user has an active connection first.
+    const [connRow] = await db
+      .select({ id: gmailConnections.id })
+      .from(gmailConnections)
+      .where(
+        and(
+          eq(gmailConnections.userId, userId),
+          eq(gmailConnections.status, "active"),
+          notDeleted(gmailConnections.deletedAt),
+        ),
+      )
+      .limit(1);
+
+    if (!connRow) {
+      log.warn(
+        { userId, event: "gmail_pull_http_no_connection" },
+        "gmail pull requested for user with no active connection",
+      );
+      return NextResponse.json(
+        { error: "No active Gmail connection for this user" },
+        { status: 404 },
+      );
+    }
+
+    const result = await pullForUser(userId, pullOpts);
+    results = [result];
+  } else {
+    // Fan-out mode — all users with active connections.
+    results = await pullAllActiveConnections({}, pullOpts);
+  }
+
   const totalPulled = results.reduce((acc, r) => acc + r.pulled, 0);
   const totalSkipped = results.reduce((acc, r) => acc + r.skipped, 0);
   const withErrors = results.filter((r) => r.errors.length > 0).length;
+
+  // Roll up byGateway across all results.
+  const byGateway: Record<string, { pulled: number; skipped: number }> = {};
+  for (const r of results) {
+    for (const [gId, counts] of Object.entries(r.byGateway)) {
+      if (!byGateway[gId]) byGateway[gId] = { pulled: 0, skipped: 0 };
+      byGateway[gId].pulled += counts.pulled;
+      byGateway[gId].skipped += counts.skipped;
+    }
+  }
+
   log.info(
     {
       users: results.length,
       pulled: totalPulled,
       skipped: totalSkipped,
       withErrors,
+      userId: userId ?? null,
+      sinceDays: pullOpts.sinceDays ?? null,
+      gateways: pullOpts.gateways ?? null,
       event: "gmail_pull_http_tick",
     },
     "gmail pull via HTTP cron",
@@ -57,5 +147,6 @@ export async function POST(req: Request) {
     pulled: totalPulled,
     skipped: totalSkipped,
     errorUsers: withErrors,
+    byGateway,
   });
 }

--- a/src/lib/gmail/pull.ts
+++ b/src/lib/gmail/pull.ts
@@ -812,8 +812,15 @@ export async function pullForUser(
  * Fan-out across every active Gmail connection. Used by the hourly cron
  * and the HTTP cron route. Per-user failures are logged and do NOT break
  * the loop.
+ *
+ * `opts` is forwarded verbatim to each `pullForUser` call so callers can
+ * override the pull window or restrict to specific gateways without touching
+ * the per-user logic.
  */
-export async function pullAllActiveConnections(deps: PullDeps = {}): Promise<PullResult[]> {
+export async function pullAllActiveConnections(
+  deps: PullDeps = {},
+  opts: PullOpts = {},
+): Promise<PullResult[]> {
   const rows = await db
     .select({ userId: gmailConnections.userId })
     .from(gmailConnections)
@@ -821,7 +828,7 @@ export async function pullAllActiveConnections(deps: PullDeps = {}): Promise<Pul
   const results: PullResult[] = [];
   for (const row of rows) {
     try {
-      const res = await pullForUser(row.userId, {}, deps);
+      const res = await pullForUser(row.userId, opts, deps);
       results.push(res);
     } catch (err) {
       log.error(

--- a/src/lib/gmail/registry.ts
+++ b/src/lib/gmail/registry.ts
@@ -90,6 +90,10 @@ export const GATEWAYS: readonly GatewayConfig[] = [
   },
 ] as const;
 
+// Tuple of all gateway IDs — used by the cron route for Zod enum validation.
+// Derived from GATEWAYS so it stays in lockstep automatically.
+export const GATEWAY_IDS = GATEWAYS.map((g) => g.id) as [GatewayId, ...GatewayId[]];
+
 export function getGatewayById(id: GatewayId): GatewayConfig {
   const cfg = GATEWAYS.find((g) => g.id === id);
   if (!cfg) throw new Error(`[gmail/registry] unknown gateway id: ${id}`);


### PR DESCRIPTION
Closes #486

## Summary
- Plumbs optional `userId`, `sinceDays`, and `gateways` params through `pullAllActiveConnections` so callers can narrow the pull scope without touching the DB-level connection query
- Adds a single-user path in the cron route: when `userId` is supplied the route resolves that one connection and returns a 404 if none found, short-circuiting the full-sweep codepath
- Zod-validates the request body at the route boundary; byGateway breakdown is included in the JSON response for observability
- Unblocks the 365-day PayPal backfill needed for #482 sample collection — `curl /api/cron/gmail-pull -d '{"userId":"...","sinceDays":365,"gateways":["paypal"]}'` is now the one-shot command

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (1357 specs across 116 files)
- [ ] manual smoke: POST `/api/cron/gmail-pull` with `userId` + `gateways: ["paypal"]` against dev, verify single-user path returns expected `processed`/`errors` breakdown