### PR TITLE
fix(logger): guard process.stdout for Edge runtime (#541)

### DIFF
--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createLogger, logger } from "./logger";
+import { createLogger, logger, shouldPrettyPrint } from "./logger";
 
 describe("logger", () => {
   it("exposes the standard pino level methods", () => {
@@ -26,5 +26,19 @@ describe("logger", () => {
     const b = a.child({ userId: 42 });
     expect(b.bindings()).toMatchObject({ module: "telegram", userId: 42 });
     expect(a.bindings()).not.toHaveProperty("userId");
+  });
+
+  it("shouldPrettyPrint survives Edge runtime where process.stdout is undefined", () => {
+    // Auth.js v5 middleware (proxy.ts) bundles into Edge runtime, where
+    // `process.stdout` is undefined. Without optional chaining the dev server
+    // crashes the first time the logger module is touched.
+    const descriptor = Object.getOwnPropertyDescriptor(process, "stdout");
+    Object.defineProperty(process, "stdout", { value: undefined, configurable: true });
+    try {
+      expect(() => shouldPrettyPrint()).not.toThrow();
+      expect(shouldPrettyPrint()).toBe(false);
+    } finally {
+      if (descriptor) Object.defineProperty(process, "stdout", descriptor);
+    }
   });
 });

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -2,10 +2,10 @@ import pino, { type Logger, type LoggerOptions } from "pino";
 
 type Bindings = Record<string, unknown>;
 
-function shouldPrettyPrint(): boolean {
+export function shouldPrettyPrint(): boolean {
   if (process.env.NODE_ENV === "production") return false;
   if (process.env.CI) return false;
-  return Boolean(process.stdout.isTTY);
+  return Boolean(process.stdout?.isTTY);
 }
 
 function resolveLevel(): string {


### PR DESCRIPTION
Closes #541

## Summary
- Guard `process.stdout?.isTTY` in `shouldPrettyPrint()` so the Edge runtime bundle (pulled in by `proxy.ts → @/auth → @/lib/logger`) doesn't crash when `process.stdout` is undefined.
- Extend `src/lib/logger.test.ts` to cover the Edge case where `process.stdout` is missing.

## Why
Dev server crashed with `TypeError: Cannot read properties of undefined (reading 'isTTY')` on every authenticated route navigation. Prod was unaffected because `shouldPrettyPrint()` short-circuits on `NODE_ENV === "production"` and `CI` before reaching the broken line.

## Test plan
- [x] Vitest covers Edge case (process.stdout = undefined)
- [x] Existing logger tests still pass
- [x] Pre-push hook (lint + typecheck + tests) passed locally