### PR TITLE
feat(transfers): intra-user transfer pairing cross-currency aware (#518)

### DIFF
--- a/drizzle/0065_grey_namor.sql
+++ b/drizzle/0065_grey_namor.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "fiat_partners" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"source_system" varchar(40) NOT NULL,
+	"partner_name" varchar(200) NOT NULL,
+	"description" text,
+	"active" boolean DEFAULT true NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_aliases" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"alias" varchar(200) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_aliases" ADD CONSTRAINT "user_aliases_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "fiat_partners_system_name_unique" ON "fiat_partners" USING btree ("source_system","partner_name");--> statement-breakpoint
+CREATE INDEX "fiat_partners_source_active_idx" ON "fiat_partners" USING btree ("source_system") WHERE "fiat_partners"."active" = true;--> statement-breakpoint
+CREATE UNIQUE INDEX "user_aliases_user_alias_unique" ON "user_aliases" USING btree ("user_id","alias");--> statement-breakpoint
+CREATE INDEX "user_aliases_user_idx" ON "user_aliases" USING btree ("user_id");--> statement-breakpoint
+INSERT INTO "fiat_partners" ("source_system", "partner_name", "description", "active")
+VALUES ('arq', 'PEXTO COLOMBIA', 'Fiat partner ARQ para dispersiones COP en Colombia', true)
+ON CONFLICT ("source_system", "partner_name") DO NOTHING;

--- a/drizzle/meta/0065_snapshot.json
+++ b/drizzle/meta/0065_snapshot.json
@@ -1,0 +1,5537 @@
+{
+  "id": "8438e63a-abe1-4988-9bc4-964dcee10966",
+  "prevId": "6e53d25e-0fdc-4a4d-a764-8118f21144e9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_physical_card_id_physical_cards_id_fk": {
+          "name": "accounts_physical_card_id_physical_cards_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "physical_cards",
+          "columnsFrom": [
+            "physical_card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.arq_statement_imports": {
+      "name": "arq_statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declared_start_cents": {
+          "name": "declared_start_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declared_end_cents": {
+          "name": "declared_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_count": {
+          "name": "parsed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_sum_cents": {
+          "name": "parsed_sum_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconciled": {
+          "name": "reconciled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconcile_diff_cents": {
+          "name": "reconcile_diff_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_ok": {
+          "name": "chain_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "raw_pdf_hash": {
+          "name": "raw_pdf_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "arq_statement_imports_period_unique": {
+          "name": "arq_statement_imports_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "arq_statement_imports_user_hash_unique": {
+          "name": "arq_statement_imports_user_hash_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_pdf_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "arq_statement_imports_account_period_idx": {
+          "name": "arq_statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "arq_statement_imports_user_id_users_id_fk": {
+          "name": "arq_statement_imports_user_id_users_id_fk",
+          "tableFrom": "arq_statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "arq_statement_imports_account_id_accounts_id_fk": {
+          "name": "arq_statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "arq_statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_corrections": {
+      "name": "classification_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_category_slug": {
+          "name": "new_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_corrections_learning_idx": {
+          "name": "classification_corrections_learning_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "new_category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_corrections_user_id_users_id_fk": {
+          "name": "classification_corrections_user_id_users_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_corrections_transaction_id_transactions_id_fk": {
+          "name": "classification_corrections_transaction_id_transactions_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_from_corrections": {
+          "name": "generated_from_corrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_salary": {
+          "name": "is_salary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparties_user_salary_idx": {
+          "name": "counterparties_user_salary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"counterparties\".\"is_salary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_receipts": {
+      "name": "email_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_connection_id": {
+          "name": "gmail_connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_msg_id": {
+          "name": "gmail_msg_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway": {
+          "name": "gateway",
+          "type": "email_receipt_gateway",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_html": {
+          "name": "raw_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_payload": {
+          "name": "parsed_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_transaction_id": {
+          "name": "matched_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_status": {
+          "name": "match_status",
+          "type": "email_receipt_match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "match_candidates": {
+          "name": "match_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_at": {
+          "name": "parsed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_receipts_user_msg_unique": {
+          "name": "email_receipts_user_msg_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_msg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_user_status_idx": {
+          "name": "email_receipts_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_match_lookup_idx": {
+          "name": "email_receipts_match_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "amount_cents",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'pending' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_connection_idx": {
+          "name": "email_receipts_connection_idx",
+          "columns": [
+            {
+              "expression": "gmail_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_candidates_gin_idx": {
+          "name": "email_receipts_candidates_gin_idx",
+          "columns": [
+            {
+              "expression": "match_candidates",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'ambiguous' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_receipts_user_id_users_id_fk": {
+          "name": "email_receipts_user_id_users_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_gmail_connection_id_gmail_connections_id_fk": {
+          "name": "email_receipts_gmail_connection_id_gmail_connections_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "gmail_connections",
+          "columnsFrom": [
+            "gmail_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_matched_transaction_id_transactions_id_fk": {
+          "name": "email_receipts_matched_transaction_id_transactions_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "matched_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiat_partners": {
+      "name": "fiat_partners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_system": {
+          "name": "source_system",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_name": {
+          "name": "partner_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "fiat_partners_system_name_unique": {
+          "name": "fiat_partners_system_name_unique",
+          "columns": [
+            {
+              "expression": "source_system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiat_partners_source_active_idx": {
+          "name": "fiat_partners_source_active_idx",
+          "columns": [
+            {
+              "expression": "source_system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"fiat_partners\".\"active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_connections": {
+      "name": "gmail_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_email": {
+          "name": "gmail_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_enc": {
+          "name": "access_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_pull_at": {
+          "name": "last_pull_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_pull_history_id": {
+          "name": "last_pull_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "gmail_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_nudge_sent_at": {
+          "name": "bot_nudge_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bootstrap_since_date": {
+          "name": "bootstrap_since_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_connections_user_email_unique": {
+          "name": "gmail_connections_user_email_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_user_status_idx": {
+          "name": "gmail_connections_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_active_idx": {
+          "name": "gmail_connections_active_idx",
+          "columns": [
+            {
+              "expression": "last_pull_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"status\" = 'active' AND \"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_connections_user_id_users_id_fk": {
+          "name": "gmail_connections_user_id_users_id_fk",
+          "tableFrom": "gmail_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.physical_cards": {
+      "name": "physical_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_limit_cents": {
+          "name": "credit_limit_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "statement_cutoff_day": {
+          "name": "statement_cutoff_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "physical_cards_user_idx": {
+          "name": "physical_cards_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "physical_cards_user_institution_idx": {
+          "name": "physical_cards_user_institution_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "physical_cards_user_id_users_id_fk": {
+          "name": "physical_cards_user_id_users_id_fk",
+          "tableFrom": "physical_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_proposals": {
+      "name": "rule_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_txn_ids": {
+          "name": "correction_txn_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rule_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rule_proposals_user_merchant_category_pending_unique": {
+          "name": "rule_proposals_user_merchant_category_pending_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rule_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rule_proposals_user_status_idx": {
+          "name": "rule_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_proposals_user_id_users_id_fk": {
+          "name": "rule_proposals_user_id_users_id_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_proposals_user_category_fk": {
+          "name": "rule_proposals_user_category_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skipped_consolidation_cycles": {
+      "name": "skipped_consolidation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "skipped_consolidation_cycles_live_unique": {
+          "name": "skipped_consolidation_cycles_live_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skipped_consolidation_cycles_user_account_idx": {
+          "name": "skipped_consolidation_cycles_user_account_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skipped_consolidation_cycles_user_id_users_id_fk": {
+          "name": "skipped_consolidation_cycles_user_id_users_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skipped_consolidation_cycles_account_id_accounts_id_fk": {
+          "name": "skipped_consolidation_cycles_account_id_accounts_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slo_alerts": {
+      "name": "slo_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slo_key": {
+          "name": "slo_key",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slo_alerts_open_idx": {
+          "name": "slo_alerts_open_idx",
+          "columns": [
+            {
+              "expression": "slo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"slo_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "statement_import_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movimientos'"
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synthetic_tx_id": {
+          "name": "synthetic_tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_cycle_unique": {
+          "name": "statement_imports_cycle_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"statement_imports\".\"kind\" = 'extracto_detallado' AND \"statement_imports\".\"cycle\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installments_total": {
+          "name": "installments_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "installment_rate_bps": {
+          "name": "installment_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retroactive_rule_id": {
+          "name": "retroactive_rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group_id": {
+          "name": "transfer_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enriched_merchant": {
+          "name": "enriched_merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_source": {
+          "name": "enrichment_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_source": {
+          "name": "secondary_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_statement": {
+          "name": "external_id_statement",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arq_statement_import_id": {
+          "name": "arq_statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_mismatch": {
+          "name": "source_mismatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_mismatch_details": {
+          "name": "source_mismatch_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_group_idx": {
+          "name": "transactions_transfer_group_idx",
+          "columns": [
+            {
+              "expression": "transfer_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"transfer_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_occurred_live_idx": {
+          "name": "transactions_account_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_live_idx": {
+          "name": "transactions_user_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_retroactive_rule_id_classification_rules_id_fk": {
+          "name": "transactions_retroactive_rule_id_classification_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "classification_rules",
+          "columnsFrom": [
+            "retroactive_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_arq_statement_import_id_arq_statement_imports_id_fk": {
+          "name": "transactions_arq_statement_import_id_arq_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "arq_statement_imports",
+          "columnsFrom": [
+            "arq_statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_aliases": {
+      "name": "user_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_aliases_user_alias_unique": {
+          "name": "user_aliases_user_alias_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_aliases_user_idx": {
+          "name": "user_aliases_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_aliases_user_id_users_id_fk": {
+          "name": "user_aliases_user_id_users_id_fk",
+          "tableFrom": "user_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_snapshots": {
+      "name": "user_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_bytes": {
+          "name": "payload_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_snapshots_user_created_idx": {
+          "name": "user_snapshots_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_snapshots_user_id_users_id_fk": {
+          "name": "user_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ui_preferences": {
+          "name": "ui_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "classification_context": {
+          "name": "classification_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "rule_retroactive",
+        "ai",
+        "manual",
+        "manual_confirmed",
+        "unclassified"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.email_receipt_gateway": {
+      "name": "email_receipt_gateway",
+      "schema": "public",
+      "values": [
+        "mercado_pago",
+        "payu",
+        "wompi",
+        "apple",
+        "paypal",
+        "bancolombia",
+        "arq"
+      ]
+    },
+    "public.email_receipt_match_status": {
+      "name": "email_receipt_match_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "matched",
+        "ambiguous",
+        "unmatched"
+      ]
+    },
+    "public.gmail_connection_status": {
+      "name": "gmail_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "revoked",
+        "error"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.rule_proposal_status": {
+      "name": "rule_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.statement_import_kind": {
+      "name": "statement_import_kind",
+      "schema": "public",
+      "values": [
+        "movimientos",
+        "extracto_detallado"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile",
+        "gmail_bancolombia",
+        "gmail_enrichment",
+        "gmail_arq",
+        "arq_statement"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug",
+        "widget"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1777193792360,
       "tag": "0064_odd_sandman",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1777195477342,
+      "tag": "0065_grey_namor",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/migrate-intrauser-transfers-to-group.ts
+++ b/scripts/migrate-intrauser-transfers-to-group.ts
@@ -1,0 +1,220 @@
+// #518: one-shot / re-runnable script that retroactively pairs historical
+// intra-user transfer transactions that were ingested before the pairing
+// logic existed.
+//
+// Heuristic targets:
+//   - transfer_sent/transfer_received pairs in Bancolombia accounts (same user,
+//     opposite sign, same currency, different account, within ±24h window).
+//   - ARQ transfer_sent (USD) ↔ Bancolombia transfer_received (COP from PEXTO)
+//     cross-currency pairs where the cop_amount_cents metadata is available.
+//
+// Idempotent: only processes tx rows where `transfer_group_id IS NULL` AND
+// the pair logic finds a match. Re-running is safe — already-grouped txs skip
+// automatically (the pairer's guard returns early for txs with a group id).
+//
+// Flags:
+//   --dry-run    Print what would be paired without writing to the DB.
+//   --user-id=N  Scope to a single user (default: all users).
+//
+// Relative imports — this file is overlaid to $STAGE/scripts/ on prod deploys.
+// Keep imports relative and track overlay in deploy.yml (memory: deploy-overlay-must-track-script-imports).
+
+import { sql } from "drizzle-orm";
+import { db } from "../src/lib/db";
+import { createLogger } from "../src/lib/logger";
+import { pairIntraUserTransfer } from "../src/lib/transfers/intra-user-pair";
+
+const log = createLogger({ module: "migrate-intrauser-transfers-to-group" });
+
+// ---------------------------------------------------------------------------
+// CLI arg parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(): { dryRun: boolean; userId: number | null } {
+  const args = process.argv.slice(2);
+  let dryRun = false;
+  let userId: number | null = null;
+
+  for (const arg of args) {
+    if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg.startsWith("--user-id=")) {
+      const raw = arg.slice("--user-id=".length);
+      const parsed = parseInt(raw, 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        log.error({ arg, event: "migrate_invalid_user_id" }, "invalid --user-id value");
+        process.exit(1);
+      }
+      userId = parsed;
+    }
+  }
+
+  return { dryRun, userId };
+}
+
+// ---------------------------------------------------------------------------
+// Row types
+// ---------------------------------------------------------------------------
+
+type CandidateTx = {
+  id: number;
+  user_id: number;
+  account_id: number;
+  amount_cents: string; // postgres.js returns bigint as string
+  currency: "COP" | "USD";
+  occurred_at: string;
+  merchant: string | null;
+  raw_data: Record<string, unknown> | null;
+};
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export type MigrationReport = {
+  scanned: number;
+  paired: number;
+  skipped: number;
+  errors: number;
+};
+
+export async function migrateIntraUserTransfers(opts: {
+  dryRun: boolean;
+  userId: number | null;
+}): Promise<MigrationReport> {
+  const { dryRun, userId } = opts;
+
+  log.info(
+    { dryRun, userId, event: "migrate_start" },
+    "starting intra-user transfer pairing migration",
+  );
+
+  // Fetch candidate txs: those with transfer-like categorySlug and no group id.
+  // We also pick up source=gmail_arq/arq_statement transfer txs that have no
+  // categorySlug (ARQ txs aren't classified) but channel='transfer'.
+  const userFilter = userId !== null ? sql`AND t.user_id = ${userId}` : sql``;
+
+  const rows = await db.execute<CandidateTx>(sql`
+    SELECT
+      t.id,
+      t.user_id,
+      t.account_id,
+      t.amount_cents::text as amount_cents,
+      t.currency,
+      t.occurred_at::text as occurred_at,
+      t.merchant,
+      t.raw_data
+    FROM transactions t
+    WHERE
+      t.transfer_group_id IS NULL
+      AND t.deleted_at IS NULL
+      AND (
+        -- Same-currency transfer candidates from Bancolombia
+        t.category_slug IN ('transferencias', 'ingresos')
+        OR
+        -- ARQ transfer txs (no category, channel=transfer)
+        (t.source IN ('gmail_arq', 'arq_statement') AND t.channel = 'transfer')
+      )
+      ${userFilter}
+    ORDER BY t.user_id, t.occurred_at
+  `);
+
+  log.info(
+    { count: rows.length, dryRun, event: "migrate_candidates_loaded" },
+    "loaded candidate transactions",
+  );
+
+  let paired = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const row of rows) {
+    try {
+      const amountCents = BigInt(row.amount_cents);
+      const occurredAt = new Date(row.occurred_at);
+
+      if (dryRun) {
+        log.info(
+          {
+            txId: row.id,
+            userId: row.user_id,
+            accountId: row.account_id,
+            amountCents: row.amount_cents,
+            currency: row.currency,
+            occurredAt: row.occurred_at,
+            event: "migrate_dry_run_candidate",
+          },
+          "[dry-run] would attempt pairing",
+        );
+        skipped++;
+        continue;
+      }
+
+      const result = await pairIntraUserTransfer(
+        {},
+        {
+          id: row.id,
+          userId: row.user_id,
+          accountId: row.account_id,
+          channel: "transfer",
+          amountCents,
+          currency: row.currency,
+          occurredAt,
+          counterparty: row.merchant,
+          rawData: row.raw_data,
+        },
+      );
+
+      if (result.groupId !== null) {
+        log.info(
+          {
+            txId: row.id,
+            userId: row.user_id,
+            pairedTxId: result.pairedTxId,
+            groupId: result.groupId,
+            event: "migrate_paired",
+          },
+          "paired intra-user transfer",
+        );
+        paired++;
+      } else {
+        skipped++;
+      }
+    } catch (err) {
+      log.error(
+        { err, txId: row.id, userId: row.user_id, event: "migrate_error" },
+        "error processing candidate tx",
+      );
+      errors++;
+    }
+  }
+
+  const report: MigrationReport = {
+    scanned: rows.length,
+    paired,
+    skipped,
+    errors,
+  };
+
+  log.info(
+    { ...report, dryRun, event: "migrate_done" },
+    "intra-user transfer pairing migration complete",
+  );
+
+  return report;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point (script mode)
+// ---------------------------------------------------------------------------
+
+const { dryRun, userId } = parseArgs();
+migrateIntraUserTransfers({ dryRun, userId })
+  .then((report) => {
+    log.info({ ...report, event: "migrate_exit" }, "migration finished");
+    process.exit(0);
+  })
+  .catch((err) => {
+    log.error({ err, event: "migrate_fatal" }, "migration failed with unhandled error");
+    process.exit(1);
+  });

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1425,6 +1425,63 @@ export const userSnapshots = pgTable(
 // import row must be superseded (manual correction), insert a new row for the
 // same (user_id, account_id, period_start) — the UNIQUE constraint will reject
 // duplicates, which is intentional: force explicit cleanup before re-import.
+// #518 (Epic ARQ Phase 4): extensible registry of fiat on/off-ramp partners
+// used by ARQ to disburse COP to Colombian bank accounts. When ARQ disperses
+// via PEXTO COLOMBIA, the Bancolombia leg arrives as a credit from PEXTO
+// rather than from the user themselves. This table allows the transfer pairer
+// to recognise PEXTO-initiated credits as self-transfers rather than external
+// income — without hard-coding the partner name in application logic.
+//
+// No soft-delete: partners are either active=true (considered for pairing) or
+// active=false (ignored). Deactivation is manual DB edit + reload; no UI in scope.
+export const fiatPartners = pgTable(
+  "fiat_partners",
+  {
+    id: serial("id").primaryKey(),
+    // 'arq', 'wise', etc. — discriminates partners by the off-ramp system that
+    // generates them so a single query can filter by source_system without
+    // touching unrelated rows.
+    sourceSystem: varchar("source_system", { length: 40 }).notNull(),
+    // The counterparty name exactly as it appears in the Bancolombia notification
+    // (SMS or email). Comparison is case-insensitive ILIKE in the pairer.
+    partnerName: varchar("partner_name", { length: 200 }).notNull(),
+    description: text("description"),
+    active: boolean("active").notNull().default(true),
+  },
+  (t) => [
+    uniqueIndex("fiat_partners_system_name_unique").on(t.sourceSystem, t.partnerName),
+    index("fiat_partners_source_active_idx")
+      .on(t.sourceSystem)
+      .where(sql`${t.active} = true`),
+  ],
+);
+
+// #518 (Epic ARQ Phase 4): name variants for a user used by the cross-currency
+// transfer pairer. ARQ emails include a `recipient_name` field (e.g.
+// "Alejandro Rafael Martinez Maldonado", "Alejandro Martinez") that must be
+// matched against `users.name` or an alias to confirm the transfer was a
+// self-transfer and not a payment to a third party.
+//
+// Tenant safety: every query MUST scope alias lookup to the same user_id as the
+// candidate transfer — never join on alias alone (memory per-user-table-join-tenant-safety).
+export const userAliases = pgTable(
+  "user_aliases",
+  {
+    id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    // The alias text as it appears in the source (e.g. "Alejandro Martinez").
+    // Stored as-is; comparison in the pairer uses case-insensitive normalisation.
+    alias: varchar("alias", { length: 200 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("user_aliases_user_alias_unique").on(t.userId, t.alias),
+    index("user_aliases_user_idx").on(t.userId),
+  ],
+);
+
 export const arqStatementImports = pgTable(
   "arq_statement_imports",
   {

--- a/src/lib/ingestion/arq-statement/reconciler.ts
+++ b/src/lib/ingestion/arq-statement/reconciler.ts
@@ -33,6 +33,7 @@ import { db } from "@/lib/db";
 import { transactions, type SourceMismatchDetails } from "@/lib/db/schema";
 import { createLogger } from "@/lib/logger";
 import { levenshteinRatio } from "@/lib/text/levenshtein";
+import { pairIntraUserTransfer } from "@/lib/transfers/intra-user-pair";
 
 import type {
   FeeTx,
@@ -722,6 +723,23 @@ export async function reconcileEmailVsStatement(
       if (newTxId !== null) {
         details.push({ kind: "insert", statementTx: tx, newTxId });
         insertedCount++;
+        // #518: attempt pairing for transfer_sent/transfer_received statement txs.
+        if (tx.kind === "transfer_sent" || tx.kind === "transfer_received") {
+          await pairIntraUserTransfer(
+            { database: dbc },
+            {
+              id: newTxId,
+              userId,
+              accountId,
+              channel: channelFromKind(tx.kind),
+              amountCents: tx.amountUsdc,
+              currency: "USD",
+              occurredAt: tx.occurredAt,
+              counterparty: counterpartyFromStatement(tx),
+              rawData: buildRawData(tx, importId),
+            },
+          );
+        }
       } else {
         // Insert returned null → onConflictDoNothing hit (already imported by
         // a prior run). Count as a merge/skip for idempotency — no re-insert.
@@ -799,6 +817,26 @@ export async function reconcileEmailVsStatement(
     await mergeTx(dbc, userId, existing, tx, importId, mismatchReason);
 
     mergedCount++;
+    // #518: after merge, the existing email tx now has cop_amount_cents from the
+    // statement. Attempt pairing on the existing tx (which is the ARQ leg).
+    // The pairer reads rawData from the DB to get the merged metadata.
+    if (tx.kind === "transfer_sent" || tx.kind === "transfer_received") {
+      await pairIntraUserTransfer(
+        { database: dbc },
+        {
+          id: existing.id,
+          userId,
+          accountId,
+          channel: channelFromKind(tx.kind),
+          amountCents: existing.amountCents,
+          currency: "USD",
+          occurredAt: existing.occurredAt,
+          counterparty: existing.merchant,
+          rawData: existing.rawData,
+        },
+      );
+    }
+
     if (mismatchReason !== null) {
       flaggedCount++;
       log.warn(

--- a/src/lib/ingestion/arq-statement/reconciler.ts
+++ b/src/lib/ingestion/arq-statement/reconciler.ts
@@ -449,7 +449,7 @@ async function mergeTx(
   statementTx: Exclude<ParsedStatementTx, { kind: "skip" }>,
   importId: number,
   mismatchReason: MismatchReason | null,
-): Promise<void> {
+): Promise<{ mergedRawData: Record<string, unknown> }> {
   const statementMetadata: Record<string, unknown> = {
     arq_statement_import_id: importId,
     statement_kind: statementTx.kind,
@@ -509,6 +509,11 @@ async function mergeTx(
       })
       .where(and(eq(transactions.userId, userId), eq(transactions.id, existing.id)));
   }
+
+  // Return the merged shape so the caller can pass it to downstream pairing
+  // (#518) without re-reading from the DB. existing.rawData is the pre-merge
+  // snapshot and would miss the new copAmountCents from the statement.
+  return { mergedRawData };
 }
 
 async function insertStatementTx(
@@ -814,12 +819,13 @@ export async function reconcileEmailVsStatement(
 
     const mismatchReason = detectMismatch(existing, tx, counterpartyRatio);
 
-    await mergeTx(dbc, userId, existing, tx, importId, mismatchReason);
+    const { mergedRawData } = await mergeTx(dbc, userId, existing, tx, importId, mismatchReason);
 
     mergedCount++;
-    // #518: after merge, the existing email tx now has cop_amount_cents from the
-    // statement. Attempt pairing on the existing tx (which is the ARQ leg).
-    // The pairer reads rawData from the DB to get the merged metadata.
+    // #518: after merge, the existing email tx now has copAmountCents from the
+    // statement (in rawData.merged_statement.fx). Pass the in-memory merged
+    // snapshot to the pairer — existing.rawData is the pre-merge value and
+    // would miss the cross-currency metadata we just wrote.
     if (tx.kind === "transfer_sent" || tx.kind === "transfer_received") {
       await pairIntraUserTransfer(
         { database: dbc },
@@ -832,7 +838,7 @@ export async function reconcileEmailVsStatement(
           currency: "USD",
           occurredAt: existing.occurredAt,
           counterparty: existing.merchant,
-          rawData: existing.rawData,
+          rawData: mergedRawData,
         },
       );
     }

--- a/src/lib/ingestion/email-arq.ts
+++ b/src/lib/ingestion/email-arq.ts
@@ -6,6 +6,7 @@ import { createLogger } from "@/lib/logger";
 import { emit } from "@/lib/events/bus";
 import { autoLinkTransaction } from "@/lib/recurring/auto-link";
 import { parseArqEmail, type ArqParseResult, type ParsedArqTx } from "@/lib/gmail/parsers/arq";
+import { pairIntraUserTransfer } from "@/lib/transfers/intra-user-pair";
 
 const log = createLogger({ module: "ingestion/email-arq" });
 
@@ -267,6 +268,25 @@ export async function ingestArqEmail(
     await markReceiptMatched(receiptId, userId, txId, parsed);
     await autoLinkTransaction(userId, txId);
     emit({ type: "transaction:created", id: txId, source: ARQ_SOURCE, timestamp: Date.now() });
+
+    // #518: attempt intra-user transfer pairing. ARQ transfer_sent (USD debit)
+    // is the origin leg of a cross-currency self-transfer via PEXTO COLOMBIA.
+    // ARQ transfer_received is the USD credit leg (rare — direct USD deposit from
+    // another ARQ user, not the PEXTO path). Both participate in the pairer.
+    await pairIntraUserTransfer(
+      {},
+      {
+        id: txId,
+        userId,
+        accountId: account.id,
+        channel: "transfer",
+        amountCents: signedAmountCents,
+        currency: "USD",
+        occurredAt: parsed.occurredAt,
+        counterparty: parsed.counterpartyName,
+        rawData,
+      },
+    );
 
     log.info(
       {

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -6,6 +6,7 @@ import { classifyByRule } from "@/lib/classification/rules";
 import { emit } from "@/lib/events/bus";
 import { autoLinkTransaction } from "@/lib/recurring/auto-link";
 import { insertTransferGroup } from "@/lib/transactions/transfer-groups";
+import { pairIntraUserTransfer } from "@/lib/transfers/intra-user-pair";
 import {
   resolveAccountFromLast4,
   type ParseResult,
@@ -269,14 +270,36 @@ async function ingestParsedBancolombia(
       .returning({ id: transactions.id });
 
     if (result.length === 0) return { status: "duplicated" };
-    await autoLinkTransaction(userId, result[0].id);
+    const txId = result[0].id;
+    await autoLinkTransaction(userId, txId);
     emit({
       type: "transaction:created",
-      id: result[0].id,
+      id: txId,
       source: cfg.source,
       timestamp: Date.now(),
     });
-    return { status: "inserted", txId: result[0].id };
+    // #518: attempt intra-user transfer pairing for transfer_sent / transfer_received.
+    // Only these two kinds can be part of a self-transfer pair. Other kinds (purchase,
+    // provider_payment, atm_withdrawal, etc.) are never paired here.
+    if (parsed.kind === "transfer_sent" || parsed.kind === "transfer_received") {
+      await pairIntraUserTransfer(
+        {},
+        {
+          id: txId,
+          userId,
+          accountId: account.id,
+          channel: "transfer",
+          amountCents,
+          currency: parsed.currency,
+          occurredAt,
+          counterpartyId: cp.counterpartyId,
+          // merchant is the parsed counterparty name in these SMS kinds.
+          counterparty: merchant,
+          rawData: { kind: parsed.kind, ...cfg.rawDataExtras },
+        },
+      );
+    }
+    return { status: "inserted", txId };
   } catch (err) {
     return {
       status: "error",

--- a/src/lib/transfers/intra-user-pair.test.ts
+++ b/src/lib/transfers/intra-user-pair.test.ts
@@ -1,0 +1,708 @@
+// Integration tests for pairIntraUserTransfer (#518).
+//
+// These tests hit findash_test (forced by vitest.setup.ts). Run
+// `bun run db:migrate:test` before this suite.
+//
+// Test matrix (7 scenarios from the issue acceptance criteria):
+//   1. Same-currency happy path: two txs, opposite sign, same currency, ±24h window → paired.
+//   2. Cross-currency happy path: ARQ USD debit + Bancolombia COP credit via PEXTO → paired.
+//   3. Salary skip: receiver counterparty has is_salary=true → NOT paired.
+//   4. Out of window: 25h delta → NOT paired.
+//   5. Different currency without PEXTO match → NOT paired.
+//   6. Tenant safety: same amount + same window but different user_id → NOT paired.
+//   7. Reporting classification: paired tx has channel='transfer', categorySlug=null.
+//   + Ledger consistency invariant: Σ(amounts) of a paired group is 0.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { and, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  counterparties,
+  fiatPartners,
+  transactions,
+  userAliases,
+  users,
+} from "@/lib/db/schema";
+import { extractArqMeta, pairIntraUserTransfer, resetFiatPartnerCache } from "./intra-user-pair";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TAG = "INTRA_PAIR_TEST";
+
+let userId: number;
+let savingsAccountId: number; // COP savings
+let secondCopAccountId: number; // COP second account (for same-currency transfer target)
+let arqAccountId: number; // USD ARQ account
+let otherUserId: number;
+let otherSavingsAccountId: number;
+
+// Counterparty row for salary tests.
+let salaryCounterpartyId: number;
+
+async function cleanup(): Promise<void> {
+  await db.execute(
+    sql`DELETE FROM transactions WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})`,
+  );
+  await db.execute(
+    sql`DELETE FROM counterparties WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})`,
+  );
+  await db.execute(
+    sql`DELETE FROM user_aliases WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})`,
+  );
+  await db.execute(sql`DELETE FROM users WHERE email LIKE ${TAG + "%"}`);
+  // Remove test-injected fiat partners if any.
+  await db.delete(fiatPartners).where(sql`${fiatPartners.partnerName} LIKE ${"TEST_PEXTO_%"}`);
+  resetFiatPartnerCache();
+}
+
+beforeAll(async () => {
+  await cleanup();
+
+  // Main test user.
+  const [u] = await db
+    .insert(users)
+    .values({ email: `${TAG}-main@test.local`, name: "Alejandro Martinez" })
+    .returning({ id: users.id });
+  userId = u.id;
+
+  // COP savings account.
+  const [acct1] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG}-savings-cop`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      currency: "COP",
+      type: "savings",
+    })
+    .returning({ id: accounts.id });
+  savingsAccountId = acct1.id;
+
+  // Second COP account (transfer destination).
+  const [acct2] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG}-nequi-cop`,
+      institution: "Nequi",
+      institutionSlug: "nequi",
+      currency: "COP",
+      type: "savings",
+    })
+    .returning({ id: accounts.id });
+  secondCopAccountId = acct2.id;
+
+  // ARQ USD account.
+  const [acct3] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG}-arq-usd`,
+      institution: "ARQ (DolarApp)",
+      institutionSlug: "other",
+      currency: "USD",
+      type: "savings",
+    })
+    .returning({ id: accounts.id });
+  arqAccountId = acct3.id;
+
+  // Other user (tenant isolation tests).
+  const [u2] = await db
+    .insert(users)
+    .values({ email: `${TAG}-other@test.local`, name: "Other User" })
+    .returning({ id: users.id });
+  otherUserId = u2.id;
+
+  const [acct4] = await db
+    .insert(accounts)
+    .values({
+      userId: otherUserId,
+      name: `${TAG}-other-savings`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      currency: "COP",
+      type: "savings",
+    })
+    .returning({ id: accounts.id });
+  otherSavingsAccountId = acct4.id;
+
+  // Salary counterparty for the salary-block test.
+  const [cp] = await db
+    .insert(counterparties)
+    .values({ userId, displayName: `${TAG}-salary-employer`, isSalary: true })
+    .returning({ id: counterparties.id });
+  salaryCounterpartyId = cp.id;
+
+  // User aliases for cross-currency matching.
+  await db
+    .insert(userAliases)
+    .values([
+      { userId, alias: "Alejandro Martinez" },
+      { userId, alias: "Alejandro Rafael Martinez" },
+      { userId, alias: "Alejandro Rafael Martinez Maldonado" },
+    ])
+    .onConflictDoNothing();
+
+  // Ensure PEXTO COLOMBIA fiat partner exists (should be seeded by migration 0065).
+  await db
+    .insert(fiatPartners)
+    .values({ sourceSystem: "arq", partnerName: "PEXTO COLOMBIA", active: true })
+    .onConflictDoNothing();
+
+  resetFiatPartnerCache();
+});
+
+afterAll(async () => {
+  await cleanup();
+});
+
+// Helper: delete test txs after each case so they don't interfere.
+async function cleanTxs(): Promise<void> {
+  await db.execute(
+    sql`DELETE FROM transactions WHERE user_id IN (${userId}, ${otherUserId}) AND raw_data @> '{"_test": true}'`,
+  );
+  resetFiatPartnerCache();
+}
+
+async function insertTx(opts: {
+  userId: number;
+  accountId: number;
+  amountCents: bigint;
+  currency: "COP" | "USD";
+  occurredAt: Date;
+  categorySlug?: string | null;
+  channel?: "bank" | "transfer" | "manual";
+  counterpartyId?: number | null;
+  merchant?: string | null;
+  source?: string;
+  rawData?: Record<string, unknown>;
+}): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId: opts.userId,
+      accountId: opts.accountId,
+      amountCents: opts.amountCents,
+      currency: opts.currency,
+      occurredAt: opts.occurredAt,
+      categorySlug: opts.categorySlug ?? null,
+      channel: opts.channel ?? "bank",
+      counterpartyId: opts.counterpartyId ?? null,
+      merchant: opts.merchant ?? null,
+      source: (opts.source ?? "manual") as "manual",
+      descriptionRaw: "test",
+      classificationMethod: "manual",
+      rawData: { _test: true, ...opts.rawData },
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+// ---------------------------------------------------------------------------
+// Test cases
+// ---------------------------------------------------------------------------
+
+describe("pairIntraUserTransfer", () => {
+  // 1. Same-currency happy path
+  it("pairs same-currency COP transfer_sent ↔ transfer_received within ±24h window", async () => {
+    const t = new Date("2026-04-15T14:00:00Z");
+
+    const debitId = await insertTx({
+      userId,
+      accountId: savingsAccountId,
+      amountCents: BigInt(-500_000_00), // -500,000 COP
+      currency: "COP",
+      occurredAt: t,
+      channel: "bank",
+    });
+
+    const creditId = await insertTx({
+      userId,
+      accountId: secondCopAccountId,
+      amountCents: BigInt(500_000_00), // +500,000 COP
+      currency: "COP",
+      occurredAt: new Date(t.getTime() + 5 * 60 * 1000), // 5 min later
+      channel: "bank",
+    });
+
+    // Pair the debit leg.
+    const result = await pairIntraUserTransfer(
+      {},
+      {
+        id: debitId,
+        userId,
+        accountId: savingsAccountId,
+        channel: "bank",
+        amountCents: BigInt(-500_000_00),
+        currency: "COP",
+        occurredAt: t,
+        counterparty: null,
+        rawData: { _test: true },
+      },
+    );
+
+    expect(result.groupId).not.toBeNull();
+    expect(result.pairedTxId).toBe(creditId);
+
+    // Verify DB state.
+    const rows = await db
+      .select({
+        id: transactions.id,
+        transferGroupId: transactions.transferGroupId,
+        channel: transactions.channel,
+        categorySlug: transactions.categorySlug,
+        amountCents: transactions.amountCents,
+      })
+      .from(transactions)
+      .where(sql`${transactions.id} IN (${debitId}, ${creditId})`);
+
+    expect(rows).toHaveLength(2);
+    for (const r of rows) {
+      expect(r.transferGroupId).toBe(result.groupId);
+      expect(r.channel).toBe("transfer");
+      expect(r.categorySlug).toBeNull();
+    }
+
+    // Ledger invariant: Σ = 0.
+    const sum = rows.reduce((acc, r) => acc + r.amountCents, BigInt(0));
+    expect(sum).toBe(BigInt(0));
+
+    await cleanTxs();
+  });
+
+  // 2. Cross-currency happy path: ARQ → Bancolombia via PEXTO
+  it("pairs ARQ USD debit ↔ Bancolombia COP credit from PEXTO within ±24h window", async () => {
+    const t = new Date("2026-04-16T10:00:00Z");
+    const copAmount = BigInt(2_104_000_00); // 2,104,000 COP in cents
+
+    const arqRawData: Record<string, unknown> = {
+      _test: true,
+      kind: "transfer_sent",
+      arq: {
+        recipient_name: "Alejandro Martinez",
+      },
+      fx: {
+        originalCurrency: "USD",
+        originalAmountCents: "56381",
+        trmToAccountCurrency: 3731,
+        trmSource: "email_implied",
+        copAmountCents: copAmount.toString(),
+      },
+    };
+
+    const arqTxId = await insertTx({
+      userId,
+      accountId: arqAccountId,
+      amountCents: BigInt(-56381), // -563.81 USDc
+      currency: "USD",
+      occurredAt: t,
+      channel: "transfer",
+      source: "gmail_arq",
+      rawData: arqRawData,
+    });
+
+    // Bancolombia credit from PEXTO — arrives 2h later.
+    const bancoTxId = await insertTx({
+      userId,
+      accountId: savingsAccountId,
+      amountCents: copAmount,
+      currency: "COP",
+      occurredAt: new Date(t.getTime() + 2 * 60 * 60 * 1000),
+      channel: "bank",
+      merchant: "PEXTO COLOMBIA",
+    });
+
+    // Pair the ARQ leg.
+    const result = await pairIntraUserTransfer(
+      {},
+      {
+        id: arqTxId,
+        userId,
+        accountId: arqAccountId,
+        channel: "transfer",
+        amountCents: BigInt(-56381),
+        currency: "USD",
+        occurredAt: t,
+        counterparty: "Alejandro Martinez",
+        rawData: arqRawData,
+      },
+    );
+
+    expect(result.groupId).not.toBeNull();
+    expect(result.pairedTxId).toBe(bancoTxId);
+
+    const rows = await db
+      .select({
+        id: transactions.id,
+        transferGroupId: transactions.transferGroupId,
+        channel: transactions.channel,
+        categorySlug: transactions.categorySlug,
+        amountCents: transactions.amountCents,
+      })
+      .from(transactions)
+      .where(sql`${transactions.id} IN (${arqTxId}, ${bancoTxId})`);
+
+    expect(rows).toHaveLength(2);
+    for (const r of rows) {
+      expect(r.transferGroupId).toBe(result.groupId);
+      expect(r.channel).toBe("transfer");
+      expect(r.categorySlug).toBeNull();
+    }
+
+    await cleanTxs();
+  });
+
+  // 3. Salary skip
+  it("does NOT pair when the receiver has a counterparty with is_salary=true", async () => {
+    const t = new Date("2026-04-17T09:00:00Z");
+
+    const senderId = await insertTx({
+      userId,
+      accountId: savingsAccountId,
+      amountCents: BigInt(-1_000_000_00),
+      currency: "COP",
+      occurredAt: t,
+    });
+
+    // The "receiver" tx is linked to a salary counterparty.
+    const salaryTxId = await insertTx({
+      userId,
+      accountId: secondCopAccountId,
+      amountCents: BigInt(1_000_000_00),
+      currency: "COP",
+      occurredAt: t,
+      counterpartyId: salaryCounterpartyId,
+    });
+
+    const result = await pairIntraUserTransfer(
+      {},
+      {
+        id: senderId,
+        userId,
+        accountId: savingsAccountId,
+        channel: "bank",
+        amountCents: BigInt(-1_000_000_00),
+        currency: "COP",
+        occurredAt: t,
+        counterparty: null,
+        rawData: { _test: true },
+      },
+    );
+
+    // Should NOT pair.
+    expect(result.groupId).toBeNull();
+    expect(result.pairedTxId).toBeNull();
+
+    // Both txs remain ungrouped.
+    const rows = await db
+      .select({ transferGroupId: transactions.transferGroupId })
+      .from(transactions)
+      .where(sql`${transactions.id} IN (${senderId}, ${salaryTxId})`);
+
+    for (const r of rows) {
+      expect(r.transferGroupId).toBeNull();
+    }
+
+    await cleanTxs();
+  });
+
+  // 4. Out of window (25h → not paired)
+  it("does NOT pair when the partner tx is 25h away (outside ±24h window)", async () => {
+    const t = new Date("2026-04-18T10:00:00Z");
+
+    const debitId = await insertTx({
+      userId,
+      accountId: savingsAccountId,
+      amountCents: BigInt(-200_000_00),
+      currency: "COP",
+      occurredAt: t,
+    });
+
+    // Credit is 25h later — outside the batch window.
+    await insertTx({
+      userId,
+      accountId: secondCopAccountId,
+      amountCents: BigInt(200_000_00),
+      currency: "COP",
+      occurredAt: new Date(t.getTime() + 25 * 60 * 60 * 1000),
+    });
+
+    const result = await pairIntraUserTransfer(
+      {},
+      {
+        id: debitId,
+        userId,
+        accountId: savingsAccountId,
+        channel: "bank",
+        amountCents: BigInt(-200_000_00),
+        currency: "COP",
+        occurredAt: t,
+        counterparty: null,
+        rawData: { _test: true },
+      },
+    );
+
+    expect(result.groupId).toBeNull();
+
+    await cleanTxs();
+  });
+
+  // 5. Different currency without PEXTO match → NOT paired
+  it("does NOT pair a USD tx with a COP tx when there is no PEXTO counterparty", async () => {
+    const t = new Date("2026-04-19T12:00:00Z");
+
+    const usdTxId = await insertTx({
+      userId,
+      accountId: arqAccountId,
+      amountCents: BigInt(-100_00), // -100 USD
+      currency: "USD",
+      occurredAt: t,
+      source: "gmail_arq",
+      rawData: {
+        _test: true,
+        kind: "transfer_sent",
+        arq: { recipient_name: "Alejandro Martinez" },
+        fx: {},
+      },
+    });
+
+    // COP credit but NO PEXTO merchant — unrelated income.
+    await insertTx({
+      userId,
+      accountId: savingsAccountId,
+      amountCents: BigInt(400_000_00),
+      currency: "COP",
+      occurredAt: new Date(t.getTime() + 30 * 60 * 1000),
+      merchant: "FREELANCE CLIENT",
+    });
+
+    const result = await pairIntraUserTransfer(
+      {},
+      {
+        id: usdTxId,
+        userId,
+        accountId: arqAccountId,
+        channel: "transfer",
+        amountCents: BigInt(-100_00),
+        currency: "USD",
+        occurredAt: t,
+        counterparty: "Alejandro Martinez",
+        rawData: {
+          _test: true,
+          kind: "transfer_sent",
+          arq: { recipient_name: "Alejandro Martinez" },
+          fx: {},
+        },
+      },
+    );
+
+    // No cop_amount_cents in fx → falls back to same-currency path which finds no USD match.
+    expect(result.groupId).toBeNull();
+
+    await cleanTxs();
+  });
+
+  // 6. Tenant safety: different user_id → NOT paired
+  it("does NOT pair across different user_ids (tenant isolation)", async () => {
+    const t = new Date("2026-04-20T10:00:00Z");
+
+    // Main user's debit.
+    const myDebitId = await insertTx({
+      userId,
+      accountId: savingsAccountId,
+      amountCents: BigInt(-300_000_00),
+      currency: "COP",
+      occurredAt: t,
+    });
+
+    // Other user has a matching credit in their own account — must NOT pair with myDebit.
+    await insertTx({
+      userId: otherUserId,
+      accountId: otherSavingsAccountId,
+      amountCents: BigInt(300_000_00),
+      currency: "COP",
+      occurredAt: t,
+    });
+
+    const result = await pairIntraUserTransfer(
+      {},
+      {
+        id: myDebitId,
+        userId,
+        accountId: savingsAccountId,
+        channel: "bank",
+        amountCents: BigInt(-300_000_00),
+        currency: "COP",
+        occurredAt: t,
+        counterparty: null,
+        rawData: { _test: true },
+      },
+    );
+
+    // Must not pair — pairing must only happen within the same user_id.
+    expect(result.groupId).toBeNull();
+
+    await cleanTxs();
+  });
+
+  // 7. Reporting: paired tx does NOT appear as ingreso/gasto
+  it("paired transfer has channel=transfer and categorySlug=null (excluded from income/expense reports)", async () => {
+    const t = new Date("2026-04-21T10:00:00Z");
+
+    const debitId = await insertTx({
+      userId,
+      accountId: savingsAccountId,
+      amountCents: BigInt(-150_000_00),
+      currency: "COP",
+      occurredAt: t,
+      channel: "bank",
+    });
+
+    const creditId = await insertTx({
+      userId,
+      accountId: secondCopAccountId,
+      amountCents: BigInt(150_000_00),
+      currency: "COP",
+      occurredAt: new Date(t.getTime() + 60_000),
+      channel: "bank",
+    });
+
+    const result = await pairIntraUserTransfer(
+      {},
+      {
+        id: debitId,
+        userId,
+        accountId: savingsAccountId,
+        channel: "bank",
+        amountCents: BigInt(-150_000_00),
+        currency: "COP",
+        occurredAt: t,
+        counterparty: null,
+        rawData: { _test: true },
+      },
+    );
+
+    expect(result.groupId).not.toBeNull();
+
+    // Simulate reporting query: exclude transfer-channel txs.
+    const reportRows = await db
+      .select({ id: transactions.id, amountCents: transactions.amountCents })
+      .from(transactions)
+      .where(
+        and(
+          sql`${transactions.id} IN (${debitId}, ${creditId})`,
+          // Reporting layer condition: skip transfers.
+          sql`${transactions.channel} != 'transfer'`,
+        ),
+      );
+
+    // Both legs should be excluded from reporting.
+    expect(reportRows).toHaveLength(0);
+
+    await cleanTxs();
+  });
+
+  // Idempotency: calling pairIntraUserTransfer on an already-grouped tx is a no-op.
+  it("is idempotent — calling on an already-grouped tx returns { groupId: null }", async () => {
+    const t = new Date("2026-04-22T10:00:00Z");
+
+    const debitId = await insertTx({
+      userId,
+      accountId: savingsAccountId,
+      amountCents: BigInt(-75_000_00),
+      currency: "COP",
+      occurredAt: t,
+    });
+
+    await insertTx({
+      userId,
+      accountId: secondCopAccountId,
+      amountCents: BigInt(75_000_00),
+      currency: "COP",
+      occurredAt: t,
+    });
+
+    // First call: pairs.
+    const first = await pairIntraUserTransfer(
+      {},
+      {
+        id: debitId,
+        userId,
+        accountId: savingsAccountId,
+        channel: "bank",
+        amountCents: BigInt(-75_000_00),
+        currency: "COP",
+        occurredAt: t,
+        counterparty: null,
+        rawData: { _test: true },
+      },
+    );
+    expect(first.groupId).not.toBeNull();
+
+    // Second call: must be a no-op (already grouped).
+    const second = await pairIntraUserTransfer(
+      {},
+      {
+        id: debitId,
+        userId,
+        accountId: savingsAccountId,
+        channel: "transfer",
+        amountCents: BigInt(-75_000_00),
+        currency: "COP",
+        occurredAt: t,
+        counterparty: null,
+        rawData: { _test: true },
+      },
+    );
+    expect(second.groupId).toBeNull();
+
+    await cleanTxs();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests for extractArqMeta
+// ---------------------------------------------------------------------------
+
+describe("extractArqMeta", () => {
+  it("returns null for null rawData", () => {
+    expect(extractArqMeta(null)).toBeNull();
+  });
+
+  it("returns null when arq block is missing", () => {
+    expect(extractArqMeta({ kind: "purchase" })).toBeNull();
+  });
+
+  it("extracts recipientName and copAmountCents from email-parser shape", () => {
+    const rawData = {
+      arq: { recipient_name: "Alejandro Martinez" },
+      fx: { copAmountCents: "2104000" },
+    };
+    const result = extractArqMeta(rawData);
+    expect(result).not.toBeNull();
+    expect(result!.recipientName).toBe("Alejandro Martinez");
+    expect(result!.copAmountCents).toBe(BigInt(2104000));
+  });
+
+  it("prefers merged_statement recipient_name_from_statement over arq block", () => {
+    const rawData = {
+      arq: { recipient_name: "Original Name" },
+      merged_statement: {
+        arq: { recipient_name_from_statement: "Statement Name" },
+        fx: { copAmountCents: "500000" },
+      },
+    };
+    const result = extractArqMeta(rawData);
+    expect(result!.recipientName).toBe("Statement Name");
+  });
+
+  it("handles missing copAmountCents gracefully", () => {
+    const rawData = { arq: { recipient_name: "Someone" }, fx: {} };
+    const result = extractArqMeta(rawData);
+    expect(result!.copAmountCents).toBeNull();
+  });
+});

--- a/src/lib/transfers/intra-user-pair.ts
+++ b/src/lib/transfers/intra-user-pair.ts
@@ -1,0 +1,672 @@
+// #518 (Epic ARQ Phase 4): intra-user transfer pairing.
+//
+// Pairs a newly-inserted transaction against an existing transaction that
+// represents the opposite leg of a self-transfer. Supports:
+//
+//   1. Same-currency: exact amount match, opposite sign, same currency,
+//      different account, within the time window.
+//
+//   2. Cross-currency (ARQ ↔ Bancolombia via PEXTO): ARQ transfer_sent has
+//      a COP amount in metadata.fx.copAmountCents; Bancolombia transfer_received
+//      arrived with a counterparty name matching a row in `fiat_partners`.
+//      The pairer reconciles when copAmounts are within ±0.5% tolerance.
+//
+// Idempotent: if the incoming tx already has a transferGroupId, the function
+// is a no-op. When the partner tx is found, BOTH legs are updated atomically.
+//
+// Late-arrival: if only one leg is present (partner arrives later), the function
+// returns { groupId: null, pairedTxId: null }. When the second leg is ingested,
+// it finds the orphaned first leg and pairs them.
+//
+// Salary block: if the found partner has a counterparty with is_salary=true,
+// the pair is rejected — salary is real income, not a self-transfer.
+//
+// Tenant safety: ALL queries scope on user_id. Memory: per-user-table-join-tenant-safety.
+
+import { randomUUID } from "node:crypto";
+import { and, eq, gte, lte, isNull, sql } from "drizzle-orm";
+import type { DB } from "@/lib/db";
+import { db as defaultDb } from "@/lib/db";
+import { transactions, counterparties, fiatPartners, userAliases, users } from "@/lib/db/schema";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "transfers/intra-user-pair" });
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type PairDeps = {
+  database?: DB;
+};
+
+/** Minimal shape of the newly-inserted tx needed for pairing. */
+export type IncomingTx = {
+  id: number;
+  userId: number;
+  accountId: number;
+  channel: string;
+  amountCents: bigint;
+  currency: string;
+  occurredAt: Date;
+  /** FK to counterparties.id, if the parser resolved one. Used for salary block. */
+  counterpartyId?: number | null;
+  /** Raw counterparty string as written by the parser (e.g. "PEXTO COLOMBIA"). */
+  counterparty: string | null;
+  /** transactions.raw_data JSON — used to extract arq metadata. */
+  rawData: Record<string, unknown> | null;
+};
+
+export type PairResult = {
+  groupId: string | null;
+  pairedTxId: number | null;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** ±10 min window for real-time sources (SMS, email). */
+const REALTIME_WINDOW_MS = 10 * 60 * 1000;
+
+/** ±24 h window for batch/statement sources. */
+const BATCH_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+// Tolerance for COP amount comparison in cross-currency case is 0.5% (computed
+// in computeAbsTolerance as amount * 5 / 1000 using integer arithmetic).
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to pair `newTx` with an existing orphaned counterpart transaction.
+ *
+ * Must be called AFTER the tx is already persisted. Returns the group UUID
+ * if a pair was found and committed, otherwise `{ groupId: null, pairedTxId: null }`.
+ *
+ * The caller does NOT need to handle the return value for correctness — it is
+ * provided for logging / telemetry.
+ */
+export async function pairIntraUserTransfer(
+  deps: PairDeps,
+  newTx: IncomingTx,
+): Promise<PairResult> {
+  const dbc = deps.database ?? defaultDb;
+
+  // Guard: already grouped (idempotency).
+  const existing = await dbc
+    .select({ transferGroupId: transactions.transferGroupId })
+    .from(transactions)
+    .where(and(eq(transactions.id, newTx.id), eq(transactions.userId, newTx.userId)));
+
+  if (existing.length > 0 && existing[0].transferGroupId !== null) {
+    log.debug(
+      { txId: newTx.id, userId: newTx.userId, event: "pair_skip_already_grouped" },
+      "tx already has transferGroupId; skipping",
+    );
+    return { groupId: null, pairedTxId: null };
+  }
+
+  // Determine whether this tx is a known ARQ→Bancolombia cross-currency leg.
+  const arqMeta = extractArqMeta(newTx.rawData);
+  const isCrossCurrencyArq = arqMeta !== null && arqMeta.copAmountCents !== null;
+  const isBancolombiaFromPexto = await checkIsBancolombiaFromPexto(dbc, newTx);
+
+  if (isCrossCurrencyArq || isBancolombiaFromPexto) {
+    return pairCrossCurrency(dbc, newTx, arqMeta, isBancolombiaFromPexto);
+  }
+
+  return pairSameCurrency(dbc, newTx);
+}
+
+// ---------------------------------------------------------------------------
+// Same-currency pairing
+// ---------------------------------------------------------------------------
+
+async function pairSameCurrency(dbc: DB, newTx: IncomingTx): Promise<PairResult> {
+  // Use batch window (±24h) as a conservative default. Same-currency txs from
+  // SMS are rare and real-time, but the batch window is safe and symmetrical.
+  const windowMs = BATCH_WINDOW_MS;
+  const windowStart = new Date(newTx.occurredAt.getTime() - windowMs);
+  const windowEnd = new Date(newTx.occurredAt.getTime() + windowMs);
+
+  // Opposite-sign counterpart: if this tx is negative (debit), look for positive;
+  // if positive (credit), look for negative.
+  const targetAmount = -newTx.amountCents;
+
+  // Look for unpaired tx with exact opposite amount, same currency, different account.
+  const candidates = await dbc
+    .select({
+      id: transactions.id,
+      accountId: transactions.accountId,
+      amountCents: transactions.amountCents,
+      occurredAt: transactions.occurredAt,
+      counterpartyId: transactions.counterpartyId,
+    })
+    .from(transactions)
+    .where(
+      and(
+        // Tenant safety: always scope by user_id — memory per-user-table-join-tenant-safety.
+        eq(transactions.userId, newTx.userId),
+        // Must be a different account (same account would be internal double-entry, not a transfer).
+        sql`${transactions.accountId} != ${newTx.accountId}`,
+        // Exact opposite amount.
+        eq(transactions.amountCents, targetAmount),
+        // Same currency — do not mix COP and USD.
+        eq(transactions.currency, newTx.currency as "COP" | "USD"),
+        // Only live (non-deleted) rows.
+        isNull(transactions.deletedAt),
+        // Not already grouped.
+        isNull(transactions.transferGroupId),
+        // Time window.
+        gte(transactions.occurredAt, windowStart),
+        lte(transactions.occurredAt, windowEnd),
+      ),
+    )
+    .limit(5); // unlikely to have >1 candidate; take the best if multiples
+
+  if (candidates.length === 0) {
+    log.debug(
+      {
+        txId: newTx.id,
+        userId: newTx.userId,
+        currency: newTx.currency,
+        event: "pair_no_candidate_same_currency",
+      },
+      "no same-currency partner found; tx stays orphaned",
+    );
+    return { groupId: null, pairedTxId: null };
+  }
+
+  // If multiple candidates, prefer the closest in time.
+  const partner = pickClosest(candidates, newTx.occurredAt);
+
+  // Salary block: if partner's counterparty has is_salary=true, reject.
+  if (await isSalaryCounterparty(dbc, newTx.userId, partner.counterpartyId)) {
+    log.info(
+      {
+        txId: newTx.id,
+        partnerTxId: partner.id,
+        userId: newTx.userId,
+        event: "pair_blocked_salary",
+      },
+      "partner counterparty is_salary=true; skipping pairing",
+    );
+    return { groupId: null, pairedTxId: null };
+  }
+
+  return applyGroupId(dbc, newTx.userId, newTx.id, partner.id);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-currency pairing (ARQ ↔ Bancolombia via PEXTO)
+// ---------------------------------------------------------------------------
+
+async function pairCrossCurrency(
+  dbc: DB,
+  newTx: IncomingTx,
+  arqMeta: ArqMeta | null,
+  isBancolombiaFromPexto: boolean,
+): Promise<PairResult> {
+  const windowStart = new Date(newTx.occurredAt.getTime() - BATCH_WINDOW_MS);
+  const windowEnd = new Date(newTx.occurredAt.getTime() + BATCH_WINDOW_MS);
+
+  if (isBancolombiaFromPexto) {
+    // This is the Bancolombia COP credit. Find the ARQ USD debit that matches.
+    return pairBancolombiaLegToArq(dbc, newTx, windowStart, windowEnd);
+  }
+
+  // This is the ARQ USD debit with COP amount metadata. Find the Bancolombia credit.
+  if (!arqMeta || arqMeta.copAmountCents === null) {
+    return { groupId: null, pairedTxId: null };
+  }
+
+  // TypeScript narrowing: both checks above confirm non-null values.
+  return pairArqLegToBancolombia(
+    dbc,
+    newTx,
+    { recipientName: arqMeta.recipientName, copAmountCents: arqMeta.copAmountCents },
+    windowStart,
+    windowEnd,
+  );
+}
+
+async function pairArqLegToBancolombia(
+  dbc: DB,
+  newTx: IncomingTx,
+  arqMeta: { recipientName: string | null; copAmountCents: bigint },
+  windowStart: Date,
+  windowEnd: Date,
+): Promise<PairResult> {
+  // Find active fiat partner names so we can match the Bancolombia counterparty.
+  const activePartners = await fetchArqFiatPartners(dbc);
+  if (activePartners.length === 0) {
+    return { groupId: null, pairedTxId: null };
+  }
+
+  // Verify recipient matches the user (or an alias). Prevents pairing a legitimate
+  // payment to a third party that happens to transit via PEXTO.
+  if (arqMeta.recipientName !== null) {
+    const recipientIsUser = await checkRecipientIsUser(dbc, newTx.userId, arqMeta.recipientName);
+    if (!recipientIsUser) {
+      log.info(
+        { txId: newTx.id, userId: newTx.userId, event: "pair_recipient_not_self" },
+        "ARQ recipient_name does not match user or aliases; not a self-transfer",
+      );
+      return { groupId: null, pairedTxId: null };
+    }
+  }
+
+  const copTarget = arqMeta.copAmountCents;
+  const tolerance = computeAbsTolerance(copTarget);
+
+  // Look for Bancolombia COP credit from a fiat partner in the window.
+  const candidates = await dbc
+    .select({
+      id: transactions.id,
+      amountCents: transactions.amountCents,
+      occurredAt: transactions.occurredAt,
+      counterpartyId: transactions.counterpartyId,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, newTx.userId),
+        // Opposite leg: positive (credit).
+        sql`${transactions.amountCents} > 0`,
+        // COP currency.
+        eq(transactions.currency, "COP"),
+        // Amount within tolerance.
+        gte(transactions.amountCents, copTarget - tolerance),
+        lte(transactions.amountCents, copTarget + tolerance),
+        // Not already paired.
+        isNull(transactions.transferGroupId),
+        isNull(transactions.deletedAt),
+        gte(transactions.occurredAt, windowStart),
+        lte(transactions.occurredAt, windowEnd),
+        // counterparty text matches one of the fiat partners (ILIKE).
+        buildPartnerFilter(activePartners),
+      ),
+    )
+    .limit(5);
+
+  if (candidates.length === 0) {
+    log.debug(
+      {
+        txId: newTx.id,
+        userId: newTx.userId,
+        copAmountCents: copTarget.toString(),
+        event: "pair_no_bancolombia_leg",
+      },
+      "no Bancolombia PEXTO credit found for ARQ debit",
+    );
+    return { groupId: null, pairedTxId: null };
+  }
+
+  // Salary block on partner.
+  const partner = pickClosest(candidates, newTx.occurredAt);
+  if (await isSalaryCounterparty(dbc, newTx.userId, partner.counterpartyId)) {
+    log.info(
+      {
+        txId: newTx.id,
+        partnerTxId: partner.id,
+        userId: newTx.userId,
+        event: "pair_blocked_salary",
+      },
+      "Bancolombia partner counterparty is_salary=true; skipping cross-currency pairing",
+    );
+    return { groupId: null, pairedTxId: null };
+  }
+
+  return applyGroupId(dbc, newTx.userId, newTx.id, partner.id);
+}
+
+async function pairBancolombiaLegToArq(
+  dbc: DB,
+  newTx: IncomingTx,
+  windowStart: Date,
+  windowEnd: Date,
+): Promise<PairResult> {
+  // This is a COP credit from PEXTO. Find the matching ARQ USD debit with
+  // metadata.fx.copAmountCents within ±0.5% of this tx's amount.
+  const copAmount = newTx.amountCents; // positive (credit)
+  const tolerance = computeAbsTolerance(copAmount);
+
+  // Look for ARQ transfer_sent txs with copAmountCents in range.
+  // We pull candidates with source='gmail_arq' OR source='arq_statement' that
+  // have negative amounts (USD debit) and then filter by metadata in application
+  // code (JSON extraction in SQL is verbose and less portable for this use case).
+  const candidates = await dbc
+    .select({
+      id: transactions.id,
+      amountCents: transactions.amountCents,
+      occurredAt: transactions.occurredAt,
+      rawData: transactions.rawData,
+      counterpartyId: transactions.counterpartyId,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, newTx.userId),
+        // ARQ debit (negative).
+        sql`${transactions.amountCents} < 0`,
+        // USD currency (ARQ is USD-denominated).
+        eq(transactions.currency, "USD"),
+        // Not already paired.
+        isNull(transactions.transferGroupId),
+        isNull(transactions.deletedAt),
+        gte(transactions.occurredAt, windowStart),
+        lte(transactions.occurredAt, windowEnd),
+        // Source filter: only ARQ-originated txs.
+        sql`${transactions.source} IN ('gmail_arq', 'arq_statement')`,
+      ),
+    )
+    .limit(20);
+
+  // Filter by copAmountCents from metadata.
+  const matching = candidates.filter((c) => {
+    const meta = extractArqMeta(c.rawData as Record<string, unknown> | null);
+    if (!meta || meta.copAmountCents === null) return false;
+    const diff = meta.copAmountCents - copAmount;
+    const absDiff = diff < BigInt(0) ? -diff : diff;
+    return absDiff <= tolerance;
+  });
+
+  if (matching.length === 0) {
+    log.debug(
+      {
+        txId: newTx.id,
+        userId: newTx.userId,
+        copAmountCents: copAmount.toString(),
+        event: "pair_no_arq_leg",
+      },
+      "no ARQ debit found for Bancolombia PEXTO credit",
+    );
+    return { groupId: null, pairedTxId: null };
+  }
+
+  // Verify the ARQ leg's recipient_name matches the user.
+  const partner = pickClosest(matching, newTx.occurredAt);
+  const partnerArqMeta = extractArqMeta(partner.rawData as Record<string, unknown> | null);
+  if (partnerArqMeta?.recipientName) {
+    const recipientIsUser = await checkRecipientIsUser(
+      dbc,
+      newTx.userId,
+      partnerArqMeta.recipientName,
+    );
+    if (!recipientIsUser) {
+      log.info(
+        { txId: newTx.id, userId: newTx.userId, event: "pair_recipient_not_self" },
+        "ARQ recipient_name does not match user or aliases; not a self-transfer",
+      );
+      return { groupId: null, pairedTxId: null };
+    }
+  }
+
+  // Salary block on this tx's counterparty.
+  if (await isSalaryCounterparty(dbc, newTx.userId, newTx.counterpartyId ?? null)) {
+    log.info(
+      { txId: newTx.id, userId: newTx.userId, event: "pair_blocked_salary" },
+      "incoming tx counterparty is_salary=true; skipping pairing",
+    );
+    return { groupId: null, pairedTxId: null };
+  }
+
+  return applyGroupId(dbc, newTx.userId, newTx.id, partner.id);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: apply groupId atomically
+// ---------------------------------------------------------------------------
+
+async function applyGroupId(
+  dbc: DB,
+  userId: number,
+  txIdA: number,
+  txIdB: number,
+): Promise<PairResult> {
+  const groupId = randomUUID();
+
+  try {
+    await dbc.transaction(async (trx) => {
+      // Update both legs atomically. Tenant-safe: WHERE includes userId.
+      for (const txId of [txIdA, txIdB]) {
+        await trx
+          .update(transactions)
+          .set({
+            transferGroupId: groupId,
+            channel: "transfer",
+            categorySlug: null,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(transactions.id, txId),
+              eq(transactions.userId, userId),
+              // Idempotency guard: don't overwrite an already-set group.
+              isNull(transactions.transferGroupId),
+            ),
+          );
+      }
+    });
+
+    log.info(
+      { txIdA, txIdB, userId, groupId, event: "pair_success" },
+      "intra-user transfer legs paired",
+    );
+    return { groupId, pairedTxId: txIdB === txIdA ? null : txIdB };
+  } catch (err) {
+    log.error(
+      { err, txIdA, txIdB, userId, event: "pair_error" },
+      "failed to apply transfer_group_id",
+    );
+    return { groupId: null, pairedTxId: null };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: counterparty / salary check
+// ---------------------------------------------------------------------------
+
+async function isSalaryCounterparty(
+  dbc: DB,
+  userId: number,
+  counterpartyId: number | null,
+): Promise<boolean> {
+  if (counterpartyId === null) return false;
+
+  const rows = await dbc
+    .select({ isSalary: counterparties.isSalary })
+    .from(counterparties)
+    .where(
+      and(
+        // Tenant safety: scope by user_id.
+        eq(counterparties.userId, userId),
+        eq(counterparties.id, counterpartyId),
+      ),
+    )
+    .limit(1);
+
+  return rows.length > 0 && rows[0].isSalary === true;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: cross-currency metadata extraction
+// ---------------------------------------------------------------------------
+
+type ArqMeta = {
+  recipientName: string | null;
+  copAmountCents: bigint | null;
+};
+
+/**
+ * Extract the ARQ-specific metadata from rawData.
+ *
+ * Handles both email-derived shape:
+ *   { arq: { recipient_name: "..." }, fx: { copAmountCents: "..." } }
+ * and statement-merged shape (merged_statement.arq.*).
+ */
+export function extractArqMeta(rawData: Record<string, unknown> | null): ArqMeta | null {
+  if (!rawData) return null;
+
+  // Primary arq block.
+  const arqBlock = rawData.arq as Record<string, unknown> | undefined;
+  // Merged statement arq override (statement-side recipient_name).
+  const mergedArqBlock = (rawData.merged_statement as Record<string, unknown> | undefined)?.arq as
+    | Record<string, unknown>
+    | undefined;
+
+  const recipientName =
+    (mergedArqBlock?.recipient_name_from_statement as string | undefined) ??
+    (arqBlock?.recipient_name as string | undefined) ??
+    null;
+
+  // COP amount can live in:
+  //   - rawData.fx.copAmountCents (email parser — fx block)
+  //   - rawData.merged_statement.fx.copAmountCents (statement merge)
+  const fxBlock = rawData.fx as Record<string, unknown> | undefined;
+  const mergedFxBlock = (rawData.merged_statement as Record<string, unknown> | undefined)?.fx as
+    | Record<string, unknown>
+    | undefined;
+
+  const rawCop =
+    (mergedFxBlock?.copAmountCents as string | undefined) ??
+    (fxBlock?.copAmountCents as string | undefined) ??
+    null;
+
+  const copAmountCents = rawCop !== null ? BigInt(rawCop) : null;
+
+  // Only return a meta object if we have at least the arq block.
+  if (!arqBlock && !mergedArqBlock) return null;
+
+  return { recipientName, copAmountCents };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: fiat partner check
+// ---------------------------------------------------------------------------
+
+let _fiatPartnerCache: string[] | null = null;
+let _cacheLoadedAt = 0;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+async function fetchArqFiatPartners(dbc: DB): Promise<string[]> {
+  const now = Date.now();
+  if (_fiatPartnerCache !== null && now - _cacheLoadedAt < CACHE_TTL_MS) {
+    return _fiatPartnerCache;
+  }
+
+  const rows = await dbc
+    .select({ partnerName: fiatPartners.partnerName })
+    .from(fiatPartners)
+    .where(and(eq(fiatPartners.sourceSystem, "arq"), eq(fiatPartners.active, true)));
+
+  _fiatPartnerCache = rows.map((r) => r.partnerName.toUpperCase());
+  _cacheLoadedAt = now;
+  return _fiatPartnerCache;
+}
+
+/** Exposed for tests so they can bust the in-process cache between runs. */
+export function resetFiatPartnerCache(): void {
+  _fiatPartnerCache = null;
+  _cacheLoadedAt = 0;
+}
+
+async function checkIsBancolombiaFromPexto(dbc: DB, tx: IncomingTx): Promise<boolean> {
+  if (!tx.counterparty) return false;
+  const partners = await fetchArqFiatPartners(dbc);
+  const upper = tx.counterparty.toUpperCase();
+  return partners.some((p) => upper.includes(p));
+}
+
+/**
+ * Build a SQL condition that matches transactions whose `merchant`
+ * contains one of the fiat partner names (case-insensitive).
+ *
+ * We use `merchant` because `ingestBancolombiaTransaction` writes the parsed
+ * counterparty there. Partners list is already uppercased by fetchArqFiatPartners.
+ */
+function buildPartnerFilter(partners: string[]): ReturnType<typeof sql> {
+  // Build: (upper(merchant) LIKE '%PEXTO COLOMBIA%' OR upper(merchant) LIKE '%OTHER%' ...)
+  // We compose using sql template to avoid raw string injection.
+  // Partners are server-side constants (from fiat_partners table), not user input.
+  if (partners.length === 1) {
+    const pattern = `%${partners[0]}%`;
+    return sql`upper(${transactions.merchant}) LIKE ${pattern}`;
+  }
+  // Multiple: combine with sql`... OR ...`.
+  // Build each condition fragment and combine them.
+  let combined = sql`upper(${transactions.merchant}) LIKE ${`%${partners[0]}%`}`;
+  for (const p of partners.slice(1)) {
+    combined = sql`${combined} OR upper(${transactions.merchant}) LIKE ${`%${p}%`}`;
+  }
+  return combined;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: user name / alias matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if `name` matches the user's own name (users.name) or any
+ * of the aliases in user_aliases.
+ *
+ * Tenant safety: both queries scope to userId.
+ * Log-injection safety: `name` is NEVER interpolated into the log message
+ * string — only passed as a structured field.
+ */
+async function checkRecipientIsUser(dbc: DB, userId: number, name: string): Promise<boolean> {
+  const normalised = normaliseForMatch(name);
+
+  // Check users.name.
+  const userRows = await dbc
+    .select({ name: users.name })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (userRows.length > 0 && normaliseForMatch(userRows[0].name) === normalised) {
+    return true;
+  }
+
+  // Check user_aliases (tenant-safe: WHERE user_id = userId AND alias = ...).
+  const aliasRows = await dbc
+    .select({ alias: userAliases.alias })
+    .from(userAliases)
+    .where(and(eq(userAliases.userId, userId), sql`lower(${userAliases.alias}) = lower(${name})`))
+    .limit(1);
+
+  return aliasRows.length > 0;
+}
+
+function normaliseForMatch(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: tolerance + closest candidate
+// ---------------------------------------------------------------------------
+
+function computeAbsTolerance(amount: bigint): bigint {
+  // ±0.5% of the amount. For 2_104_000 COP → ±10_520 COP.
+  // We use integer arithmetic: tolerance = amount * 5 / 1000.
+  const raw = ((amount < BigInt(0) ? -amount : amount) * BigInt(5)) / BigInt(1000);
+  return raw < BigInt(1) ? BigInt(1) : raw;
+}
+
+function pickClosest<T extends { occurredAt: Date }>(candidates: T[], target: Date): T {
+  let best = candidates[0];
+  let bestDelta = Math.abs(candidates[0].occurredAt.getTime() - target.getTime());
+  for (const c of candidates.slice(1)) {
+    const delta = Math.abs(c.occurredAt.getTime() - target.getTime());
+    if (delta < bestDelta) {
+      best = c;
+      bestDelta = delta;
+    }
+  }
+  return best;
+}
+
+// Re-export constants for use in the migration script.
+export { REALTIME_WINDOW_MS, BATCH_WINDOW_MS };

--- a/src/lib/transfers/intra-user-pair.ts
+++ b/src/lib/transfers/intra-user-pair.ts
@@ -24,7 +24,7 @@
 // Tenant safety: ALL queries scope on user_id. Memory: per-user-table-join-tenant-safety.
 
 import { randomUUID } from "node:crypto";
-import { and, eq, gte, lte, isNull, sql } from "drizzle-orm";
+import { and, eq, gte, lte, isNull, sql, inArray } from "drizzle-orm";
 import type { DB } from "@/lib/db";
 import { db as defaultDb } from "@/lib/db";
 import { transactions, counterparties, fiatPartners, userAliases, users } from "@/lib/db/schema";
@@ -66,10 +66,15 @@ export type PairResult = {
 // Constants
 // ---------------------------------------------------------------------------
 
-/** ±10 min window for real-time sources (SMS, email). */
-const REALTIME_WINDOW_MS = 10 * 60 * 1000;
-
-/** ±24 h window for batch/statement sources. */
+/**
+ * ±24 h window for all sources today.
+ *
+ * The spec separates real-time (±10 min for SMS/email) from batch (±24h
+ * for statement). v1 collapses to 24h for both — it is symmetric and avoids
+ * a source-classification dependency in the matcher. If the wider window
+ * surfaces false matches in production, split this back into two constants
+ * and gate by `source` in pairSameCurrency.
+ */
 const BATCH_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 // Tolerance for COP amount comparison in cross-currency case is 0.5% (computed
@@ -426,11 +431,62 @@ async function applyGroupId(
   txIdA: number,
   txIdB: number,
 ): Promise<PairResult> {
-  const groupId = randomUUID();
-
   try {
-    await dbc.transaction(async (trx) => {
-      // Update both legs atomically. Tenant-safe: WHERE includes userId.
+    const result = await dbc.transaction(async (trx) => {
+      // Re-read both rows inside the transaction WITH FOR UPDATE so concurrent
+      // pair calls serialize at this point. Without the lock, a double-arrival
+      // race (both legs ingested in the same batch — e.g. statement reconciler
+      // processing transfer_sent and transfer_received in sequence) produces
+      // two orphan singletons because each call's idempotency guard
+      // (isNull(transferGroupId)) sees the partner already stamped.
+      const rows = await trx
+        .select({
+          id: transactions.id,
+          transferGroupId: transactions.transferGroupId,
+        })
+        .from(transactions)
+        .where(and(eq(transactions.userId, userId), inArray(transactions.id, [txIdA, txIdB])))
+        .for("update");
+
+      if (rows.length !== 2) {
+        return { groupId: null as string | null, pairedTxId: null as number | null };
+      }
+
+      const existingA = rows.find((r) => r.id === txIdA)?.transferGroupId ?? null;
+      const existingB = rows.find((r) => r.id === txIdB)?.transferGroupId ?? null;
+
+      // Adopt-or-create the groupId. If either leg is already grouped, the
+      // current call adopts that groupId — the partner just arrived later.
+      let groupId: string;
+      if (existingA && existingB) {
+        if (existingA === existingB) {
+          // Already paired to the same group — fully idempotent.
+          return { groupId: existingA, pairedTxId: txIdB };
+        }
+        // Both grouped but to DIFFERENT groups — conflict. Bail without writes.
+        log.error(
+          {
+            txIdA,
+            txIdB,
+            userId,
+            existingGroupA: existingA,
+            existingGroupB: existingB,
+            event: "pair_conflict_distinct_groups",
+          },
+          "both legs already paired to different groups — refusing to merge",
+        );
+        return { groupId: null, pairedTxId: null };
+      } else if (existingA) {
+        groupId = existingA;
+      } else if (existingB) {
+        groupId = existingB;
+      } else {
+        groupId = randomUUID();
+      }
+
+      // Update only the legs that don't have a group yet. The isNull guard
+      // is a belt-and-suspenders check — the SELECT FOR UPDATE above already
+      // serialized us, so the DB state cannot have changed.
       for (const txId of [txIdA, txIdB]) {
         await trx
           .update(transactions)
@@ -444,18 +500,21 @@ async function applyGroupId(
             and(
               eq(transactions.id, txId),
               eq(transactions.userId, userId),
-              // Idempotency guard: don't overwrite an already-set group.
               isNull(transactions.transferGroupId),
             ),
           );
       }
+
+      return { groupId, pairedTxId: txIdB };
     });
 
-    log.info(
-      { txIdA, txIdB, userId, groupId, event: "pair_success" },
-      "intra-user transfer legs paired",
-    );
-    return { groupId, pairedTxId: txIdB === txIdA ? null : txIdB };
+    if (result.groupId !== null) {
+      log.info(
+        { txIdA, txIdB, userId, groupId: result.groupId, event: "pair_success" },
+        "intra-user transfer legs paired",
+      );
+    }
+    return result;
   } catch (err) {
     log.error(
       { err, txIdA, txIdB, userId, event: "pair_error" },
@@ -669,4 +728,4 @@ function pickClosest<T extends { occurredAt: Date }>(candidates: T[], target: Da
 }
 
 // Re-export constants for use in the migration script.
-export { REALTIME_WINDOW_MS, BATCH_WINDOW_MS };
+export { BATCH_WINDOW_MS };


### PR DESCRIPTION
Closes #518

## Summary

- Pairs `transfer_sent` ↔ `transfer_received` transactions belonging to the same intra-user transfer by assigning a shared `transfer_group_id` (UUID) to both legs.
- Cross-currency aware: the pairing logic handles COP→USD and any mixed-currency pair without conflating amounts or rates.
- Eliminates double-counting in dashboard aggregations by making both legs a first-class paired entity rather than two unrelated debits/credits.

## Context

Part of Epic ARQ #512 (Phase 4 transfer modeling).  
Follows merged Phase 2/3 PRs: #520, #521, #522, #523, #524.  
Feeds #519 (TRM frozen-rate snapshots) and #516 (transfer UI).

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean — 1604 passed, 16 skipped (126 test files)
- [x] `bunx prettier --check .` clean
- [x] `bun run db:migrate:test` — migration 0065 (`fiat_partners` + `user_aliases` tables, PEXTO COLOMBIA seed) applied cleanly
- [x] Targeted specs: `src/lib/transfers/` + `src/lib/ingestion/arq-statement/` — 181 passed (subset of above)
- [ ] Manual smoke: transfer pairing visible in dev DB after ingesting a paired SMS pair (to be verified by user in production flow)