### PR TITLE
fix(proxy): bypass /api/cron/* so bearer-auth routes are reachable (#488)

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,6 +35,6 @@ export default auth((req) => {
 // /login before their own handler (or Next.js's static handler) ever runs.
 export const config = {
   matcher: [
-    "/((?!api/auth|api/telegram/webhook|api/ingest|api/fx/refresh|api/health|api/widget|api/dev/login|login|signup|_next/static|_next/image|favicon.ico|widgets|.*\\.(?:png|svg|ico|webmanifest)$).*)",
+    "/((?!api/auth|api/cron|api/telegram/webhook|api/ingest|api/fx/refresh|api/health|api/widget|api/dev/login|login|signup|_next/static|_next/image|favicon.ico|widgets|.*\\.(?:png|svg|ico|webmanifest)$).*)",
   ],
 };


### PR DESCRIPTION
## Summary

- One-line addition of `api/cron` to the negative-lookahead matcher in `src/proxy.ts`, joining `api/auth`, `api/telegram/webhook`, `api/ingest`, `api/fx/refresh`, `api/health`, `api/widget`, and `api/dev/login` as bearer-auth families that bypass the session-based redirect-to-login.
- Unblocks all four cron routes (`canary-check`, `slo-alerts`, `gmail-pull`, `gmail-backfill`) which were previously 307'd to `/login` for any external caller — their own bearer-token handlers were never reached.
- Immediate use case: enables the 365-day PayPal backfill for #482 sample collection (after operator sets `CRON_TOKEN` in prod env post-merge).

## Test plan

- [x] Lint clean
- [x] Typecheck clean
- [x] Pre-push hook ran full suite: 1357 / 1357 tests passing
- [ ] Post-merge manual smoke: `curl -X POST https://findash.alejoframes.com/api/cron/gmail-pull` (no auth header) → expect `401` from the route handler, not `307` to `/login`
- [ ] Regression: `curl https://findash.alejoframes.com/transactions` (no session) → still `307` to `/login`

## Operator follow-up (post-merge, not in this PR)

`CRON_TOKEN` env var is not set in prod today. After merge:

1. `openssl rand -hex 32`
2. Append `CRON_TOKEN=<value>` to `/srv/findash/env/findash.env`
3. `systemctl restart findash`

Without `CRON_TOKEN`, routes return 500 ("CRON_TOKEN not configured") which is the existing safe-fail behavior — no change vs today.

Closes #488