### PR TITLE
feat(dashboard): pay-period awareness with opt-in salary anchoring (#493)

### DIFF
--- a/drizzle/0059_naive_silver_surfer.sql
+++ b/drizzle/0059_naive_silver_surfer.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "counterparties" ADD COLUMN "is_salary" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+CREATE INDEX "counterparties_user_salary_idx" ON "counterparties" USING btree ("user_id") WHERE "counterparties"."is_salary" = true;

--- a/drizzle/meta/0059_snapshot.json
+++ b/drizzle/meta/0059_snapshot.json
@@ -1,0 +1,5125 @@
+{
+  "id": "f8a5e7ef-72be-4ccb-9c0d-a4eb0d6f8fa5",
+  "prevId": "e412961f-414b-40d4-84fb-fc2c97ef7c04",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_physical_card_id_physical_cards_id_fk": {
+          "name": "accounts_physical_card_id_physical_cards_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "physical_cards",
+          "columnsFrom": [
+            "physical_card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_corrections": {
+      "name": "classification_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_category_slug": {
+          "name": "new_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_corrections_learning_idx": {
+          "name": "classification_corrections_learning_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "new_category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_corrections_user_id_users_id_fk": {
+          "name": "classification_corrections_user_id_users_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_corrections_transaction_id_transactions_id_fk": {
+          "name": "classification_corrections_transaction_id_transactions_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_from_corrections": {
+          "name": "generated_from_corrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_salary": {
+          "name": "is_salary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparties_user_salary_idx": {
+          "name": "counterparties_user_salary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"counterparties\".\"is_salary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_receipts": {
+      "name": "email_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_connection_id": {
+          "name": "gmail_connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_msg_id": {
+          "name": "gmail_msg_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway": {
+          "name": "gateway",
+          "type": "email_receipt_gateway",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_html": {
+          "name": "raw_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_payload": {
+          "name": "parsed_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_transaction_id": {
+          "name": "matched_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_status": {
+          "name": "match_status",
+          "type": "email_receipt_match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "match_candidates": {
+          "name": "match_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_at": {
+          "name": "parsed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_receipts_user_msg_unique": {
+          "name": "email_receipts_user_msg_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_msg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_user_status_idx": {
+          "name": "email_receipts_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_match_lookup_idx": {
+          "name": "email_receipts_match_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "amount_cents",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'pending' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_connection_idx": {
+          "name": "email_receipts_connection_idx",
+          "columns": [
+            {
+              "expression": "gmail_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_candidates_gin_idx": {
+          "name": "email_receipts_candidates_gin_idx",
+          "columns": [
+            {
+              "expression": "match_candidates",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'ambiguous' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_receipts_user_id_users_id_fk": {
+          "name": "email_receipts_user_id_users_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_gmail_connection_id_gmail_connections_id_fk": {
+          "name": "email_receipts_gmail_connection_id_gmail_connections_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "gmail_connections",
+          "columnsFrom": [
+            "gmail_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_matched_transaction_id_transactions_id_fk": {
+          "name": "email_receipts_matched_transaction_id_transactions_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "matched_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_connections": {
+      "name": "gmail_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_email": {
+          "name": "gmail_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_enc": {
+          "name": "access_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_pull_at": {
+          "name": "last_pull_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_pull_history_id": {
+          "name": "last_pull_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "gmail_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_nudge_sent_at": {
+          "name": "bot_nudge_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_connections_user_email_unique": {
+          "name": "gmail_connections_user_email_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_user_status_idx": {
+          "name": "gmail_connections_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_active_idx": {
+          "name": "gmail_connections_active_idx",
+          "columns": [
+            {
+              "expression": "last_pull_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"status\" = 'active' AND \"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_connections_user_id_users_id_fk": {
+          "name": "gmail_connections_user_id_users_id_fk",
+          "tableFrom": "gmail_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.physical_cards": {
+      "name": "physical_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_limit_cents": {
+          "name": "credit_limit_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "statement_cutoff_day": {
+          "name": "statement_cutoff_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "physical_cards_user_idx": {
+          "name": "physical_cards_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "physical_cards_user_institution_idx": {
+          "name": "physical_cards_user_institution_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "physical_cards_user_id_users_id_fk": {
+          "name": "physical_cards_user_id_users_id_fk",
+          "tableFrom": "physical_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_proposals": {
+      "name": "rule_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_txn_ids": {
+          "name": "correction_txn_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rule_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rule_proposals_user_merchant_category_pending_unique": {
+          "name": "rule_proposals_user_merchant_category_pending_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rule_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rule_proposals_user_status_idx": {
+          "name": "rule_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_proposals_user_id_users_id_fk": {
+          "name": "rule_proposals_user_id_users_id_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_proposals_user_category_fk": {
+          "name": "rule_proposals_user_category_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skipped_consolidation_cycles": {
+      "name": "skipped_consolidation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "skipped_consolidation_cycles_live_unique": {
+          "name": "skipped_consolidation_cycles_live_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skipped_consolidation_cycles_user_account_idx": {
+          "name": "skipped_consolidation_cycles_user_account_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skipped_consolidation_cycles_user_id_users_id_fk": {
+          "name": "skipped_consolidation_cycles_user_id_users_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skipped_consolidation_cycles_account_id_accounts_id_fk": {
+          "name": "skipped_consolidation_cycles_account_id_accounts_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slo_alerts": {
+      "name": "slo_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slo_key": {
+          "name": "slo_key",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slo_alerts_open_idx": {
+          "name": "slo_alerts_open_idx",
+          "columns": [
+            {
+              "expression": "slo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"slo_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "statement_import_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movimientos'"
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synthetic_tx_id": {
+          "name": "synthetic_tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_cycle_unique": {
+          "name": "statement_imports_cycle_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"statement_imports\".\"kind\" = 'extracto_detallado' AND \"statement_imports\".\"cycle\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installments_total": {
+          "name": "installments_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "installment_rate_bps": {
+          "name": "installment_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retroactive_rule_id": {
+          "name": "retroactive_rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group_id": {
+          "name": "transfer_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enriched_merchant": {
+          "name": "enriched_merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_source": {
+          "name": "enrichment_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_mismatch": {
+          "name": "source_mismatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_mismatch_details": {
+          "name": "source_mismatch_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_group_idx": {
+          "name": "transactions_transfer_group_idx",
+          "columns": [
+            {
+              "expression": "transfer_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"transfer_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_occurred_live_idx": {
+          "name": "transactions_account_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_live_idx": {
+          "name": "transactions_user_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_retroactive_rule_id_classification_rules_id_fk": {
+          "name": "transactions_retroactive_rule_id_classification_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "classification_rules",
+          "columnsFrom": [
+            "retroactive_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_snapshots": {
+      "name": "user_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_bytes": {
+          "name": "payload_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_snapshots_user_created_idx": {
+          "name": "user_snapshots_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_snapshots_user_id_users_id_fk": {
+          "name": "user_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ui_preferences": {
+          "name": "ui_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "classification_context": {
+          "name": "classification_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "rule_retroactive",
+        "ai",
+        "manual",
+        "manual_confirmed",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.email_receipt_gateway": {
+      "name": "email_receipt_gateway",
+      "schema": "public",
+      "values": [
+        "mercado_pago",
+        "payu",
+        "wompi",
+        "apple",
+        "paypal",
+        "bancolombia"
+      ]
+    },
+    "public.email_receipt_match_status": {
+      "name": "email_receipt_match_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "matched",
+        "ambiguous",
+        "unmatched"
+      ]
+    },
+    "public.gmail_connection_status": {
+      "name": "gmail_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "revoked",
+        "error"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.rule_proposal_status": {
+      "name": "rule_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.statement_import_kind": {
+      "name": "statement_import_kind",
+      "schema": "public",
+      "values": [
+        "movimientos",
+        "extracto_detallado"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile",
+        "gmail_bancolombia",
+        "gmail_enrichment"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug",
+        "widget"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1777100613720,
       "tag": "0058_nebulous_amphibian",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1777134354131,
+      "tag": "0059_naive_silver_surfer",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/budgets/page.tsx
+++ b/src/app/(app)/budgets/page.tsx
@@ -1,5 +1,6 @@
 import { getSessionUser } from "@/lib/auth/session";
 import { getBudgetsOverview } from "@/lib/budgets/queries";
+import { getFinancialPeriod } from "@/lib/dashboard/period";
 import { BudgetsManager } from "./budgets-manager";
 
 export const dynamic = "force-dynamic";
@@ -20,7 +21,18 @@ export default async function BudgetsPage({
   const params = await searchParams;
   const ym = params.ym && /^\d{4}-\d{2}$/.test(params.ym) ? params.ym : currentYearMonth();
 
-  const { categories: cats, items } = await getBudgetsOverview(session.id, ym);
+  // #493: budget plans stay calendar-anchored (a budget is "April 2026"),
+  // but spend aggregation respects the user's financial cycle so the bar
+  // matches the dashboard's "Flujo del mes". Bank-truth views (cuotas,
+  // statements) are NOT in scope here.
+  const [y, m] = ym.split("-").map(Number);
+  const refDate = new Date(Date.UTC(y, m - 1, 15));
+  const period = await getFinancialPeriod(session.id, refDate);
+
+  const { categories: cats, items } = await getBudgetsOverview(session.id, ym, {
+    start: period.start,
+    end: period.end,
+  });
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">

--- a/src/app/(app)/insights/actions.ts
+++ b/src/app/(app)/insights/actions.ts
@@ -8,6 +8,7 @@ import { insightsReports } from "@/lib/db/schema";
 import { getSessionUser } from "@/lib/auth/session";
 import { buildInsightsSummary, generateInsightsReport, hashSummary } from "@/lib/ai/insights";
 import { getCurrentFxRate } from "@/lib/fx/repo";
+import { getFinancialPeriod } from "@/lib/dashboard/period";
 
 const ymSchema = z.string().regex(/^\d{4}-\d{2}$/);
 
@@ -15,7 +16,17 @@ export async function generateInsight(ym: string) {
   const session = await getSessionUser();
   const parsed = ymSchema.parse(ym);
   const fx = await getCurrentFxRate();
-  const summary = await buildInsightsSummary(session.id, parsed, fx.rate);
+  // Resolve current + previous periods so the AI input matches the
+  // dashboard / page view exactly. Previous month uses the same cycle mode.
+  const [y, m] = parsed.split("-").map(Number);
+  const [currentPeriod, previousPeriod] = await Promise.all([
+    getFinancialPeriod(session.id, new Date(Date.UTC(y, m - 1, 15))),
+    getFinancialPeriod(session.id, new Date(Date.UTC(y, m - 2, 15))),
+  ]);
+  const summary = await buildInsightsSummary(session.id, parsed, fx.rate, undefined, {
+    currentRange: { start: currentPeriod.start, end: currentPeriod.end },
+    previousRange: { start: previousPeriod.start, end: previousPeriod.end },
+  });
   const inputHash = hashSummary(summary);
   const result = await generateInsightsReport({ summary });
 

--- a/src/app/(app)/insights/page.tsx
+++ b/src/app/(app)/insights/page.tsx
@@ -4,6 +4,7 @@ import { insightsReports } from "@/lib/db/schema";
 import { getSessionUser } from "@/lib/auth/session";
 import { buildInsightsSummary, hashSummary, isStale } from "@/lib/ai/insights";
 import { getCurrentFxRate } from "@/lib/fx/repo";
+import { getFinancialPeriod } from "@/lib/dashboard/period";
 import { InsightsViewer } from "./insights-viewer";
 
 export const dynamic = "force-dynamic";
@@ -23,7 +24,18 @@ export default async function InsightsPage({
 
   const session = await getSessionUser();
   const fx = await getCurrentFxRate();
-  const summary = await buildInsightsSummary(session.id, ym, fx.rate);
+  // Resolve current AND previous financial periods so the month-over-month
+  // comparison stays apples-to-apples (both salary-anchored if pay_period
+  // mode is on, both calendar otherwise).
+  const [y, m] = ym.split("-").map(Number);
+  const [currentPeriod, previousPeriod] = await Promise.all([
+    getFinancialPeriod(session.id, new Date(Date.UTC(y, m - 1, 15))),
+    getFinancialPeriod(session.id, new Date(Date.UTC(y, m - 2, 15))),
+  ]);
+  const summary = await buildInsightsSummary(session.id, ym, fx.rate, undefined, {
+    currentRange: { start: currentPeriod.start, end: currentPeriod.end },
+    previousRange: { start: previousPeriod.start, end: previousPeriod.end },
+  });
   const currentHash = hashSummary(summary);
 
   const [existing] = await db

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -7,6 +7,8 @@ import {
   getMonthlyProgress,
   getTopExpenses,
 } from "@/lib/dashboard/queries";
+import { getFinancialPeriod, getPayPeriodReadiness } from "@/lib/dashboard/period";
+import { getUiPreferences } from "@/lib/preferences/repo";
 import { SaldoLiquidoCard } from "@/components/dashboard/saldo-liquido-card";
 import { MonthlyFlowCard } from "@/components/dashboard/monthly-flow-card";
 import { ProgressCard } from "@/components/dashboard/progress-card";
@@ -19,6 +21,7 @@ import { RecurringInboxCard } from "@/components/dashboard/recurring-inbox-card"
 import { SmsHealthCard } from "@/components/dashboard/sms-health-card";
 import { CreditCardsCard } from "@/components/dashboard/credit-cards-card";
 import { PendingConsolidationBanner } from "@/components/dashboard/pending-consolidation-banner";
+import { PayPeriodNudge } from "@/components/dashboard/pay-period-nudge";
 import { getUpcomingForMonth } from "@/lib/recurring/upcoming";
 import { getOpenGaps } from "@/lib/recurring/gap-queries";
 import { getCurrentFxRate } from "@/lib/fx/repo";
@@ -48,6 +51,25 @@ export default async function DashboardPage({
 
   const session = await getSessionUser();
   const fx = await getCurrentFxRate();
+
+  // Resolve the financial period ONCE and pass it to every month-bound
+  // query — this guarantees all dashboard cards aggregate over the same
+  // boundaries (calendar OR salary-anchored). Fallback semantics live in
+  // the `mode`/`fallbackReason` fields so cards can render the right
+  // subtitle and inline notes. See #493 + src/lib/dashboard/period.ts.
+  const period = await getFinancialPeriod(session.id, refDate);
+  const range = { start: period.start, end: period.end };
+
+  const [prefs, readiness] = await Promise.all([
+    getUiPreferences(session.id),
+    getPayPeriodReadiness(session.id),
+  ]);
+  // Show the dashboard nudge when the user is eligible for pay_period mode
+  // (≥1 salary flag + ≥2 paychecks) but still on calendar AND has not
+  // dismissed the banner before. One-shot opt-in surface.
+  const showPayPeriodNudge =
+    prefs.financialCycleMode === "calendar" && readiness.ready && !prefs.payPeriodNudgeDismissed;
+
   const [
     picture,
     flow,
@@ -61,10 +83,10 @@ export default async function DashboardPage({
     creditCards,
   ] = await Promise.all([
     getFinancialPicture(session.id, fx.rate),
-    getMonthlyFlow(session.id, fx.rate, refDate),
-    getMonthlyProgress(session.id, fx.rate, refDate),
-    getCategoryBreakdown(session.id, fx.rate, refDate),
-    getTopExpenses(session.id, fx.rate, refDate, 5),
+    getMonthlyFlow(session.id, fx.rate, range),
+    getMonthlyProgress(session.id, fx.rate, range),
+    getCategoryBreakdown(session.id, fx.rate, range),
+    getTopExpenses(session.id, fx.rate, range, 5),
     getAccountStatuses(session.id),
     getUpcomingForMonth({
       userId: session.id,
@@ -75,6 +97,7 @@ export default async function DashboardPage({
     }),
     getOpenGaps(session.id),
     getSmsHealthSnapshot(session.id, now),
+    // Bank truth — TC summary stays on calendar regardless of cycle mode.
     getCreditCardsSummary(session.id, fx.rate, now),
   ]);
 
@@ -118,13 +141,25 @@ export default async function DashboardPage({
 
         <PendingConsolidationBanner userId={session.id} />
 
+        {showPayPeriodNudge ? <PayPeriodNudge /> : null}
+
         <section>
           <SaldoLiquidoCard data={picture} fx={fx} monthLabel={monthLabel} />
         </section>
 
         <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <MonthlyFlowCard data={flow} monthLabel={monthLabel} isFuture={isFuture} />
-          <ProgressCard data={progress} monthLabel={monthLabel} isFuture={isFuture} />
+          <MonthlyFlowCard
+            data={flow}
+            monthLabel={monthLabel}
+            period={period}
+            isFuture={isFuture}
+          />
+          <ProgressCard
+            data={progress}
+            monthLabel={monthLabel}
+            period={period}
+            isFuture={isFuture}
+          />
         </section>
 
         {creditCards.cardCount > 0 ? (
@@ -134,12 +169,23 @@ export default async function DashboardPage({
         ) : null}
 
         <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <TopExpensesCard rows={top} monthLabel={monthLabel} ym={ym} isFuture={isFuture} />
+          <TopExpensesCard
+            rows={top}
+            monthLabel={monthLabel}
+            ym={ym}
+            period={period}
+            isFuture={isFuture}
+          />
           <UpcomingCard items={upcomingItems} monthLabel={monthLabel} />
         </section>
 
         <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <CategoryDonut slices={donutSlices} monthLabel={monthLabel} isFuture={isFuture} />
+          <CategoryDonut
+            slices={donutSlices}
+            monthLabel={monthLabel}
+            period={period}
+            isFuture={isFuture}
+          />
           <SmsHealthCard snapshot={smsHealth} />
         </section>
 

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -16,6 +16,12 @@ const LINKS = [
       "Tu taxonomía personal: agregá, renombrá o archivá categorías. Cada usuario tiene la suya.",
   },
   {
+    href: "/settings/period",
+    title: "Período financiero",
+    description:
+      "Mes calendario o anclado en tu sueldo. Marcá tus fuentes de ingreso fijo para que el flujo del mes refleje tu ciclo real.",
+  },
+  {
     href: "/settings/rules",
     title: "Reglas de clasificación",
     description:

--- a/src/app/(app)/settings/period/page.tsx
+++ b/src/app/(app)/settings/period/page.tsx
@@ -1,0 +1,61 @@
+import { getSessionUser } from "@/lib/auth/session";
+import { getUiPreferences } from "@/lib/preferences/repo";
+import {
+  formatPeriodDateRange,
+  getFinancialPeriod,
+  getPayPeriodReadiness,
+  listSalaryCandidates,
+} from "@/lib/dashboard/period";
+import { PeriodModeForm } from "./period-mode-form";
+import { SalaryCandidatesList } from "./salary-candidates-list";
+
+export const dynamic = "force-dynamic";
+
+export default async function PeriodSettingsPage() {
+  const session = await getSessionUser();
+  const [prefs, readiness, candidates, period] = await Promise.all([
+    getUiPreferences(session.id),
+    getPayPeriodReadiness(session.id),
+    listSalaryCandidates(session.id),
+    // Always resolve so we can preview the current period when the mode is
+    // active. When mode = "calendar" the helper returns the calendar range;
+    // we hide the preview in that case.
+    getFinancialPeriod(session.id),
+  ]);
+
+  const dateRange = formatPeriodDateRange(period);
+  const showPreview = prefs.financialCycleMode === "pay_period" && dateRange !== null;
+
+  return (
+    <main
+      id="periodo-financiero"
+      className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-4 sm:p-6"
+    >
+      <header>
+        <h1 className="text-h1">Período financiero</h1>
+        <p className="text-body text-muted-foreground">
+          Por defecto, Findash usa el mes calendario para el flujo, los presupuestos y los insights.
+          Si cobrás un sueldo regular, podés anclar el período en tus fechas reales de pago para que
+          el flujo del mes refleje tu ciclo, no el del banco.
+        </p>
+      </header>
+
+      <PeriodModeForm currentMode={prefs.financialCycleMode} ready={readiness.ready} />
+
+      <SalaryCandidatesList candidates={candidates} />
+
+      {showPreview ? (
+        <section className="card-paper paper-rise-1 flex flex-col gap-1 p-4 text-sm">
+          <span className="text-eyebrow">Tu período actual</span>
+          <p className="text-ink">
+            <span className="lowercase">{dateRange}</span>
+          </p>
+          <p className="text-ink-muted text-xs">
+            El flujo del mes, los presupuestos y los insights agregan transacciones dentro de este
+            rango. Las cuotas de TC y el próximo pago siguen el calendario del banco.
+          </p>
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/src/app/(app)/settings/period/period-mode-form.tsx
+++ b/src/app/(app)/settings/period/period-mode-form.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useTransition } from "react";
+import { CalendarIcon, WalletIcon } from "lucide-react";
+import { toast } from "sonner";
+import { setFinancialCycleMode } from "@/lib/preferences/actions";
+import type { FinancialCycleMode } from "@/lib/db/schema";
+
+export function PeriodModeForm({
+  currentMode,
+  ready,
+}: {
+  currentMode: FinancialCycleMode;
+  ready: boolean;
+}) {
+  const [pending, startTransition] = useTransition();
+
+  function pick(mode: FinancialCycleMode) {
+    if (mode === currentMode) return;
+    if (mode === "pay_period" && !ready) return;
+    startTransition(async () => {
+      try {
+        await setFinancialCycleMode(mode);
+        toast.success(
+          mode === "pay_period" ? "Modo sueldo activado" : "Modo mes calendario activado",
+        );
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "No se pudo cambiar el modo");
+      }
+    });
+  }
+
+  return (
+    <section className="card-paper paper-rise-1 flex flex-col gap-3 p-5">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-eyebrow">Modo de ciclo financiero</span>
+        <p className="text-ink-muted text-xs">
+          Cómo se calculan los bordes del mes en el dashboard, presupuestos e insights.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <ModeOption
+          active={currentMode === "calendar"}
+          disabled={pending}
+          icon={<CalendarIcon className="size-4" />}
+          title="Mes calendario"
+          description="Del 1 al fin de mes. Comportamiento por defecto."
+          onClick={() => pick("calendar")}
+        />
+        <ModeOption
+          active={currentMode === "pay_period"}
+          disabled={pending || !ready}
+          icon={<WalletIcon className="size-4" />}
+          title="Anclado en mi sueldo"
+          description={
+            ready
+              ? "El mes va de un pago al siguiente. Recomendado si cobrás regular."
+              : "Marcá tu sueldo y registrá al menos 2 pagos para activar este modo."
+          }
+          onClick={() => pick("pay_period")}
+        />
+      </div>
+    </section>
+  );
+}
+
+function ModeOption({
+  active,
+  disabled,
+  icon,
+  title,
+  description,
+  onClick,
+}: {
+  active: boolean;
+  disabled: boolean;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active}
+      className={`flex flex-col items-start gap-1.5 rounded-md border p-4 text-left transition-colors ${
+        active ? "border-primary bg-primary/5" : "bg-background hover:bg-muted/40 border-border"
+      } ${disabled && !active ? "cursor-not-allowed opacity-60" : ""}`}
+    >
+      <span className="text-ink flex items-center gap-2 text-sm font-medium">
+        {icon}
+        {title}
+        {active ? (
+          <span className="text-primary text-[10px] tracking-wider uppercase">activo</span>
+        ) : null}
+      </span>
+      <span className="text-ink-muted text-xs leading-snug">{description}</span>
+    </button>
+  );
+}

--- a/src/app/(app)/settings/period/salary-candidates-list.tsx
+++ b/src/app/(app)/settings/period/salary-candidates-list.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { WalletIcon } from "lucide-react";
+import { toast } from "sonner";
+import { setCounterpartyIsSalary } from "@/lib/preferences/actions";
+import { Money } from "@/components/display/money";
+import type { SalaryCandidate } from "@/lib/dashboard/period";
+
+export function SalaryCandidatesList({ candidates }: { candidates: SalaryCandidate[] }) {
+  // Optimistic local mirror — toggling each row is independent, so we keep
+  // the user's view responsive while the server action revalidates the page.
+  const [optimistic, setOptimistic] = useState<Record<number, boolean>>(
+    Object.fromEntries(candidates.map((c) => [c.id, c.isSalary])),
+  );
+  const [pending, startTransition] = useTransition();
+
+  function toggle(id: number, next: boolean) {
+    const previous = optimistic[id];
+    setOptimistic((s) => ({ ...s, [id]: next }));
+    startTransition(async () => {
+      try {
+        await setCounterpartyIsSalary({ counterpartyId: id, isSalary: next });
+      } catch (err) {
+        // Revert on failure so the UI stays truthful.
+        setOptimistic((s) => ({ ...s, [id]: previous }));
+        toast.error(err instanceof Error ? err.message : "No se pudo guardar");
+      }
+    });
+  }
+
+  if (candidates.length === 0) {
+    return (
+      <section className="card-paper paper-rise-1 flex flex-col gap-2 p-5">
+        <span className="text-eyebrow">Sueldos</span>
+        <p className="text-ink-muted text-sm">
+          Aún no recibiste pagos en Findash. Cuando entren los primeros ingresos vas a poder
+          marcarlos como sueldo acá.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="card-paper paper-rise-1 flex flex-col gap-3 p-5">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-eyebrow">Sueldos</span>
+        <p className="text-ink-muted text-xs">
+          Marcá la(s) fuente(s) de ingreso fijo. Findash usa los pagos detectados para anclar el
+          período financiero. Listamos solo los counterparties con ingresos registrados.
+        </p>
+      </div>
+
+      <ul className="flex flex-col divide-y">
+        {candidates.map((c) => {
+          const checked = optimistic[c.id] ?? false;
+          return (
+            <li key={c.id} className="flex items-center justify-between gap-3 py-2.5">
+              <div className="flex min-w-0 flex-col">
+                <span className="text-ink truncate text-sm font-medium">{c.displayName}</span>
+                <span className="text-ink-muted text-xs">
+                  {c.incomeTxCount} ingreso{c.incomeTxCount === 1 ? "" : "s"} · total{" "}
+                  <Money cents={c.totalIncomeCents} currency="COP" />
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={() => toggle(c.id, !checked)}
+                disabled={pending}
+                aria-pressed={checked}
+                aria-label={
+                  checked
+                    ? `Desmarcar ${c.displayName} como sueldo`
+                    : `Marcar ${c.displayName} como sueldo`
+                }
+                className={`flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-xs transition-colors ${
+                  checked
+                    ? "border-primary bg-primary/10 text-foreground"
+                    : "bg-background text-muted-foreground hover:bg-muted"
+                }`}
+              >
+                <WalletIcon className="size-3" />
+                <span>{checked ? "Sueldo" : "Marcar sueldo"}</span>
+                <span
+                  className={`relative inline-flex h-3 w-6 shrink-0 items-center rounded-full transition-colors ${
+                    checked ? "bg-primary" : "bg-muted-foreground/30"
+                  }`}
+                  aria-hidden
+                >
+                  <span
+                    className={`bg-background inline-block size-2.5 rounded-full transition-transform ${
+                      checked ? "translate-x-3" : "translate-x-0.5"
+                    }`}
+                  />
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -446,6 +446,10 @@ const updateCounterpartySchema = z.object({
   id: z.coerce.number().int().positive(),
   displayName: z.string().trim().min(1).max(120),
   type: counterpartyTypeSchema,
+  // #493: orthogonal to `type` — flagging an employer as salary anchors the
+  // pay-period helper. Optional in the schema so existing callers (drag/drop
+  // rename, type-only edits) don't have to pass it explicitly.
+  isSalary: z.boolean().optional(),
   defaultCategorySlug: z.string().min(1).max(60).nullable(),
   notes: z.string().max(500).nullable(),
 });
@@ -492,6 +496,7 @@ export async function updateCounterparty(
       .set({
         displayName: parsed.displayName,
         type: parsed.type,
+        ...(parsed.isSalary !== undefined ? { isSalary: parsed.isSalary } : {}),
         defaultCategorySlug: parsed.defaultCategorySlug,
         notes: parsed.notes,
         updatedAt: new Date(),

--- a/src/components/dashboard/category-donut.tsx
+++ b/src/components/dashboard/category-donut.tsx
@@ -5,6 +5,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Money } from "@/components/display/money";
 import { useMoneyMode } from "@/components/display/money-mode-provider";
 import { convertCents, displayCurrencyFor, formatMoney } from "@/lib/money";
+import {
+  formatPeriodDateRange,
+  periodFallbackNote,
+  type FinancialPeriod,
+} from "@/lib/dashboard/period-format";
 
 const PALETTE = [
   "var(--chart-1)",
@@ -24,10 +29,12 @@ export type DonutSlice = {
 export function CategoryDonut({
   slices,
   monthLabel,
+  period,
   isFuture = false,
 }: {
   slices: DonutSlice[];
   monthLabel: string;
+  period?: FinancialPeriod;
   isFuture?: boolean;
 }) {
   const total = slices.reduce((acc, s) => acc + s.value, 0);
@@ -38,11 +45,19 @@ export function CategoryDonut({
     if (target === "COP" || fxRate === null) return formatMoney(copCents, "COP");
     return formatMoney(convertCents(copCents, "COP", target, fxRate.rate), target);
   };
+  const dateRange = period ? formatPeriodDateRange(period) : null;
+  const fallbackNote = period ? periodFallbackNote(period) : null;
 
   return (
     <Card className="lg:col-span-2">
       <CardHeader>
-        <CardDescription>Expenses by category · {monthLabel}</CardDescription>
+        <CardDescription>
+          Expenses by category · {monthLabel}
+          {dateRange ? <span className="lowercase"> · {dateRange}</span> : null}
+          {fallbackNote ? (
+            <span className="text-muted-foreground/70 ml-2 text-[10px]">{fallbackNote}</span>
+          ) : null}
+        </CardDescription>
         <CardTitle className="text-2xl tabular-nums">
           <Money cents={BigInt(Math.round(total))} currency="COP" />
         </CardTitle>

--- a/src/components/dashboard/monthly-flow-card.tsx
+++ b/src/components/dashboard/monthly-flow-card.tsx
@@ -1,6 +1,11 @@
 import { AnimatedMoney } from "@/components/ui/animated-money";
 import { cn } from "@/lib/utils";
 import type { MonthlyFlow } from "@/lib/dashboard/queries";
+import {
+  formatPeriodDateRange,
+  periodFallbackNote,
+  type FinancialPeriod,
+} from "@/lib/dashboard/period-format";
 
 function pctOf(part: bigint, whole: bigint): number {
   if (whole <= BigInt(0)) return 0;
@@ -10,10 +15,12 @@ function pctOf(part: bigint, whole: bigint): number {
 export function MonthlyFlowCard({
   data,
   monthLabel,
+  period,
   isFuture = false,
 }: {
   data: MonthlyFlow;
   monthLabel: string;
+  period?: FinancialPeriod;
   isFuture?: boolean;
 }) {
   if (isFuture) {
@@ -29,12 +36,22 @@ export function MonthlyFlowCard({
   const positive = data.netCopCents >= BigInt(0);
   const total = data.incomeCopCents + data.expenseCopCents;
   const incomePct = pctOf(data.incomeCopCents, total);
+  const dateRange = period ? formatPeriodDateRange(period) : null;
+  const fallbackNote = period ? periodFallbackNote(period) : null;
 
   return (
     <article className="card-paper paper-rise-1 flex h-full flex-col gap-4 p-6">
-      <div className="flex items-baseline justify-between gap-2">
-        <span className="text-eyebrow">Flujo del mes</span>
-        <span className="text-ink-subtle text-xs capitalize">{monthLabel}</span>
+      <div className="flex flex-col items-end gap-0.5 sm:flex-row sm:items-baseline sm:justify-between">
+        <span className="text-eyebrow self-start">Flujo del mes</span>
+        <div className="flex flex-col items-end">
+          <span className="text-ink-subtle text-xs capitalize">
+            {monthLabel}
+            {dateRange ? <span className="lowercase"> · {dateRange}</span> : null}
+          </span>
+          {fallbackNote ? (
+            <span className="text-ink-subtle/80 text-[10px]">{fallbackNote}</span>
+          ) : null}
+        </div>
       </div>
 
       <div className="flex items-baseline gap-2">

--- a/src/components/dashboard/pay-period-nudge.tsx
+++ b/src/components/dashboard/pay-period-nudge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useTransition } from "react";
+import Link from "next/link";
+import { LightbulbIcon, XIcon } from "lucide-react";
+import { dismissPayPeriodNudge } from "@/lib/preferences/actions";
+
+/**
+ * One-time opt-in banner shown on the dashboard when the user already meets
+ * the pay-period activation pre-conditions (≥1 salary flag + ≥2 paychecks)
+ * but has not turned the mode on. Dismissal persists in
+ * `uiPreferences.payPeriodNudgeDismissed`, so this never re-appears.
+ *
+ * Rendering is gated by the page (`showPayPeriodNudge`) — this component
+ * trusts the parent to decide visibility.
+ */
+export function PayPeriodNudge() {
+  const [pending, startTransition] = useTransition();
+
+  function onDismiss() {
+    startTransition(async () => {
+      try {
+        await dismissPayPeriodNudge();
+      } catch {
+        /* swallow — dismissal is best-effort */
+      }
+    });
+  }
+
+  return (
+    <div
+      role="region"
+      aria-label="Sugerencia de modo sueldo"
+      className="card-paper paper-rise-1 flex items-start gap-3 p-4 sm:items-center"
+    >
+      <LightbulbIcon className="text-botanical-fg mt-0.5 size-4 shrink-0 sm:mt-0" aria-hidden />
+      <div className="flex-1 text-sm">
+        <p className="text-ink leading-snug">
+          Detectamos tus pagos de sueldo. Activá el{" "}
+          <Link
+            href="/settings#periodo-financiero"
+            className="text-botanical-fg underline-offset-2 hover:underline"
+          >
+            modo sueldo
+          </Link>{" "}
+          para que el flujo del mes se ancle en tu ciclo real.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        disabled={pending}
+        aria-label="Descartar sugerencia"
+        className="text-ink-muted hover:text-ink shrink-0 rounded-sm p-1 transition-colors disabled:opacity-50"
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/dashboard/progress-card.tsx
+++ b/src/components/dashboard/progress-card.tsx
@@ -1,13 +1,20 @@
 import { AnimatedMoney } from "@/components/ui/animated-money";
 import type { MonthlyProgress } from "@/lib/dashboard/queries";
+import {
+  formatPeriodDateRange,
+  periodFallbackNote,
+  type FinancialPeriod,
+} from "@/lib/dashboard/period-format";
 
 export function ProgressCard({
   data,
   monthLabel,
+  period,
   isFuture = false,
 }: {
   data: MonthlyProgress;
   monthLabel: string;
+  period?: FinancialPeriod;
   isFuture?: boolean;
 }) {
   if (isFuture) {
@@ -25,11 +32,22 @@ export function ProgressCard({
     );
   }
 
+  const dateRange = period ? formatPeriodDateRange(period) : null;
+  const fallbackNote = period ? periodFallbackNote(period) : null;
+
   return (
     <article className="card-paper paper-rise-2 flex h-full flex-col gap-5 p-6">
-      <div className="flex items-baseline justify-between gap-2">
-        <span className="text-eyebrow">Progreso</span>
-        <span className="text-ink-subtle text-xs capitalize">{monthLabel}</span>
+      <div className="flex flex-col items-end gap-0.5 sm:flex-row sm:items-baseline sm:justify-between">
+        <span className="text-eyebrow self-start">Progreso</span>
+        <div className="flex flex-col items-end">
+          <span className="text-ink-subtle text-xs capitalize">
+            {monthLabel}
+            {dateRange ? <span className="lowercase"> · {dateRange}</span> : null}
+          </span>
+          {fallbackNote ? (
+            <span className="text-ink-subtle/80 text-[10px]">{fallbackNote}</span>
+          ) : null}
+        </div>
       </div>
 
       <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">

--- a/src/components/dashboard/top-expenses-card.tsx
+++ b/src/components/dashboard/top-expenses-card.tsx
@@ -9,6 +9,11 @@ import { useNewIds } from "@/lib/hooks/use-new-ids";
 import { Money } from "@/components/display/money";
 import { hasSecondaryDescription, primaryDescription } from "@/lib/transactions/description";
 import type { TopExpense } from "@/lib/dashboard/queries";
+import {
+  formatPeriodDateRange,
+  periodFallbackNote,
+  type FinancialPeriod,
+} from "@/lib/dashboard/period-format";
 
 const dateFmt = new Intl.DateTimeFormat("es-CO", { day: "2-digit", month: "short" });
 
@@ -31,11 +36,13 @@ export function TopExpensesCard({
   rows,
   monthLabel,
   ym,
+  period,
   isFuture = false,
 }: {
   rows: TopExpense[];
   monthLabel: string;
   ym: string;
+  period?: FinancialPeriod;
   isFuture?: boolean;
 }) {
   const shouldReduceMotion = useReducedMotion();
@@ -44,11 +51,19 @@ export function TopExpensesCard({
   const enterInitial = shouldReduceMotion ? false : { opacity: 0, y: -8 };
   const enterAnimate = { opacity: 1, y: 0 };
   const enterTransition = { duration: 0.25, ease: "easeOut" as const };
+  const dateRange = period ? formatPeriodDateRange(period) : null;
+  const fallbackNote = period ? periodFallbackNote(period) : null;
 
   return (
     <Card>
       <CardHeader>
-        <CardDescription>Top expenses · {monthLabel}</CardDescription>
+        <CardDescription>
+          Top expenses · {monthLabel}
+          {dateRange ? <span className="lowercase"> · {dateRange}</span> : null}
+          {fallbackNote ? (
+            <span className="text-muted-foreground/70 ml-2 text-[10px]">{fallbackNote}</span>
+          ) : null}
+        </CardDescription>
         <CardTitle className="text-base">{rows.length} of top 5</CardTitle>
       </CardHeader>
       <CardContent>

--- a/src/components/transactions/counterparty-dialog.tsx
+++ b/src/components/transactions/counterparty-dialog.tsx
@@ -8,6 +8,7 @@ import {
   CircleHelpIcon,
   MergeIcon,
   SplitIcon,
+  WalletIcon,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -64,6 +65,7 @@ export function CounterpartyDialog({
   const [pending, startTransition] = useTransition();
   const [displayName, setDisplayName] = useState(counterparty.displayName);
   const [type, setType] = useState<CounterpartyValue["type"]>(counterparty.type);
+  const [isSalary, setIsSalary] = useState<boolean>(counterparty.isSalary);
   const [defaultCategorySlug, setDefaultCategorySlug] = useState<string>(
     counterparty.defaultCategorySlug ?? "",
   );
@@ -80,6 +82,7 @@ export function CounterpartyDialog({
   function reset() {
     setDisplayName(counterparty.displayName);
     setType(counterparty.type);
+    setIsSalary(counterparty.isSalary);
     setDefaultCategorySlug(counterparty.defaultCategorySlug ?? "");
     setNotes(counterparty.notes ?? "");
     setMergeTargetId("");
@@ -103,6 +106,7 @@ export function CounterpartyDialog({
           id: counterparty.id,
           displayName: displayName.trim(),
           type,
+          isSalary,
           defaultCategorySlug: defaultCategorySlug || null,
           notes: notes.trim() || null,
         });
@@ -261,6 +265,41 @@ export function CounterpartyDialog({
                 label="Unknown"
               />
             </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>Sueldo / Nómina</Label>
+            <button
+              type="button"
+              onClick={() => setIsSalary((v) => !v)}
+              className={`flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+                isSalary
+                  ? "border-primary bg-primary/10 text-foreground"
+                  : "bg-background text-muted-foreground hover:bg-muted"
+              }`}
+              aria-pressed={isSalary}
+            >
+              <span className="flex items-center gap-2">
+                <WalletIcon className="size-3.5" />
+                Marcar como sueldo
+              </span>
+              <span
+                className={`relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors ${
+                  isSalary ? "bg-primary" : "bg-muted-foreground/30"
+                }`}
+                aria-hidden
+              >
+                <span
+                  className={`bg-background inline-block size-3 rounded-full transition-transform ${
+                    isSalary ? "translate-x-3.5" : "translate-x-0.5"
+                  }`}
+                />
+              </span>
+            </button>
+            <p className="text-muted-foreground text-xs">
+              Activá para que el flujo del mes se ancle en tus fechas reales de pago (Settings →
+              Período financiero).
+            </p>
           </div>
 
           <div className="flex flex-col gap-1.5">

--- a/src/lib/ai/insights.ts
+++ b/src/lib/ai/insights.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { aliasedTable, and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { aliasedTable, and, asc, desc, eq, gte, lt, sql } from "drizzle-orm";
 import { db as defaultDb, type DB } from "@/lib/db";
 import {
   accounts,
@@ -58,11 +58,11 @@ function shiftMonth(ym: string, delta: number): string {
   return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
-function monthBounds(ym: string) {
+function calendarBounds(ym: string) {
   const [y, m] = ym.split("-").map(Number);
   return {
     start: new Date(Date.UTC(y, m - 1, 1)),
-    end: new Date(Date.UTC(y, m, 0, 23, 59, 59)),
+    end: new Date(Date.UTC(y, m, 1)),
     startIso: `${ym}-01`,
   };
 }
@@ -72,15 +72,31 @@ function toCopNumber(cents: bigint, currency: Currency, copPerUsd: number): numb
   return currency === "USD" ? pesos * copPerUsd : pesos;
 }
 
+/**
+ * Build the structured summary that feeds Claude. Spend/income aggregations
+ * respect the optional `currentRange` / `previousRange` overrides — pass the
+ * resolved `getFinancialPeriod` ranges from the call site so insights match
+ * the dashboard's "Flujo del mes". Budget plans stay calendar-anchored
+ * (`budgets.periodStart` is calendar) regardless of cycle mode.
+ */
 export async function buildInsightsSummary(
   userId: number,
   ym: string,
   copPerUsd: number,
   db: DB = defaultDb,
+  ranges?: {
+    currentRange?: { start: Date; end: Date };
+    previousRange?: { start: Date; end: Date };
+  },
 ): Promise<InsightsSummary> {
   const prevYm = shiftMonth(ym, -1);
-  const cur = monthBounds(ym);
-  const prev = monthBounds(prevYm);
+  const calCur = calendarBounds(ym);
+  const calPrev = calendarBounds(prevYm);
+  const cur = {
+    ...(ranges?.currentRange ?? calCur),
+    startIso: calCur.startIso, // budget plan period is always calendar-anchored
+  };
+  const prev = ranges?.previousRange ?? calPrev;
 
   const [accs, curTxTotals, prevTxTotals, curCats, prevCats, topMer, budgetRows, recRows] =
     await Promise.all([
@@ -112,7 +128,7 @@ export async function buildInsightsSummary(
           and(
             eq(transactions.userId, userId),
             gte(transactions.occurredAt, cur.start),
-            lte(transactions.occurredAt, cur.end),
+            lt(transactions.occurredAt, cur.end),
             notAdjustment(transactions.isAdjustment),
             notDeleted(transactions.deletedAt),
           ),
@@ -129,7 +145,7 @@ export async function buildInsightsSummary(
           and(
             eq(transactions.userId, userId),
             gte(transactions.occurredAt, prev.start),
-            lte(transactions.occurredAt, prev.end),
+            lt(transactions.occurredAt, prev.end),
             notAdjustment(transactions.isAdjustment),
             notDeleted(transactions.deletedAt),
           ),
@@ -157,7 +173,7 @@ export async function buildInsightsSummary(
             and(
               eq(transactions.userId, userId),
               gte(transactions.occurredAt, cur.start),
-              lte(transactions.occurredAt, cur.end),
+              lt(transactions.occurredAt, cur.end),
               notAdjustment(transactions.isAdjustment),
               notDeleted(transactions.deletedAt),
             ),
@@ -182,7 +198,7 @@ export async function buildInsightsSummary(
             and(
               eq(transactions.userId, userId),
               gte(transactions.occurredAt, prev.start),
-              lte(transactions.occurredAt, prev.end),
+              lt(transactions.occurredAt, prev.end),
               notAdjustment(transactions.isAdjustment),
               notDeleted(transactions.deletedAt),
             ),
@@ -201,7 +217,7 @@ export async function buildInsightsSummary(
           and(
             eq(transactions.userId, userId),
             gte(transactions.occurredAt, cur.start),
-            lte(transactions.occurredAt, cur.end),
+            lt(transactions.occurredAt, cur.end),
             sql`${transactions.merchant} IS NOT NULL`,
             sql`${transactions.amountCents} < 0`,
             notAdjustment(transactions.isAdjustment),

--- a/src/lib/budgets/queries.ts
+++ b/src/lib/budgets/queries.ts
@@ -1,4 +1,4 @@
-import { aliasedTable, and, asc, eq, gte, lte, sql } from "drizzle-orm";
+import { aliasedTable, and, asc, eq, gte, lt, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { budgets, categories, transactions } from "@/lib/db/schema";
 import { notAdjustment, notDeleted } from "@/lib/db/helpers";
@@ -24,18 +24,27 @@ export type BudgetsOverview = {
   items: BudgetOverviewItem[];
 };
 
-function monthRange(ym: string) {
+function defaultCalendarRange(ym: string) {
   const [y, m] = ym.split("-").map(Number);
   const start = new Date(Date.UTC(y, m - 1, 1));
-  const end = new Date(Date.UTC(y, m, 0, 23, 59, 59));
-  return { start, end, startIso: `${ym}-01` };
+  const end = new Date(Date.UTC(y, m, 1));
+  return { start, end };
 }
 
+/**
+ * Budget plans are anchored on calendar months (`budgets.periodStart` matches
+ * `${ym}-01`). Spend aggregation, however, can run over a different range so
+ * pay-period users see consistent numbers across the dashboard and budgets
+ * page. Pass `spendRange` resolved from `getFinancialPeriod` at the call
+ * site; omit it to fall back to the calendar month implied by `yearMonth`.
+ */
 export async function getBudgetsOverview(
   userId: number,
   yearMonth: string,
+  spendRange?: { start: Date; end: Date },
 ): Promise<BudgetsOverview> {
-  const { start, end, startIso } = monthRange(yearMonth);
+  const startIso = `${yearMonth}-01`;
+  const { start, end } = spendRange ?? defaultCalendarRange(yearMonth);
 
   const [cats, rows, spentRows] = await Promise.all([
     db
@@ -88,7 +97,7 @@ export async function getBudgetsOverview(
           and(
             eq(transactions.userId, userId),
             gte(transactions.occurredAt, start),
-            lte(transactions.occurredAt, end),
+            lt(transactions.occurredAt, end),
             notAdjustment(transactions.isAdjustment),
             notDeleted(transactions.deletedAt),
           ),

--- a/src/lib/dashboard/period-format.ts
+++ b/src/lib/dashboard/period-format.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure types + formatters for financial-period rendering. Lives in its own
+ * module so client components can import it without dragging the server-only
+ * `db` import chain (`period.ts` reaches into postgres.js + auth + drizzle).
+ *
+ * Anything that touches the database stays in `./period.ts`.
+ */
+
+export type FinancialPeriodFallback =
+  | "no_salary_flagged"
+  | "insufficient_history"
+  | "no_recent_paycheck";
+
+export type FinancialPeriod = {
+  start: Date;
+  end: Date;
+  mode: "calendar" | "pay_period";
+  fallbackReason?: FinancialPeriodFallback;
+};
+
+/**
+ * Format the period's date range for card subtitles. Returns `null` when
+ * the period is calendar — callers should fall back to the existing
+ * "abril 2026" label in that case.
+ *
+ * Display convention: the end label is "the day before the next anchor"
+ * because both calendar and pay-period ends are exclusive (next-period
+ * boundary), so `end - 1d` is the last day fully inside this period.
+ */
+export function formatPeriodDateRange(period: FinancialPeriod, locale = "es-CO"): string | null {
+  if (period.mode !== "pay_period") return null;
+  const oneDay = 24 * 60 * 60 * 1000;
+  const lastDay = new Date(period.end.getTime() - oneDay);
+  const fmt = (d: Date) =>
+    d.toLocaleDateString(locale, { day: "numeric", month: "short", timeZone: "UTC" });
+  return `${fmt(period.start)} — ${fmt(lastDay)}`;
+}
+
+/**
+ * Inline note to render below the subtitle when the period helper degraded
+ * to calendar despite the user being in pay_period mode. `null` when no
+ * note is needed (calendar-mode-by-choice or successful pay_period).
+ */
+export function periodFallbackNote(period: FinancialPeriod): string | null {
+  if (!period.fallbackReason) return null;
+  return "Sin datos de sueldo · mostrando mes calendario";
+}

--- a/src/lib/dashboard/period.test.ts
+++ b/src/lib/dashboard/period.test.ts
@@ -1,0 +1,539 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, counterparties, transactions, users } from "@/lib/db/schema";
+import { copyCategorySeedsToUser, copyRuleSeedsToUser } from "@/lib/auth/signup";
+import { updateUiPreferences } from "@/lib/preferences/repo";
+import { getFinancialPeriod, getPayPeriodReadiness, currentCalendarMonth } from "./period";
+
+const TAG = "+period-test@findash.local";
+
+async function createUser(email: string): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({ email, name: "Period Test", role: "user", active: true, googleSub: `sub-${email}` })
+    .returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  await copyRuleSeedsToUser(row.id);
+  return row.id;
+}
+
+async function createAccount(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: "Test Acct",
+      institution: "PERIOD_TEST",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createSalaryCounterparty(userId: number, name: string): Promise<number> {
+  const [row] = await db
+    .insert(counterparties)
+    .values({ userId, displayName: name, type: "merchant", isSalary: true })
+    .returning({ id: counterparties.id });
+  return row.id;
+}
+
+async function insertSalary(
+  userId: number,
+  accountId: number,
+  counterpartyId: number,
+  occurredAt: Date,
+  amountCents: bigint,
+  externalIdSuffix: string,
+) {
+  await db.insert(transactions).values({
+    userId,
+    accountId,
+    counterpartyId,
+    occurredAt,
+    amountCents,
+    currency: "COP",
+    descriptionRaw: "Salary",
+    categorySlug: "ingresos",
+    classificationMethod: "manual",
+    source: "manual",
+    externalId: `period-test-${userId}-${externalIdSuffix}`,
+  });
+}
+
+async function cleanup() {
+  const tags = ["a", "b", "c"].map((p) => `${p}${TAG}`);
+  const userRows = await db.select({ id: users.id }).from(users).where(inArray(users.email, tags));
+  if (userRows.length === 0) return;
+  const ids = userRows.map((u) => u.id);
+  await db.delete(transactions).where(inArray(transactions.userId, ids));
+  await db.delete(counterparties).where(inArray(counterparties.userId, ids));
+  await db.delete(accounts).where(inArray(accounts.userId, ids));
+  await db.delete(users).where(inArray(users.id, ids));
+}
+
+// Wall-clock helper — Bun vitest does not implement vi.setSystemTime, so the
+// helper exposes wallNow as a parameter and tests inject deterministic values.
+const REF_APR = new Date("2026-04-15T10:00:00Z");
+const WALL_MAY = new Date("2026-05-15T10:00:00Z").getTime();
+const WALL_APR = new Date("2026-04-15T10:00:00Z").getTime();
+
+describe("dashboard/period", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  describe("currentCalendarMonth", () => {
+    it("returns UTC month boundaries for the given date", () => {
+      const range = currentCalendarMonth(REF_APR);
+      expect(range.start.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+      expect(range.end.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+    });
+  });
+
+  describe("getFinancialPeriod — mode = calendar (default)", () => {
+    it("returns calendar range when mode is calendar, regardless of salary data", async () => {
+      const userId = await createUser(`a${TAG}`);
+      const acc = await createAccount(userId);
+      const cp = await createSalaryCounterparty(userId, "Empresa SAS");
+      // Plant several "real-looking" paychecks — should be ignored.
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-02-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "1",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-03-30T12:00:00Z"),
+        BigInt(500_000_00),
+        "2",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-04-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "3",
+      );
+
+      const period = await getFinancialPeriod(userId, REF_APR, WALL_MAY);
+      expect(period.mode).toBe("calendar");
+      expect(period.start.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+      expect(period.end.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+      expect(period.fallbackReason).toBeUndefined();
+    });
+  });
+
+  describe("getFinancialPeriod — mode = pay_period", () => {
+    it("anchors on latest paycheck before each month boundary (monthly leading payroll)", async () => {
+      const userId = await createUser(`a${TAG}`);
+      await updateUiPreferences(userId, { financialCycleMode: "pay_period" });
+      const acc = await createAccount(userId);
+      const cp = await createSalaryCounterparty(userId, "Empresa SAS");
+
+      // Monthly paychecks landing 1-3 days before each month
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-02-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "1",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-03-30T12:00:00Z"),
+        BigInt(500_000_00),
+        "2",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-04-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "3",
+      );
+
+      const period = await getFinancialPeriod(userId, REF_APR, WALL_MAY);
+      expect(period.mode).toBe("pay_period");
+      expect(period.start.toISOString()).toBe("2026-03-30T12:00:00.000Z");
+      expect(period.end.toISOString()).toBe("2026-04-28T12:00:00.000Z");
+      expect(period.fallbackReason).toBeUndefined();
+    });
+
+    it("biweekly paychecks: April period contains both quincenas", async () => {
+      const userId = await createUser(`a${TAG}`);
+      await updateUiPreferences(userId, { financialCycleMode: "pay_period" });
+      const acc = await createAccount(userId);
+      const cp = await createSalaryCounterparty(userId, "Empresa SAS");
+
+      // Biweekly: 14 mar, 30 mar, 14 abr, 28 abr, 14 may
+      const dates = [
+        "2026-03-14T12:00:00Z",
+        "2026-03-30T12:00:00Z",
+        "2026-04-14T12:00:00Z",
+        "2026-04-28T12:00:00Z",
+        "2026-05-14T12:00:00Z",
+      ];
+      for (let i = 0; i < dates.length; i++) {
+        await insertSalary(userId, acc, cp, new Date(dates[i]), BigInt(250_000_00), `bi-${i}`);
+      }
+
+      const period = await getFinancialPeriod(userId, REF_APR, WALL_MAY);
+      expect(period.mode).toBe("pay_period");
+      // Anchor for Apr 1 is closest paycheck → Mar 30 (2 days)
+      expect(period.start.toISOString()).toBe("2026-03-30T12:00:00.000Z");
+      // Anchor for May 1 is closest → Apr 28 (3 days) over May 14 (13 days)
+      expect(period.end.toISOString()).toBe("2026-04-28T12:00:00.000Z");
+      // Mid-month paycheck Apr 14 lives INSIDE [Mar 30, Apr 28) ✓
+      expect(period.start.getTime()).toBeLessThan(new Date("2026-04-14T12:00:00Z").getTime());
+      expect(period.end.getTime()).toBeGreaterThan(new Date("2026-04-14T12:00:00Z").getTime());
+    });
+
+    it("filters out reimbursements (amounts <50% of paycheck median)", async () => {
+      const userId = await createUser(`a${TAG}`);
+      await updateUiPreferences(userId, { financialCycleMode: "pay_period" });
+      const acc = await createAccount(userId);
+      const cp = await createSalaryCounterparty(userId, "Empresa SAS");
+
+      // Real paychecks (median = 500_000_00 = 5_000_000 in pesos)
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-02-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "1",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-03-30T12:00:00Z"),
+        BigInt(500_000_00),
+        "2",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-04-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "3",
+      );
+      // Reimbursement landing close to a month boundary — would shift the
+      // anchor to mid-month if the median filter let it through.
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-04-30T20:00:00Z"),
+        BigInt(50_000_00),
+        "reimb",
+      );
+
+      const period = await getFinancialPeriod(userId, REF_APR, WALL_MAY);
+      expect(period.mode).toBe("pay_period");
+      // If the reimbursement on Apr 30 leaked, the May-1 anchor would shift
+      // to Apr 30 instead of staying at the legitimate paycheck Apr 28.
+      expect(period.end.toISOString()).toBe("2026-04-28T12:00:00.000Z");
+    });
+
+    it("multiple salary counterparties: anchors on whichever paycheck is closest to each boundary", async () => {
+      const userId = await createUser(`a${TAG}`);
+      await updateUiPreferences(userId, { financialCycleMode: "pay_period" });
+      const acc = await createAccount(userId);
+      const cpA = await createSalaryCounterparty(userId, "Empresa SAS");
+      const cpB = await createSalaryCounterparty(userId, "Otro Empleo");
+
+      // CpA pays last day of month (~30), CpB pays 3rd of month — both monthly
+      await insertSalary(
+        userId,
+        acc,
+        cpA,
+        new Date("2026-02-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "a1",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cpA,
+        new Date("2026-03-30T12:00:00Z"),
+        BigInt(500_000_00),
+        "a2",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cpA,
+        new Date("2026-04-29T12:00:00Z"),
+        BigInt(500_000_00),
+        "a3",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cpB,
+        new Date("2026-03-03T12:00:00Z"),
+        BigInt(300_000_00),
+        "b1",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cpB,
+        new Date("2026-04-03T12:00:00Z"),
+        BigInt(300_000_00),
+        "b2",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cpB,
+        new Date("2026-05-03T12:00:00Z"),
+        BigInt(300_000_00),
+        "b3",
+      );
+
+      const period = await getFinancialPeriod(userId, REF_APR, WALL_MAY);
+      expect(period.mode).toBe("pay_period");
+      // Sanity: period spans roughly one month regardless of which counterparty wins each anchor
+      const periodDays = (period.end.getTime() - period.start.getTime()) / (1000 * 60 * 60 * 24);
+      expect(periodDays).toBeGreaterThan(20);
+      expect(periodDays).toBeLessThan(40);
+    });
+
+    it("projects end from median spacing when current-month next paycheck has not landed", async () => {
+      // Wall clock mid-April. Last paycheck Mar 30, no Apr paycheck yet.
+      const userId = await createUser(`a${TAG}`);
+      await updateUiPreferences(userId, { financialCycleMode: "pay_period" });
+      const acc = await createAccount(userId);
+      const cp = await createSalaryCounterparty(userId, "Empresa SAS");
+
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-01-30T12:00:00Z"),
+        BigInt(500_000_00),
+        "1",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-02-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "2",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-03-30T12:00:00Z"),
+        BigInt(500_000_00),
+        "3",
+      );
+
+      const period = await getFinancialPeriod(userId, REF_APR, WALL_APR);
+      expect(period.mode).toBe("pay_period");
+      expect(period.start.toISOString()).toBe("2026-03-30T12:00:00.000Z");
+      // Projected end = Mar 30 + median spacing (~29 days)
+      const expectedEnd = new Date(period.start.getTime() + 29 * 24 * 60 * 60 * 1000);
+      const diffDays =
+        Math.abs(period.end.getTime() - expectedEnd.getTime()) / (1000 * 60 * 60 * 24);
+      expect(diffDays).toBeLessThan(2);
+    });
+
+    it("falls back to calendar with no_salary_flagged when user has no salary counterparty", async () => {
+      const userId = await createUser(`a${TAG}`);
+      await updateUiPreferences(userId, { financialCycleMode: "pay_period" });
+
+      const period = await getFinancialPeriod(userId, REF_APR, WALL_MAY);
+      expect(period.mode).toBe("calendar");
+      expect(period.fallbackReason).toBe("no_salary_flagged");
+    });
+
+    it("falls back to calendar with insufficient_history when <2 paychecks pass the filter", async () => {
+      const userId = await createUser(`a${TAG}`);
+      await updateUiPreferences(userId, { financialCycleMode: "pay_period" });
+      const acc = await createAccount(userId);
+      const cp = await createSalaryCounterparty(userId, "Empresa SAS");
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-03-30T12:00:00Z"),
+        BigInt(500_000_00),
+        "1",
+      );
+
+      const period = await getFinancialPeriod(userId, REF_APR, WALL_MAY);
+      expect(period.mode).toBe("calendar");
+      expect(period.fallbackReason).toBe("insufficient_history");
+    });
+
+    it("falls back with no_recent_paycheck when no paycheck before monthStart", async () => {
+      const userId = await createUser(`a${TAG}`);
+      await updateUiPreferences(userId, { financialCycleMode: "pay_period" });
+      const acc = await createAccount(userId);
+      const cp = await createSalaryCounterparty(userId, "Empresa SAS");
+      // Paychecks landed ONLY in April — none before April → no anchor for monthStart
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-04-15T12:00:00Z"),
+        BigInt(500_000_00),
+        "1",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-04-29T12:00:00Z"),
+        BigInt(500_000_00),
+        "2",
+      );
+
+      const period = await getFinancialPeriod(userId, REF_APR, WALL_APR);
+      expect(period.mode).toBe("calendar");
+      expect(period.fallbackReason).toBe("no_recent_paycheck");
+    });
+
+    it("past month with sparse data falls back to calendar (insufficient_history)", async () => {
+      // Wall clock is May. Querying Feb but only have Jan paycheck and a much later one.
+      const userId = await createUser(`a${TAG}`);
+      await updateUiPreferences(userId, { financialCycleMode: "pay_period" });
+      const acc = await createAccount(userId);
+      const cp = await createSalaryCounterparty(userId, "Empresa SAS");
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-01-30T12:00:00Z"),
+        BigInt(500_000_00),
+        "1",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-04-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "2",
+      );
+      // Spacing = 88 days, anchorWindow = 88 * 0.75 ≈ 66 days
+      // For Feb 1: closest is Jan 30 (2 days) ✓ start = Jan 30
+      // For Mar 1: closest is Jan 30 (30 days) within window → end == start
+      // Past month (wall clock = May 15) → fallback insufficient_history
+
+      const period = await getFinancialPeriod(userId, new Date("2026-02-15T10:00:00Z"), WALL_MAY);
+      expect(period.mode).toBe("calendar");
+      expect(period.fallbackReason).toBe("insufficient_history");
+    });
+  });
+
+  describe("getFinancialPeriod — tenant safety", () => {
+    it("only considers salary txs from the requested user", async () => {
+      const userA = await createUser(`a${TAG}`);
+      const userB = await createUser(`b${TAG}`);
+      await updateUiPreferences(userA, { financialCycleMode: "pay_period" });
+      await updateUiPreferences(userB, { financialCycleMode: "pay_period" });
+      const accB = await createAccount(userB);
+      const cpB = await createSalaryCounterparty(userB, "Otra Empresa");
+
+      // userB has full paycheck history — userA has nothing
+      await insertSalary(
+        userB,
+        accB,
+        cpB,
+        new Date("2026-02-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "b1",
+      );
+      await insertSalary(
+        userB,
+        accB,
+        cpB,
+        new Date("2026-03-30T12:00:00Z"),
+        BigInt(500_000_00),
+        "b2",
+      );
+      await insertSalary(
+        userB,
+        accB,
+        cpB,
+        new Date("2026-04-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "b3",
+      );
+
+      const periodA = await getFinancialPeriod(userA, REF_APR, WALL_MAY);
+      expect(periodA.mode).toBe("calendar");
+      expect(periodA.fallbackReason).toBe("no_salary_flagged");
+
+      const periodB = await getFinancialPeriod(userB, REF_APR, WALL_MAY);
+      expect(periodB.mode).toBe("pay_period");
+    });
+  });
+
+  describe("getPayPeriodReadiness", () => {
+    it("returns ready=false with no salary flag", async () => {
+      const userId = await createUser(`a${TAG}`);
+      const r = await getPayPeriodReadiness(userId);
+      expect(r).toEqual({ ready: false, hasSalaryFlag: false, paycheckCount: 0 });
+    });
+
+    it("returns ready=false with one paycheck", async () => {
+      const userId = await createUser(`a${TAG}`);
+      const acc = await createAccount(userId);
+      const cp = await createSalaryCounterparty(userId, "Empresa SAS");
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-03-30T12:00:00Z"),
+        BigInt(500_000_00),
+        "1",
+      );
+      const r = await getPayPeriodReadiness(userId);
+      expect(r).toEqual({ ready: false, hasSalaryFlag: true, paycheckCount: 1 });
+    });
+
+    it("returns ready=true with two valid paychecks", async () => {
+      const userId = await createUser(`a${TAG}`);
+      const acc = await createAccount(userId);
+      const cp = await createSalaryCounterparty(userId, "Empresa SAS");
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-02-28T12:00:00Z"),
+        BigInt(500_000_00),
+        "1",
+      );
+      await insertSalary(
+        userId,
+        acc,
+        cp,
+        new Date("2026-03-30T12:00:00Z"),
+        BigInt(500_000_00),
+        "2",
+      );
+      const r = await getPayPeriodReadiness(userId);
+      expect(r).toEqual({ ready: true, hasSalaryFlag: true, paycheckCount: 2 });
+    });
+  });
+});

--- a/src/lib/dashboard/period.ts
+++ b/src/lib/dashboard/period.ts
@@ -1,0 +1,288 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { counterparties, transactions } from "@/lib/db/schema";
+import { notAdjustment, notDeleted } from "@/lib/db/helpers";
+import { getUiPreferences } from "@/lib/preferences/repo";
+import type { FinancialPeriod, FinancialPeriodFallback } from "./period-format";
+
+// Re-export so existing server-side callers can keep importing types from
+// `./period`. Client components must import from `./period-format` to avoid
+// dragging this module's db chain into the browser bundle.
+export type { FinancialPeriod, FinancialPeriodFallback } from "./period-format";
+export { formatPeriodDateRange, periodFallbackNote } from "./period-format";
+
+/**
+ * Calendar-month range — used wherever bank truth matters (TC statements,
+ * cuotas, próximo pago, fechas de corte, extractos). DO NOT replace with
+ * `getFinancialPeriod` for these flows; the calendar boundary is the bank's
+ * billing boundary, not the user's.
+ */
+export function currentCalendarMonth(now = new Date()): { start: Date; end: Date } {
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+  return { start, end };
+}
+
+type SalaryTx = {
+  occurredAt: Date;
+  amountCents: bigint;
+  counterpartyId: number;
+};
+
+async function loadSalaryTxs(userId: number): Promise<SalaryTx[]> {
+  const rows = await db
+    .select({
+      occurredAt: transactions.occurredAt,
+      amountCents: transactions.amountCents,
+      counterpartyId: transactions.counterpartyId,
+    })
+    .from(transactions)
+    .innerJoin(
+      counterparties,
+      and(
+        eq(counterparties.id, transactions.counterpartyId),
+        // Tenant safety: pair the JOIN by user_id too. A counterparty.id
+        // shouldn't ever cross tenants (FK to users), but pairing makes the
+        // intent explicit and CodeQL-friendly.
+        eq(counterparties.userId, transactions.userId),
+      ),
+    )
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(counterparties.isSalary, true),
+        sql`${transactions.amountCents} > 0`,
+        notAdjustment(transactions.isAdjustment),
+        notDeleted(transactions.deletedAt),
+      ),
+    )
+    .orderBy(transactions.occurredAt);
+
+  return rows
+    .filter(
+      (r): r is { occurredAt: Date; amountCents: bigint; counterpartyId: number } =>
+        r.counterpartyId !== null,
+    )
+    .map((r) => ({
+      occurredAt: r.occurredAt,
+      amountCents: r.amountCents,
+      counterpartyId: r.counterpartyId,
+    }));
+}
+
+function medianAmountByCounterparty(txs: readonly SalaryTx[]): Map<number, bigint> {
+  const grouped = new Map<number, bigint[]>();
+  for (const t of txs) {
+    const list = grouped.get(t.counterpartyId);
+    if (list) list.push(t.amountCents);
+    else grouped.set(t.counterpartyId, [t.amountCents]);
+  }
+  const medians = new Map<number, bigint>();
+  for (const [cpId, amounts] of grouped) {
+    const sorted = [...amounts].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    medians.set(cpId, sorted[Math.floor(sorted.length / 2)]);
+  }
+  return medians;
+}
+
+/**
+ * Filter salary-counterparty txs to "real paychecks" — drop reimbursements,
+ * refunds, partial bonuses below 50% of the historical median for that
+ * counterparty. Threshold 50% chosen empirically: real paycheck variance is
+ * usually <30% (overtime, bonuses), and reimbursements are typically <20%
+ * of a paycheck. 50% leaves headroom on both sides.
+ */
+function filterPaychecks(txs: readonly SalaryTx[], medians: Map<number, bigint>): SalaryTx[] {
+  return txs.filter((t) => {
+    const median = medians.get(t.counterpartyId);
+    if (!median) return false;
+    // amount >= 0.5 * median  ⇔  2 * amount >= median  (avoids fractional bigint)
+    return t.amountCents * BigInt(2) >= median;
+  });
+}
+
+function medianSpacingMs(paychecks: readonly SalaryTx[]): number | null {
+  if (paychecks.length < 2) return null;
+  const sorted = [...paychecks].sort((a, b) => a.occurredAt.getTime() - b.occurredAt.getTime());
+  const diffs: number[] = [];
+  for (let i = 1; i < sorted.length; i++) {
+    diffs.push(sorted[i].occurredAt.getTime() - sorted[i - 1].occurredAt.getTime());
+  }
+  diffs.sort((a, b) => a - b);
+  return diffs[Math.floor(diffs.length / 2)];
+}
+
+/**
+ * Find the paycheck whose date is closest to `target`, within `maxDistMs`.
+ * Returns null if no paycheck falls inside the window — caller decides
+ * whether to fall back to calendar or project.
+ *
+ * This is the core anchoring rule: a paycheck "anchors" a month boundary
+ * when it's the closest one to that boundary. Each paycheck claims at most
+ * one month boundary (because `maxDistMs` is half-spacing; two boundaries
+ * can't both be closest to the same paycheck).
+ */
+function nearestAnchor(
+  paychecks: readonly SalaryTx[],
+  target: Date,
+  maxDistMs: number,
+): Date | null {
+  let best: Date | null = null;
+  let bestDist = Infinity;
+  const tt = target.getTime();
+  for (const p of paychecks) {
+    const d = Math.abs(p.occurredAt.getTime() - tt);
+    if (d < bestDist && d <= maxDistMs) {
+      bestDist = d;
+      best = p.occurredAt;
+    }
+  }
+  return best;
+}
+
+/**
+ * Resolve the financial period for the calendar month containing `now`.
+ *
+ * Decision flow:
+ *  1. If user pref `financialCycleMode = "calendar"` → return calendar range.
+ *  2. Load all salary-flagged-counterparty positive transactions for `userId`.
+ *  3. Filter to "real paychecks" via per-counterparty median amount (≥50%).
+ *  4. Anchor the period bounds on the paychecks closest to monthStart and
+ *     nextMonthStart, within ±0.75 * medianSpacing of each boundary.
+ *  5. Graceful degradation: if any step fails, return calendar with a
+ *     `fallbackReason` so the UI can show an inline note. The setting itself
+ *     is not flipped — degradation is per-call, per-month.
+ *
+ * The "current month with no future paycheck yet" case is handled by
+ * projecting `end = start + medianSpacing` when (a) the wall clock is inside
+ * the queried month and (b) `start` resolved successfully but `end` did not.
+ *
+ * `wallNow` is the actual current time used for the "current month" check.
+ * Defaults to `Date.now()`; injectable for deterministic tests since Bun's
+ * vitest does not support `vi.setSystemTime`.
+ */
+export async function getFinancialPeriod(
+  userId: number,
+  now = new Date(),
+  wallNow: number = Date.now(),
+): Promise<FinancialPeriod> {
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const nextMonthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+
+  const calendar = (reason?: FinancialPeriodFallback): FinancialPeriod => ({
+    start: monthStart,
+    end: nextMonthStart,
+    mode: "calendar",
+    ...(reason ? { fallbackReason: reason } : {}),
+  });
+
+  const prefs = await getUiPreferences(userId);
+  if (prefs.financialCycleMode === "calendar") return calendar();
+
+  const all = await loadSalaryTxs(userId);
+  if (all.length === 0) return calendar("no_salary_flagged");
+
+  const medians = medianAmountByCounterparty(all);
+  const paychecks = filterPaychecks(all, medians);
+  if (paychecks.length < 2) return calendar("insufficient_history");
+
+  const spacingMs = medianSpacingMs(paychecks);
+  if (!spacingMs) return calendar("insufficient_history");
+  const anchorWindow = spacingMs * 0.75;
+
+  const start = nearestAnchor(paychecks, monthStart, anchorWindow);
+  if (!start) return calendar("no_recent_paycheck");
+
+  const end = nearestAnchor(paychecks, nextMonthStart, anchorWindow);
+
+  if (!end || end.getTime() <= start.getTime()) {
+    // No anchor for the next month boundary. Two cases:
+    //  - Current month, next paycheck not yet landed → project from spacing.
+    //  - Past month with sparse data → fall back to calendar.
+    const isCurrent = wallNow >= monthStart.getTime() && wallNow < nextMonthStart.getTime();
+    if (isCurrent) {
+      return {
+        start,
+        end: new Date(start.getTime() + spacingMs),
+        mode: "pay_period",
+      };
+    }
+    return calendar("insufficient_history");
+  }
+
+  return { start, end, mode: "pay_period" };
+}
+
+/**
+ * Pre-conditions for activating `pay_period` mode in Settings UI. Returns
+ * which gates the user has met / failed so the toggle can be enabled and
+ * the failure reason explained inline.
+ */
+export type PayPeriodReadiness = {
+  ready: boolean;
+  hasSalaryFlag: boolean;
+  paycheckCount: number;
+};
+
+export async function getPayPeriodReadiness(userId: number): Promise<PayPeriodReadiness> {
+  const txs = await loadSalaryTxs(userId);
+  const hasSalaryFlag = txs.length > 0;
+  const medians = medianAmountByCounterparty(txs);
+  const paychecks = filterPaychecks(txs, medians);
+  return {
+    hasSalaryFlag,
+    paycheckCount: paychecks.length,
+    ready: hasSalaryFlag && paychecks.length >= 2,
+  };
+}
+
+/**
+ * Counterparties that have at least one positive transaction (income), with
+ * their `isSalary` flag and rolled-up income stats. Drives the Settings UI's
+ * "Sueldos" list — users flag the right counterparty(ies) without scrolling
+ * past every merchant they've ever paid.
+ */
+export type SalaryCandidate = {
+  id: number;
+  displayName: string;
+  isSalary: boolean;
+  incomeTxCount: number;
+  totalIncomeCents: bigint;
+};
+
+export async function listSalaryCandidates(userId: number): Promise<SalaryCandidate[]> {
+  const rows = await db
+    .select({
+      id: counterparties.id,
+      displayName: counterparties.displayName,
+      isSalary: counterparties.isSalary,
+      incomeTxCount: sql<number>`COUNT(${transactions.id})::int`,
+      totalIncomeCents: sql<string>`COALESCE(SUM(${transactions.amountCents}), 0)`,
+    })
+    .from(counterparties)
+    .innerJoin(
+      transactions,
+      and(
+        eq(transactions.counterpartyId, counterparties.id),
+        eq(transactions.userId, counterparties.userId),
+      ),
+    )
+    .where(
+      and(
+        eq(counterparties.userId, userId),
+        sql`${transactions.amountCents} > 0`,
+        notAdjustment(transactions.isAdjustment),
+        notDeleted(transactions.deletedAt),
+      ),
+    )
+    .groupBy(counterparties.id, counterparties.displayName, counterparties.isSalary)
+    .orderBy(sql`SUM(${transactions.amountCents}) DESC`);
+
+  return rows.map((r) => ({
+    id: r.id,
+    displayName: r.displayName,
+    isSalary: r.isSalary,
+    incomeTxCount: r.incomeTxCount,
+    totalIncomeCents: BigInt(r.totalIncomeCents),
+  }));
+}

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -5,13 +5,19 @@ import { notAdjustment, notDeleted } from "@/lib/db/helpers";
 import { toCop } from "@/lib/money";
 import { groupCreditCards, listAccountsDetailed } from "@/lib/accounts/queries";
 import { computeNextPayment } from "@/lib/accounts/next-payment";
+import { currentCalendarMonth } from "@/lib/dashboard/period";
 import type { AccountType, CounterpartyType, Currency } from "@/lib/types";
 
+/** @deprecated Use `currentCalendarMonth` from `@/lib/dashboard/period` for
+ *  bank-truth ranges, or `getFinancialPeriod` for user-anchored pay periods. */
 export function currentMonthRange(now = new Date()): { start: Date; end: Date } {
-  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
-  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
-  return { start, end };
+  return currentCalendarMonth(now);
 }
+
+/** Range of dates covering the period a month-bound query should aggregate
+ *  over. Resolve via `getFinancialPeriod` (pay-period mode) or
+ *  `currentCalendarMonth` (bank truth) at the call site. */
+export type DateRange = { start: Date; end: Date };
 
 export type AccountStatus = {
   id: number;
@@ -122,9 +128,9 @@ export type MonthlyFlow = {
 export async function getMonthlyFlow(
   userId: number,
   copPerUsd: number,
-  now = new Date(),
+  range: DateRange = currentCalendarMonth(),
 ): Promise<MonthlyFlow> {
-  const { start, end } = currentMonthRange(now);
+  const { start, end } = range;
 
   const rows = await db
     .select({
@@ -174,9 +180,9 @@ export type MonthlyProgress = {
 export async function getMonthlyProgress(
   userId: number,
   copPerUsd: number,
-  now = new Date(),
+  range: DateRange = currentCalendarMonth(),
 ): Promise<MonthlyProgress> {
-  const { start, end } = currentMonthRange(now);
+  const { start, end } = range;
 
   const debtRows = await db
     .select({
@@ -202,7 +208,7 @@ export async function getMonthlyProgress(
     debtPaidCopCents += toCop(BigInt(r.paidCents), r.currency, copPerUsd);
   }
 
-  const flow = await getMonthlyFlow(userId, copPerUsd, now);
+  const flow = await getMonthlyFlow(userId, copPerUsd, range);
   const savingsCopCents = flow.netCopCents > BigInt(0) ? flow.netCopCents : BigInt(0);
 
   return {
@@ -222,9 +228,9 @@ export type CategorySlice = {
 export async function getCategoryBreakdown(
   userId: number,
   copPerUsd: number,
-  now = new Date(),
+  range: DateRange = currentCalendarMonth(),
 ): Promise<CategorySlice[]> {
-  const { start, end } = currentMonthRange(now);
+  const { start, end } = range;
 
   const rootCategories = aliasedTable(categories, "root_categories");
   const rootSlug = sql<string | null>`COALESCE(${categories.parentSlug}, ${categories.slug})`;
@@ -297,10 +303,10 @@ export type TopExpense = {
 export async function getTopExpenses(
   userId: number,
   copPerUsd: number,
-  now = new Date(),
+  range: DateRange = currentCalendarMonth(),
   limit = 5,
 ): Promise<TopExpense[]> {
-  const { start, end } = currentMonthRange(now);
+  const { start, end } = range;
   const rateMicros = Math.round(copPerUsd * 1_000_000);
   const rows = await db
     .select({

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -25,8 +25,21 @@ export const DISPLAY_CURRENCY_MODES = ["native", "all-cop", "all-usd"] as const;
 export type DisplayCurrencyMode = (typeof DISPLAY_CURRENCY_MODES)[number];
 export const DEFAULT_DISPLAY_CURRENCY_MODE: DisplayCurrencyMode = "native";
 
+export const FINANCIAL_CYCLE_MODES = ["calendar", "pay_period"] as const;
+export type FinancialCycleMode = (typeof FINANCIAL_CYCLE_MODES)[number];
+export const DEFAULT_FINANCIAL_CYCLE_MODE: FinancialCycleMode = "calendar";
+
 export type UiPreferences = {
   displayCurrencyMode?: DisplayCurrencyMode;
+  // #493: opt-in toggle. When "pay_period" the dashboard / budgets / insights
+  // anchor month boundaries on detected salary income instead of the calendar
+  // month. Defaults to "calendar" — irregular-income users (freelancers, gig
+  // workers, multi-source) keep the original behavior.
+  financialCycleMode?: FinancialCycleMode;
+  // #493: dashboard one-time nudge dismissal. Once true the banner that
+  // suggests turning on pay_period mode never re-appears, even if the user
+  // later flips back to calendar mode.
+  payPeriodNudgeDismissed?: boolean;
 };
 
 // Per-user feature toggles. Default for every flag is "inherit from process
@@ -430,6 +443,11 @@ export const counterparties = pgTable(
     type: counterpartyType("type").notNull().default("unknown"),
     defaultCategorySlug: varchar("default_category_slug", { length: 60 }),
     notes: text("notes"),
+    // #493: orthogonal to `type` — your employer is a `merchant` AND
+    // `isSalary=true`. Drives the pay-period anchoring helper. A counterparty
+    // can be flagged regardless of `type`; the helper only looks at this flag
+    // plus the user's `financialCycleMode` preference.
+    isSalary: boolean("is_salary").notNull().default(false),
     hitCount: integer("hit_count").notNull().default(0),
     lastHitAt: timestamp("last_hit_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -437,6 +455,11 @@ export const counterparties = pgTable(
   },
   (t) => [
     index("counterparties_user_display_idx").on(t.userId, t.displayName),
+    // Partial index — most counterparties are NOT salary, so we only pay the
+    // index cost for the rows the period helper actually scans.
+    index("counterparties_user_salary_idx")
+      .on(t.userId)
+      .where(sql`${t.isSalary} = true`),
     foreignKey({
       columns: [t.userId, t.defaultCategorySlug],
       foreignColumns: [categories.userId, categories.slug],

--- a/src/lib/preferences/actions.ts
+++ b/src/lib/preferences/actions.ts
@@ -1,14 +1,52 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
+import { db } from "@/lib/db";
 import { getSessionUser } from "@/lib/auth/session";
-import { DISPLAY_CURRENCY_MODES } from "@/lib/db/schema";
+import { counterparties, DISPLAY_CURRENCY_MODES, FINANCIAL_CYCLE_MODES } from "@/lib/db/schema";
 import { updateUiPreferences } from "./repo";
 
 export async function setDisplayCurrencyMode(mode: unknown): Promise<void> {
   const session = await getSessionUser();
   const parsed = z.enum(DISPLAY_CURRENCY_MODES).parse(mode);
   await updateUiPreferences(session.id, { displayCurrencyMode: parsed });
+  revalidatePath("/", "layout");
+}
+
+export async function setFinancialCycleMode(mode: unknown): Promise<void> {
+  const session = await getSessionUser();
+  const parsed = z.enum(FINANCIAL_CYCLE_MODES).parse(mode);
+  await updateUiPreferences(session.id, { financialCycleMode: parsed });
+  // The cycle mode affects the dashboard, budgets and insights views — bust
+  // the layout cache so all three pages re-render with the new boundaries.
+  revalidatePath("/", "layout");
+}
+
+export async function dismissPayPeriodNudge(): Promise<void> {
+  const session = await getSessionUser();
+  await updateUiPreferences(session.id, { payPeriodNudgeDismissed: true });
+  revalidatePath("/");
+}
+
+const counterpartySalaryToggleSchema = z.object({
+  counterpartyId: z.coerce.number().int().positive(),
+  isSalary: z.boolean(),
+});
+
+/**
+ * Slim toggle for `counterparties.isSalary` from the Settings UI. Scoped to
+ * the calling user so a leaked counterparty id can't be flipped on someone
+ * else's row.
+ */
+export async function setCounterpartyIsSalary(input: unknown): Promise<void> {
+  const session = await getSessionUser();
+  const { counterpartyId, isSalary } = counterpartySalaryToggleSchema.parse(input);
+  await db
+    .update(counterparties)
+    .set({ isSalary, updatedAt: new Date() })
+    .where(and(eq(counterparties.userId, session.id), eq(counterparties.id, counterpartyId)));
+  revalidatePath("/settings/period");
   revalidatePath("/", "layout");
 }

--- a/src/lib/preferences/repo.ts
+++ b/src/lib/preferences/repo.ts
@@ -2,14 +2,19 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   DEFAULT_DISPLAY_CURRENCY_MODE,
+  DEFAULT_FINANCIAL_CYCLE_MODE,
   DISPLAY_CURRENCY_MODES,
+  FINANCIAL_CYCLE_MODES,
   type DisplayCurrencyMode,
+  type FinancialCycleMode,
   type UiPreferences,
   users,
 } from "@/lib/db/schema";
 
 export type ResolvedUiPreferences = {
   displayCurrencyMode: DisplayCurrencyMode;
+  financialCycleMode: FinancialCycleMode;
+  payPeriodNudgeDismissed: boolean;
 };
 
 export async function getUiPreferences(userId: number): Promise<ResolvedUiPreferences> {
@@ -38,11 +43,17 @@ export async function updateUiPreferences(
 }
 
 function resolvePreferences(raw: UiPreferences): ResolvedUiPreferences {
-  const mode = raw.displayCurrencyMode;
+  const currencyMode = raw.displayCurrencyMode;
+  const cycleMode = raw.financialCycleMode;
   return {
     displayCurrencyMode:
-      mode && (DISPLAY_CURRENCY_MODES as readonly string[]).includes(mode)
-        ? mode
+      currencyMode && (DISPLAY_CURRENCY_MODES as readonly string[]).includes(currencyMode)
+        ? currencyMode
         : DEFAULT_DISPLAY_CURRENCY_MODE,
+    financialCycleMode:
+      cycleMode && (FINANCIAL_CYCLE_MODES as readonly string[]).includes(cycleMode)
+        ? cycleMode
+        : DEFAULT_FINANCIAL_CYCLE_MODE,
+    payPeriodNudgeDismissed: raw.payPeriodNudgeDismissed === true,
   };
 }

--- a/src/lib/tenant-isolation.test.ts
+++ b/src/lib/tenant-isolation.test.ts
@@ -306,14 +306,19 @@ describe("#183 tenant isolation", () => {
     expect(statusesA).toHaveLength(1);
     expect(statusesA[0].id).toBe(accountA);
 
-    const flowA = await getMonthlyFlow(userA, 4000, new Date("2026-04-15"));
+    const aprilRange = {
+      start: new Date(Date.UTC(2026, 3, 1)),
+      end: new Date(Date.UTC(2026, 4, 1)),
+    };
+
+    const flowA = await getMonthlyFlow(userA, 4000, aprilRange);
     // Sum of -1000 + -2000 = -3000 for userA, so expense=3000.
     expect(flowA.expenseCopCents).toBe(BigInt(3000));
 
-    const flowB = await getMonthlyFlow(userB, 4000, new Date("2026-04-15"));
+    const flowB = await getMonthlyFlow(userB, 4000, aprilRange);
     expect(flowB.expenseCopCents).toBe(BigInt(3000));
 
-    const catA = await getCategoryBreakdown(userA, 4000, new Date("2026-04-15"));
+    const catA = await getCategoryBreakdown(userA, 4000, aprilRange);
     expect(catA.every((c) => c.amountCopCents >= BigInt(0))).toBe(true);
     // #336: categories is per-user, but getCategoryBreakdown joined it only
     // by slug — every user sharing the "otros" slug compounded the fanout
@@ -326,7 +331,7 @@ describe("#183 tenant isolation", () => {
     const totalCatA = catA.reduce((s, c) => s + c.amountCopCents, BigInt(0));
     expect(totalCatA).toBe(BigInt(3000));
 
-    const topA = await getTopExpenses(userA, 4000, new Date("2026-04-15"), 10);
+    const topA = await getTopExpenses(userA, 4000, aprilRange, 10);
     expect(topA.every((t) => t.descriptionRaw.includes(`${TAG}-A`))).toBe(true);
     // #336: the categories slug join fanout also duplicates rows in top
     // expenses — userA has exactly 2 fixture transactions, not 4.

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -114,6 +114,7 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
       cpId: counterparties.id,
       cpDisplayName: counterparties.displayName,
       cpType: counterparties.type,
+      cpIsSalary: counterparties.isSalary,
       cpDefaultCategorySlug: counterparties.defaultCategorySlug,
       cpNotes: counterparties.notes,
       cpAliases: sql<CounterpartyAlias[] | null>`(
@@ -161,6 +162,7 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
           id: r.cpId,
           displayName: r.cpDisplayName!,
           type: r.cpType!,
+          isSalary: r.cpIsSalary ?? false,
           defaultCategorySlug: r.cpDefaultCategorySlug,
           notes: r.cpNotes,
           aliases: r.cpAliases ?? [],

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,6 +47,7 @@ export type CounterpartyValue = {
   id: number;
   displayName: string;
   type: CounterpartyType;
+  isSalary: boolean;
   defaultCategorySlug: string | null;
   notes: string | null;
   aliases: CounterpartyAlias[];


### PR DESCRIPTION
## Summary

Closes #493.

Adds an **opt-in `pay_period` mode** that anchors the dashboard / budgets / insights month boundaries on detected salary income instead of the calendar month. Default stays `calendar` so freelancers and multi-source-income users keep the original behavior; `pay_period` requires ≥1 salary-flagged counterparty + ≥2 historical paychecks before the toggle activates, and degrades gracefully per-month with a `fallbackReason` when data is insufficient.

**Bank-truth views (TC summary, cuotas, statements) stay calendar-anchored** — the period helper deliberately separates user-anchored aggregations from bank-anchored ones.

### What changed

**Schema (migration `0059_naive_silver_surfer.sql`)**
- `counterparties.is_salary boolean NOT NULL DEFAULT false` + partial index on `(user_id) WHERE is_salary = true`
- `UiPreferences.financialCycleMode` (`"calendar" | "pay_period"`, default `"calendar"`) + `payPeriodNudgeDismissed`

**Period helper** (`src/lib/dashboard/period.ts` + `period-format.ts`)
- `getFinancialPeriod(userId, refDate, wallNow?)` resolves \`{start, end, mode, fallbackReason?}\`
- Salary detection: ≥0.5 × per-counterparty median amount filter (rejects reimbursements / refunds)
- Anchor selection: nearest paycheck within ±0.75 × medianSpacing of each calendar month boundary
- Current-month projection from medianSpacing when next paycheck has not yet landed
- 15 unit tests covering monthly / biweekly / multi-source / fallback cases
- Module split into server (\`period.ts\`) vs client-safe (\`period-format.ts\`) so cards can import formatters without dragging postgres.js into the browser bundle

**Migrated to financial period**
- \`getMonthlyFlow\` / \`getMonthlyProgress\` / \`getCategoryBreakdown\` / \`getTopExpenses\`
- \`getBudgetsOverview\` (plan stays calendar-anchored, spend respects period)
- \`buildInsightsSummary\` (current + previous period both resolved per cycle mode)

**Stays calendar-anchored**
- \`getCreditCardsSummary\`, cuotas, statements, fechas de corte — bank truth, never anchored on user salary

**UI**
- 4 dashboard cards now show \`abril 2026 · 30 mar — 27 abr\` subtitle when \`mode=pay_period\` and an inline \"Sin datos de sueldo · mostrando mes calendario\" note when degraded
- New \`/settings/period\` page with mode radio (disabled until pre-conditions met) + salary candidates list with isSalary toggle + current-period preview
- \`isSalary\` toggle inline in the existing counterparty edit dialog
- One-time dismissable nudge banner on the dashboard when the user is eligible for \`pay_period\` but still on \`calendar\`

## Test plan

- [x] Unit: \`bun test src/lib/dashboard/period.test.ts\` — 15/15 pass
- [x] Lint + typecheck — clean
- [x] Test suite: zero regressions vs main (618/996 pass, 378 pre-existing Bun vitest API-gap failures)
- [x] Manual smoke (chrome-devtools-mcp on real prod-mirrored data):
  - Dashboard renders unchanged in default \`calendar\` mode
  - \`/settings/period\` lists counterparties with positive ingresos, sorted desc by total
  - Toggling a counterparty as salary enables the \`pay_period\` mode toggle
  - Activating \`pay_period\` with non-regular paychecks degrades gracefully — all 4 cards show the fallback note
  - Reverting to \`calendar\` and unmarking salary returns the toggle to disabled
  - State restored to default before merge

## Out of scope (separate follow-ups if validated)

- Q1/Q2 quincenal split (one card showing two sub-periods per month)
- Auto-detection of salary counterparty (amount + cadence heuristic, no manual flag)
- Approach C (full pay-period rewrite of recurring, statements, cuotas)