### PR TITLE
fix(ingestion): defend pdfjs workerSrc resolution under Turbopack (#531 sequel)

### DIFF
--- a/src/lib/ingestion/arq-statement/pdf-adapter.ts
+++ b/src/lib/ingestion/arq-statement/pdf-adapter.ts
@@ -4,6 +4,60 @@ import { createLogger } from "@/lib/logger";
 
 import type { ArqEquivalentCurrency, RawStatement, RawTxLine } from "./types";
 
+// ---------------------------------------------------------------------------
+// pdfjs-dist browser-globals shim — MUST run before any code path that may
+// load the pdfjs-dist module graph. Turbopack/Next standalone evaluate
+// dynamic imports eagerly when bundling for Server Components, so installing
+// the shim inside the loader function is too late under Turbopack.
+//
+// pdfjs-dist's legacy build still references DOMMatrix / Path2D / ImageData
+// at module-evaluation time (used by canvas rendering paths we never hit).
+// Stub classes are sufficient because we only extract text — never render.
+//
+// In jsdom (test) these globals exist natively, which is why tests passed
+// while production crashed on the first PDF upload.
+// ---------------------------------------------------------------------------
+{
+  const g = globalThis as unknown as Record<string, unknown>;
+  if (typeof g.DOMMatrix === "undefined") {
+    class StubDOMMatrix {
+      constructor() {}
+      multiplySelf() {
+        return this;
+      }
+      multiply() {
+        return this;
+      }
+      invertSelf() {
+        return this;
+      }
+      translateSelf() {
+        return this;
+      }
+      scaleSelf() {
+        return this;
+      }
+    }
+    g.DOMMatrix = StubDOMMatrix;
+  }
+  if (typeof g.Path2D === "undefined") {
+    class StubPath2D {
+      constructor() {}
+      addPath() {}
+      moveTo() {}
+      lineTo() {}
+      closePath() {}
+    }
+    g.Path2D = StubPath2D;
+  }
+  if (typeof g.ImageData === "undefined") {
+    class StubImageData {
+      constructor() {}
+    }
+    g.ImageData = StubImageData;
+  }
+}
+
 const log = createLogger({ module: "arq-statement-pdf" });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/ingestion/arq-statement/pdf-adapter.ts
+++ b/src/lib/ingestion/arq-statement/pdf-adapter.ts
@@ -72,12 +72,28 @@ const log = createLogger({ module: "arq-statement-pdf" });
 // We resolve that path at module-init time so it survives cwd changes.
 //
 // createRequire resolves relative to THIS source file, so it correctly finds
-// the package regardless of cwd at invocation time.
-const _require = createRequire(import.meta.url);
-const PDFJS_WORKER_PATH: string = _require.resolve("pdfjs-dist/legacy/build/pdf.worker.mjs");
+// the package in pure Node + Bun. Under Next.js standalone + Turbopack,
+// `import.meta.url` points at the bundled chunk and the resolution may fail —
+// fall back to an empty string so pdfjs's type check passes. In Node, pdfjs
+// uses an in-process LoopbackPort fake worker regardless of workerSrc value,
+// so the actual path is irrelevant for our text-only extraction path.
+function resolvePdfjsWorkerPath(): string {
+  try {
+    const _require = createRequire(import.meta.url);
+    const resolved: unknown = _require.resolve("pdfjs-dist/legacy/build/pdf.worker.mjs");
+    return typeof resolved === "string" ? resolved : "";
+  } catch {
+    // Turbopack may stub createRequire entirely or have it throw under the
+    // bundled standalone runtime — fall back to empty string.
+    return "";
+  }
+}
+const PDFJS_WORKER_PATH: string = resolvePdfjsWorkerPath();
 
 async function getPdfjsLib() {
   const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
+  // pdfjs's setter rejects non-string assignments with "Invalid workerSrc type".
+  // resolvePdfjsWorkerPath() guarantees a string return.
   pdfjs.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_PATH;
   return pdfjs;
 }


### PR DESCRIPTION
## Summary
- Sequel hotfix to #531 / PR #532. After the DOMMatrix shim landed, prod surfaced the next pdfjs initialization error: \`Invalid workerSrc type\`. Cause: under Next.js standalone + Turbopack, \`createRequire(import.meta.url)\` is stubbed/intercepted by the bundler and \`_require.resolve(...)\` returns a non-string (undefined) rather than throwing. The undefined gets assigned to \`GlobalWorkerOptions.workerSrc\`, whose setter rejects non-strings.
- Wrap resolution in try/catch AND validate the return is a string. Fall back to empty string — in Node, pdfjs uses an in-process LoopbackPort fake worker regardless of workerSrc value for text-only extraction.

## Test plan
- [x] \`bunx vitest run src/lib/ingestion/arq-statement/pdf-adapter.test.ts\` → 48 pass
- [x] \`bunx tsc --noEmit\` clean
- [x] \`bunx prettier --check\` clean
- [ ] After merge + auto-deploy → retry \`/imports\` upload of a real ARQ PDF on prod