### PR TITLE
feat(cron): HTTP route for email_received_at backfill (#553)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,15 +98,11 @@ jobs:
           # Overlay migrate-prod + backfill scripts under scripts/ preserving
           # dev layout so their relative `../src/...` imports resolve the same
           # way on prod as in local runs.
-          mkdir -p "$STAGE/scripts" "$STAGE/src/lib/db" "$STAGE/src/lib/auth" "$STAGE/src/lib/gmail" "$STAGE/src/lib/crypto"
+          mkdir -p "$STAGE/scripts" "$STAGE/src/lib/db" "$STAGE/src/lib/auth"
           cp scripts/migrate-prod.ts "$STAGE/scripts/migrate-prod.ts"
           cp scripts/backfill-users-reference.ts "$STAGE/scripts/backfill-users-reference.ts"
           # #405: migrate-prod also calls the pago-tc → transfer-group backfill.
           cp scripts/migrate-pago-tc-to-transfer.ts "$STAGE/scripts/migrate-pago-tc-to-transfer.ts"
-          # #545/#551: one-shot backfill for legacy email_receipts that were
-          # inserted before the internalDate fix landed. Idempotent — re-runs
-          # are no-ops once email_received_at is populated.
-          cp scripts/backfill-email-received-at.ts "$STAGE/scripts/backfill-email-received-at.ts"
           # migrate-prod imports these for reference-data seeding + per-user
           # backfill; they live under src/ and are NOT traced by Next
           # standalone, so overlay them explicitly.
@@ -117,12 +113,6 @@ jobs:
           cp src/lib/db/seed-user-aliases.ts "$STAGE/src/lib/db/seed-user-aliases.ts"
           cp src/lib/auth/signup.ts "$STAGE/src/lib/auth/signup.ts"
           cp src/lib/logger.ts "$STAGE/src/lib/logger.ts"
-          # #551: backfill-email-received-at imports gmail/client (which
-          # transitively pulls db/helpers + crypto/gmail-cipher + crypto/symmetric).
-          cp src/lib/gmail/client.ts "$STAGE/src/lib/gmail/client.ts"
-          cp src/lib/db/helpers.ts "$STAGE/src/lib/db/helpers.ts"
-          cp src/lib/crypto/gmail-cipher.ts "$STAGE/src/lib/crypto/gmail-cipher.ts"
-          cp src/lib/crypto/symmetric.ts "$STAGE/src/lib/crypto/symmetric.ts"
           echo "$GIT_SHA" > "$STAGE/GIT_SHA"
           tar -czf release.tar.gz -C "$STAGE" .
           ls -lh release.tar.gz

--- a/src/app/api/cron/backfill-email-received-at/route.test.ts
+++ b/src/app/api/cron/backfill-email-received-at/route.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BackfillReport } from "@/lib/gmail/backfill-received-at";
+
+const mocks = vi.hoisted(() => ({
+  backfillEmailReceivedAt: vi.fn<(opts: Record<string, unknown>) => Promise<BackfillReport>>(),
+}));
+
+vi.mock("@/lib/gmail/backfill-received-at", () => ({
+  backfillEmailReceivedAt: mocks.backfillEmailReceivedAt,
+}));
+
+const { POST } = await import("./route");
+
+const VALID_TOKEN = "test-cron-token";
+
+function makeRequest(opts: { token?: string | null; body?: unknown }): Request {
+  const headers: Record<string, string> = {};
+  if (opts.token !== null) {
+    headers["authorization"] = `Bearer ${opts.token ?? VALID_TOKEN}`;
+  }
+  let bodyStr: string | undefined;
+  if (opts.body !== undefined) {
+    headers["content-type"] = "application/json";
+    bodyStr = JSON.stringify(opts.body);
+  }
+  return new Request("http://localhost/api/cron/backfill-email-received-at", {
+    method: "POST",
+    headers,
+    body: bodyStr,
+  });
+}
+
+function emptyReport(dryRun = false): BackfillReport {
+  return {
+    dryRun,
+    totals: { total: 0, fetched: 0, receiptsUpdated: 0, txsUpdated: 0, errors: 0 },
+    perUser: [],
+  };
+}
+
+beforeEach(() => {
+  process.env.CRON_TOKEN = VALID_TOKEN;
+  vi.clearAllMocks();
+  mocks.backfillEmailReceivedAt.mockResolvedValue(emptyReport());
+});
+
+describe("POST /api/cron/backfill-email-received-at — auth", () => {
+  it("returns 401 when Authorization header is missing", async () => {
+    const res = await POST(makeRequest({ token: null }));
+    expect(res.status).toBe(401);
+    expect(mocks.backfillEmailReceivedAt).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when CRON_TOKEN does not match", async () => {
+    const res = await POST(makeRequest({ token: "wrong-token" }));
+    expect(res.status).toBe(401);
+    expect(mocks.backfillEmailReceivedAt).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when CRON_TOKEN is not configured", async () => {
+    delete process.env.CRON_TOKEN;
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/cron/backfill-email-received-at — body validation", () => {
+  it("accepts empty body and defaults to non-dry-run, all users", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(200);
+    expect(mocks.backfillEmailReceivedAt).toHaveBeenCalledOnce();
+    const [opts] = mocks.backfillEmailReceivedAt.mock.calls[0];
+    expect(opts).toEqual({ dryRun: false });
+  });
+
+  it("returns 400 when userId is negative", async () => {
+    const res = await POST(makeRequest({ body: { userId: -1 } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when batchSize exceeds 100", async () => {
+    const res = await POST(makeRequest({ body: { batchSize: 101 } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when sleepMs is negative", async () => {
+    const res = await POST(makeRequest({ body: { sleepMs: -1 } }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/cron/backfill-email-received-at — happy path", () => {
+  it("forwards options and returns the report", async () => {
+    const report: BackfillReport = {
+      dryRun: true,
+      totals: { total: 5, fetched: 5, receiptsUpdated: 0, txsUpdated: 0, errors: 0 },
+      perUser: [{ userId: 1, total: 5, fetched: 5, receiptsUpdated: 0, txsUpdated: 0, errors: 0 }],
+    };
+    mocks.backfillEmailReceivedAt.mockResolvedValue(report);
+
+    const res = await POST(
+      makeRequest({ body: { dryRun: true, userId: 1, batchSize: 50, sleepMs: 100 } }),
+    );
+    expect(res.status).toBe(200);
+    expect(mocks.backfillEmailReceivedAt).toHaveBeenCalledWith({
+      dryRun: true,
+      userId: 1,
+      batchSize: 50,
+      sleepMs: 100,
+    });
+    const json = (await res.json()) as { ok: boolean } & BackfillReport;
+    expect(json.ok).toBe(true);
+    expect(json.dryRun).toBe(true);
+    expect(json.totals.total).toBe(5);
+    expect(json.perUser[0].userId).toBe(1);
+  });
+
+  it("returns 500 when the backfill function throws", async () => {
+    mocks.backfillEmailReceivedAt.mockRejectedValue(new Error("boom"));
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/cron/backfill-email-received-at/route.ts
+++ b/src/app/api/cron/backfill-email-received-at/route.ts
@@ -1,0 +1,82 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { backfillEmailReceivedAt } from "@/lib/gmail/backfill-received-at";
+import { createLogger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// #553 — one-shot HTTP trigger to populate email_receipts.email_received_at
+// from Gmail's internalDate for legacy receipts ingested before #545.
+//
+// Lives as a cron route (not a script) because googleapis is bundled inside
+// .next/chunks by Turbopack and isn't reachable from external scripts.
+
+const log = createLogger({ module: "api/cron/backfill-email-received-at" });
+
+const BodySchema = z.object({
+  dryRun: z.boolean().optional().default(false),
+  userId: z.number().int().positive().optional(),
+  batchSize: z.number().int().positive().max(100).optional(),
+  sleepMs: z.number().int().min(0).max(60_000).optional(),
+});
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+function resolveToken(req: Request): string | null {
+  const header = req.headers.get("authorization");
+  if (!header?.startsWith("Bearer ")) return null;
+  return header.slice(7).trim() || null;
+}
+
+export async function POST(req: Request) {
+  const expected = process.env.CRON_TOKEN;
+  if (!expected) {
+    return NextResponse.json({ error: "CRON_TOKEN not configured" }, { status: 500 });
+  }
+  const provided = resolveToken(req);
+  if (!provided || !constantTimeEquals(provided, expected)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let payload: z.infer<typeof BodySchema>;
+  try {
+    const body = await req.json().catch(() => ({}));
+    const parsed = BodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "invalid body", details: parsed.error.format() },
+        { status: 400 },
+      );
+    }
+    payload = parsed.data;
+  } catch {
+    return NextResponse.json({ error: "bad request" }, { status: 400 });
+  }
+
+  try {
+    const report = await backfillEmailReceivedAt(payload);
+    log.info(
+      {
+        dryRun: report.dryRun,
+        userIdFilter: payload.userId ?? null,
+        ...report.totals,
+        event: "backfill_received_at_http_completed",
+      },
+      "email_received_at backfill via HTTP cron",
+    );
+    return NextResponse.json({ ok: true, ...report });
+  } catch (err) {
+    log.error(
+      { err, payload, event: "backfill_received_at_http_failed" },
+      "email_received_at backfill route threw",
+    );
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
+  }
+}

--- a/src/lib/gmail/backfill-received-at.ts
+++ b/src/lib/gmail/backfill-received-at.ts
@@ -1,71 +1,57 @@
-/**
- * Backfill script: populate email_receipts.email_received_at from Gmail's
- * `internalDate` for receipts ingested before #545.
- *
- * Also corrects transactions.occurred_at when the receipt is matched to a
- * transaction (matched_transaction_id IS NOT NULL) AND that transaction's
- * source is `gmail_arq` or `gmail_*` — i.e. cases where the original wrong
- * occurred_at came from the receipt-pull's createdAt fallback.
- *
- * Idempotent: re-running skips receipts that already have email_received_at.
- *
- * CLI flags:
- *   --dry-run           Print what would change without writing.
- *   --user-id=N         Only process receipts for user N (otherwise all users).
- *   --batch-size=N      Receipts fetched per Gmail API tick (default 25).
- *   --sleep-ms=N        Delay between batches to stay under quota (default 200).
- *
- * Usage:
- *   bun scripts/backfill-email-received-at.ts --dry-run
- *   bun scripts/backfill-email-received-at.ts --user-id=1
- *   bun scripts/backfill-email-received-at.ts
- */
+// #553 — Backfill module: populate email_receipts.email_received_at from
+// Gmail's `internalDate` for receipts ingested before #545. Also corrects
+// transactions.occurred_at when the receipt is matched to a tx whose source
+// is gmail_* — those rows took the wrong cron-run timestamp from the
+// receivedAt fallback.
+//
+// Idempotent: receipts with email_received_at already set are skipped.
+// Exposed via /api/cron/backfill-email-received-at.
 
 import { and, eq, isNull, sql } from "drizzle-orm";
-import { db } from "../src/lib/db";
-import { emailReceipts, transactions } from "../src/lib/db/schema";
-import { getAuthedClient, isInvalidGrantError } from "../src/lib/gmail/client";
-import { createLogger } from "../src/lib/logger";
+import { db } from "@/lib/db";
+import { emailReceipts, transactions } from "@/lib/db/schema";
+import { getAuthedClient, isInvalidGrantError } from "@/lib/gmail/client";
+import { createLogger } from "@/lib/logger";
 
-const log = createLogger({ module: "backfill-email-received-at" });
+const log = createLogger({ module: "gmail/backfill-received-at" });
 
-// ---------------------------------------------------------------------------
-// CLI argument parsing
-// ---------------------------------------------------------------------------
-
-const args = process.argv.slice(2);
-const DRY_RUN = args.includes("--dry-run");
-const USER_ID_ARG = args.find((a) => a.startsWith("--user-id="));
-const BATCH_SIZE_ARG = args.find((a) => a.startsWith("--batch-size="));
-const SLEEP_MS_ARG = args.find((a) => a.startsWith("--sleep-ms="));
-
-const userIdFilter: number | null = USER_ID_ARG ? Number(USER_ID_ARG.split("=")[1]) : null;
-const batchSize: number = BATCH_SIZE_ARG ? Number(BATCH_SIZE_ARG.split("=")[1]) : 25;
-const sleepMs: number = SLEEP_MS_ARG ? Number(SLEEP_MS_ARG.split("=")[1]) : 200;
-
-if (userIdFilter !== null && (!Number.isFinite(userIdFilter) || userIdFilter <= 0)) {
-  log.error({ userIdArg: USER_ID_ARG }, "--user-id must be a positive integer");
-  process.exit(1);
-}
-if (!Number.isFinite(batchSize) || batchSize <= 0) {
-  log.error({ batchSizeArg: BATCH_SIZE_ARG }, "--batch-size must be a positive integer");
-  process.exit(1);
+export interface BackfillOptions {
+  dryRun?: boolean;
+  userId?: number;
+  batchSize?: number;
+  sleepMs?: number;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
-interface UserStats {
+export interface UserStats {
   userId: number;
   total: number;
   fetched: number;
   receiptsUpdated: number;
   txsUpdated: number;
   errors: number;
+  aborted?: "invalid_grant" | "no_connection";
 }
 
-async function backfillUser(userId: number): Promise<UserStats> {
+export interface BackfillReport {
+  dryRun: boolean;
+  totals: {
+    total: number;
+    fetched: number;
+    receiptsUpdated: number;
+    txsUpdated: number;
+    errors: number;
+  };
+  perUser: UserStats[];
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function backfillUser(
+  userId: number,
+  opts: Required<Omit<BackfillOptions, "userId">>,
+): Promise<UserStats> {
   const stats: UserStats = {
     userId,
     total: 0,
@@ -83,6 +69,7 @@ async function backfillUser(userId: number): Promise<UserStats> {
       { err, userId, event: "gmail_client_unavailable" },
       "user has no usable Gmail connection; skipping",
     );
+    stats.aborted = "no_connection";
     return stats;
   }
 
@@ -99,12 +86,12 @@ async function backfillUser(userId: number): Promise<UserStats> {
   if (pending.length === 0) return stats;
 
   log.info(
-    { userId, total: pending.length, dryRun: DRY_RUN, event: "backfill_user_start" },
+    { userId, total: pending.length, dryRun: opts.dryRun, event: "backfill_user_start" },
     "starting backfill for user",
   );
 
-  for (let i = 0; i < pending.length; i += batchSize) {
-    const batch = pending.slice(i, i + batchSize);
+  for (let i = 0; i < pending.length; i += opts.batchSize) {
+    const batch = pending.slice(i, i + opts.batchSize);
 
     for (const receipt of batch) {
       try {
@@ -133,7 +120,7 @@ async function backfillUser(userId: number): Promise<UserStats> {
         }
         const emailReceivedAt = new Date(ms);
 
-        if (DRY_RUN) {
+        if (opts.dryRun) {
           log.info(
             {
               userId,
@@ -152,8 +139,6 @@ async function backfillUser(userId: number): Promise<UserStats> {
           .where(and(eq(emailReceipts.id, receipt.id), eq(emailReceipts.userId, userId)));
         stats.receiptsUpdated++;
 
-        // If the receipt is matched to a tx whose source is gmail_*, the tx's
-        // occurred_at was set from the wrong receivedAt fallback. Correct it.
         if (receipt.matchedTxnId !== null) {
           const updated = await db
             .update(transactions)
@@ -175,6 +160,7 @@ async function backfillUser(userId: number): Promise<UserStats> {
             { err, userId, event: "invalid_grant_abort" },
             "Gmail token invalid for this user; aborting backfill for this user",
           );
+          stats.aborted = "invalid_grant";
           return stats;
         }
         log.error(
@@ -184,17 +170,28 @@ async function backfillUser(userId: number): Promise<UserStats> {
       }
     }
 
-    if (i + batchSize < pending.length) await sleep(sleepMs);
+    if (i + opts.batchSize < pending.length) await sleep(opts.sleepMs);
   }
 
   return stats;
 }
 
-async function main() {
-  log.info({ dryRun: DRY_RUN, userIdFilter, batchSize, sleepMs }, "backfill start");
+export async function backfillEmailReceivedAt(
+  options: BackfillOptions = {},
+): Promise<BackfillReport> {
+  const opts = {
+    dryRun: options.dryRun ?? false,
+    batchSize: options.batchSize ?? 25,
+    sleepMs: options.sleepMs ?? 200,
+  };
 
-  const userIds: number[] = userIdFilter
-    ? [userIdFilter]
+  log.info(
+    { ...opts, userIdFilter: options.userId ?? null, event: "backfill_start" },
+    "backfill start",
+  );
+
+  const userIds: number[] = options.userId
+    ? [options.userId]
     : (
         await db
           .selectDistinct({ userId: emailReceipts.userId })
@@ -202,14 +199,16 @@ async function main() {
           .where(isNull(emailReceipts.emailReceivedAt))
       ).map((r) => r.userId);
 
+  const totals = { total: 0, fetched: 0, receiptsUpdated: 0, txsUpdated: 0, errors: 0 };
+  const perUser: UserStats[] = [];
+
   if (userIds.length === 0) {
     log.info({ event: "nothing_to_backfill" }, "no receipts with NULL email_received_at");
-    return;
+    return { dryRun: opts.dryRun, totals, perUser };
   }
 
-  const totals = { total: 0, fetched: 0, receiptsUpdated: 0, txsUpdated: 0, errors: 0 };
   for (const uid of userIds) {
-    const s = await backfillUser(uid);
+    const s = await backfillUser(uid, opts);
     log.info(
       {
         userId: s.userId,
@@ -218,10 +217,12 @@ async function main() {
         receiptsUpdated: s.receiptsUpdated,
         txsUpdated: s.txsUpdated,
         errors: s.errors,
+        aborted: s.aborted,
         event: "backfill_user_done",
       },
       "user backfill complete",
     );
+    perUser.push(s);
     totals.total += s.total;
     totals.fetched += s.fetched;
     totals.receiptsUpdated += s.receiptsUpdated;
@@ -230,10 +231,9 @@ async function main() {
   }
 
   log.info(
-    { ...totals, dryRun: DRY_RUN, event: "backfill_complete" },
+    { ...totals, dryRun: opts.dryRun, event: "backfill_complete" },
     "backfill complete across all users",
   );
-}
 
-await main();
-process.exit(0);
+  return { dryRun: opts.dryRun, totals, perUser };
+}


### PR DESCRIPTION
Closes #553

## Summary
- New module `src/lib/gmail/backfill-received-at.ts` — pure async `backfillEmailReceivedAt(opts)` with the same logic as the deleted script (idempotent per-receipt loop, tx `occurred_at` correction for `gmail_*` sources, abort on `invalid_grant`).
- New route `src/app/api/cron/backfill-email-received-at/route.ts` — POST with Bearer-token auth via `CRON_TOKEN`, body `{ dryRun?, userId?, batchSize?, sleepMs? }`, returns `BackfillReport` JSON. Mirrors `gmail-backfill` and `gmail-pull` route patterns.
- Tests: auth (401 missing/wrong/no-config), body validation (negative userId, batchSize > 100, negative sleepMs), happy path (forwards opts, returns report), 500 on backfill throw.
- Deleted `scripts/backfill-email-received-at.ts` (superseded).
- Reverted PR #552's overlay additions in `deploy.yml` (script + transitive deps) — no longer needed inside the runtime.

## Why
PR #552's standalone-script approach failed at runtime: `googleapis` (~196 MB) is bundled INSIDE `.next/chunks` by Turbopack, not exposed as a separate `node_modules` package. External scripts can't reach it, and overlaying the full package blows past the tarball limit. The cron route avoids the architecture wall by living inside the same bundle that already has googleapis available.

## Trigger after deploy
```bash
# Dry-run (preview what would change — no writes)
curl -X POST -H "Authorization: Bearer $CRON_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"dryRun": true}' \
  https://findash.alejomartinez.dev/api/cron/backfill-email-received-at

# For real
curl -X POST -H "Authorization: Bearer $CRON_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{}' \
  https://findash.alejomartinez.dev/api/cron/backfill-email-received-at
```

Expected scope on prod: 476 receipts to backfill (Bancolombia 355, ARQ 54, Apple 45, PayU/MP 9 each, PayPal 3, Wompi 1).

## Test plan
- [x] Pre-push hook (lint + typecheck + tests) passed locally
- [ ] After merge + deploy: dry-run via curl, inspect report JSON, then run for real