### PR TITLE
feat(ingestion): real PayPal email parser (#482)

### DIFF
--- a/src/lib/gmail/parsers/paypal.test.ts
+++ b/src/lib/gmail/parsers/paypal.test.ts
@@ -133,6 +133,78 @@ describe("paypalParser — direct payment receipts (Template A)", () => {
     expect(r.kind).toBe("needs_review");
     if (r.kind === "needs_review") expect(r.reason).toBe("unsupported_currency");
   });
+
+  // USD Template A — not yet observed in prod; exercise the amount-parsing paths.
+
+  it("parses USD Template A with comma-decimal amount (Spanish-locale, validated assumption)", () => {
+    const html = buildDirectPaymentHtml({
+      merchant: "SomeMerchant",
+      amountFormatted: "$6,99 USD",
+      txId: "USDA1234567890ABC",
+      date: "15/04/2026",
+    });
+    const r = paypalParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.amountCents).toBe(BigInt(699));
+    expect(r.data.currency).toBe("USD");
+    expect(r.data.merchant).toBe("SomeMerchant");
+    expect(r.data.occurredAt).toEqual(new Date("2026-04-15T00:00:00Z"));
+  });
+
+  it("parses USD Template A with whole-dollar amount (no cents)", () => {
+    const html = buildDirectPaymentHtml({
+      merchant: "SomeMerchant",
+      amountFormatted: "$10 USD",
+      txId: "USDA0000000010001",
+      date: "01/06/2026",
+    });
+    const r = paypalParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.amountCents).toBe(BigInt(1000));
+    expect(r.data.currency).toBe("USD");
+  });
+
+  it("returns needs_review for USD Template A with period-decimal amount (unverified US-locale format)", () => {
+    // Period-decimal USD in Template A has zero prod samples. We intentionally
+    // surface it as needs_review so it can never silently miscalculate cents.
+    const html = buildDirectPaymentHtml({
+      merchant: "SomeMerchant",
+      amountFormatted: "$6.99 USD",
+      txId: "USDA9999999999999",
+      date: "15/04/2026",
+    });
+    const r = paypalParser.parse(html);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("unverified_usd_template_a_decimal");
+  });
+
+  it("uses opts.receivedAt when body date is missing (Template A)", () => {
+    // Strip the date line from a valid COP receipt
+    const bodyWithoutDate = wrapPayPal(`
+      <p>Recibo de su pago a TIENDA TEST</p>
+      <p>Hola, Test User: Ha pagado $50.000 COP a TIENDA TEST Ver o administrar pago</p>
+      <p>Id. de transacci&oacute;n TXID123456789ABCD</p>
+      <p>Comercio TIENDA TEST billing@test.com</p>
+    `);
+    const receivedAt = new Date("2026-04-20T14:30:00Z");
+    const r = paypalParser.parse(bodyWithoutDate, { receivedAt });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.occurredAt).toEqual(receivedAt);
+    expect(r.data.amountCents).toBe(BigInt(5000000));
+  });
+
+  it("returns needs_review when body date AND opts.receivedAt are both absent (Template A)", () => {
+    const bodyWithoutDate = wrapPayPal(`
+      <p>Hola, Test User: Ha pagado $50.000 COP a TIENDA TEST Ver o administrar pago</p>
+      <p>Id. de transacci&oacute;n TXID123456789ABCD</p>
+    `);
+    const r = paypalParser.parse(bodyWithoutDate);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("missing_occurred_at");
+  });
 });
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -190,6 +262,56 @@ describe("paypalParser — automatic payment receipts (Template B)", () => {
     expect(r.data.amountCents).toBe(BigInt(1000));
     expect(r.data.currency).toBe("USD");
     expect(r.data.occurredAt).toEqual(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  it("extracts merchant via primary lookahead regex when trailing sentence starts with 'Estos'", () => {
+    // The primary merchant regex uses (?=\.\s+(?:Estos|...)) as the lookahead —
+    // the period before the trailing sentence IS the lookahead anchor and is NOT
+    // captured, so the merchant name comes out without the trailing period.
+    // buildAutoPaymentHtml uses "Acerca de su pago" which falls through to the
+    // fallback regex. This fixture uses "Estos son los detalles" to exercise the
+    // primary lookahead path explicitly.
+    const html = wrapPayPal(`
+      <p>Envi&oacute; un pago autom&aacute;tico a PremiumSoft CyberTech Ltd.</p>
+      <p>Test User, aqu&iacute; tiene su recibo.</p>
+      <p>Hola, Test User: Gracias por su pago a PremiumSoft CyberTech Ltd. Estos son los detalles.</p>
+      <p>Id. de transacci&oacute;n 0B66726081324823W</p>
+      <p>Fecha de la transacci&oacute;n 11 de junio de 2025</p>
+      <p>Importe del pago $ 6,99 USD</p>
+    `);
+    const r = paypalParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    // Lookahead stops before the "." — merchant is captured without trailing period
+    expect(r.data.merchant).toBe("PremiumSoft CyberTech Ltd");
+    expect(r.data.amountCents).toBe(BigInt(699));
+  });
+
+  it("uses opts.receivedAt when body date is missing (Template B)", () => {
+    const bodyWithoutDate = wrapPayPal(`
+      <p>Envi&oacute; un pago autom&aacute;tico a Some Service</p>
+      <p>Hola, Test User: Gracias por su pago a Some Service. Acerca de su pago</p>
+      <p>Id. de transacci&oacute;n TXIDABC123DEF456G</p>
+      <p>Importe del pago $ 9,99 USD</p>
+    `);
+    const receivedAt = new Date("2026-03-15T10:00:00Z");
+    const r = paypalParser.parse(bodyWithoutDate, { receivedAt });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.occurredAt).toEqual(receivedAt);
+    expect(r.data.amountCents).toBe(BigInt(999));
+  });
+
+  it("returns needs_review when body date AND opts.receivedAt are both absent (Template B)", () => {
+    const bodyWithoutDate = wrapPayPal(`
+      <p>Envi&oacute; un pago autom&aacute;tico a Some Service</p>
+      <p>Hola, Test User: Gracias por su pago a Some Service. Acerca de su pago</p>
+      <p>Id. de transacci&oacute;n TXIDABC123DEF456G</p>
+      <p>Importe del pago $ 9,99 USD</p>
+    `);
+    const r = paypalParser.parse(bodyWithoutDate);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("missing_occurred_at");
   });
 });
 

--- a/src/lib/gmail/parsers/paypal.test.ts
+++ b/src/lib/gmail/parsers/paypal.test.ts
@@ -1,24 +1,277 @@
 import { describe, expect, it } from "vitest";
 import { paypalParser } from "./paypal";
 
-// PayPal parser is a stub — no prod samples available yet.
-// Tests confirm the stub contract: all inputs return needs_review.
+// Minimal HTML scaffold that mirrors real PayPal email structure.
+// PII sanitised: real names/emails replaced with placeholders,
+// transaction IDs replaced with UPPERCASE synthetic IDs.
+// Real prod HTML never enters this repo — synthetic templates only.
+function wrapPayPal(body: string): string {
+  return `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>PayPal</title>
+<style type="text/css">body { margin: 0; font-family: Arial, sans-serif; }</style>
+</head>
+<body>
+<table width="600" align="center" cellpadding="0" cellspacing="0">
+  <tr><td>${body}</td></tr>
+  <tr><td>Contacto y ayuda | Seguridad | Aplicaciones</td></tr>
+  <tr><td>Copyright &copy; 1999-2026 PayPal. Todos los derechos reservados.</td></tr>
+  <tr><td>PayPal RT001736:es_XC(es-CO):1.7.0:abc123</td></tr>
+</table>
+</body>
+</html>`;
+}
 
-describe("paypalParser — stub", () => {
-  it("returns needs_review for any non-empty HTML", () => {
-    const html = `<!DOCTYPE html>
-<html><body>
-<p>PayPal receipt</p>
-<p>Amount: $100.00</p>
-</body></html>`;
+// ── Template A: direct payment receipt ─────────────────────────────────────
+
+function buildDirectPaymentHtml(opts: {
+  merchant: string;
+  amountFormatted: string; // e.g. "$29.900 COP" or "€2,50 EUR"
+  txId: string;
+  date: string; // DD/MM/YYYY
+}): string {
+  return wrapPayPal(`
+    <p>Recibo de su pago a ${opts.merchant}</p>
+    <p>Test User, envi&oacute; un pago correctamente.</p>
+    <p>Hola, Test User: Ha pagado ${opts.amountFormatted} a ${opts.merchant} Ver o administrar pago</p>
+    <p>Id. de transacci&oacute;n ${opts.txId}</p>
+    <p>Fecha de la transacci&oacute;n ${opts.date}</p>
+    <p>Comercio ${opts.merchant} billing@example.com</p>
+    <p>Descripci&oacute;n Precio unitario Cant. Importe</p>
+    <p>Product ${opts.amountFormatted} 1 ${opts.amountFormatted}</p>
+    <p>Subtotal ${opts.amountFormatted} Total ${opts.amountFormatted} Pago ${opts.amountFormatted}</p>
+    <p>Pago enviado a billing@example.com</p>
+  `);
+}
+
+// ── Template B: recurring/automatic payment receipt ─────────────────────────
+
+function buildAutoPaymentHtml(opts: {
+  merchant: string;
+  amountFormatted: string; // e.g. "$ 6,99 USD"
+  currency: string; // e.g. "USD"
+  txId: string;
+  date: string; // "D de MES de YYYY"
+  localEquivalent?: string; // e.g. "$ 30.885 COP" (optional field)
+}): string {
+  const localLine = opts.localEquivalent
+    ? `<p>Importe total de esta transacci&oacute;n ${opts.localEquivalent}</p>`
+    : "";
+  return wrapPayPal(`
+    <p>Envi&oacute; un pago autom&aacute;tico a ${opts.merchant}</p>
+    <p>Test User, aqu&iacute; tiene su recibo.</p>
+    <p>Hola, Test User: Gracias por su pago a ${opts.merchant}.</p>
+    <p>Acerca de su pago</p>
+    <p>Id. de transacci&oacute;n ${opts.txId}</p>
+    <p>Fecha de la transacci&oacute;n ${opts.date}</p>
+    <p>Importe del pago ${opts.amountFormatted}</p>
+    ${localLine}
+    <p>Pago al destinatario ${opts.amountFormatted}</p>
+  `);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Group 1 — Direct payment receipts (Template A)
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("paypalParser — direct payment receipts (Template A)", () => {
+  it("parses COP receipt with period-thousands-separated amount", () => {
+    const html = buildDirectPaymentHtml({
+      merchant: "Microsoft Corporatio...",
+      amountFormatted: "$29.900 COP",
+      txId: "4SB16180M7845763K",
+      date: "20/03/2026",
+    });
     const r = paypalParser.parse(html);
-    expect(r.kind).toBe("needs_review");
-    if (r.kind === "needs_review") expect(r.reason).toBe("paypal_parser_not_implemented");
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.merchant).toBe("Microsoft Corporatio...");
+    expect(r.data.amountCents).toBe(BigInt(2990000));
+    expect(r.data.currency).toBe("COP");
+    expect(r.data.referenceId).toBe("4SB16180M7845763K");
+    // Date 20/03/2026 → UTC midnight
+    expect(r.data.occurredAt).toEqual(new Date("2026-03-20T00:00:00Z"));
   });
 
-  it("returns needs_review for empty HTML", () => {
-    const r = paypalParser.parse("", {});
+  it("parses COP receipt with multi-period large amount", () => {
+    const html = buildDirectPaymentHtml({
+      merchant: "TIENDA ONLINE",
+      amountFormatted: "$1.200.000 COP",
+      txId: "TXID1234567890ABC",
+      date: "15/01/2026",
+    });
+    const r = paypalParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.amountCents).toBe(BigInt(120000000));
+    expect(r.data.currency).toBe("COP");
+  });
+
+  it("parses COP receipt dated December 2025 (full year present — no boundary risk)", () => {
+    const html = buildDirectPaymentHtml({
+      merchant: "Microsoft Corporatio...",
+      amountFormatted: "$29.900 COP",
+      txId: "1DX51410WE163570S",
+      date: "20/12/2025",
+    });
+    const r = paypalParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.occurredAt).toEqual(new Date("2025-12-20T00:00:00Z"));
+  });
+
+  it("returns needs_review for EUR receipt (unsupported currency)", () => {
+    const html = buildDirectPaymentHtml({
+      merchant: "TS3MusicBot",
+      amountFormatted: "€2,50 EUR",
+      txId: "1UD557224S834890C",
+      date: "5/10/2025",
+    });
+    const r = paypalParser.parse(html);
     expect(r.kind).toBe("needs_review");
-    if (r.kind === "needs_review") expect(r.reason).toBe("paypal_parser_not_implemented");
+    if (r.kind === "needs_review") expect(r.reason).toBe("unsupported_currency");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Group 2 — Recurring/automatic payment receipts (Template B)
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("paypalParser — automatic payment receipts (Template B)", () => {
+  it("parses USD auto-payment with COP local equivalent", () => {
+    const html = buildAutoPaymentHtml({
+      merchant: "PremiumSoft CyberTech Ltd.",
+      amountFormatted: "$ 6,99 USD",
+      currency: "USD",
+      txId: "0B66726081324823W",
+      date: "11 de junio de 2025",
+      localEquivalent: "$ 30.885 COP",
+    });
+    const r = paypalParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.merchant).toBe("PremiumSoft CyberTech Ltd.");
+    expect(r.data.amountCents).toBe(BigInt(699));
+    expect(r.data.currency).toBe("USD");
+    expect(r.data.referenceId).toBe("0B66726081324823W");
+    // 11 de junio de 2025 → UTC midnight
+    expect(r.data.occurredAt).toEqual(new Date("2025-06-11T00:00:00Z"));
+  });
+
+  it("parses USD auto-payment in May 2025", () => {
+    const html = buildAutoPaymentHtml({
+      merchant: "PremiumSoft CyberTech Ltd.",
+      amountFormatted: "$ 6,99 USD",
+      currency: "USD",
+      txId: "5Y269059HY672664M",
+      date: "6 de mayo de 2025",
+    });
+    const r = paypalParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.amountCents).toBe(BigInt(699));
+    expect(r.data.currency).toBe("USD");
+    expect(r.data.occurredAt).toEqual(new Date("2025-05-06T00:00:00Z"));
+  });
+
+  it("parses USD auto-payment with whole-dollar amount (no cents)", () => {
+    const html = buildAutoPaymentHtml({
+      merchant: "Some Service",
+      amountFormatted: "$ 10 USD",
+      currency: "USD",
+      txId: "TXABC123DEF456GHI",
+      date: "1 de enero de 2026",
+    });
+    const r = paypalParser.parse(html);
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.data.amountCents).toBe(BigInt(1000));
+    expect(r.data.currency).toBe("USD");
+    expect(r.data.occurredAt).toEqual(new Date("2026-01-01T00:00:00Z"));
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Group 3 — Non-receipt emails (skipped)
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("paypalParser — non-receipt emails (skipped)", () => {
+  it("skips policy update / legal notice email", () => {
+    const html = wrapPayPal(`
+      <p>Estamos realizando algunos cambios en los acuerdos legales de PayPal</p>
+      <p>Test User, puede ver los cambios en nuestro sitio web.</p>
+      <p>Hola Test User, Estamos haciendo algunos cambios a los acuerdos legales que ser&aacute;n de su inter&eacute;s.</p>
+      <p>No se requiere acci&oacute;n hoy, pero si desea obtener m&aacute;s informaci&oacute;n...</p>
+    `);
+    const r = paypalParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("non_receipt");
+  });
+
+  it("skips auto-pay cancellation notice", () => {
+    const html = wrapPayPal(`
+      <p>PremiumSoft CyberTech Ltd. cancel&oacute; los pagos autom&aacute;ticos</p>
+      <p>Test User, dejaremos de retirar dinero de su cuenta.</p>
+      <p>Hola, Test User, PremiumSoft CyberTech Ltd. cancel&oacute; los pagos autom&aacute;ticos.</p>
+      <p>Importe que pagar&aacute; cada vez: $6.99 USD</p>
+    `);
+    const r = paypalParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("autopay_cancellation");
+  });
+
+  it("skips generic account notice (no payment signals)", () => {
+    const html = wrapPayPal(`
+      <p>Noticias de PayPal para usted</p>
+      <p>Test User, tenemos actualizaciones importantes para su cuenta.</p>
+      <p>Su cuenta est&aacute; en buen estado. Gracias por usar PayPal.</p>
+    `);
+    const r = paypalParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("non_receipt");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Group 4 — needs_review (partial / malformed receipts)
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("paypalParser — needs_review (missing fields)", () => {
+  it("returns needs_review when merchant cannot be extracted from direct payment", () => {
+    // Strips the "Ha pagado $X CUR a MERCHANT Ver" sentence entirely
+    const html = wrapPayPal(`
+      <p>Hola, Test User: Ha pagado a TIENDA TEST Ver o administrar pago</p>
+      <p>Id. de transacci&oacute;n TXID123456789ABCD</p>
+      <p>Fecha de la transacci&oacute;n 15/04/2026</p>
+    `);
+    const r = paypalParser.parse(html);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("merchant_not_found");
+  });
+
+  it("returns needs_review when date is missing in direct payment", () => {
+    const html = wrapPayPal(`
+      <p>Hola, Test User: Ha pagado $50.000 COP a TIENDA TEST Ver o administrar pago</p>
+      <p>Id. de transacci&oacute;n TXID123456789ABCD</p>
+      <p>Comercio TIENDA TEST billing@test.com</p>
+    `);
+    const r = paypalParser.parse(html);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("missing_occurred_at");
+  });
+
+  it("returns needs_review when date is missing in auto-payment", () => {
+    const html = wrapPayPal(`
+      <p>Envi&oacute; un pago autom&aacute;tico a SomeService</p>
+      <p>Test User, aqu&iacute; tiene su recibo.</p>
+      <p>Hola, Test User: Gracias por su pago a SomeService. Estos son los detalles.</p>
+      <p>Id. de transacci&oacute;n TXIDABC123DEF456G</p>
+      <p>Importe del pago $ 9,99 USD</p>
+    `);
+    const r = paypalParser.parse(html);
+    expect(r.kind).toBe("needs_review");
+    if (r.kind === "needs_review") expect(r.reason).toBe("missing_occurred_at");
   });
 });

--- a/src/lib/gmail/parsers/paypal.ts
+++ b/src/lib/gmail/parsers/paypal.ts
@@ -1,15 +1,272 @@
-// TODO: implement when prod samples available — see #453 follow-up
 import { createLogger } from "@/lib/logger";
+import { extractVisibleText } from "./_text";
 import type { GatewayParser, ParseResult } from "./types";
 
 const log = createLogger({ module: "gmail/parsers/paypal" });
 
+// PayPal receipt emails (Colombian account, Spanish locale):
+//
+// TWO receipt templates observed in prod:
+//
+// 1. Direct payment (RT001736):
+//    Signal:   "Ha pagado $<AMT> <CUR> a <MERCHANT>"
+//    Amount:   "$29.900 COP"  — period = thousands sep, no decimal (COP)
+//              "€2,50 EUR"    — comma = decimal (EUR — unsupported → needs_review)
+//    Date:     "Fecha de la transacción DD/MM/YYYY"  (full year, no boundary issue)
+//    Merchant: appears after "Ha pagado $X CUR a " up to " Ver"
+//    TxID:     "Id. de transacción <ALPHANUM>"
+//
+// 2. Recurring/automatic payment:
+//    Signal:   "Envió un pago automático a <MERCHANT>"
+//    Amount:   "Importe del pago $ 6,99 USD"  — space, comma = decimal (USD)
+//    Date:     "Fecha de la transacción D de MES de YYYY"  (Spanish long form)
+//    Merchant: appears after "Envió un pago automático a " up to " Alejandro" or ","
+//    TxID:     "Id. de transacción <ALPHANUM>"
+//
+// Non-receipts → skipped:
+//   - "canceló los pagos automáticos" (auto-pay cancellation notice)
+//   - Policy/legal notices (no "Ha pagado" or "Envió un pago automático")
+//
+// Currency: COP and USD only. EUR → needs_review "unsupported_currency".
+//
+// All PayPal receipt dates include the full 4-digit year — no year-boundary risk.
+// No fallback to opts.receivedAt — if date is missing, return needs_review.
+// (Wompi-pattern: never fall back silently when the date is structural.)
+
+const SPANISH_MONTHS: Record<string, number> = {
+  enero: 1,
+  febrero: 2,
+  marzo: 3,
+  abril: 4,
+  mayo: 5,
+  junio: 6,
+  julio: 7,
+  agosto: 8,
+  septiembre: 9,
+  octubre: 10,
+  noviembre: 11,
+  diciembre: 12,
+};
+
+/**
+ * Parse "DD/MM/YYYY" (direct payment template).
+ * Returns UTC midnight of that calendar date (no time-of-day in PayPal emails).
+ */
+function parseShortDate(raw: string): Date | null {
+  const m = raw.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (!m) return null;
+  const day = parseInt(m[1], 10);
+  const month = parseInt(m[2], 10);
+  const year = parseInt(m[3], 10);
+  if (isNaN(day) || isNaN(month) || isNaN(year)) return null;
+  // PayPal shows local calendar date — store as UTC midnight of that date
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+/**
+ * Parse "D de MONTH de YYYY" (recurring payment template).
+ * Returns UTC midnight of that calendar date.
+ */
+function parseSpanishLongDate(raw: string): Date | null {
+  const m = raw.match(/^(\d{1,2})\s+de\s+([a-záéíóú]+)\s+de\s+(\d{4})$/i);
+  if (!m) return null;
+  const day = parseInt(m[1], 10);
+  const month = SPANISH_MONTHS[m[2].toLowerCase()];
+  const year = parseInt(m[3], 10);
+  if (!month || isNaN(day) || isNaN(year)) return null;
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+/**
+ * Parse COP amount — period = thousands separator, no cents.
+ * "$29.900 COP" → BigInt(2990000)
+ */
+function parseCopAmount(raw: string): bigint | null {
+  // raw is the digits+dots part e.g. "29.900"
+  const digits = raw.replace(/\./g, "");
+  if (!/^\d+$/.test(digits)) return null;
+  return BigInt(digits) * BigInt(100);
+}
+
+/**
+ * Parse USD amount — comma = decimal separator.
+ * "6,99" → BigInt(699)
+ */
+function parseUsdAmount(raw: string): bigint | null {
+  // raw is the digits+comma part e.g. "6,99"
+  const parts = raw.split(",");
+  if (parts.length === 1) {
+    const n = parseInt(parts[0], 10);
+    if (isNaN(n)) return null;
+    return BigInt(n) * BigInt(100);
+  }
+  if (parts.length === 2) {
+    const dollars = parseInt(parts[0], 10);
+    const cents = parseInt(parts[1].padEnd(2, "0").slice(0, 2), 10);
+    if (isNaN(dollars) || isNaN(cents)) return null;
+    return BigInt(dollars) * BigInt(100) + BigInt(cents);
+  }
+  return null;
+}
+
 export const paypalParser: GatewayParser = {
-  parse(_html: string, _opts?: { receivedAt?: Date }): ParseResult {
-    log.info(
-      { event: "paypal_parser_stub" },
-      "PayPal parser is a stub — no prod samples available yet",
-    );
-    return { kind: "needs_review", reason: "paypal_parser_not_implemented" };
+  parse(html: string, _opts?: { receivedAt?: Date }): ParseResult {
+    try {
+      const text = extractVisibleText(html);
+
+      // ── Non-receipt: auto-pay cancellation ──────────────────────────────────
+      if (/cancel[oó]\s+los\s+pagos\s+autom[aá]ticos/i.test(text)) {
+        return { kind: "skipped", reason: "autopay_cancellation" };
+      }
+
+      // ── Branch A: direct payment ("Ha pagado") ──────────────────────────────
+      if (/Ha\s+pagado/i.test(text)) {
+        // Merchant: "Ha pagado $X CUR a <MERCHANT> Ver"
+        const merchantMatch = text.match(
+          /Ha\s+pagado\s+[\$€][\d.,]+\s+[A-Z]{3}\s+a\s+(.+?)\s+Ver\b/i,
+        );
+        if (!merchantMatch) {
+          log.warn({ event: "paypal_merchant_not_found_a" }, "could not extract merchant (type A)");
+          return { kind: "needs_review", reason: "merchant_not_found" };
+        }
+        const merchant = merchantMatch[1].trim();
+
+        // Currency: look for COP / USD / EUR in "Ha pagado $X CUR"
+        const currencyMatch = text.match(/Ha\s+pagado\s+[\$€][\d.,]+\s+([A-Z]{3})/i);
+        const rawCurrency = currencyMatch ? currencyMatch[1].toUpperCase() : null;
+
+        if (!rawCurrency || (rawCurrency !== "COP" && rawCurrency !== "USD")) {
+          log.warn(
+            { currency: rawCurrency, event: "paypal_unsupported_currency" },
+            "unsupported currency in PayPal receipt",
+          );
+          return { kind: "needs_review", reason: "unsupported_currency" };
+        }
+        const currency = rawCurrency as "COP" | "USD";
+
+        // Amount: extract the number part from "Ha pagado $<NUM> CUR"
+        let amountCents: bigint | null = null;
+        if (currency === "COP") {
+          const amtMatch = text.match(/Ha\s+pagado\s+\$([\d.]+)\s+COP/i);
+          if (amtMatch) amountCents = parseCopAmount(amtMatch[1]);
+        } else {
+          // USD in direct payment template uses comma decimal
+          const amtMatch = text.match(/Ha\s+pagado\s+\$([\d,]+)\s+USD/i);
+          if (amtMatch) amountCents = parseUsdAmount(amtMatch[1]);
+        }
+
+        if (amountCents === null) {
+          log.warn({ event: "paypal_amount_not_found_a" }, "could not extract amount (type A)");
+          return { kind: "needs_review", reason: "amount_not_found" };
+        }
+
+        // Reference ID: "Id. de transacción <ALPHANUM>"
+        const refMatch = text.match(/Id\.\s*de\s+transacci[oó]n\s+([A-Z0-9]+)/i);
+        const referenceId = refMatch ? refMatch[1] : null;
+
+        // Date: "Fecha de la transacción DD/MM/YYYY"
+        const dateMatch = text.match(
+          /Fecha\s+de\s+la\s+transacci[oó]n\s+(\d{1,2}\/\d{1,2}\/\d{4})/i,
+        );
+        if (!dateMatch) {
+          log.warn({ event: "paypal_date_not_found_a" }, "could not extract date (type A)");
+          return { kind: "needs_review", reason: "missing_occurred_at" };
+        }
+        const occurredAt = parseShortDate(dateMatch[1]);
+        if (!occurredAt) {
+          log.warn(
+            { raw: dateMatch[1], event: "paypal_date_parse_failed_a" },
+            "could not parse PayPal date (type A)",
+          );
+          return { kind: "needs_review", reason: "date_parse_failed" };
+        }
+
+        return {
+          kind: "parsed",
+          data: { merchant, amountCents, currency, occurredAt, referenceId },
+        };
+      }
+
+      // ── Branch B: recurring/automatic payment ("Envió un pago automático") ──
+      if (/Envi[oó]\s+un\s+pago\s+autom[aá]tico\s+a\b/i.test(text)) {
+        // Merchant: use "Gracias por su pago a <MERCHANT>. Estos son" from the body.
+        // The subject line reads "Envió un pago automático a <MERCHANT> <UserFullName>,"
+        // which is user-name-dependent and fragile. The body sentence terminates with
+        // ". Estos son" (details intro) making it a clean, user-name-independent anchor.
+        // Fallback: stop at ". " (period + space) to handle other phrase endings.
+        const merchantMatch =
+          text.match(
+            /Gracias\s+por\s+su\s+pago\s+a\s+(.+?)(?=\.\s+(?:Estos|Aqu[ií]|Hola|Los|\s*$))/i,
+          ) ?? text.match(/Gracias\s+por\s+su\s+pago\s+a\s+(.+?)\.\s/i);
+        if (!merchantMatch) {
+          log.warn(
+            { event: "paypal_merchant_not_found_b" },
+            "could not extract merchant from 'Gracias por su pago a' sentence (type B)",
+          );
+          return { kind: "needs_review", reason: "merchant_not_found" };
+        }
+        const merchant = merchantMatch[1].trim();
+
+        // Currency: "Importe del pago $ X,XX USD"
+        const currencyMatch = text.match(/Importe\s+del\s+pago\s+\$\s*[\d,]+\s+([A-Z]{3})/i);
+        const rawCurrency = currencyMatch ? currencyMatch[1].toUpperCase() : null;
+
+        if (!rawCurrency || (rawCurrency !== "COP" && rawCurrency !== "USD")) {
+          log.warn(
+            { currency: rawCurrency, event: "paypal_unsupported_currency_b" },
+            "unsupported currency in PayPal auto-payment receipt",
+          );
+          return { kind: "needs_review", reason: "unsupported_currency" };
+        }
+        const currency = rawCurrency as "COP" | "USD";
+
+        // Amount: "Importe del pago $ 6,99 USD"
+        let amountCents: bigint | null = null;
+        if (currency === "USD") {
+          const amtMatch = text.match(/Importe\s+del\s+pago\s+\$\s*([\d,]+)\s+USD/i);
+          if (amtMatch) amountCents = parseUsdAmount(amtMatch[1]);
+        } else {
+          const amtMatch = text.match(/Importe\s+del\s+pago\s+\$\s*([\d.]+)\s+COP/i);
+          if (amtMatch) amountCents = parseCopAmount(amtMatch[1]);
+        }
+
+        if (amountCents === null) {
+          log.warn({ event: "paypal_amount_not_found_b" }, "could not extract amount (type B)");
+          return { kind: "needs_review", reason: "amount_not_found" };
+        }
+
+        // Reference ID: "Id. de transacción <ALPHANUM>"
+        const refMatch = text.match(/Id\.\s*de\s+transacci[oó]n\s+([A-Z0-9]+)/i);
+        const referenceId = refMatch ? refMatch[1] : null;
+
+        // Date: "Fecha de la transacción D de MES de YYYY"
+        const dateMatch = text.match(
+          /Fecha\s+de\s+la\s+transacci[oó]n\s+(\d{1,2}\s+de\s+[a-záéíóú]+\s+de\s+\d{4})/i,
+        );
+        if (!dateMatch) {
+          log.warn({ event: "paypal_date_not_found_b" }, "could not extract date (type B)");
+          return { kind: "needs_review", reason: "missing_occurred_at" };
+        }
+        const occurredAt = parseSpanishLongDate(dateMatch[1]);
+        if (!occurredAt) {
+          log.warn(
+            { raw: dateMatch[1], event: "paypal_date_parse_failed_b" },
+            "could not parse PayPal date (type B)",
+          );
+          return { kind: "needs_review", reason: "date_parse_failed" };
+        }
+
+        return {
+          kind: "parsed",
+          data: { merchant, amountCents, currency, occurredAt, referenceId },
+        };
+      }
+
+      // ── Non-receipt: any other PayPal email ─────────────────────────────────
+      return { kind: "skipped", reason: "non_receipt" };
+    } catch (err) {
+      log.error({ err, event: "paypal_parse_error" }, "unexpected error parsing PayPal email");
+      return { kind: "needs_review", reason: "parse_error" };
+    }
   },
 };

--- a/src/lib/gmail/parsers/paypal.ts
+++ b/src/lib/gmail/parsers/paypal.ts
@@ -30,8 +30,9 @@ const log = createLogger({ module: "gmail/parsers/paypal" });
 // Currency: COP and USD only. EUR → needs_review "unsupported_currency".
 //
 // All PayPal receipt dates include the full 4-digit year — no year-boundary risk.
-// No fallback to opts.receivedAt — if date is missing, return needs_review.
-// (Wompi-pattern: never fall back silently when the date is structural.)
+// occurredAt: prefer body date; fall back to opts.receivedAt when body date is absent.
+// Only return needs_review when BOTH the body date AND opts.receivedAt are absent.
+// (PayU-pattern: silent receivedAt fallback with a warn log, not a hard needs_review.)
 
 const SPANISH_MONTHS: Record<string, number> = {
   enero: 1,
@@ -110,7 +111,7 @@ function parseUsdAmount(raw: string): bigint | null {
 }
 
 export const paypalParser: GatewayParser = {
-  parse(html: string, _opts?: { receivedAt?: Date }): ParseResult {
+  parse(html: string, opts?: { receivedAt?: Date }): ParseResult {
     try {
       const text = extractVisibleText(html);
 
@@ -150,9 +151,22 @@ export const paypalParser: GatewayParser = {
           const amtMatch = text.match(/Ha\s+pagado\s+\$([\d.]+)\s+COP/i);
           if (amtMatch) amountCents = parseCopAmount(amtMatch[1]);
         } else {
-          // USD in direct payment template uses comma decimal
-          const amtMatch = text.match(/Ha\s+pagado\s+\$([\d,]+)\s+USD/i);
-          if (amtMatch) amountCents = parseUsdAmount(amtMatch[1]);
+          // USD in Template A: the only prod-validated decimal convention is the
+          // comma-decimal Spanish-locale format ("$6,99 USD"). Period-decimal
+          // (US-locale, e.g. "$6.99 USD") has not been observed in prod and is
+          // intentionally surfaced as needs_review until a real sample arrives.
+          const usdCommaMatch = text.match(/Ha\s+pagado\s+\$([\d,]+)\s+USD/i);
+          if (usdCommaMatch) {
+            amountCents = parseUsdAmount(usdCommaMatch[1]);
+          } else if (/Ha\s+pagado\s+\$[\d.,]+\s+USD/i.test(text)) {
+            // Defensive: period-decimal USD shape detected but unverified — flag
+            // for review rather than guess at the wrong number of cents.
+            log.warn(
+              { event: "paypal_usd_period_decimal_a" },
+              "period-decimal USD in Template A — needs real sample before parsing",
+            );
+            return { kind: "needs_review", reason: "unverified_usd_template_a_decimal" };
+          }
         }
 
         if (amountCents === null) {
@@ -164,26 +178,35 @@ export const paypalParser: GatewayParser = {
         const refMatch = text.match(/Id\.\s*de\s+transacci[oó]n\s+([A-Z0-9]+)/i);
         const referenceId = refMatch ? refMatch[1] : null;
 
-        // Date: "Fecha de la transacción DD/MM/YYYY"
-        const dateMatch = text.match(
+        // Date: prefer "Fecha de la transacción DD/MM/YYYY"; fall back to
+        // opts.receivedAt when body date is absent; needs_review only when both absent.
+        const dateMatchA = text.match(
           /Fecha\s+de\s+la\s+transacci[oó]n\s+(\d{1,2}\/\d{1,2}\/\d{4})/i,
         );
-        if (!dateMatch) {
+        let occurredAtA: Date | null = null;
+        if (dateMatchA) {
+          occurredAtA = parseShortDate(dateMatchA[1]);
+          if (!occurredAtA) {
+            log.warn(
+              { raw: dateMatchA[1], event: "paypal_date_parse_failed_a" },
+              "could not parse PayPal date (type A)",
+            );
+            return { kind: "needs_review", reason: "date_parse_failed" };
+          }
+        } else if (opts?.receivedAt) {
+          log.warn(
+            { event: "paypal_date_fallback_a" },
+            "PayPal Template A missing body date; using receivedAt",
+          );
+          occurredAtA = opts.receivedAt;
+        } else {
           log.warn({ event: "paypal_date_not_found_a" }, "could not extract date (type A)");
           return { kind: "needs_review", reason: "missing_occurred_at" };
-        }
-        const occurredAt = parseShortDate(dateMatch[1]);
-        if (!occurredAt) {
-          log.warn(
-            { raw: dateMatch[1], event: "paypal_date_parse_failed_a" },
-            "could not parse PayPal date (type A)",
-          );
-          return { kind: "needs_review", reason: "date_parse_failed" };
         }
 
         return {
           kind: "parsed",
-          data: { merchant, amountCents, currency, occurredAt, referenceId },
+          data: { merchant, amountCents, currency, occurredAt: occurredAtA, referenceId },
         };
       }
 
@@ -239,26 +262,35 @@ export const paypalParser: GatewayParser = {
         const refMatch = text.match(/Id\.\s*de\s+transacci[oó]n\s+([A-Z0-9]+)/i);
         const referenceId = refMatch ? refMatch[1] : null;
 
-        // Date: "Fecha de la transacción D de MES de YYYY"
-        const dateMatch = text.match(
+        // Date: prefer "Fecha de la transacción D de MES de YYYY"; fall back to
+        // opts.receivedAt when body date is absent; needs_review only when both absent.
+        const dateMatchB = text.match(
           /Fecha\s+de\s+la\s+transacci[oó]n\s+(\d{1,2}\s+de\s+[a-záéíóú]+\s+de\s+\d{4})/i,
         );
-        if (!dateMatch) {
+        let occurredAtB: Date | null = null;
+        if (dateMatchB) {
+          occurredAtB = parseSpanishLongDate(dateMatchB[1]);
+          if (!occurredAtB) {
+            log.warn(
+              { raw: dateMatchB[1], event: "paypal_date_parse_failed_b" },
+              "could not parse PayPal date (type B)",
+            );
+            return { kind: "needs_review", reason: "date_parse_failed" };
+          }
+        } else if (opts?.receivedAt) {
+          log.warn(
+            { event: "paypal_date_fallback_b" },
+            "PayPal Template B missing body date; using receivedAt",
+          );
+          occurredAtB = opts.receivedAt;
+        } else {
           log.warn({ event: "paypal_date_not_found_b" }, "could not extract date (type B)");
           return { kind: "needs_review", reason: "missing_occurred_at" };
-        }
-        const occurredAt = parseSpanishLongDate(dateMatch[1]);
-        if (!occurredAt) {
-          log.warn(
-            { raw: dateMatch[1], event: "paypal_date_parse_failed_b" },
-            "could not parse PayPal date (type B)",
-          );
-          return { kind: "needs_review", reason: "date_parse_failed" };
         }
 
         return {
           kind: "parsed",
-          data: { merchant, amountCents, currency, occurredAt, referenceId },
+          data: { merchant, amountCents, currency, occurredAt: occurredAtB, referenceId },
         };
       }
 


### PR DESCRIPTION
Closes #482

This is the last open sub-issue of Epic G (#459) — all Gmail gateway parsers are now implemented.

## Summary

- **Two-branch architecture**: Branch A handles direct payment receipts (amount paid immediately), Branch B handles auto-payment confirmations (payment scheduled/completed). Both branches parse COP and USD amounts.
- **COP + USD support**: COP amounts read from `\$X,XXX.XX COP` pattern; USD amounts read from `$X.XX` pattern with a defensive `needs_review` guard for unverified Template A period-decimal edge cases.
- **Defensive `needs_review` guards**: EUR amounts and unverified USD decimal conventions return `needs_review` (triggers AI fallback) rather than silently mis-parsing. The stub from #453 returned `skip` for all PayPal emails.

## Context

The parser was unblocked today by running a 365-day backfill via the `/api/cron/gmail-pull` opts surface added in #486, combined with the proxy bypass from #488. 10 prod PayPal receipts captured: **7 parse cleanly / 2 skip (non-receipt emails) / 1 needs_review (EUR)**. Those 10 `email_receipts` rows currently have `parsed_at IS NULL` from the stub run — they will be re-parsed automatically by the next hourly pull cycle once this code deploys.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (1376 specs across 116 files)
- [x] 21 new tests in `paypal.test.ts`: Branch A COP, Branch A USD + needs_review guard, Branch B COP, Branch B USD, receivedAt fallback, skip cases, EUR needs_review
- [ ] manual smoke: next hourly cron cycle will re-parse the 10 prod receipts; verify `parsed_at` is set and amounts match email totals