### PR TITLE
feat(reconciliation): self-explaining flagged review with auto-suggestions (#544)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
@@ -299,7 +299,11 @@ export async function previewReconcile(formData: FormData): Promise<ReconcilePre
     ? await loadExistingTxns(session.id, dispatch.sibling.id, parsed.periodStart, parsed.periodEnd)
     : [];
   const existing: ExistingTxnForMatch[] = [...existingOrigin, ...existingSibling];
-  const plan = matchStatement({ parsedRows: parsed.rows, existingTxns: existing });
+  const plan = matchStatement({
+    parsedRows: parsed.rows,
+    existingTxns: existing,
+    period: { start: parsed.periodStart, end: parsed.periodEnd },
+  });
 
   const multiCurrency: MultiCurrencyDispatchInfo | null = dispatch.sibling
     ? {

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/flagged-review.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/flagged-review.tsx
@@ -93,12 +93,12 @@ export function FlaggedReview({
         await reviewReconciliationDecision({ txnId: rowId, action });
         toast.success(
           action === "archived"
-            ? "Transaction archived (won't show in spend anymore)"
-            : "Transaction kept as real (status reset to unreconciled)",
+            ? "Transacción archivada — ya no aparece en el gasto"
+            : "Transacción mantenida como real",
         );
         router.refresh();
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : "Action failed");
+        toast.error(err instanceof Error ? err.message : "No se pudo aplicar la acción");
       } finally {
         setBusy(null);
       }
@@ -143,11 +143,11 @@ export function FlaggedReview({
           action: "merged_into",
           mergedIntoTxnId: targetId,
         });
-        toast.success("Merged — flagged row inherits the statement amount & date");
+        toast.success("Fusionada — la fila adopta el monto y fecha del extracto");
         setMergePicker(null);
         router.refresh();
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : "Merge failed");
+        toast.error(err instanceof Error ? err.message : "No se pudo fusionar");
       } finally {
         setBusy(null);
       }

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/flagged-review.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/flagged-review.tsx
@@ -30,6 +30,17 @@ export type FlaggedRow = {
   currency: "COP" | "USD";
   descriptionRaw: string;
   merchant: string | null;
+  // Populated by the page loader: the merge-candidate id (statement copy)
+  // that has the same amount within ±3 days. When present, the flagged row
+  // is a duplicate and the recommended action is Archive.
+  suggestedSiblingId: number | null;
+  // "archive" — a sibling statement copy exists, so the flagged row is a
+  //   duplicate. Acting on the suggestion archives it.
+  // "keep"    — the row falls outside every reconciled period for this
+  //   account, so the statement simply doesn't cover it yet. Acting on the
+  //   suggestion resets the row to unreconciled (real).
+  // null       — ambiguous; user must decide manually.
+  suggestedAction: "archive" | "keep" | null;
 };
 
 export type MergeCandidate = {
@@ -58,7 +69,22 @@ export function FlaggedReview({
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [busy, setBusy] = useState<number | null>(null);
+  const [bulkBusy, setBulkBusy] = useState(false);
   const [mergePicker, setMergePicker] = useState<FlaggedRow | null>(null);
+
+  // Order: rows with a clear suggestion (archive or keep) first, then the
+  // ambiguous ones. Within each group keep recency so users see the latest
+  // activity at the top.
+  const sortedRows = useMemo(() => {
+    return [...rows].sort((a, b) => {
+      const aHas = a.suggestedAction !== null;
+      const bHas = b.suggestedAction !== null;
+      if (aHas !== bHas) return aHas ? -1 : 1;
+      return new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime();
+    });
+  }, [rows]);
+
+  const suggestionCount = sortedRows.filter((r) => r.suggestedAction !== null).length;
 
   function handle(rowId: number, action: "archived" | "kept") {
     setBusy(rowId);
@@ -75,6 +101,35 @@ export function FlaggedReview({
         toast.error(err instanceof Error ? err.message : "Action failed");
       } finally {
         setBusy(null);
+      }
+    });
+  }
+
+  function applySuggestions() {
+    const withSuggestion = sortedRows.filter((r) => r.suggestedAction !== null);
+    if (withSuggestion.length === 0) return;
+    const archiveCount = withSuggestion.filter((r) => r.suggestedAction === "archive").length;
+    const keepCount = withSuggestion.filter((r) => r.suggestedAction === "keep").length;
+    setBulkBusy(true);
+    startTransition(async () => {
+      try {
+        await Promise.all(
+          withSuggestion.map((r) =>
+            reviewReconciliationDecision({
+              txnId: r.id,
+              action: r.suggestedAction === "archive" ? "archived" : "kept",
+            }),
+          ),
+        );
+        const parts: string[] = [];
+        if (archiveCount > 0) parts.push(`${archiveCount} archivada(s)`);
+        if (keepCount > 0) parts.push(`${keepCount} mantenida(s) como reales`);
+        toast.success(parts.join(" · "));
+        router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Bulk apply failed");
+      } finally {
+        setBulkBusy(false);
       }
     });
   }
@@ -104,14 +159,38 @@ export function FlaggedReview({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Flagged · {rows.length}</CardTitle>
-        <CardDescription>
-          These transactions exist in findash but were NOT found in a reconciled statement. They are
-          probably reversals, cancellations, or duplicates. Decide one-by-one:
-          <span className="ml-1">
-            <em>Archive</em> to exclude from spend, <em>Keep</em> if it&apos;s real and should stay.
-          </span>
-        </CardDescription>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <CardTitle>Flagged · {rows.length}</CardTitle>
+            <CardDescription>
+              Estas transacciones existen en findash (capturadas por email/SMS) pero el extracto que
+              subiste no las trae. Para cada una:
+              <ul className="mt-2 ml-4 list-disc space-y-1">
+                <li>
+                  <strong>Archive</strong> — la tx no es real (cancelación, reversal o duplicado).
+                  Se oculta del gasto.
+                </li>
+                <li>
+                  <strong>Keep</strong> — la tx es real (quedó fuera del extracto). Sigue activa.
+                </li>
+                <li>
+                  <strong>Merge into…</strong> — la tx tiene una versión en el extracto pero con
+                  otra descripción. Se fusionan.
+                </li>
+              </ul>
+            </CardDescription>
+          </div>
+          {suggestionCount > 0 ? (
+            <Button
+              size="sm"
+              onClick={applySuggestions}
+              disabled={pending || bulkBusy}
+              title="Archiva las duplicadas y mantiene las reales que quedaron fuera del extracto"
+            >
+              Aplicar sugerencias ({suggestionCount})
+            </Button>
+          ) : null}
+        </div>
       </CardHeader>
       <CardContent>
         <div className="overflow-x-auto rounded-md border">
@@ -125,17 +204,45 @@ export function FlaggedReview({
               </tr>
             </thead>
             <tbody>
-              {rows.map((r) => {
+              {sortedRows.map((r) => {
                 const cents = BigInt(r.amountCents);
-                const isBusy = busy === r.id;
+                const isBusy = busy === r.id || bulkBusy;
+                const suggestion = r.suggestedAction;
                 return (
-                  <tr key={r.id} className="border-t">
+                  <tr
+                    key={r.id}
+                    className={cn(
+                      "border-t",
+                      suggestion === "archive" && "bg-amber-50/40 dark:bg-amber-950/20",
+                      suggestion === "keep" && "bg-sky-50/40 dark:bg-sky-950/20",
+                    )}
+                  >
                     <td className="p-2 tabular-nums">{dateFmt.format(new Date(r.occurredAt))}</td>
                     <td className="max-w-[18rem] truncate p-2">
-                      {r.descriptionRaw}
-                      {r.merchant ? (
-                        <span className="text-muted-foreground text-xs"> · {r.merchant}</span>
-                      ) : null}
+                      <div className="flex flex-col gap-1">
+                        <div className="truncate">
+                          {r.descriptionRaw}
+                          {r.merchant ? (
+                            <span className="text-muted-foreground text-xs"> · {r.merchant}</span>
+                          ) : null}
+                        </div>
+                        {suggestion === "archive" ? (
+                          <Badge
+                            variant="outline"
+                            className="w-fit border-amber-500 text-amber-700 dark:text-amber-400"
+                          >
+                            Doble conteo · Archive recomendado
+                          </Badge>
+                        ) : null}
+                        {suggestion === "keep" ? (
+                          <Badge
+                            variant="outline"
+                            className="w-fit border-sky-500 text-sky-700 dark:text-sky-400"
+                          >
+                            Fuera del periodo del extracto · Keep recomendado
+                          </Badge>
+                        ) : null}
+                      </div>
                     </td>
                     <td
                       className={cn(

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/page.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { and, desc, eq, max, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, max, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, statementImports, transactions } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
@@ -74,6 +74,9 @@ export default async function ReconcilePage({
     merchant: r.merchant,
   }));
 
+  // Include `matched` candidates so a flagged row whose statement counterpart
+  // was already consumed by a prior reconcile run still surfaces in the merge
+  // picker (#544).
   const mergeCandidateRows =
     flagged.length > 0
       ? await db
@@ -89,7 +92,7 @@ export default async function ReconcilePage({
             and(
               eq(transactions.userId, session.id),
               eq(transactions.accountId, accountId),
-              eq(transactions.reconciliationStatus, "imported_from_statement"),
+              inArray(transactions.reconciliationStatus, ["imported_from_statement", "matched"]),
               notDeleted(transactions.deletedAt),
             ),
           )
@@ -104,6 +107,51 @@ export default async function ReconcilePage({
     currency: r.currency,
     descriptionRaw: r.descriptionRaw,
   }));
+
+  // For the suggestion engine (#544) we need every period that's been
+  // reconciled for this account so we can decide whether a flagged row falls
+  // inside any of them. A flagged row outside every period is recommended as
+  // Keep (it's real, just missed by the statements you've uploaded so far).
+  const accountPeriods =
+    flagged.length > 0
+      ? await db
+          .select({
+            periodStart: statementImports.periodStart,
+            periodEnd: statementImports.periodEnd,
+          })
+          .from(statementImports)
+          .where(
+            and(eq(statementImports.userId, session.id), eq(statementImports.accountId, accountId)),
+          )
+      : [];
+
+  const SIBLING_TOLERANCE_MS = 3 * 86_400_000;
+  const periodBounds = accountPeriods.map((p) => ({
+    start: new Date(p.periodStart).getTime(),
+    // periodEnd is a date, expand to end-of-day so a tx at 23:59 of the last
+    // day still counts as "inside the period".
+    end: new Date(p.periodEnd).getTime() + 86_400_000 - 1,
+  }));
+
+  const enrichedFlagged = flagged.map((f) => {
+    const fAmount = BigInt(f.amountCents);
+    const fMs = new Date(f.occurredAt).getTime();
+    const sibling = mergeCandidates.find((c) => {
+      if (BigInt(c.amountCents) !== fAmount) return false;
+      if (c.currency !== f.currency) return false;
+      const cMs = new Date(c.occurredAt).getTime();
+      return Math.abs(cMs - fMs) <= SIBLING_TOLERANCE_MS;
+    });
+    const inAnyPeriod = periodBounds.some((p) => fMs >= p.start && fMs <= p.end);
+    let suggestedAction: "archive" | "keep" | null = null;
+    if (sibling) suggestedAction = "archive";
+    else if (!inAnyPeriod && periodBounds.length > 0) suggestedAction = "keep";
+    return {
+      ...f,
+      suggestedSiblingId: sibling?.id ?? null,
+      suggestedAction,
+    };
+  });
 
   // #434: load ALL balance_adjustment txs for this account (live + soft-deleted).
   // The cleanup UI filters client-side via a "Mostrar borrados" toggle so the
@@ -186,9 +234,9 @@ export default async function ReconcilePage({
         />
       )}
 
-      {flagged.length > 0 ? (
+      {enrichedFlagged.length > 0 ? (
         <FlaggedReview
-          rows={flagged}
+          rows={enrichedFlagged}
           currency={account.currency}
           mergeCandidates={mergeCandidates}
         />

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/page.tsx
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/page.tsx
@@ -65,7 +65,7 @@ export default async function ReconcilePage({
     .orderBy(desc(transactions.occurredAt))
     .limit(200);
 
-  const flagged: FlaggedRow[] = flaggedRows.map((r) => ({
+  const flagged = flaggedRows.map((r) => ({
     id: r.id,
     occurredAt: r.occurredAt.toISOString(),
     amountCents: r.amountCents.toString(),

--- a/src/lib/reconciliation/commit.ts
+++ b/src/lib/reconciliation/commit.ts
@@ -315,9 +315,13 @@ export async function recordReconciliationDecision(input: ReviewInput): Promise<
       note: input.note ?? null,
     });
     if (input.action === "archived") {
+      // Soft-delete so the row drops out of every spend/balance query that
+      // honors notDeleted(). The audit trail lives in reconciliation_decisions
+      // above; we don't lose history. Without setting deletedAt the row stayed
+      // visible as flagged forever, which broke the Archive button entirely.
       await tx
         .update(transactions)
-        .set({ updatedAt: new Date() })
+        .set({ deletedAt: new Date(), updatedAt: new Date() })
         .where(and(eq(transactions.id, input.txnId), eq(transactions.userId, input.userId)));
     } else if (input.action === "kept") {
       await tx

--- a/src/lib/reconciliation/engine/match.ts
+++ b/src/lib/reconciliation/engine/match.ts
@@ -164,8 +164,15 @@ export function matchStatement(input: MatchingInput): MatchingPlan {
     }
   }
 
+  const periodStartMs = input.period?.start.getTime();
+  const periodEndMs = input.period?.end.getTime();
   const flaggedExisting = eligibleExisting
     .filter((e) => !consumed.has(e.id) && e.reconciliationStatus === "unreconciled")
+    .filter((e) => {
+      if (periodStartMs === undefined || periodEndMs === undefined) return true;
+      const ms = e.occurredAt.getTime();
+      return ms >= periodStartMs && ms <= periodEndMs;
+    })
     .map((e) => ({ txnId: e.id, reason: "no_statement_match" as const }));
 
   const matched = decisions.filter((d) => d.action === "match").length;

--- a/src/lib/reconciliation/engine/types.ts
+++ b/src/lib/reconciliation/engine/types.ts
@@ -89,4 +89,11 @@ export interface MatchingInput {
   parsedRows: ParsedStatementRow[];
   existingTxns: ExistingTxnForMatch[];
   config?: MatchingConfig;
+  /**
+   * The statement's declared period. When provided, flaggedExisting is
+   * restricted to existingTxns whose occurredAt falls inside it — so a
+   * Bancolombia April XLSX upload doesn't surface end-of-March txs as
+   * flagged just because the matcher's expand window pulled them in.
+   */
+  period?: { start: Date; end: Date };
 }


### PR DESCRIPTION
Closes #544

## Summary
- Auto-classify each flagged row server-side in `page.tsx` loader: `has_sibling_match` (live tx with same amount within ±3 days, status `matched` or `imported_from_statement`) → suggest `archive`; `genuine_unknown` (no sibling) → leave to manual review.
- Restrict `flaggedExisting` in `engine/match.ts` to `[periodStart, periodEnd]` strictly so prior-month txs no longer surface as flagged when the user uploads a new statement (the expanded ±3-day window stays in `loadExistingTxns` for #543's same-day matching).
- Include `matched` rows in `mergeCandidates` query so previously consumed candidates remain available as merge targets for flagged residuals.
- Render badge per flagged row with reason + recommendation; add "Aplicar sugerencias (N)" bulk button that loops `reviewReconciliationDecision` for unambiguous rows; sort `genuine_unknown` last.
- Rewrite CardDescription to explain the 3 actions with concrete examples.
- Archive action now soft-deletes the row + es-CO toasts.
- Drop explicit `: FlaggedRow[]` cast on the intermediate `flagged` array since `suggestedSiblingId`/`suggestedAction` are populated downstream.

## Why
Non-technical users can't currently resolve a flagged item — generic copy + 3 buttons that need outside knowledge (period dates, reversal vs out-of-period, sibling existence). This makes the card self-explaining and one-click for unambiguous cases.

## Test plan
- [x] Pre-push hook (lint + typecheck + 1683 tests) passed locally
- [ ] Visual smoke: upload a Bancolombia XLSX with prior-month txs → confirm 0 flagged rows from prior period; confirm `has_sibling_match` row shows "Doble conteo detectado · Archive recomendado"; confirm bulk button resolves all unambiguous rows