### PR TITLE
fix(ingestion): polyfill pdfjs browser globals at module top (#531)

### DIFF
--- a/src/lib/ingestion/arq-statement/pdf-adapter.ts
+++ b/src/lib/ingestion/arq-statement/pdf-adapter.ts
@@ -4,6 +4,60 @@ import { createLogger } from "@/lib/logger";
 
 import type { ArqEquivalentCurrency, RawStatement, RawTxLine } from "./types";
 
+// ---------------------------------------------------------------------------
+// pdfjs-dist browser-globals shim — MUST run before any code path that may
+// load the pdfjs-dist module graph. Turbopack/Next standalone evaluate
+// dynamic imports eagerly when bundling for Server Components, so installing
+// the shim inside the loader function is too late under Turbopack.
+//
+// pdfjs-dist's legacy build still references DOMMatrix / Path2D / ImageData
+// at module-evaluation time (used by canvas rendering paths we never hit).
+// Stub classes are sufficient because we only extract text — never render.
+//
+// In jsdom (test) these globals exist natively, which is why tests passed
+// while production crashed on the first PDF upload.
+// ---------------------------------------------------------------------------
+{
+  const g = globalThis as unknown as Record<string, unknown>;
+  if (typeof g.DOMMatrix === "undefined") {
+    class StubDOMMatrix {
+      constructor() {}
+      multiplySelf() {
+        return this;
+      }
+      multiply() {
+        return this;
+      }
+      invertSelf() {
+        return this;
+      }
+      translateSelf() {
+        return this;
+      }
+      scaleSelf() {
+        return this;
+      }
+    }
+    g.DOMMatrix = StubDOMMatrix;
+  }
+  if (typeof g.Path2D === "undefined") {
+    class StubPath2D {
+      constructor() {}
+      addPath() {}
+      moveTo() {}
+      lineTo() {}
+      closePath() {}
+    }
+    g.Path2D = StubPath2D;
+  }
+  if (typeof g.ImageData === "undefined") {
+    class StubImageData {
+      constructor() {}
+    }
+    g.ImageData = StubImageData;
+  }
+}
+
 const log = createLogger({ module: "arq-statement-pdf" });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Production hotfix for the ARQ statement PDF parser. Uploads to \`/imports\` crashed with \`ReferenceError: DOMMatrix is not defined\` from inside the bundled \`pdfjs-dist\` legacy build (Turbopack chunk).
- Installs stub classes for \`DOMMatrix\`, \`Path2D\`, \`ImageData\` at the very top of \`src/lib/ingestion/arq-statement/pdf-adapter.ts\`, before any reference to pdfjs. Stubs are sufficient because we only extract text via \`getTextContent()\` — never render.
- Top-of-module placement is required: Turbopack pre-evaluates dynamic imports when bundling for Server Components, so the shim inside the loader function was too late.

## Why the bug was invisible until now
- jsdom (the existing test env in Bun) provides \`DOMMatrix\` natively — the 48 \`pdf-adapter.test.ts\` smoke tests passed.
- Bun in dev mode also exposes these globals.
- Only the Next.js standalone build under \`bun server.js\` running the bundled SSR chunk lacks them.

## Test plan
- [x] \`bunx vitest run src/lib/ingestion/arq-statement/pdf-adapter.test.ts\` → 48 pass
- [x] \`bunx tsc --noEmit\` clean
- [x] \`bunx prettier --check\` clean
- [ ] After merge + auto-deploy → retry \`/imports\` upload of a real ARQ PDF on prod

Closes #531