### PR TITLE
fix(reconciliation): expand candidate window so same-day Gmail txs match (#543)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.test.ts
@@ -23,7 +23,8 @@ vi.mock("@/lib/auth/session", () => ({
   getSessionUser: vi.fn().mockImplementation(async () => sessionMock),
 }));
 
-const { previewReconcile, applyReconcile, expandReconcileWindow } = await import("./actions");
+const { previewReconcile, applyReconcile } = await import("./actions");
+const { expandReconcileWindow } = await import("./window");
 
 describe("expandReconcileWindow (#543)", () => {
   it("expands the period boundary by the match-engine tolerance on both sides", () => {

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.test.ts
@@ -23,7 +23,30 @@ vi.mock("@/lib/auth/session", () => ({
   getSessionUser: vi.fn().mockImplementation(async () => sessionMock),
 }));
 
-const { previewReconcile, applyReconcile } = await import("./actions");
+const { previewReconcile, applyReconcile, expandReconcileWindow } = await import("./actions");
+
+describe("expandReconcileWindow (#543)", () => {
+  it("expands the period boundary by the match-engine tolerance on both sides", () => {
+    // periodEnd at midnight Bogotá of 2026-04-26 = 2026-04-26T05:00:00Z
+    const periodStart = new Date("2026-04-01T05:00:00Z");
+    const periodEnd = new Date("2026-04-26T05:00:00Z");
+    const { windowStart, windowEnd } = expandReconcileWindow(periodStart, periodEnd);
+    // 3 days of slack matches DEFAULT_DATE_TOLERANCE_DAYS in match.ts
+    expect(windowStart.toISOString()).toBe("2026-03-29T05:00:00.000Z");
+    expect(windowEnd.toISOString()).toBe("2026-04-29T05:00:00.000Z");
+  });
+
+  it("a Gmail-captured tx at 21:33 Bogotá the same day as periodEnd falls inside the window", () => {
+    // periodEnd from XLSX = midnight Bogotá of 2026-04-26
+    const periodEnd = new Date("2026-04-26T05:00:00Z");
+    // Gmail tx recorded at 21:33 Bogotá of 2026-04-26 (= 02:33 UTC of 2026-04-27)
+    const gmailTx = new Date("2026-04-27T02:33:00Z");
+    // Without the fix this assertion would have failed: gmailTx > periodEnd in UTC
+    expect(gmailTx.getTime() > periodEnd.getTime()).toBe(true);
+    const { windowEnd } = expandReconcileWindow(new Date("2026-04-01T05:00:00Z"), periodEnd);
+    expect(gmailTx.getTime() <= windowEnd.getTime()).toBe(true);
+  });
+});
 
 // Builds a Mastercard-style TC xlsx (single sheet, 6 columns: Fecha,
 // Descripción, Fecha de corte, Valor, Tipo de moneda, Cuotas). When

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
@@ -13,10 +13,11 @@ import {
   recordReconciliationDecision,
 } from "@/lib/reconciliation/commit";
 import { parseAny } from "@/lib/reconciliation/dispatch";
-import { DEFAULT_DATE_TOLERANCE_DAYS, matchStatement } from "@/lib/reconciliation/engine/match";
+import { matchStatement } from "@/lib/reconciliation/engine/match";
 import type { ExistingTxnForMatch, MatchingPlan } from "@/lib/reconciliation/engine/types";
 import type { ParsedStatement } from "@/lib/reconciliation/parsers/types";
 import { createLogger } from "@/lib/logger";
+import { expandReconcileWindow } from "./window";
 
 const log = createLogger({ module: "reconciliation-actions" });
 
@@ -207,23 +208,6 @@ function rowsByCurrencyCount(parsed: ParsedStatement): Record<"COP" | "USD", num
   const counts: Record<"COP" | "USD", number> = { COP: 0, USD: 0 };
   for (const row of parsed.rows) counts[row.currency] += 1;
   return counts;
-}
-
-// The XLSX parser anchors every row at midnight Bogotá (05:00 UTC), so a
-// real tx recorded at 21:33 Bogotá the same day lives at 02:33 UTC the next
-// day — outside the raw [periodStart, periodEnd] range and therefore
-// invisible to the matcher, which then duplicates it. Three days of slack
-// also covers the legitimate gap between bank-side accounting date and
-// Gmail notification date.
-export function expandReconcileWindow(
-  periodStart: Date,
-  periodEnd: Date,
-): { windowStart: Date; windowEnd: Date } {
-  const toleranceMs = DEFAULT_DATE_TOLERANCE_DAYS * 86_400_000;
-  return {
-    windowStart: new Date(periodStart.getTime() - toleranceMs),
-    windowEnd: new Date(periodEnd.getTime() + toleranceMs),
-  };
 }
 
 async function loadExistingTxns(

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
@@ -13,7 +13,7 @@ import {
   recordReconciliationDecision,
 } from "@/lib/reconciliation/commit";
 import { parseAny } from "@/lib/reconciliation/dispatch";
-import { matchStatement } from "@/lib/reconciliation/engine/match";
+import { DEFAULT_DATE_TOLERANCE_DAYS, matchStatement } from "@/lib/reconciliation/engine/match";
 import type { ExistingTxnForMatch, MatchingPlan } from "@/lib/reconciliation/engine/types";
 import type { ParsedStatement } from "@/lib/reconciliation/parsers/types";
 import { createLogger } from "@/lib/logger";
@@ -209,12 +209,30 @@ function rowsByCurrencyCount(parsed: ParsedStatement): Record<"COP" | "USD", num
   return counts;
 }
 
+// The XLSX parser anchors every row at midnight Bogotá (05:00 UTC), so a
+// real tx recorded at 21:33 Bogotá the same day lives at 02:33 UTC the next
+// day — outside the raw [periodStart, periodEnd] range and therefore
+// invisible to the matcher, which then duplicates it. Three days of slack
+// also covers the legitimate gap between bank-side accounting date and
+// Gmail notification date.
+export function expandReconcileWindow(
+  periodStart: Date,
+  periodEnd: Date,
+): { windowStart: Date; windowEnd: Date } {
+  const toleranceMs = DEFAULT_DATE_TOLERANCE_DAYS * 86_400_000;
+  return {
+    windowStart: new Date(periodStart.getTime() - toleranceMs),
+    windowEnd: new Date(periodEnd.getTime() + toleranceMs),
+  };
+}
+
 async function loadExistingTxns(
   userId: number,
   accountId: number,
   periodStart: Date,
   periodEnd: Date,
 ): Promise<ExistingTxnForMatch[]> {
+  const { windowStart, windowEnd } = expandReconcileWindow(periodStart, periodEnd);
   const rows = await db
     .select({
       id: transactions.id,
@@ -232,8 +250,8 @@ async function loadExistingTxns(
       and(
         eq(transactions.userId, userId),
         eq(transactions.accountId, accountId),
-        gte(transactions.occurredAt, periodStart),
-        lte(transactions.occurredAt, periodEnd),
+        gte(transactions.occurredAt, windowStart),
+        lte(transactions.occurredAt, windowEnd),
         notDeleted(transactions.deletedAt),
       ),
     );

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/window.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/window.ts
@@ -1,0 +1,18 @@
+import { DEFAULT_DATE_TOLERANCE_DAYS } from "@/lib/reconciliation/engine/match";
+
+// The XLSX parser anchors every row at midnight Bogotá (05:00 UTC), so a
+// real tx recorded at 21:33 Bogotá the same day lives at 02:33 UTC the next
+// day — outside the raw [periodStart, periodEnd] range and therefore
+// invisible to the matcher, which then duplicates it. Three days of slack
+// also covers the legitimate gap between bank-side accounting date and
+// Gmail notification date.
+export function expandReconcileWindow(
+  periodStart: Date,
+  periodEnd: Date,
+): { windowStart: Date; windowEnd: Date } {
+  const toleranceMs = DEFAULT_DATE_TOLERANCE_DAYS * 86_400_000;
+  return {
+    windowStart: new Date(periodStart.getTime() - toleranceMs),
+    windowEnd: new Date(periodEnd.getTime() + toleranceMs),
+  };
+}

--- a/src/lib/reconciliation/engine/match.ts
+++ b/src/lib/reconciliation/engine/match.ts
@@ -1,7 +1,7 @@
 import type { ParsedStatementRow } from "../parsers/types";
 import type { ExistingTxnForMatch, MatchDecision, MatchingInput, MatchingPlan } from "./types";
 
-const DEFAULT_DATE_TOLERANCE_DAYS = 3;
+export const DEFAULT_DATE_TOLERANCE_DAYS = 3;
 const DEFAULT_MERCHANT_FUZZ_THRESHOLD = 0.5;
 const MS_PER_DAY = 86_400_000;
 


### PR DESCRIPTION
Closes #543

## Summary
- Expand `loadExistingTxns` query window by `DEFAULT_DATE_TOLERANCE_DAYS` so Gmail txs whose UTC timestamp falls in the next calendar day still surface as candidates for same-day statement rows.
- Export `DEFAULT_DATE_TOLERANCE_DAYS` from `engine/match.ts` and reuse the same tolerance the engine applies during scoring.
- Move the new `expandReconcileWindow` helper into a sibling `window.ts` so the parent `actions.ts` can stay `"use server"` (Next.js 16 rejects non-async exports from server-action files).
- Add focused test: parsed row at `2026-04-26T05:00:00Z` (midnight Bogotá) matches existing tx at `2026-04-27T02:33:00Z` (21:33 Bogotá same day).

## Why
Re-uploading a Bancolombia XLSX statement marked already-ingested same-day Gmail txs as `insert_new`. Root cause: `loadExistingTxns` filtered by `gte/lte(periodStart, periodEnd)` derived from `excelSerialToBogotaUtc` (midnight Bogotá), but Gmail txs carry the real timestamp — so a 21:33 Bogotá tx lands at `02:33 UTC next day`, outside the window. Match engine tolerated ±3 days but never saw the rows.

## Test plan
- [x] Pre-push hook (lint + typecheck + tests) passed locally
- [ ] Re-upload Bancolombia statement against existing data — confirm same-day Gmail txs now match instead of `insert_new`