### PR TITLE
chore(gmail): reduce pull cron from hourly to every 5 minutes (#499)

### DIFF
--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -153,7 +153,7 @@ export async function registerNode() {
   // others. Manual backfills go through /enriquecer (bot) or
   // POST /api/cron/gmail-pull.
   cron.schedule(
-    "0 * * * *",
+    "*/5 * * * *",
     async () => {
       try {
         const results = await pullAllActiveConnections();


### PR DESCRIPTION
Closes #499

## Summary

- Changes the Gmail pull cron schedule in `src/instrumentation.node.ts` from `"0 * * * *"` (hourly) to `"*/5 * * * *"` (every 5 minutes)
- One-line diff — no logic changes, no schema changes, no new dependencies

## Smoke test

- [ ] Deploy to prod, confirm the cron fires at 5-min intervals via server logs (`log.info({ event: "gmail_pull_cron_tick" })`)
- [ ] Verify no duplicate ingestion across two consecutive runs (dedup key in `gmail_messages.message_id` enforces idempotency)