### PR TITLE
refactor(dashboard): rename Editorial Calm → Warm Paper (#494)

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -108,7 +108,7 @@ export default async function DashboardPage({
         <header className="paper-rise flex flex-wrap items-end justify-between gap-3">
           <div className="flex flex-col gap-1">
             <span className="text-eyebrow">Findash</span>
-            <h1 className="text-serif-display text-ink text-4xl font-semibold sm:text-5xl">
+            <h1 className="text-display text-ink text-4xl font-semibold sm:text-5xl">
               Tu mes en una hoja
             </h1>
             <p className="text-ink-muted text-sm capitalize">{monthLabel}</p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,7 +13,7 @@
   --font-display: var(--font-geist-sans);
   --font-numeric: var(--font-jetbrains-mono);
 
-  /* Editorial Calm — paper / ink / botanical accent tokens (dashboard) */
+  /* Warm Paper — paper / ink / botanical accent tokens (dashboard) */
   --color-paper: var(--paper);
   --color-paper-elevated: var(--paper-elevated);
   --color-ink: var(--ink);
@@ -96,7 +96,7 @@
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.63 0.18 45);
 
-  /* Editorial Calm — light paper palette */
+  /* Warm Paper — light paper palette */
   --paper: oklch(0.973 0.008 80);
   --paper-elevated: oklch(0.99 0.005 80);
   --ink: oklch(0.18 0.008 60);
@@ -142,7 +142,7 @@
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.75 0.15 50);
 
-  /* Editorial Calm — dark warm palette */
+  /* Warm Paper — dark palette */
   --paper: oklch(0.13 0.006 60);
   --paper-elevated: oklch(0.185 0.008 60);
   --ink: oklch(0.93 0.012 80);
@@ -167,9 +167,6 @@
   }
 }
 
-@utility text-display {
-  @apply text-3xl leading-tight font-semibold tracking-tight;
-}
 @utility text-h1 {
   @apply text-2xl leading-tight font-semibold tracking-tight;
 }
@@ -221,8 +218,8 @@
   animation: tx-row-highlight 2.5s ease-out forwards;
 }
 
-/* === Editorial Calm — typography utilities === */
-@utility text-serif-display {
+/* === Warm Paper — typography utilities === */
+@utility text-display {
   font-family: var(--font-display), ui-sans-serif, system-ui, sans-serif;
   letter-spacing: -0.03em;
   @apply font-semibold;
@@ -239,7 +236,7 @@
   @apply font-semibold;
 }
 
-/* === Editorial Calm — paper surface (dashboard only) === */
+/* === Warm Paper — paper surface (dashboard only) === */
 @utility surface-paper {
   background-color: var(--paper);
   color: var(--ink);
@@ -267,7 +264,7 @@
   opacity: 0.06;
 }
 
-/* === Editorial Calm — card surface override === */
+/* === Warm Paper — card surface override === */
 @utility card-paper {
   background-color: var(--paper-elevated);
   color: var(--ink);
@@ -282,7 +279,7 @@
   border-color: var(--ink-subtle);
 }
 
-/* === Editorial Calm — meter (progress bar) === */
+/* === Warm Paper — meter (progress bar) === */
 @utility meter-track {
   background-color: var(--rule);
   border-radius: 9999px;
@@ -300,7 +297,7 @@
   transition: width 600ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-/* === Editorial Calm — staggered reveal on page load === */
+/* === Warm Paper — staggered reveal on page load === */
 @keyframes paper-rise {
   from {
     opacity: 0;

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -22,7 +22,7 @@ export type AccountStatus = {
   balanceCents: bigint;
   /** Native-currency credit limit; populated only for credit_card accounts that
    * declare a limit (either via shared physical_card or per-account metadata).
-   * Used by the Editorial Calm reframe to show "cupo disponible" instead of
+   * Used by the Warm Paper reframe to show "cupo disponible" instead of
    * negative debt as the headline number. */
   creditLimitCents?: bigint;
 };
@@ -80,7 +80,7 @@ export type FinancialPicture = {
 };
 
 /**
- * Editorial Calm reframe (#491): primary KPI is "saldo líquido"
+ * Warm Paper reframe (#491): primary KPI is "saldo líquido"
  * (only savings balances, always non-negative for healthy accounts) and
  * "patrimonio neto" lives as a secondary line. Liabilities are surfaced
  * separately so the hero can render an assets-vs-debts mini bar without
@@ -164,7 +164,7 @@ export type MonthlyProgress = {
 };
 
 /**
- * Editorial Calm reframe (#491): "what did the user accomplish this month"
+ * Warm Paper reframe (#491): "what did the user accomplish this month"
  * — surfaces positive credit-card payments + positive cash flow as
  * encouragement, not just spend.
  *   debtPaid = SUM(positive transactions on credit_card accounts) this month


### PR DESCRIPTION
Closes #494

## Summary

Pure rename / cleanup. The original \"Editorial Calm\" direction implied a serif display font; user kept Geist + JetBrains Mono in #491 (PR #492), so the name stopped describing the implementation. New name = **Warm Paper**, which names the real differentiation (warm paper palette + botanical accent + spacing).

## Changes

- \`globals.css\`: comment headers \"Editorial Calm —\" → \"Warm Paper —\"
- \`globals.css\`: drop unused legacy \`@utility text-display { @apply text-3xl ... }\` (no callers in codebase)
- \`globals.css\`: rename \`@utility text-serif-display\` → \`@utility text-display\` (already sans since Fraunces revert)
- \`page.tsx\`: only caller's className updated
- \`queries.ts\`: JSDoc references updated

No behavioral change. Visually identical (verified with chrome-devtools after rename).

## Test plan

- [x] \`bun run lint\` clean
- [x] \`bunx tsc --noEmit\` clean
- [x] Manual smoke (dev server reload after rename) — dashboard renders identically
- [ ] CI green
- [ ] User review (cosmetic only — should be a no-op)