### PR TITLE
feat(db): seed user_aliases for cross-currency transfer pairing (#538)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,6 +109,8 @@ jobs:
           cp src/lib/db/index.ts "$STAGE/src/lib/db/index.ts"
           cp src/lib/db/schema.ts "$STAGE/src/lib/db/schema.ts"
           cp src/lib/db/seed-reference-data.ts "$STAGE/src/lib/db/seed-reference-data.ts"
+          # #538: migrate-prod now calls seedUserAliases — overlay the module.
+          cp src/lib/db/seed-user-aliases.ts "$STAGE/src/lib/db/seed-user-aliases.ts"
           cp src/lib/auth/signup.ts "$STAGE/src/lib/auth/signup.ts"
           cp src/lib/logger.ts "$STAGE/src/lib/logger.ts"
           echo "$GIT_SHA" > "$STAGE/GIT_SHA"

--- a/scripts/migrate-prod.ts
+++ b/scripts/migrate-prod.ts
@@ -17,6 +17,7 @@ import { migrate } from "drizzle-orm/postgres-js/migrator";
 // layout so dev and prod resolve these identically.
 import { db } from "../src/lib/db";
 import { seedReferenceData } from "../src/lib/db/seed-reference-data";
+import { seedUserAliases } from "../src/lib/db/seed-user-aliases";
 import { createLogger } from "../src/lib/logger";
 import { backfillUsersReferenceData } from "./backfill-users-reference";
 import { migratePagoTcToTransfer } from "./migrate-pago-tc-to-transfer";
@@ -74,5 +75,11 @@ log.info(
   { ...pagoTcReport, event: "migrate_prod_pago_tc_done" },
   "pago-tc transfer-group backfill complete",
 );
+
+// #538: permanent seed for user_aliases (cross-currency transfer pairing).
+// Idempotent: inserts canonical aliases, removes deprecated ones.
+log.info({ event: "migrate_prod_user_aliases_start" }, "seeding user aliases");
+await seedUserAliases(db);
+log.info({ event: "migrate_prod_user_aliases_done" }, "user aliases seeded");
 
 await db.$client.end();

--- a/src/lib/db/seed-user-aliases.test.ts
+++ b/src/lib/db/seed-user-aliases.test.ts
@@ -1,0 +1,161 @@
+// Integration tests for seedUserAliases (#538).
+//
+// These tests hit findash_test (forced by vitest.setup.ts). Run
+// `bun run db:migrate:test` before this suite.
+//
+// Test matrix:
+//   1. No user with target email → no-op, no error, no inserts.
+//   2. User exists, fresh user_aliases → inserts all 3 canonical aliases.
+//   3. Idempotency: run twice → second run inserts 0 (no duplicates).
+//   4. Deprecated cleanup: deprecated alias present → deleted; canonical 3 present.
+//   5. Tenant safety: deprecated alias on a DIFFERENT user is NOT touched.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { userAliases, users } from "@/lib/db/schema";
+import { USER_ALIAS_SEEDS, seedUserAliases } from "./seed-user-aliases";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Stable tag to isolate test rows; all inserts use email addresses prefixed
+// with this tag so cleanup is a simple LIKE query.
+const TAG = "SEED_UA_TEST";
+
+const CANONICAL_ALIASES = USER_ALIAS_SEEDS[0].aliases;
+const DEPRECATED_ALIASES = USER_ALIAS_SEEDS[0].deprecated;
+
+const testEmail = (suffix: string) => `${TAG}-${suffix}@test.local`;
+
+async function cleanup(): Promise<void> {
+  await db.execute(
+    sql`DELETE FROM user_aliases WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})`,
+  );
+  await db.execute(sql`DELETE FROM users WHERE email LIKE ${TAG + "%"}`);
+}
+
+beforeAll(cleanup);
+afterAll(cleanup);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function insertUser(email: string, name = "Test User"): Promise<number> {
+  const [u] = await db.insert(users).values({ email, name }).returning({ id: users.id });
+  return u.id;
+}
+
+async function getAliasesForUser(userId: number): Promise<string[]> {
+  const rows = await db
+    .select({ alias: userAliases.alias })
+    .from(userAliases)
+    .where(eq(userAliases.userId, userId));
+  return rows.map((r) => r.alias).sort();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("seedUserAliases", () => {
+  it("no-ops when no user with target email exists", async () => {
+    const email = testEmail("nonexistent");
+
+    // Should not throw.
+    await expect(
+      seedUserAliases(db, [{ email, aliases: CANONICAL_ALIASES, deprecated: DEPRECATED_ALIASES }]),
+    ).resolves.toBeUndefined();
+
+    // No alias rows inserted (user doesn't exist, seed should skip).
+    const [{ count }] = await db.execute<{ count: string }>(
+      sql`SELECT COUNT(*) AS count FROM user_aliases WHERE user_id IN (SELECT id FROM users WHERE email = ${email})`,
+    );
+    expect(Number(count)).toBe(0);
+  });
+
+  it("inserts all canonical aliases when user exists and aliases table is empty", async () => {
+    const email = testEmail("fresh");
+    const userId = await insertUser(email);
+
+    await seedUserAliases(db, [
+      { email, aliases: CANONICAL_ALIASES, deprecated: DEPRECATED_ALIASES },
+    ]);
+
+    const aliases = await getAliasesForUser(userId);
+    expect(aliases).toEqual([...CANONICAL_ALIASES].sort());
+    expect(aliases).toHaveLength(CANONICAL_ALIASES.length);
+  });
+
+  it("is idempotent — second run inserts 0 rows", async () => {
+    const email = testEmail("idempotent");
+    const userId = await insertUser(email);
+
+    const spec = [{ email, aliases: CANONICAL_ALIASES, deprecated: DEPRECATED_ALIASES }];
+
+    await seedUserAliases(db, spec);
+    // Second call — must not throw, must not duplicate.
+    await seedUserAliases(db, spec);
+
+    const aliases = await getAliasesForUser(userId);
+    // Still exactly the canonical set — no duplicates.
+    expect(aliases).toEqual([...CANONICAL_ALIASES].sort());
+    expect(aliases).toHaveLength(CANONICAL_ALIASES.length);
+  });
+
+  it("removes deprecated aliases and inserts canonical ones", async () => {
+    const email = testEmail("deprecated");
+    const userId = await insertUser(email);
+
+    // Pre-insert one deprecated alias before running the seed.
+    const deprecated0 = DEPRECATED_ALIASES[0];
+    await db.insert(userAliases).values({ userId, alias: deprecated0 });
+
+    await seedUserAliases(db, [
+      { email, aliases: CANONICAL_ALIASES, deprecated: DEPRECATED_ALIASES },
+    ]);
+
+    const aliases = await getAliasesForUser(userId);
+
+    // Canonical 3 are present.
+    expect(aliases).toEqual([...CANONICAL_ALIASES].sort());
+
+    // Deprecated alias is gone.
+    expect(aliases).not.toContain(deprecated0);
+  });
+
+  it("does NOT touch deprecated aliases belonging to a different user (tenant safety)", async () => {
+    // Main user: seed will clean their deprecated aliases.
+    const emailMain = testEmail("tenant-main");
+    const userIdMain = await insertUser(emailMain);
+
+    // Unrelated user who happens to share the same deprecated alias string —
+    // their row must be untouched (proves DELETE is scoped by user_id).
+    const emailOther = testEmail("tenant-other");
+    const userIdOther = await insertUser(emailOther);
+
+    const deprecated0 = DEPRECATED_ALIASES[0]; // e.g. "Alejandro Rafael"
+
+    // Pre-insert the deprecated alias for BOTH users.
+    await db.insert(userAliases).values([
+      { userId: userIdMain, alias: deprecated0 },
+      { userId: userIdOther, alias: deprecated0 },
+    ]);
+
+    // Run seed scoped to main user only.
+    await seedUserAliases(db, [
+      { email: emailMain, aliases: CANONICAL_ALIASES, deprecated: DEPRECATED_ALIASES },
+    ]);
+
+    // Main user: deprecated alias removed, canonical 3 present.
+    const mainAliases = await getAliasesForUser(userIdMain);
+    expect(mainAliases).toEqual([...CANONICAL_ALIASES].sort());
+    expect(mainAliases).not.toContain(deprecated0);
+
+    // Other user: their row is UNTOUCHED — proves tenant safety.
+    const otherAliases = await getAliasesForUser(userIdOther);
+    expect(otherAliases).toContain(deprecated0);
+  });
+});

--- a/src/lib/db/seed-user-aliases.ts
+++ b/src/lib/db/seed-user-aliases.ts
@@ -1,0 +1,132 @@
+// Permanent seed for user_aliases — canonical name variants used by the
+// cross-currency transfer pairer (#518) to recognise self-transfers in
+// ARQ email data.
+//
+// Design: TS function (NOT a drizzle migration) — matches the established
+// pattern of seedReferenceData / backfillUsersReferenceData / migratePagoTcToTransfer
+// and avoids the drizzle-snapshot-chain-gotcha (engram).
+//
+// Idempotency:
+//   - Canonical aliases: INSERT ... ON CONFLICT DO NOTHING
+//   - Deprecated aliases: DELETE WHERE alias IN (...) AND user_id = userId
+//
+// Tenant safety: all queries scope to userId — never operate on alias alone.
+
+import { and, eq, inArray } from "drizzle-orm";
+import { createLogger } from "@/lib/logger";
+import type { DB } from "./index";
+import { userAliases, users } from "./schema";
+
+const log = createLogger({ module: "seed-user-aliases" });
+
+type AliasSeedSpec = {
+  /** Email address used to look up the user. Skipped if no user found. */
+  email: string;
+  /** Canonical aliases to ensure exist. */
+  aliases: readonly string[];
+  /**
+   * Deprecated aliases to remove if present — typically ones that were
+   * manually inserted in dev/prod but are unsafe (no evidence, or name
+   * collides with a known third party).
+   */
+  deprecated: readonly string[];
+};
+
+/**
+ * Canonical alias set for the operator account.
+ *
+ * Validated against 11 real ARQ transactions in dev DB (2026-04-26):
+ *   - "Alejandro Rafael Martinez Maldonado" — appears verbatim in ARQ data
+ *   - "Alejandro Rafael Martinez" — plausible bank variant (drop second surname)
+ *   - "Alejandro Martinez Maldonado" — plausible bank variant (drop second given name)
+ *
+ * NOT included — reasons documented:
+ *   - "Alejandro Martinez": already matched via users.name in checkRecipientIsUser
+ *   - "Alejandro Rafael": no evidence in real data
+ *   - "Rafael Martinez": collides with user's father's name; would mislabel
+ *     third-party transfers as self-transfers
+ */
+export const USER_ALIAS_SEEDS: readonly AliasSeedSpec[] = [
+  {
+    email: "ing.amartinez94@gmail.com",
+    aliases: [
+      "Alejandro Rafael Martinez Maldonado",
+      "Alejandro Rafael Martinez",
+      "Alejandro Martinez Maldonado",
+    ],
+    deprecated: ["Alejandro Rafael", "Rafael Martinez"],
+  },
+];
+
+/**
+ * Upserts canonical user aliases and removes deprecated ones.
+ *
+ * Safe to call on every deploy — all operations are idempotent.
+ * Skips silently when no user with the target email exists (covers fresh
+ * dev DBs with a different BOOTSTRAP_USER_EMAIL).
+ *
+ * @param database  Drizzle DB instance.
+ * @param specs     Override the default USER_ALIAS_SEEDS — useful in tests
+ *                  to scope operations to a test-local user without touching
+ *                  the real operator account.
+ */
+export async function seedUserAliases(
+  database: DB,
+  specs: readonly AliasSeedSpec[] = USER_ALIAS_SEEDS,
+): Promise<void> {
+  for (const { email, aliases, deprecated } of specs) {
+    const userRows = await database
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+
+    if (userRows.length === 0) {
+      log.debug(
+        { email, event: "seed_user_aliases_user_not_found" },
+        "skipping alias seed; no user with email",
+      );
+      continue;
+    }
+
+    const userId = userRows[0].id;
+
+    // DELETE deprecated aliases (idempotent — no-op if already absent).
+    if (deprecated.length > 0) {
+      const removed = await database
+        .delete(userAliases)
+        .where(and(eq(userAliases.userId, userId), inArray(userAliases.alias, [...deprecated])))
+        .returning({ alias: userAliases.alias });
+
+      if (removed.length > 0) {
+        log.info(
+          {
+            userId,
+            removedCount: removed.length,
+            removed: removed.map((r) => r.alias),
+            event: "seed_user_aliases_deprecated_removed",
+          },
+          "removed deprecated user aliases",
+        );
+      }
+    }
+
+    // INSERT canonical aliases — ON CONFLICT DO NOTHING for idempotency.
+    const inserted = await database
+      .insert(userAliases)
+      .values(aliases.map((alias) => ({ userId, alias })))
+      .onConflictDoNothing()
+      .returning({ alias: userAliases.alias });
+
+    log.info(
+      {
+        userId,
+        email,
+        totalAliases: aliases.length,
+        insertedCount: inserted.length,
+        event: "seed_user_aliases_done",
+      },
+      "seeded user aliases",
+    );
+  }
+}

--- a/src/lib/db/seed-user-aliases.ts
+++ b/src/lib/db/seed-user-aliases.ts
@@ -13,7 +13,7 @@
 // Tenant safety: all queries scope to userId — never operate on alias alone.
 
 import { and, eq, inArray } from "drizzle-orm";
-import { createLogger } from "@/lib/logger";
+import { createLogger } from "../logger";
 import type { DB } from "./index";
 import { userAliases, users } from "./schema";
 
@@ -118,15 +118,22 @@ export async function seedUserAliases(
       .onConflictDoNothing()
       .returning({ alias: userAliases.alias });
 
-    log.info(
-      {
-        userId,
-        email,
-        totalAliases: aliases.length,
-        insertedCount: inserted.length,
-        event: "seed_user_aliases_done",
-      },
-      "seeded user aliases",
-    );
+    if (inserted.length > 0) {
+      log.info(
+        {
+          userId,
+          email,
+          totalAliases: aliases.length,
+          insertedCount: inserted.length,
+          event: "seed_user_aliases_done",
+        },
+        "seeded user aliases",
+      );
+    } else {
+      log.debug(
+        { userId, email, event: "seed_user_aliases_already_seeded" },
+        "user aliases already seeded; no inserts",
+      );
+    }
   }
 }

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -25,6 +25,7 @@ import {
 } from "./schema";
 import { copyCategorySeedsToUser, copyRuleSeedsToUser } from "@/lib/auth/signup";
 import { seedReferenceData } from "./seed-reference-data";
+import { seedUserAliases } from "./seed-user-aliases";
 import type { AccountType, Currency } from "@/lib/types";
 
 const log = createLogger({ module: "seed" });
@@ -268,6 +269,13 @@ export async function runSeed() {
       `${existingRuleCount} classification rules already present — skipping`,
     );
   }
+
+  // #538: seed canonical user aliases for cross-currency transfer pairing.
+  // Idempotent: skips if no matching email, removes deprecated aliases,
+  // inserts canonical ones via ON CONFLICT DO NOTHING.
+  log.info({ event: "seed_user_aliases_start" }, "seeding user aliases");
+  await seedUserAliases(db);
+  log.info({ event: "seed_user_aliases_done" }, "user aliases seeded");
 
   log.info({ event: "seed_done" }, "done");
 }


### PR DESCRIPTION
## Summary
- Permanent seed for `user_aliases` so the cross-currency transfer pairer (#518) recognises ARQ → Bancolombia self-transfers.
- 3 canonical aliases for `ing.amartinez94@gmail.com`: `Alejandro Rafael Martinez Maldonado` (validated against 11 real ARQ tx), plus two defensive variants (`Alejandro Rafael Martinez`, `Alejandro Martinez Maldonado`).
- Idempotent DELETE of 2 deprecated aliases (`Alejandro Rafael` and `Rafael Martinez`) to clean up any DB that had them — `Rafael Martinez` was unsafe because it collides with the user's father's name (would mislabel third-party transfers as self-transfers).
- Wired into `scripts/migrate-prod.ts` (prod) and `src/lib/db/seed.ts` (dev parity). Pure data — no schema changes.

## Test plan
- [x] Unit/integration: 5 tests in `src/lib/db/seed-user-aliases.test.ts` (no-user skip, fresh insert, idempotency, deprecated cleanup, tenant safety)
- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` clean (1680 specs across 133 files)
- [ ] CI green
- [ ] After merge: run `seedUserAliases` step on prod via the next deploy or one-off, then verify with `SELECT * FROM user_aliases WHERE user_id = (SELECT id FROM users WHERE email = 'ing.amartinez94@gmail.com')` — expect 3 rows.

Closes #538