### PR TITLE
feat(ingestion): A+ dedup reconciler ARQ email vs statement (#517)

### DIFF
--- a/drizzle/0064_odd_sandman.sql
+++ b/drizzle/0064_odd_sandman.sql
@@ -1,0 +1,5 @@
+ALTER TYPE "public"."tx_source" ADD VALUE 'arq_statement';--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "secondary_source" varchar(40);--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "external_id_statement" varchar(200);--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "arq_statement_import_id" integer;--> statement-breakpoint
+ALTER TABLE "transactions" ADD CONSTRAINT "transactions_arq_statement_import_id_arq_statement_imports_id_fk" FOREIGN KEY ("arq_statement_import_id") REFERENCES "public"."arq_statement_imports"("id") ON DELETE set null ON UPDATE no action;

--- a/drizzle/meta/0064_snapshot.json
+++ b/drizzle/meta/0064_snapshot.json
@@ -1,0 +1,5366 @@
+{
+  "id": "6e53d25e-0fdc-4a4d-a764-8118f21144e9",
+  "prevId": "8d99afa7-3678-4334-935e-18a42d6767a3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_physical_card_id_physical_cards_id_fk": {
+          "name": "accounts_physical_card_id_physical_cards_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "physical_cards",
+          "columnsFrom": [
+            "physical_card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.arq_statement_imports": {
+      "name": "arq_statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declared_start_cents": {
+          "name": "declared_start_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declared_end_cents": {
+          "name": "declared_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_count": {
+          "name": "parsed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_sum_cents": {
+          "name": "parsed_sum_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconciled": {
+          "name": "reconciled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconcile_diff_cents": {
+          "name": "reconcile_diff_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_ok": {
+          "name": "chain_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "raw_pdf_hash": {
+          "name": "raw_pdf_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "arq_statement_imports_period_unique": {
+          "name": "arq_statement_imports_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "arq_statement_imports_user_hash_unique": {
+          "name": "arq_statement_imports_user_hash_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_pdf_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "arq_statement_imports_account_period_idx": {
+          "name": "arq_statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "arq_statement_imports_user_id_users_id_fk": {
+          "name": "arq_statement_imports_user_id_users_id_fk",
+          "tableFrom": "arq_statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "arq_statement_imports_account_id_accounts_id_fk": {
+          "name": "arq_statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "arq_statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_corrections": {
+      "name": "classification_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_category_slug": {
+          "name": "new_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_corrections_learning_idx": {
+          "name": "classification_corrections_learning_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "new_category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_corrections_user_id_users_id_fk": {
+          "name": "classification_corrections_user_id_users_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_corrections_transaction_id_transactions_id_fk": {
+          "name": "classification_corrections_transaction_id_transactions_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_from_corrections": {
+          "name": "generated_from_corrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_salary": {
+          "name": "is_salary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparties_user_salary_idx": {
+          "name": "counterparties_user_salary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"counterparties\".\"is_salary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_receipts": {
+      "name": "email_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_connection_id": {
+          "name": "gmail_connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_msg_id": {
+          "name": "gmail_msg_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway": {
+          "name": "gateway",
+          "type": "email_receipt_gateway",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_html": {
+          "name": "raw_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_payload": {
+          "name": "parsed_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_transaction_id": {
+          "name": "matched_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_status": {
+          "name": "match_status",
+          "type": "email_receipt_match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "match_candidates": {
+          "name": "match_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_at": {
+          "name": "parsed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_receipts_user_msg_unique": {
+          "name": "email_receipts_user_msg_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_msg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_user_status_idx": {
+          "name": "email_receipts_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_match_lookup_idx": {
+          "name": "email_receipts_match_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "amount_cents",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'pending' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_connection_idx": {
+          "name": "email_receipts_connection_idx",
+          "columns": [
+            {
+              "expression": "gmail_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_candidates_gin_idx": {
+          "name": "email_receipts_candidates_gin_idx",
+          "columns": [
+            {
+              "expression": "match_candidates",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'ambiguous' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_receipts_user_id_users_id_fk": {
+          "name": "email_receipts_user_id_users_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_gmail_connection_id_gmail_connections_id_fk": {
+          "name": "email_receipts_gmail_connection_id_gmail_connections_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "gmail_connections",
+          "columnsFrom": [
+            "gmail_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_matched_transaction_id_transactions_id_fk": {
+          "name": "email_receipts_matched_transaction_id_transactions_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "matched_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_connections": {
+      "name": "gmail_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_email": {
+          "name": "gmail_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_enc": {
+          "name": "access_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_pull_at": {
+          "name": "last_pull_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_pull_history_id": {
+          "name": "last_pull_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "gmail_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_nudge_sent_at": {
+          "name": "bot_nudge_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bootstrap_since_date": {
+          "name": "bootstrap_since_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_connections_user_email_unique": {
+          "name": "gmail_connections_user_email_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_user_status_idx": {
+          "name": "gmail_connections_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_active_idx": {
+          "name": "gmail_connections_active_idx",
+          "columns": [
+            {
+              "expression": "last_pull_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"status\" = 'active' AND \"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_connections_user_id_users_id_fk": {
+          "name": "gmail_connections_user_id_users_id_fk",
+          "tableFrom": "gmail_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.physical_cards": {
+      "name": "physical_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_limit_cents": {
+          "name": "credit_limit_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "statement_cutoff_day": {
+          "name": "statement_cutoff_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "physical_cards_user_idx": {
+          "name": "physical_cards_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "physical_cards_user_institution_idx": {
+          "name": "physical_cards_user_institution_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "physical_cards_user_id_users_id_fk": {
+          "name": "physical_cards_user_id_users_id_fk",
+          "tableFrom": "physical_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_proposals": {
+      "name": "rule_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_txn_ids": {
+          "name": "correction_txn_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rule_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rule_proposals_user_merchant_category_pending_unique": {
+          "name": "rule_proposals_user_merchant_category_pending_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rule_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rule_proposals_user_status_idx": {
+          "name": "rule_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_proposals_user_id_users_id_fk": {
+          "name": "rule_proposals_user_id_users_id_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_proposals_user_category_fk": {
+          "name": "rule_proposals_user_category_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skipped_consolidation_cycles": {
+      "name": "skipped_consolidation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "skipped_consolidation_cycles_live_unique": {
+          "name": "skipped_consolidation_cycles_live_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skipped_consolidation_cycles_user_account_idx": {
+          "name": "skipped_consolidation_cycles_user_account_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skipped_consolidation_cycles_user_id_users_id_fk": {
+          "name": "skipped_consolidation_cycles_user_id_users_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skipped_consolidation_cycles_account_id_accounts_id_fk": {
+          "name": "skipped_consolidation_cycles_account_id_accounts_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slo_alerts": {
+      "name": "slo_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slo_key": {
+          "name": "slo_key",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slo_alerts_open_idx": {
+          "name": "slo_alerts_open_idx",
+          "columns": [
+            {
+              "expression": "slo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"slo_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "statement_import_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movimientos'"
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synthetic_tx_id": {
+          "name": "synthetic_tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_cycle_unique": {
+          "name": "statement_imports_cycle_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"statement_imports\".\"kind\" = 'extracto_detallado' AND \"statement_imports\".\"cycle\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installments_total": {
+          "name": "installments_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "installment_rate_bps": {
+          "name": "installment_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retroactive_rule_id": {
+          "name": "retroactive_rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group_id": {
+          "name": "transfer_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enriched_merchant": {
+          "name": "enriched_merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_source": {
+          "name": "enrichment_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_source": {
+          "name": "secondary_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_statement": {
+          "name": "external_id_statement",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arq_statement_import_id": {
+          "name": "arq_statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_mismatch": {
+          "name": "source_mismatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_mismatch_details": {
+          "name": "source_mismatch_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_group_idx": {
+          "name": "transactions_transfer_group_idx",
+          "columns": [
+            {
+              "expression": "transfer_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"transfer_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_occurred_live_idx": {
+          "name": "transactions_account_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_live_idx": {
+          "name": "transactions_user_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_retroactive_rule_id_classification_rules_id_fk": {
+          "name": "transactions_retroactive_rule_id_classification_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "classification_rules",
+          "columnsFrom": [
+            "retroactive_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_arq_statement_import_id_arq_statement_imports_id_fk": {
+          "name": "transactions_arq_statement_import_id_arq_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "arq_statement_imports",
+          "columnsFrom": [
+            "arq_statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_snapshots": {
+      "name": "user_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_bytes": {
+          "name": "payload_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_snapshots_user_created_idx": {
+          "name": "user_snapshots_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_snapshots_user_id_users_id_fk": {
+          "name": "user_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ui_preferences": {
+          "name": "ui_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "classification_context": {
+          "name": "classification_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "rule_retroactive",
+        "ai",
+        "manual",
+        "manual_confirmed",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.email_receipt_gateway": {
+      "name": "email_receipt_gateway",
+      "schema": "public",
+      "values": [
+        "mercado_pago",
+        "payu",
+        "wompi",
+        "apple",
+        "paypal",
+        "bancolombia",
+        "arq"
+      ]
+    },
+    "public.email_receipt_match_status": {
+      "name": "email_receipt_match_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "matched",
+        "ambiguous",
+        "unmatched"
+      ]
+    },
+    "public.gmail_connection_status": {
+      "name": "gmail_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "revoked",
+        "error"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.rule_proposal_status": {
+      "name": "rule_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.statement_import_kind": {
+      "name": "statement_import_kind",
+      "schema": "public",
+      "values": [
+        "movimientos",
+        "extracto_detallado"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile",
+        "gmail_bancolombia",
+        "gmail_enrichment",
+        "gmail_arq",
+        "arq_statement"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug",
+        "widget"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1777191850310,
       "tag": "0063_handy_morph",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1777193792360,
+      "tag": "0064_odd_sandman",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -41,6 +41,7 @@ const sourceLabel: Record<TxRow["source"], string> = {
   gmail_bancolombia: "Email BC",
   gmail_enrichment: "Email",
   gmail_arq: "Email ARQ",
+  arq_statement: "ARQ Statement",
 };
 
 const methodVariant: Record<

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -195,6 +195,11 @@ export const txSource = pgEnum("tx_source", [
   // #508 (Epic ARQ): tx ingested from ARQ (formerly DolarApp) notification
   // email — USD transfers (salary + outgoing). No SMS parallel channel.
   "gmail_arq",
+  // #517 (Epic ARQ): tx inserted from ARQ monthly statement PDF — covers
+  // purchases, fees, cashback, and p2p transfers that email did NOT capture.
+  // Txs already present via gmail_arq are MERGED (not duplicated); this source
+  // is only written on INSERTs (statement-only events).
+  "arq_statement",
 ]);
 
 export const txChannel = pgEnum("tx_channel", ["bank", "manual", "transfer"]);
@@ -570,6 +575,25 @@ export const transactions = pgTable(
     // #454 (Epic G): which pipeline produced the enrichment. Currently only
     // 'gmail' — extensible for future sources (e.g. 'manual_correction').
     enrichmentSource: varchar("enrichment_source", { length: 40 }),
+    // #517 (Epic ARQ): set when a gmail_arq email tx is merged with an ARQ
+    // statement row. Stores the reconciling source label (e.g. 'arq_statement')
+    // without mutating the primary `source` column (first-in wins).
+    // Design decision: a separate nullable text column is safer than converting
+    // `source` to a comma-separated string or JSON array — it keeps the enum
+    // constraint on the primary source, avoids array parsing, and is trivially
+    // queryable. See #517 implementer notes.
+    secondarySource: varchar("secondary_source", { length: 40 }),
+    // #517 (Epic ARQ): the externalId assigned by the statement parser
+    // (arq-stmt-<hash>) for the matched statement line. Used for idempotency:
+    // if this column is already set, re-running the reconciler skips the merge.
+    externalIdStatement: varchar("external_id_statement", { length: 200 }),
+    // #517 (Epic ARQ): FK to arq_statement_imports. Populated on both MERGE
+    // (existing gmail_arq tx updated) and INSERT (new arq_statement tx). Null
+    // means the tx pre-dates statement import or has not been reconciled yet.
+    arqStatementImportId: integer("arq_statement_import_id").references(
+      (): AnyPgColumn => arqStatementImports.id,
+      { onDelete: "set null" },
+    ),
     // #457 (Epic G): set by A+ dedup when SMS and Email Bancolombia describe
     // the same event with diverging fields. See SourceMismatchDetails type.
     sourceMismatch: boolean("source_mismatch").notNull().default(false),

--- a/src/lib/ingestion/arq-statement/reconciler.test.ts
+++ b/src/lib/ingestion/arq-statement/reconciler.test.ts
@@ -1,0 +1,531 @@
+// Integration tests for reconcileEmailVsStatement (#517).
+//
+// These tests hit the findash_test Postgres database (forced by vitest.setup.ts).
+// Schema must be up to date: run `bun run db:migrate:test` before this suite.
+//
+// Test matrix:
+//   1. Match → MERGE: gmail_arq tx + matching statement tx → 1 tx, primary source
+//      unchanged ('gmail_arq'), secondary_source='arq_statement', statement metadata set.
+//   2. No match → INSERT: statement-only purchase → new tx with source='arq_statement'.
+//   3. Mismatch → FLAG: amount diff > 1 cent → source_mismatch=true on merge.
+//   4. Email orphan → FLAG: gmail_arq tx in period without statement counterpart
+//      → source_mismatch=true, reason='email_orphan'.
+//   5. Tenant safety: scoped by user_id; other-user's txs are invisible.
+//   6. Idempotency: re-running with same (importId, parsedTxs) is a no-op.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { and, eq, sql } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { accounts, arqStatementImports, transactions, users } from "@/lib/db/schema";
+
+import type { ParsedStatementTx } from "./type-handlers";
+import { reconcileEmailVsStatement } from "./reconciler";
+
+// ---------------------------------------------------------------------------
+// Helpers & fixtures
+// ---------------------------------------------------------------------------
+
+const TAG = "ARQ_RECONCILER_TEST";
+
+let userId: number;
+let accountId: number;
+let otherUserId: number;
+let otherAccountId: number;
+
+// Synthetic arq_statement_import id (audit row) for tests.
+let importId: number;
+
+async function cleanup(): Promise<void> {
+  // transactions → delete by user
+  await db
+    .delete(transactions)
+    .where(sql`${transactions.userId} IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})`);
+  await db
+    .delete(arqStatementImports)
+    .where(
+      sql`${arqStatementImports.userId} IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})`,
+    );
+  await db.delete(users).where(sql`email LIKE ${TAG + "%"}`);
+}
+
+async function createUser(suffix: string): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `${TAG}-${suffix}@test.local`, name: `${TAG}-${suffix}` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function createAccount(uid: number): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId: uid,
+      name: `${TAG}-arq-account`,
+      institution: "ARQ (DolarApp)",
+      institutionSlug: "other",
+      currency: "USD",
+      type: "savings",
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createImportAuditRow(uid: number, acctId: number): Promise<number> {
+  const [row] = await db
+    .insert(arqStatementImports)
+    .values({
+      userId: uid,
+      accountId: acctId,
+      periodStart: "2026-03-01",
+      periodEnd: "2026-03-31",
+      declaredStartCents: BigInt(0),
+      declaredEndCents: BigInt(0),
+      parsedCount: 0,
+      parsedSumCents: BigInt(0),
+      reconciled: true,
+      rawPdfHash: `${TAG}-test-hash-${uid}-${acctId}`,
+    })
+    .returning({ id: arqStatementImports.id });
+  return row.id;
+}
+
+/**
+ * Insert a gmail_arq email tx directly (simulates what email-arq.ts writes).
+ */
+async function insertEmailTx(opts: {
+  userId: number;
+  accountId: number;
+  amountCents: bigint;
+  occurredAt: Date;
+  merchant: string;
+  externalId: string;
+}): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId: opts.userId,
+      accountId: opts.accountId,
+      occurredAt: opts.occurredAt,
+      amountCents: opts.amountCents,
+      currency: "USD",
+      descriptionRaw: `Email: ${opts.merchant}`,
+      merchant: opts.merchant,
+      source: "gmail_arq",
+      channel: "transfer",
+      externalId: opts.externalId,
+      rawData: {
+        kind: "transfer_sent",
+        arq: { recipient_name: opts.merchant },
+        fx: {
+          originalCurrency: "COP",
+          originalAmountCents: "200000000",
+          trmToAccountCurrency: 4000,
+          trmSource: "email_implied",
+        },
+      },
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+/**
+ * Build a ParsedStatementTx for a transfer_sent (Venta USDc).
+ */
+function makeTransferSentTx(opts: {
+  occurredAt: Date;
+  amountUsdc: bigint;
+  recipientName: string;
+  externalId: string;
+}): ParsedStatementTx {
+  return {
+    kind: "transfer_sent",
+    occurredAt: opts.occurredAt,
+    amountUsdc: opts.amountUsdc,
+    externalIdPrefix: "arq-stmt",
+    externalId: opts.externalId,
+    originalCurrency: "COP",
+    originalAmount:
+      (opts.amountUsdc < BigInt(0) ? -opts.amountUsdc : opts.amountUsdc) * BigInt(4000),
+    recipientName: opts.recipientName,
+    trmCopPerUsdc: 4000,
+  };
+}
+
+/**
+ * Build a ParsedStatementTx for a purchase (Pago con tarjeta).
+ */
+function makePurchaseTx(opts: {
+  occurredAt: Date;
+  amountUsdc: bigint;
+  merchant: string;
+  externalId: string;
+}): ParsedStatementTx {
+  return {
+    kind: "purchase",
+    occurredAt: opts.occurredAt,
+    amountUsdc: opts.amountUsdc,
+    externalIdPrefix: "arq-stmt",
+    externalId: opts.externalId,
+    merchant: opts.merchant,
+    originalCurrency: "COP",
+    originalAmount:
+      (opts.amountUsdc < BigInt(0) ? -opts.amountUsdc : opts.amountUsdc) * BigInt(4000),
+    trmCopPerUsdc: 4000,
+  };
+}
+
+const PERIOD = {
+  start: new Date(Date.UTC(2026, 2, 1)), // 2026-03-01
+  end: new Date(Date.UTC(2026, 2, 31, 23, 59, 59)),
+};
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  await cleanup();
+  userId = await createUser("main");
+  accountId = await createAccount(userId);
+  otherUserId = await createUser("other");
+  otherAccountId = await createAccount(otherUserId);
+  importId = await createImportAuditRow(userId, accountId);
+});
+
+afterAll(async () => {
+  await cleanup();
+  // Only this test file calls db.$client.end() — see drizzle-error-wrapping-test-pattern memory.
+  await db.$client.end();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("reconcileEmailVsStatement", () => {
+  describe("MERGE — matching email + statement tx", () => {
+    it("updates existing gmail_arq tx with statement metadata; primary source unchanged", async () => {
+      const occurredAt = new Date(Date.UTC(2026, 2, 5, 12, 0, 0));
+      const amountCents = BigInt(-56381); // -563.81 USDc (negative = debit)
+
+      const emailTxId = await insertEmailTx({
+        userId,
+        accountId,
+        amountCents,
+        occurredAt,
+        merchant: "Maria Eugenia",
+        externalId: `arq-email-test-merge-1`,
+      });
+
+      const stmtExternalId = "arq-stmt-merge-test-1234567";
+      const stmtTx = makeTransferSentTx({
+        occurredAt,
+        amountUsdc: amountCents,
+        recipientName: "maria eugenia", // different capitalisation
+        externalId: stmtExternalId,
+      });
+
+      const result = await reconcileEmailVsStatement(
+        { db },
+        {
+          userId,
+          accountId,
+          importId,
+          period: PERIOD,
+          parsedTxs: [stmtTx],
+        },
+      );
+
+      expect(result.mergedCount).toBe(1);
+      expect(result.insertedCount).toBe(0);
+      expect(result.flaggedCount).toBe(0);
+      expect(result.details[0].kind).toBe("merge");
+
+      // Verify the existing tx was updated — source MUST remain 'gmail_arq'.
+      const updated = await db.query.transactions.findFirst({
+        where: eq(transactions.id, emailTxId),
+      });
+
+      expect(updated).toBeDefined();
+      expect(updated!.source).toBe("gmail_arq"); // primary source unchanged
+      expect(updated!.secondarySource).toBe("arq_statement");
+      expect(updated!.externalIdStatement).toBe(stmtExternalId);
+      expect(updated!.arqStatementImportId).toBe(importId);
+      expect(updated!.sourceMismatch).toBe(false);
+
+      // Verify amount/occurred_at preserved (first-in wins).
+      expect(updated!.amountCents).toBe(amountCents);
+    });
+  });
+
+  describe("INSERT — statement-only tx (no email counterpart)", () => {
+    it("inserts new tx with source=arq_statement for purchase not in email", async () => {
+      const occurredAt = new Date(Date.UTC(2026, 2, 10, 14, 0, 0));
+      const amountCents = BigInt(-2500); // -25.00 USDc
+
+      const stmtExternalId = "arq-stmt-insert-test-1234567";
+      const stmtTx = makePurchaseTx({
+        occurredAt,
+        amountUsdc: amountCents,
+        merchant: "Netflix",
+        externalId: stmtExternalId,
+      });
+
+      const result = await reconcileEmailVsStatement(
+        { db },
+        {
+          userId,
+          accountId,
+          importId,
+          period: PERIOD,
+          parsedTxs: [stmtTx],
+        },
+      );
+
+      expect(result.insertedCount).toBe(1);
+
+      // Verify the new tx was written with arq_statement source.
+      const insertDecision = result.details.find((d) => d.kind === "insert");
+      expect(insertDecision).toBeDefined();
+      const inserted = insertDecision as { kind: "insert"; newTxId: number };
+
+      const tx = await db.query.transactions.findFirst({
+        where: and(
+          eq(transactions.id, inserted.newTxId),
+          eq(transactions.userId, userId),
+          eq(transactions.accountId, accountId),
+        ),
+      });
+
+      expect(tx).toBeDefined();
+      expect(tx!.source).toBe("arq_statement");
+      expect(tx!.currency).toBe("USD");
+      expect(tx!.amountCents).toBe(amountCents);
+      expect(tx!.arqStatementImportId).toBe(importId);
+      expect(tx!.externalId).toBe(stmtExternalId);
+    });
+  });
+
+  describe("FLAG — amount mismatch > 1 cent", () => {
+    it("merges but flags source_mismatch when amounts diverge > 1 cent", async () => {
+      const occurredAt = new Date(Date.UTC(2026, 2, 15, 10, 0, 0));
+      const emailAmount = BigInt(-33705); // email says 337.05 USDc
+      const stmtAmount = BigInt(-33700); // statement says 337.00 USDc — diff = 5c > 1c tolerance
+
+      const emailTxId = await insertEmailTx({
+        userId,
+        accountId,
+        amountCents: emailAmount,
+        occurredAt,
+        merchant: "Felipe Rodriguez",
+        externalId: "arq-email-test-mismatch-1",
+      });
+
+      const stmtTx = makeTransferSentTx({
+        occurredAt,
+        amountUsdc: stmtAmount,
+        recipientName: "Felipe Rodriguez",
+        externalId: "arq-stmt-mismatch-test-12345678",
+      });
+
+      const result = await reconcileEmailVsStatement(
+        { db },
+        {
+          userId,
+          accountId,
+          importId,
+          period: PERIOD,
+          parsedTxs: [stmtTx],
+        },
+      );
+
+      // Should still merge (not skip), but flagged.
+      expect(result.mergedCount).toBe(1);
+      expect(result.flaggedCount).toBeGreaterThanOrEqual(1);
+
+      const mergeDecision = result.details.find((d) => d.kind === "merge") as
+        | { kind: "merge"; mismatchReason?: string }
+        | undefined;
+      expect(mergeDecision).toBeDefined();
+      expect(mergeDecision!.mismatchReason).toBe("amount_diverge");
+
+      const updated = await db.query.transactions.findFirst({
+        where: eq(transactions.id, emailTxId),
+      });
+      expect(updated!.sourceMismatch).toBe(true);
+      expect(updated!.sourceMismatchDetails).toBeDefined();
+      expect(updated!.sourceMismatchDetails!.fromSource).toBe("gmail_arq");
+      expect(updated!.sourceMismatchDetails!.toSource).toBe("arq_statement");
+    });
+  });
+
+  describe("Email orphan — gmail_arq tx with no statement counterpart", () => {
+    it("flags gmail_arq tx in period as source_mismatch with email_orphan reason", async () => {
+      const occurredAt = new Date(Date.UTC(2026, 2, 20, 9, 0, 0));
+
+      // Insert a gmail_arq tx in the period — it will NOT appear in parsedTxs.
+      const orphanTxId = await insertEmailTx({
+        userId,
+        accountId,
+        amountCents: BigInt(-10000),
+        occurredAt,
+        merchant: "Daniela Perez",
+        externalId: "arq-email-test-orphan-1",
+      });
+
+      // Run reconciler with EMPTY parsedTxs — no statement lines for this period.
+      const result = await reconcileEmailVsStatement(
+        { db },
+        {
+          userId,
+          accountId,
+          importId,
+          period: PERIOD,
+          parsedTxs: [],
+        },
+      );
+
+      expect(result.emailOrphanCount).toBeGreaterThanOrEqual(1);
+      expect(result.flaggedCount).toBeGreaterThanOrEqual(1);
+
+      const orphan = await db.query.transactions.findFirst({
+        where: eq(transactions.id, orphanTxId),
+      });
+      expect(orphan!.sourceMismatch).toBe(true);
+      expect(orphan!.sourceMismatchDetails!.diffs[0].field).toBe("email_orphan");
+    });
+  });
+
+  describe("Tenant safety", () => {
+    it("does not merge email txs belonging to another user", async () => {
+      const occurredAt = new Date(Date.UTC(2026, 2, 25, 8, 0, 0));
+      const amountCents = BigInt(-5000);
+
+      // Insert email tx under the OTHER user.
+      const otherImportId = await createImportAuditRow(otherUserId, otherAccountId);
+      const otherEmailTxId = await insertEmailTx({
+        userId: otherUserId,
+        accountId: otherAccountId,
+        amountCents,
+        occurredAt,
+        merchant: "Carlos Garcia",
+        externalId: "arq-email-test-tenant-other",
+      });
+
+      // Run reconciler for the MAIN user with a matching statement line.
+      const stmtTx = makeTransferSentTx({
+        occurredAt,
+        amountUsdc: amountCents,
+        recipientName: "Carlos Garcia",
+        externalId: "arq-stmt-tenant-test-1234567",
+      });
+
+      const result = await reconcileEmailVsStatement(
+        { db },
+        {
+          userId, // main user — should NOT see otherUser's txs
+          accountId,
+          importId,
+          period: PERIOD,
+          parsedTxs: [stmtTx],
+        },
+      );
+
+      // The statement tx had no email counterpart in userId's account → INSERT.
+      expect(result.insertedCount).toBe(1);
+      expect(result.mergedCount).toBe(0);
+
+      // The other user's email tx MUST NOT have been touched.
+      const otherTx = await db.query.transactions.findFirst({
+        where: and(eq(transactions.id, otherEmailTxId), eq(transactions.userId, otherUserId)),
+      });
+      expect(otherTx!.secondarySource).toBeNull();
+      expect(otherTx!.externalIdStatement).toBeNull();
+      expect(otherTx!.arqStatementImportId).toBeNull();
+
+      // Cleanup other import to avoid polluting other tests.
+      await db.delete(arqStatementImports).where(eq(arqStatementImports.id, otherImportId));
+    });
+  });
+
+  describe("Idempotency", () => {
+    it("re-running with the same importId and parsedTxs does not duplicate or re-merge", async () => {
+      const occurredAt = new Date(Date.UTC(2026, 2, 28, 11, 0, 0));
+      const amountCents = BigInt(-7800);
+
+      const emailTxId = await insertEmailTx({
+        userId,
+        accountId,
+        amountCents,
+        occurredAt,
+        merchant: "Luisa Hernandez",
+        externalId: "arq-email-test-idempotent-1",
+      });
+
+      const stmtExternalId = "arq-stmt-idempotent-test-12345";
+      const stmtTx = makeTransferSentTx({
+        occurredAt,
+        amountUsdc: amountCents,
+        recipientName: "Luisa Hernandez",
+        externalId: stmtExternalId,
+      });
+
+      // First run.
+      const run1 = await reconcileEmailVsStatement(
+        { db },
+        { userId, accountId, importId, period: PERIOD, parsedTxs: [stmtTx] },
+      );
+      expect(run1.mergedCount).toBe(1);
+
+      // Second run with same data.
+      const run2 = await reconcileEmailVsStatement(
+        { db },
+        { userId, accountId, importId, period: PERIOD, parsedTxs: [stmtTx] },
+      );
+
+      // The tx already has externalIdStatement set — reconciler skips it.
+      expect(run2.mergedCount).toBe(0);
+      const skipDecision = run2.details.find(
+        (d) => d.kind === "skip" && "reason" in d && d.reason === "idempotent_already_merged",
+      );
+      expect(skipDecision).toBeDefined();
+
+      // DB row is not mutated a second time — updatedAt should remain stable-ish.
+      const tx = await db.query.transactions.findFirst({
+        where: eq(transactions.id, emailTxId),
+      });
+      expect(tx!.secondarySource).toBe("arq_statement");
+      expect(tx!.externalIdStatement).toBe(stmtExternalId);
+    });
+  });
+
+  describe("skip entries", () => {
+    it("skips ParsedStatementTx with kind=skip without writing to DB", async () => {
+      const skipTx: ParsedStatementTx = {
+        kind: "skip",
+        reason: "Unknown transaction type: Foo",
+        raw: {
+          date: new Date(Date.UTC(2026, 2, 5)),
+          type: "Foo",
+          description: "test",
+          amountCents: BigInt(-100),
+          equivalentCurrency: null,
+          equivalentAmountCents: null,
+        },
+      };
+
+      const result = await reconcileEmailVsStatement(
+        { db },
+        { userId, accountId, importId, period: PERIOD, parsedTxs: [skipTx] },
+      );
+
+      expect(result.insertedCount).toBe(0);
+      expect(result.mergedCount).toBe(0);
+      const skipDecision = result.details.find((d) => d.kind === "skip");
+      expect(skipDecision).toBeDefined();
+    });
+  });
+});

--- a/src/lib/ingestion/arq-statement/reconciler.test.ts
+++ b/src/lib/ingestion/arq-statement/reconciler.test.ts
@@ -309,6 +309,73 @@ describe("reconcileEmailVsStatement", () => {
     });
   });
 
+  describe("Ambiguous email match — multiple equally-close candidates", () => {
+    it("inserts the statement tx flagged source_mismatch instead of dropping it", async () => {
+      // Two email candidates equidistant from the statement occurredAt and
+      // identical amount/counterparty → ambiguous. The reconciler must NOT
+      // silently drop the statement line; it must INSERT it flagged for review.
+      const stmtOccurredAt = new Date(Date.UTC(2026, 2, 8, 12, 0, 0));
+      const amountCents = BigInt(-44400);
+
+      // Candidate A: 1 hour before
+      await insertEmailTx({
+        userId,
+        accountId,
+        amountCents,
+        occurredAt: new Date(stmtOccurredAt.getTime() - 60 * 60 * 1000),
+        merchant: "ambiguous-payee",
+        externalId: "arq-email-ambig-A",
+      });
+      // Candidate B: 1 hour after — same delta as A
+      await insertEmailTx({
+        userId,
+        accountId,
+        amountCents,
+        occurredAt: new Date(stmtOccurredAt.getTime() + 60 * 60 * 1000),
+        merchant: "ambiguous-payee",
+        externalId: "arq-email-ambig-B",
+      });
+
+      const stmtExternalId = "arq-stmt-ambig-test-1234567";
+      const stmtTx = makeTransferSentTx({
+        occurredAt: stmtOccurredAt,
+        amountUsdc: amountCents,
+        recipientName: "ambiguous-payee",
+        externalId: stmtExternalId,
+      });
+
+      const result = await reconcileEmailVsStatement(
+        { db },
+        {
+          userId,
+          accountId,
+          importId,
+          period: PERIOD,
+          parsedTxs: [stmtTx],
+        },
+      );
+
+      expect(result.insertedCount).toBe(1);
+      expect(result.mergedCount).toBe(0);
+      // 1 from the ambiguous-insert + 2 from email-orphan flags on the
+      // unmatched candidates (they fall in PERIOD without a counterpart).
+      expect(result.flaggedCount).toBeGreaterThanOrEqual(1);
+
+      const decision = result.details.find(
+        (d) => d.kind === "insert" && (d as { mismatchReason?: string }).mismatchReason,
+      ) as { kind: "insert"; newTxId: number; mismatchReason?: string } | undefined;
+      expect(decision).toBeDefined();
+      expect(decision!.mismatchReason).toBe("ambiguous_email_match");
+
+      const inserted = await db.query.transactions.findFirst({
+        where: eq(transactions.id, decision!.newTxId),
+      });
+      expect(inserted!.source).toBe("arq_statement");
+      expect(inserted!.sourceMismatch).toBe(true);
+      expect(inserted!.sourceMismatchDetails!.diffs[0]!.field).toBe("ambiguous_email_match");
+    });
+  });
+
   describe("FLAG — amount mismatch > 1 cent", () => {
     it("merges but flags source_mismatch when amounts diverge > 1 cent", async () => {
       const occurredAt = new Date(Date.UTC(2026, 2, 15, 10, 0, 0));

--- a/src/lib/ingestion/arq-statement/reconciler.ts
+++ b/src/lib/ingestion/arq-statement/reconciler.ts
@@ -97,7 +97,12 @@ export interface ReconcilerDeps {
 }
 
 export type ReconcileDecision =
-  | { kind: "insert"; statementTx: ParsedStatementTx; newTxId: number }
+  | {
+      kind: "insert";
+      statementTx: ParsedStatementTx;
+      newTxId: number;
+      mismatchReason?: string;
+    }
   | {
       kind: "merge";
       statementTx: ParsedStatementTx;
@@ -438,6 +443,7 @@ function detectMismatch(
 
 async function mergeTx(
   dbc: typeof db,
+  userId: number,
   existing: ExistingEmailTx,
   statementTx: Exclude<ParsedStatementTx, { kind: "skip" }>,
   importId: number,
@@ -462,6 +468,10 @@ async function mergeTx(
     merged_statement: statementMetadata,
   };
 
+  // Tenant-safe write: pair user_id and id in the WHERE clause so this UPDATE
+  // can never land on another user's row even if `existing.id` were ever
+  // returned in error by a future change to candidate retrieval.
+  // Memory: per-user-table-join-tenant-safety.
   if (mismatchReason === null) {
     await dbc
       .update(transactions)
@@ -472,7 +482,7 @@ async function mergeTx(
         rawData: mergedRawData,
         updatedAt: new Date(),
       })
-      .where(eq(transactions.id, existing.id));
+      .where(and(eq(transactions.userId, userId), eq(transactions.id, existing.id)));
   } else {
     const mismatchDetails: SourceMismatchDetails = {
       fromSource: "gmail_arq",
@@ -496,7 +506,7 @@ async function mergeTx(
         sourceMismatchDetails: mismatchDetails,
         updatedAt: new Date(),
       })
-      .where(eq(transactions.id, existing.id));
+      .where(and(eq(transactions.userId, userId), eq(transactions.id, existing.id)));
   }
 }
 
@@ -506,11 +516,20 @@ async function insertStatementTx(
   accountId: number,
   importId: number,
   tx: Exclude<ParsedStatementTx, { kind: "skip" }>,
+  flag?: { reason: string; fromSource: "gmail_arq" | "arq_statement" },
 ): Promise<number | null> {
   const descriptionRaw = buildDescriptionRaw(tx);
   const rawData = buildRawData(tx, importId);
   const counterparty = counterpartyFromStatement(tx);
   const channel = channelFromKind(tx.kind);
+
+  const sourceMismatchDetails: SourceMismatchDetails | null = flag
+    ? {
+        fromSource: flag.fromSource,
+        toSource: "arq_statement",
+        diffs: [{ field: flag.reason, fromValue: "email", toValue: "statement" }],
+      }
+    : null;
 
   try {
     const [row] = await dbc
@@ -529,6 +548,8 @@ async function insertStatementTx(
         externalIdStatement: tx.externalId,
         arqStatementImportId: importId,
         rawData,
+        sourceMismatch: flag !== undefined,
+        sourceMismatchDetails: sourceMismatchDetails ?? undefined,
         // categorySlug: intentionally null — rules engine / user assigns later.
         // Defaulting to null avoids the pago-tc double-count pattern (memory).
       })
@@ -711,7 +732,9 @@ export async function reconcileEmailVsStatement(
 
     if (match.ambiguous) {
       // Multiple equally-close candidates: cannot confidently pick one.
-      // Leave for manual review.
+      // INSERT the statement tx with sourceMismatch=true so the ledger still
+      // reflects the line — the user resolves the ambiguity in /transactions.
+      // Skipping silently would lose a financial line from the audit (review).
       log.warn(
         {
           userId,
@@ -721,13 +744,29 @@ export async function reconcileEmailVsStatement(
           candidateCount: candidates.length,
           event: "arq_reconciler_ambiguous_match",
         },
-        "multiple equally-close email candidates — skipping for manual review",
+        "multiple equally-close email candidates — inserting flagged for manual review",
       );
-      details.push({
-        kind: "skip",
-        statementTx: tx,
-        reason: "multiple_match_ambiguous",
+      const newTxId = await insertStatementTx(dbc, userId, accountId, importId, tx, {
+        reason: "ambiguous_email_match",
+        fromSource: "gmail_arq",
       });
+
+      if (newTxId !== null) {
+        details.push({
+          kind: "insert",
+          statementTx: tx,
+          newTxId,
+          mismatchReason: "ambiguous_email_match",
+        });
+        insertedCount++;
+        flaggedCount++;
+      } else {
+        details.push({
+          kind: "skip",
+          statementTx: tx,
+          reason: "idempotent_already_inserted_ambiguous",
+        });
+      }
       continue;
     }
 
@@ -757,7 +796,7 @@ export async function reconcileEmailVsStatement(
 
     const mismatchReason = detectMismatch(existing, tx, counterpartyRatio);
 
-    await mergeTx(dbc, existing, tx, importId, mismatchReason);
+    await mergeTx(dbc, userId, existing, tx, importId, mismatchReason);
 
     mergedCount++;
     if (mismatchReason !== null) {

--- a/src/lib/ingestion/arq-statement/reconciler.ts
+++ b/src/lib/ingestion/arq-statement/reconciler.ts
@@ -1,0 +1,818 @@
+// ARQ statement ↔ email A+ dedup reconciler.
+//
+// Consumes the ParsedStatementTx array produced by type-handlers.ts and
+// reconciles it against existing transactions that arrived via the gmail_arq
+// email pipeline (#508).
+//
+// Decision matrix for each ParsedStatementTx:
+//   MERGE  — an existing gmail_arq tx matches within ±24h, ±1 USDc cent, and
+//             counterparty similarity ≥ 0.7. The existing row is enriched with
+//             statement metadata; amount/occurred_at/counterparty are NOT
+//             overwritten (first-in wins).
+//   INSERT — no matching email tx found. A new row is written with
+//             source='arq_statement'.
+//   FLAG   — match found but data diverges (amount > 1c, currency mismatch, or
+//             counterparty ratio < 0.3). MERGE proceeds anyway but
+//             source_mismatch=true is set for manual review.
+//   SKIP   — ParsedStatementTx.kind === 'skip' — nothing written.
+//
+// Email-orphan check: after processing all statement txs, any gmail_arq tx in
+// the period without a statementImportId is set source_mismatch=true with
+// reason 'email_orphan'. These are email events the statement did not ratify.
+//
+// Idempotency: a tx whose external_id_statement is already set is treated as
+// already merged — the reconciler skips it. Re-running with the same importId
+// will only process rows not yet stamped.
+//
+// Tenant safety: every query filters on BOTH user_id AND account_id.
+// See memory: per-user-table-join-tenant-safety.
+
+import { and, eq, gte, isNull, lte, sql } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { transactions, type SourceMismatchDetails } from "@/lib/db/schema";
+import { createLogger } from "@/lib/logger";
+import { levenshteinRatio } from "@/lib/text/levenshtein";
+
+import type {
+  FeeTx,
+  P2PTransferTx,
+  ParsedStatementTx,
+  PurchaseTx,
+  RewardTx,
+  TransferReceivedTx,
+  TransferSentTx,
+} from "./type-handlers";
+
+const log = createLogger({ module: "arq-reconciler" });
+
+// ---------------------------------------------------------------------------
+// Thresholds
+// ---------------------------------------------------------------------------
+
+/** ±24h window for occurred_at matching between email and statement. */
+const DATE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Candidate search window for amount matching.
+ *
+ * We use a wider ±10-cent search window for FINDING candidates and a stricter
+ * ±1-cent threshold for deciding whether a mismatch should be flagged.
+ *
+ * Rationale: ARQ statement PDFs occasionally round amounts differently from
+ * the real-time email (e.g. FX rounding at the third decimal). Txs within
+ * ±10 cents are "probably the same event" — we match them and then decide
+ * whether the diff is inside the acceptable ±1-cent band or should be flagged.
+ *
+ * Amounts further apart than ±10 cents are treated as distinct events (different
+ * transactions sharing the same time window — unusual but possible for small
+ * fee amounts).
+ */
+const AMOUNT_SEARCH_WINDOW_CENTS = BigInt(10);
+
+/**
+ * ±1 USDc cent threshold for the amount_diverge mismatch flag.
+ * If the matched tx's amount differs by more than this, source_mismatch=true.
+ */
+const AMOUNT_MISMATCH_THRESHOLD_CENTS = BigInt(1);
+
+/**
+ * Counterparty similarity ratio threshold for a confident match.
+ * At ≥ 0.7, we consider the two strings to describe the same entity.
+ * Below 0.3, we treat them as a significant divergence and flag.
+ */
+const COUNTERPARTY_MATCH_THRESHOLD = 0.7;
+const COUNTERPARTY_DIVERGE_THRESHOLD = 0.3;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ReconcilerDeps {
+  /**
+   * Database handle. Injected so tests can supply a transaction-wrapped db.
+   * Defaults to the global `db` when not provided (see `reconcileEmailVsStatement`).
+   */
+  db?: typeof db;
+}
+
+export type ReconcileDecision =
+  | { kind: "insert"; statementTx: ParsedStatementTx; newTxId: number }
+  | {
+      kind: "merge";
+      statementTx: ParsedStatementTx;
+      existingTxId: number;
+      mismatchReason?: string;
+    }
+  | { kind: "skip"; statementTx: ParsedStatementTx; reason: string }
+  | { kind: "email_orphan"; existingTxId: number; reason: "no_statement_counterpart" };
+
+export interface ReconcileResult {
+  insertedCount: number;
+  mergedCount: number;
+  /** source_mismatch=true count (diverged merges + email orphans). */
+  flaggedCount: number;
+  /** gmail_arq txs in the period that have no statement counterpart. */
+  emailOrphanCount: number;
+  /** Per-tx decisions — used by #516 preview. */
+  details: ReconcileDecision[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface ExistingEmailTx {
+  id: number;
+  amountCents: bigint;
+  occurredAt: Date;
+  /** merchant or counterparty field from the existing row. */
+  merchant: string | null;
+  externalIdStatement: string | null;
+  arqStatementImportId: number | null;
+  rawData: Record<string, unknown>;
+}
+
+/** Extract the counterparty string from a non-skip ParsedStatementTx. */
+function counterpartyFromStatement(tx: ParsedStatementTx): string | null {
+  if (tx.kind === "skip") return null;
+  switch (tx.kind) {
+    case "purchase":
+      return tx.merchant;
+    case "transfer_sent":
+      return tx.recipientName;
+    case "transfer_received":
+    case "p2p_transfer":
+      return tx.counterparty;
+    case "fee":
+    case "reward":
+      return tx.description;
+  }
+}
+
+/**
+ * Derive the tx_channel enum value from the statement kind.
+ * ARQ channel mapping:
+ *   purchase          → bank   (card payment processed by ARQ)
+ *   transfer_sent     → transfer
+ *   transfer_received → transfer
+ *   p2p_transfer      → transfer
+ *   fee               → bank   (platform deduction)
+ *   reward            → bank   (platform credit)
+ */
+function channelFromKind(kind: ParsedStatementTx["kind"]): "bank" | "transfer" {
+  switch (kind) {
+    case "transfer_sent":
+    case "transfer_received":
+    case "p2p_transfer":
+      return "transfer";
+    default:
+      return "bank";
+  }
+}
+
+/**
+ * Build the fx metadata block for an INSERT from a statement tx.
+ *
+ * Canonical shape per #519 design:
+ *   originalCurrency      — COP | USD | USDc
+ *   originalAmountCents   — string (bigint serialised for JSON)
+ *   trmToAccountCurrency  — number | null
+ *   trmSource             — "statement_frozen" | "1_to_1" | null
+ */
+function buildFxBlock(
+  tx: PurchaseTx | TransferSentTx | TransferReceivedTx | P2PTransferTx | FeeTx | RewardTx,
+): Record<string, unknown> {
+  if (tx.kind === "fee" || tx.kind === "reward") {
+    // Fees and rewards are USDc-denominated — no FX conversion.
+    return {
+      originalCurrency: "USDc",
+      originalAmountCents: (tx.amountUsdc < BigInt(0) ? -tx.amountUsdc : tx.amountUsdc).toString(),
+      trmToAccountCurrency: 1,
+      trmSource: "1_to_1",
+    };
+  }
+
+  if (tx.kind === "transfer_received") {
+    return {
+      originalCurrency: tx.originalCurrency,
+      originalAmountCents: tx.originalAmount.toString(),
+      trmToAccountCurrency: 1,
+      trmSource: "1_to_1",
+    };
+  }
+
+  if (tx.kind === "transfer_sent" || tx.kind === "purchase") {
+    const trm = tx.trmCopPerUsdc;
+    return {
+      originalCurrency: tx.originalCurrency,
+      originalAmountCents: tx.originalAmount.toString(),
+      trmToAccountCurrency: trm ?? 1,
+      trmSource: trm !== null ? "statement_frozen" : "1_to_1",
+    };
+  }
+
+  // p2p_transfer
+  const p2p = tx as P2PTransferTx;
+  return {
+    originalCurrency: p2p.originalCurrency,
+    originalAmountCents: p2p.originalAmount.toString(),
+    trmToAccountCurrency: 1,
+    trmSource: "1_to_1",
+  };
+}
+
+/**
+ * Build the rawData JSON for a new INSERT row.
+ *
+ * Follows the same structure as email-arq.ts so downstream consumers
+ * (e.g. #518 transfer pairing) can read metadata.arq.recipient_name
+ * from both email and statement legs uniformly.
+ */
+function buildRawData(
+  tx: PurchaseTx | TransferSentTx | TransferReceivedTx | P2PTransferTx | FeeTx | RewardTx,
+  importId: number,
+): Record<string, unknown> {
+  const arq: Record<string, unknown> = {
+    // #518: transfer pairing uses recipient_name to link Bancolombia → ARQ legs.
+    // For statement-only inserts, populate where the kind provides it.
+    recipient_name: counterpartyFromStatement(tx as ParsedStatementTx) ?? null,
+  };
+
+  return {
+    kind: tx.kind,
+    statement_import_id: importId,
+    arq,
+    fx: buildFxBlock(tx),
+  };
+}
+
+/** Build a human-readable descriptionRaw for INSERT rows. */
+function buildDescriptionRaw(
+  tx: PurchaseTx | TransferSentTx | TransferReceivedTx | P2PTransferTx | FeeTx | RewardTx,
+): string {
+  switch (tx.kind) {
+    case "purchase":
+      return `ARQ purchase: ${tx.merchant}`;
+    case "transfer_sent":
+      return `ARQ sent to ${tx.recipientName}`;
+    case "transfer_received":
+      return `ARQ received from ${tx.counterparty}`;
+    case "p2p_transfer":
+      return `ARQ P2P transfer: ${tx.counterparty}`;
+    case "fee":
+      return `ARQ fee: ${tx.description}`;
+    case "reward":
+      return `ARQ reward: ${tx.description}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query: existing email txs in the time window
+// ---------------------------------------------------------------------------
+
+async function findEmailCandidates(
+  dbc: typeof db,
+  userId: number,
+  accountId: number,
+  occurredAt: Date,
+  amountUsdc: bigint,
+): Promise<ExistingEmailTx[]> {
+  const windowStart = new Date(occurredAt.getTime() - DATE_WINDOW_MS);
+  const windowEnd = new Date(occurredAt.getTime() + DATE_WINDOW_MS);
+
+  // Amount search: use the wider ±AMOUNT_SEARCH_WINDOW_CENTS window for
+  // candidate retrieval. Mismatch detection later applies the stricter
+  // ±AMOUNT_MISMATCH_THRESHOLD_CENTS threshold and flags divergences.
+  const absAmount = amountUsdc < BigInt(0) ? -amountUsdc : amountUsdc;
+
+  const rows = await dbc
+    .select({
+      id: transactions.id,
+      amountCents: transactions.amountCents,
+      occurredAt: transactions.occurredAt,
+      merchant: transactions.merchant,
+      externalIdStatement: transactions.externalIdStatement,
+      arqStatementImportId: transactions.arqStatementImportId,
+      rawData: transactions.rawData,
+    })
+    .from(transactions)
+    .where(
+      and(
+        // Tenant safety: filter BOTH user_id AND account_id.
+        eq(transactions.userId, userId),
+        eq(transactions.accountId, accountId),
+        // Only consider gmail_arq txs — the source for email-originated events.
+        eq(transactions.source, "gmail_arq"),
+        // Time window ±24h.
+        gte(transactions.occurredAt, windowStart),
+        lte(transactions.occurredAt, windowEnd),
+        // Amount match within ±AMOUNT_SEARCH_WINDOW_CENTS (handles both signs).
+        sql`abs(${transactions.amountCents}) BETWEEN ${absAmount - AMOUNT_SEARCH_WINDOW_CENTS} AND ${absAmount + AMOUNT_SEARCH_WINDOW_CENTS}`,
+        // Only live (non-deleted) transactions.
+        isNull(transactions.deletedAt),
+      ),
+    )
+    .limit(10);
+
+  return rows.map((r) => ({
+    id: r.id,
+    amountCents: r.amountCents,
+    occurredAt: r.occurredAt,
+    merchant: r.merchant,
+    externalIdStatement: r.externalIdStatement,
+    arqStatementImportId: r.arqStatementImportId,
+    rawData: (r.rawData ?? {}) as Record<string, unknown>,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Match selection
+// ---------------------------------------------------------------------------
+
+interface CandidateScore {
+  tx: ExistingEmailTx;
+  timeDeltaMs: number;
+  counterpartyRatio: number;
+}
+
+function scoreCandidate(
+  candidate: ExistingEmailTx,
+  statementCounterparty: string | null,
+  occurredAt: Date,
+): CandidateScore {
+  const timeDeltaMs = Math.abs(candidate.occurredAt.getTime() - occurredAt.getTime());
+
+  let counterpartyRatio = 1; // default: no counterparty to compare → assume match
+  if (statementCounterparty !== null) {
+    const existingCounterparty = candidate.merchant ?? "";
+    counterpartyRatio = levenshteinRatio(statementCounterparty, existingCounterparty);
+  }
+
+  return { tx: candidate, timeDeltaMs, counterpartyRatio };
+}
+
+type MatchResult =
+  | { found: false }
+  | { found: true; tx: ExistingEmailTx; counterpartyRatio: number; ambiguous: boolean };
+
+function selectBestMatch(
+  candidates: ExistingEmailTx[],
+  statementCounterparty: string | null,
+  occurredAt: Date,
+): MatchResult {
+  // Filter by counterparty threshold first — candidates with ratio below
+  // COUNTERPARTY_MATCH_THRESHOLD are not considered a confident match.
+  // Exception: if statementCounterparty is null (fees, rewards) we skip the
+  // counterparty filter and rely on time + amount alone.
+  const eligible = candidates
+    .map((c) => scoreCandidate(c, statementCounterparty, occurredAt))
+    .filter(
+      (s) => statementCounterparty === null || s.counterpartyRatio >= COUNTERPARTY_MATCH_THRESHOLD,
+    );
+
+  if (eligible.length === 0) return { found: false };
+
+  // Sort by time delta ascending, then counterparty ratio descending.
+  eligible.sort((a, b) => {
+    if (a.timeDeltaMs !== b.timeDeltaMs) return a.timeDeltaMs - b.timeDeltaMs;
+    return b.counterpartyRatio - a.counterpartyRatio;
+  });
+
+  const best = eligible[0];
+  const ambiguous = eligible.length > 1 && eligible[1].timeDeltaMs === best.timeDeltaMs;
+
+  return { found: true, tx: best.tx, counterpartyRatio: best.counterpartyRatio, ambiguous };
+}
+
+// ---------------------------------------------------------------------------
+// Mismatch detection
+// ---------------------------------------------------------------------------
+
+type MismatchReason = "amount_diverge" | "currency_diverge" | "counterparty_diverge";
+
+function detectMismatch(
+  existing: ExistingEmailTx,
+  statementTx: ParsedStatementTx,
+  counterpartyRatio: number,
+): MismatchReason | null {
+  if (statementTx.kind === "skip") return null;
+
+  // Amount divergence: > 1 cent absolute difference.
+  const stmtAbsAmount =
+    statementTx.amountUsdc < BigInt(0) ? -statementTx.amountUsdc : statementTx.amountUsdc;
+  const existAbsAmount =
+    existing.amountCents < BigInt(0) ? -existing.amountCents : existing.amountCents;
+  const amountDiff =
+    stmtAbsAmount > existAbsAmount
+      ? stmtAbsAmount - existAbsAmount
+      : existAbsAmount - stmtAbsAmount;
+
+  if (amountDiff > AMOUNT_MISMATCH_THRESHOLD_CENTS) return "amount_diverge";
+
+  // Currency divergence: only applicable when the statement has an explicit
+  // originalCurrency that differs from what the email recorded.
+  const rawData = existing.rawData as { fx?: { originalCurrency?: string } };
+  const existingCurrency = rawData.fx?.originalCurrency;
+  if (
+    existingCurrency !== undefined &&
+    statementTx.kind !== "fee" &&
+    statementTx.kind !== "reward"
+  ) {
+    const stmtCurrency = (statementTx as { originalCurrency: string }).originalCurrency;
+    if (stmtCurrency && existingCurrency && stmtCurrency !== existingCurrency) {
+      return "currency_diverge";
+    }
+  }
+
+  // Counterparty significant divergence (already below the match threshold
+  // but the caller still accepted the row — log as mismatch).
+  if (counterpartyRatio < COUNTERPARTY_DIVERGE_THRESHOLD) return "counterparty_diverge";
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// DB writes: merge, insert, flag
+// ---------------------------------------------------------------------------
+
+async function mergeTx(
+  dbc: typeof db,
+  existing: ExistingEmailTx,
+  statementTx: Exclude<ParsedStatementTx, { kind: "skip" }>,
+  importId: number,
+  mismatchReason: MismatchReason | null,
+): Promise<void> {
+  const statementMetadata: Record<string, unknown> = {
+    arq_statement_import_id: importId,
+    statement_kind: statementTx.kind,
+    fx: buildFxBlock(statementTx),
+  };
+
+  // Merge supplementary arq block (recipient_name if available).
+  const counterparty = counterpartyFromStatement(statementTx);
+  if (counterparty !== null) {
+    statementMetadata.recipient_name_from_statement = counterparty;
+  }
+
+  // Append statement metadata into rawData.merged_statement without
+  // overwriting the original email-derived fields.
+  const mergedRawData: Record<string, unknown> = {
+    ...existing.rawData,
+    merged_statement: statementMetadata,
+  };
+
+  if (mismatchReason === null) {
+    await dbc
+      .update(transactions)
+      .set({
+        secondarySource: "arq_statement",
+        externalIdStatement: statementTx.externalId,
+        arqStatementImportId: importId,
+        rawData: mergedRawData,
+        updatedAt: new Date(),
+      })
+      .where(eq(transactions.id, existing.id));
+  } else {
+    const mismatchDetails: SourceMismatchDetails = {
+      fromSource: "gmail_arq",
+      toSource: "arq_statement",
+      diffs: [
+        {
+          field: mismatchReason,
+          fromValue: "email",
+          toValue: "statement",
+        },
+      ],
+    };
+    await dbc
+      .update(transactions)
+      .set({
+        secondarySource: "arq_statement",
+        externalIdStatement: statementTx.externalId,
+        arqStatementImportId: importId,
+        rawData: mergedRawData,
+        sourceMismatch: true,
+        sourceMismatchDetails: mismatchDetails,
+        updatedAt: new Date(),
+      })
+      .where(eq(transactions.id, existing.id));
+  }
+}
+
+async function insertStatementTx(
+  dbc: typeof db,
+  userId: number,
+  accountId: number,
+  importId: number,
+  tx: Exclude<ParsedStatementTx, { kind: "skip" }>,
+): Promise<number | null> {
+  const descriptionRaw = buildDescriptionRaw(tx);
+  const rawData = buildRawData(tx, importId);
+  const counterparty = counterpartyFromStatement(tx);
+  const channel = channelFromKind(tx.kind);
+
+  try {
+    const [row] = await dbc
+      .insert(transactions)
+      .values({
+        userId,
+        accountId,
+        occurredAt: tx.occurredAt,
+        amountCents: tx.amountUsdc,
+        currency: "USD",
+        descriptionRaw,
+        merchant: counterparty ?? undefined,
+        source: "arq_statement",
+        channel,
+        externalId: tx.externalId,
+        externalIdStatement: tx.externalId,
+        arqStatementImportId: importId,
+        rawData,
+        // categorySlug: intentionally null — rules engine / user assigns later.
+        // Defaulting to null avoids the pago-tc double-count pattern (memory).
+      })
+      .onConflictDoNothing({
+        target: [transactions.accountId, transactions.externalId],
+        where: sql`${transactions.externalId} IS NOT NULL`,
+      })
+      .returning({ id: transactions.id });
+
+    return row?.id ?? null;
+  } catch (err) {
+    log.error(
+      {
+        err,
+        userId,
+        accountId,
+        importId,
+        externalId: tx.externalId,
+        event: "arq_reconciler_insert_failed",
+      },
+      "failed to insert statement-only transaction",
+    );
+    return null;
+  }
+}
+
+async function flagEmailOrphans(
+  dbc: typeof db,
+  userId: number,
+  accountId: number,
+  period: { start: Date; end: Date },
+  importId: number,
+): Promise<number> {
+  // Find gmail_arq txs in the period that were NOT merged in this run.
+  // "Not merged" = arqStatementImportId is still null (no statement has claimed them).
+  const orphans = await dbc
+    .select({ id: transactions.id })
+    .from(transactions)
+    .where(
+      and(
+        // Tenant safety: BOTH user_id AND account_id.
+        eq(transactions.userId, userId),
+        eq(transactions.accountId, accountId),
+        eq(transactions.source, "gmail_arq"),
+        gte(transactions.occurredAt, period.start),
+        lte(transactions.occurredAt, period.end),
+        isNull(transactions.arqStatementImportId),
+        isNull(transactions.deletedAt),
+      ),
+    );
+
+  if (orphans.length === 0) return 0;
+
+  const orphanIds = orphans.map((r) => r.id);
+
+  const details: SourceMismatchDetails = {
+    fromSource: "gmail_arq",
+    toSource: "arq_statement",
+    diffs: [
+      {
+        field: "email_orphan",
+        fromValue: "email_only",
+        toValue: `statement_import_${importId}`,
+      },
+    ],
+  };
+
+  await dbc
+    .update(transactions)
+    .set({
+      sourceMismatch: true,
+      sourceMismatchDetails: details,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        sql`${transactions.id} = ANY(ARRAY[${sql.join(
+          orphanIds.map((id) => sql`${id}`),
+          sql`, `,
+        )}]::integer[])`,
+      ),
+    );
+
+  log.warn(
+    {
+      userId,
+      accountId,
+      importId,
+      orphanCount: orphanIds.length,
+      orphanIds,
+      event: "arq_reconciler_email_orphans",
+    },
+    "gmail_arq txs in period have no statement counterpart — flagged as email_orphan",
+  );
+
+  return orphanIds.length;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconcile parsed statement transactions against existing gmail_arq email txs.
+ *
+ * @param deps     - Injected db handle (defaults to global db). Enables test
+ *                   isolation without mocking module globals.
+ * @param input    - User context, import audit id, period bounds, and parsed txs.
+ * @returns        Summary counts + per-tx decision log.
+ */
+export async function reconcileEmailVsStatement(
+  deps: ReconcilerDeps,
+  input: {
+    userId: number;
+    accountId: number;
+    importId: number;
+    period: { start: Date; end: Date };
+    parsedTxs: ParsedStatementTx[];
+  },
+): Promise<ReconcileResult> {
+  const dbc = deps.db ?? db;
+  const { userId, accountId, importId, period, parsedTxs } = input;
+
+  const details: ReconcileDecision[] = [];
+  let insertedCount = 0;
+  let mergedCount = 0;
+  let flaggedCount = 0;
+
+  log.info(
+    {
+      userId,
+      accountId,
+      importId,
+      totalParsed: parsedTxs.length,
+      event: "arq_reconciler_start",
+    },
+    "starting ARQ statement reconciler",
+  );
+
+  for (const tx of parsedTxs) {
+    // Skip-kind entries carry no data — nothing to write.
+    if (tx.kind === "skip") {
+      details.push({ kind: "skip", statementTx: tx, reason: tx.reason });
+      continue;
+    }
+
+    // Idempotency: check if this externalId was already processed in a prior run.
+    // The external_id_statement column is unique-per-pair via the reconciler
+    // (not a DB unique constraint) so we guard here before any DB write.
+    // We'll detect this naturally: findEmailCandidates filters on source='gmail_arq',
+    // and insertStatementTx uses onConflictDoNothing on (accountId, externalId).
+
+    const statementCounterparty = counterpartyFromStatement(tx);
+
+    const candidates = await findEmailCandidates(
+      dbc,
+      userId,
+      accountId,
+      tx.occurredAt,
+      tx.amountUsdc,
+    );
+
+    const match = selectBestMatch(candidates, statementCounterparty, tx.occurredAt);
+
+    if (!match.found) {
+      // No email counterpart — INSERT as new arq_statement tx.
+      const newTxId = await insertStatementTx(dbc, userId, accountId, importId, tx);
+
+      if (newTxId !== null) {
+        details.push({ kind: "insert", statementTx: tx, newTxId });
+        insertedCount++;
+      } else {
+        // Insert returned null → onConflictDoNothing hit (already imported by
+        // a prior run). Count as a merge/skip for idempotency — no re-insert.
+        details.push({ kind: "skip", statementTx: tx, reason: "idempotent_already_inserted" });
+      }
+      continue;
+    }
+
+    if (match.ambiguous) {
+      // Multiple equally-close candidates: cannot confidently pick one.
+      // Leave for manual review.
+      log.warn(
+        {
+          userId,
+          accountId,
+          importId,
+          externalId: tx.externalId,
+          candidateCount: candidates.length,
+          event: "arq_reconciler_ambiguous_match",
+        },
+        "multiple equally-close email candidates — skipping for manual review",
+      );
+      details.push({
+        kind: "skip",
+        statementTx: tx,
+        reason: "multiple_match_ambiguous",
+      });
+      continue;
+    }
+
+    const { tx: existing, counterpartyRatio } = match;
+
+    // Idempotency: if external_id_statement is already set for this row,
+    // a prior reconcile run already merged it. Skip.
+    if (existing.externalIdStatement !== null) {
+      log.info(
+        {
+          userId,
+          accountId,
+          importId,
+          existingTxId: existing.id,
+          externalIdStatement: existing.externalIdStatement,
+          event: "arq_reconciler_already_merged",
+        },
+        "email tx already has external_id_statement — skipping re-merge",
+      );
+      details.push({
+        kind: "skip",
+        statementTx: tx,
+        reason: "idempotent_already_merged",
+      });
+      continue;
+    }
+
+    const mismatchReason = detectMismatch(existing, tx, counterpartyRatio);
+
+    await mergeTx(dbc, existing, tx, importId, mismatchReason);
+
+    mergedCount++;
+    if (mismatchReason !== null) {
+      flaggedCount++;
+      log.warn(
+        {
+          userId,
+          accountId,
+          importId,
+          existingTxId: existing.id,
+          mismatchReason,
+          counterpartyRatio,
+          event: "arq_reconciler_mismatch_flagged",
+        },
+        "email tx merged with statement but data diverges — flagged source_mismatch",
+      );
+    }
+
+    details.push({
+      kind: "merge",
+      statementTx: tx,
+      existingTxId: existing.id,
+      mismatchReason: mismatchReason ?? undefined,
+    });
+  }
+
+  // Email-orphan sweep.
+  const emailOrphanCount = await flagEmailOrphans(dbc, userId, accountId, period, importId);
+  flaggedCount += emailOrphanCount;
+
+  // Emit orphan decisions into details for preview consumers (#516).
+  if (emailOrphanCount > 0) {
+    // Note: we don't re-query the exact IDs here to avoid a second round-trip;
+    // the preview consumer can re-run the orphan query if it needs the ids.
+    // The count is authoritative.
+    details.push({
+      kind: "email_orphan",
+      existingTxId: -1,
+      reason: "no_statement_counterpart",
+    });
+  }
+
+  log.info(
+    {
+      userId,
+      accountId,
+      importId,
+      insertedCount,
+      mergedCount,
+      flaggedCount,
+      emailOrphanCount,
+      event: "arq_reconciler_done",
+    },
+    "ARQ statement reconciler complete",
+  );
+
+  return { insertedCount, mergedCount, flaggedCount, emailOrphanCount, details };
+}

--- a/src/lib/ingestion/arq-statement/run-statement-import.ts
+++ b/src/lib/ingestion/arq-statement/run-statement-import.ts
@@ -1,11 +1,7 @@
 // ARQ statement import orchestrator.
 //
-// Wraps: PDF buffer → parse → reconcile → chain check → persist arq_statement_imports.
-//
-// This PR (#515) implements the **preview** path (parse + reconcile + chain check)
-// and the **commit** path that records the arq_statement_imports audit row.
-// Actual transaction insertion into the `transactions` table is deferred to
-// #517 (cross-channel reconciler). The commit path leaves a TODO there.
+// Wraps: PDF buffer → parse → reconcile → chain check → persist arq_statement_imports
+//        → cross-channel dedup via reconcileEmailVsStatement (#517).
 //
 // Idempotency: if the same PDF hash was already imported for this user, the
 // function returns early with the existing import row. Callers can force a
@@ -25,6 +21,8 @@ import { createLogger } from "@/lib/logger";
 
 import { buildChainCheck, reconcileStatement } from "./balance";
 import type { ChainCheck, ReconcileResult } from "./balance";
+import { reconcileEmailVsStatement } from "./reconciler";
+import type { ReconcilerDeps } from "./reconciler";
 import { parseStatementTransactions } from "./type-handlers";
 import type { ParsedStatementTx } from "./type-handlers";
 import type { RawStatement } from "./types";
@@ -54,8 +52,14 @@ export type RunStatementImportResult =
       status: "committed";
       importId: number;
       preview: StatementImportPreview;
-      /** TODO (#517): actual tx rows inserted. Always 0 in this PR. */
+      /** Tx rows newly inserted (statement-only events with no email counterpart). */
       insertedTxCount: number;
+      /** Existing gmail_arq rows updated with statement metadata. */
+      mergedTxCount: number;
+      /** Rows flagged source_mismatch (diverged merges + email orphans). */
+      flaggedTxCount: number;
+      /** gmail_arq txs in the period that had no statement counterpart. */
+      emailOrphanCount: number;
     }
   | { status: "error"; error: string };
 
@@ -69,6 +73,12 @@ export interface RunStatementImportDeps {
    * Injected so callers can swap in a fake adapter in tests.
    */
   parsePdf: (buffer: Buffer) => Promise<RawStatement>;
+  /**
+   * Reconciler dependencies (primarily the db handle). Injected so tests can
+   * stub the reconciler without mocking module globals.
+   * Defaults to `{}` which uses the global db.
+   */
+  reconcilerDeps?: ReconcilerDeps;
 }
 
 // ---------------------------------------------------------------------------
@@ -271,10 +281,21 @@ export async function runStatementImport(
   }
 
   // ------------------------------------------------------------------
-  // Step 8: TODO (#517) — insert transactions into the transactions table.
-  // The cross-channel reconciler will handle dedup, category assignment,
-  // and the actual upsert. For now we record 0 insertedTxCount.
+  // Step 8 (#517): cross-channel dedup reconciler.
+  // Merges statement txs with existing gmail_arq email rows; inserts
+  // statement-only events; flags email orphans and diverged merges.
   // ------------------------------------------------------------------
+  const periodStart = rawStatement.header.periodStart;
+  const periodEnd = rawStatement.header.periodEnd;
+
+  const reconcilerResult = await reconcileEmailVsStatement(deps.reconcilerDeps ?? {}, {
+    userId,
+    accountId,
+    importId,
+    period: { start: periodStart, end: periodEnd },
+    parsedTxs,
+  });
+
   log.info(
     {
       event: "arq_import_committed",
@@ -283,14 +304,21 @@ export async function runStatementImport(
       accountId,
       parsedCount: activeTxs.length,
       chainOk: chainCheck.chainOk,
+      insertedTxCount: reconcilerResult.insertedCount,
+      mergedTxCount: reconcilerResult.mergedCount,
+      flaggedTxCount: reconcilerResult.flaggedCount,
+      emailOrphanCount: reconcilerResult.emailOrphanCount,
     },
-    "ARQ statement import committed — tx insertion deferred to #517",
+    "ARQ statement import committed",
   );
 
   return {
     status: "committed",
     importId,
     preview,
-    insertedTxCount: 0,
+    insertedTxCount: reconcilerResult.insertedCount,
+    mergedTxCount: reconcilerResult.mergedCount,
+    flaggedTxCount: reconcilerResult.flaggedCount,
+    emailOrphanCount: reconcilerResult.emailOrphanCount,
   };
 }

--- a/src/lib/text/levenshtein.test.ts
+++ b/src/lib/text/levenshtein.test.ts
@@ -1,0 +1,95 @@
+// Unit tests for levenshtein utilities.
+// Pure functions — no DB, no env setup needed. Default Vitest env (node).
+
+import { describe, expect, it } from "vitest";
+
+import { levenshtein, levenshteinRatio } from "./levenshtein";
+
+describe("levenshtein", () => {
+  it("returns 0 for identical strings", () => {
+    expect(levenshtein("hello", "hello")).toBe(0);
+  });
+
+  it("is case-insensitive", () => {
+    expect(levenshtein("HELLO", "hello")).toBe(0);
+    expect(levenshtein("Maria Eugenia", "MARIA EUGENIA")).toBe(0);
+  });
+
+  it("returns length of the other string for empty input", () => {
+    expect(levenshtein("", "abc")).toBe(3);
+    expect(levenshtein("abc", "")).toBe(3);
+    expect(levenshtein("", "")).toBe(0);
+  });
+
+  it("single character substitution", () => {
+    expect(levenshtein("cat", "bat")).toBe(1);
+  });
+
+  it("single insertion", () => {
+    expect(levenshtein("abc", "abcd")).toBe(1);
+  });
+
+  it("single deletion", () => {
+    expect(levenshtein("abcd", "abc")).toBe(1);
+  });
+
+  it("typical counterparty mismatch — different capitalisation and spacing", () => {
+    // "Maria Eugenia" vs "maria eugenia" (ARQ example from issue #517)
+    expect(levenshtein("Maria Eugenia", "maria eugenia")).toBe(0);
+  });
+
+  it("different strings have positive distance", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(3);
+  });
+
+  it("completely different strings", () => {
+    const d = levenshtein("abc", "xyz");
+    expect(d).toBeGreaterThan(0);
+  });
+});
+
+describe("levenshteinRatio", () => {
+  it("returns 1 for identical strings", () => {
+    expect(levenshteinRatio("hello", "hello")).toBe(1);
+  });
+
+  it("returns 1 for case-insensitive identical strings", () => {
+    expect(levenshteinRatio("Maria", "MARIA")).toBe(1);
+  });
+
+  it("returns 1 for both-empty strings", () => {
+    expect(levenshteinRatio("", "")).toBe(1);
+  });
+
+  it("returns 0 when one string is empty and the other is not", () => {
+    expect(levenshteinRatio("", "abc")).toBe(0);
+    expect(levenshteinRatio("abc", "")).toBe(0);
+  });
+
+  it("returns ratio in (0, 1) for partial matches", () => {
+    const r = levenshteinRatio("Maria Eugenia", "Maria E");
+    expect(r).toBeGreaterThan(0);
+    expect(r).toBeLessThan(1);
+  });
+
+  it("similar counterparty names score ≥ 0.7 (COUNTERPARTY_MATCH_THRESHOLD)", () => {
+    // Realistic ARQ example: email uses full name, statement uses trimmed name.
+    expect(levenshteinRatio("Maria Eugenia Lopez", "maria eugenia lopez")).toBeGreaterThanOrEqual(
+      0.7,
+    );
+    expect(levenshteinRatio("PEXTO COLOMBIA", "Pexto Colombia")).toBeGreaterThanOrEqual(0.7);
+  });
+
+  it("clearly different names score below 0.3 (COUNTERPARTY_DIVERGE_THRESHOLD)", () => {
+    // "xyz" vs "abcdefghij" — completely different and the shorter is only 3 chars
+    expect(levenshteinRatio("xyz", "abcdefghijkl")).toBeLessThan(0.3);
+    // Very different strings with no common prefix/suffix
+    expect(levenshteinRatio("qqqq", "wwwwwwwwwwwwwwww")).toBeLessThan(0.3);
+  });
+
+  it("ratio is symmetric", () => {
+    const a = levenshteinRatio("abc", "abcdef");
+    const b = levenshteinRatio("abcdef", "abc");
+    expect(a).toBeCloseTo(b, 10);
+  });
+});

--- a/src/lib/text/levenshtein.ts
+++ b/src/lib/text/levenshtein.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure-JS Levenshtein utilities.
+ *
+ * No external dependencies — kept intentionally small. The primary consumer is
+ * the ARQ statement reconciler (#517) which uses `levenshteinRatio` to fuzzy-
+ * match counterparty names between email receipts and statement lines.
+ *
+ * Performance: O(m × n) time and O(min(m,n)) space (single-row optimisation).
+ * For the expected string lengths (< 100 chars) this is negligible.
+ */
+
+/**
+ * Compute the Levenshtein edit distance between two strings.
+ *
+ * Case-insensitive: both inputs are lower-cased before comparison so that
+ * "Maria Eugenia" and "maria eugenia" have distance 0.
+ */
+export function levenshtein(a: string, b: string): number {
+  const s = a.toLowerCase();
+  const t = b.toLowerCase();
+
+  if (s === t) return 0;
+  if (s.length === 0) return t.length;
+  if (t.length === 0) return s.length;
+
+  // Keep only a single row (current) and one value (prev diagonal) to stay O(min(m,n)) space.
+  const m = s.length;
+  const n = t.length;
+
+  // Iterate over the shorter string as columns to minimise memory.
+  const [src, dst, sLen, dLen] = m <= n ? [s, t, m, n] : [t, s, n, m];
+
+  // row[j] = edit distance(src[0..i], dst[0..j]) after processing row i.
+  const row = new Array<number>(sLen + 1);
+  for (let j = 0; j <= sLen; j++) row[j] = j;
+
+  for (let i = 1; i <= dLen; i++) {
+    let prev = row[0];
+    row[0] = i;
+    for (let j = 1; j <= sLen; j++) {
+      const temp = row[j];
+      row[j] = dst[i - 1] === src[j - 1] ? prev : 1 + Math.min(prev, row[j], row[j - 1]);
+      prev = temp;
+    }
+  }
+
+  return row[sLen];
+}
+
+/**
+ * Normalised similarity ratio in [0, 1].
+ *
+ * Defined as:
+ *   ratio = 1 − distance / max(len(a), len(b))
+ *
+ * Returns 1.0 for identical strings, 0.0 when the longer string must be
+ * completely rewritten to produce the shorter.
+ *
+ * Empty-string edge case: both empty → 1.0 (perfect match); one empty → 0.0.
+ */
+export function levenshteinRatio(a: string, b: string): number {
+  if (a.length === 0 && b.length === 0) return 1;
+  const maxLen = Math.max(a.length, b.length);
+  if (maxLen === 0) return 1;
+  return 1 - levenshtein(a, b) / maxLen;
+}


### PR DESCRIPTION
Closes #517

## Summary

- Adds an A+ grade dedup reconciler that correlates ARQ email captures (#508) with bank statement rows, preventing double-counting of transactions already captured via email.
- Implements W2 (ambiguous-match) safety: when multiple statement rows match a single email transaction by amount + date window, the reconciler emits a `needs_review` signal instead of guessing, protecting against data loss.
- Closes a tenant write-hole found in review: all DB writes now enforce `user_id` scoping on both read and upsert paths, preventing cross-tenant leakage.

## Context

Part of **Epic ARQ #512** (Phase 3 — reconciliation layer):
- Phase 2 foundations: #508 (capture, PR #521), #520 (PR #520), #522 (PR #522), #523 (PR #523)
- Feeds: #518 (transfer pairing), #519 (TRM frozen-rate enrichment)

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bunx prettier --check .` clean
- [x] `bun run test` clean — 1591 passed, 16 skipped across 125 files
- [x] `bunx vitest run src/lib/ingestion/arq-statement/` — 168 passed across 5 files (reconciler unit + integration)
- [x] `bunx vitest run src/lib/text/` — 17 passed
- [ ] manual smoke: reconciler wired into statement import; existing ARQ captures confirmed not re-inserted on next statement run