### PR TITLE
fix(ingestion): prevent auth=000000 externalId collision for refinanciación pairs (#556)

### DIFF
--- a/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
@@ -382,3 +382,105 @@ describe("consolidateCycleFromStatement — integration against findash_test", (
     ).rejects.toThrow(/cycle must be YYYY-MM/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Refinanciación pairs — auth=000000 externalId collision regression (#556)
+// ---------------------------------------------------------------------------
+// AMPLIACION DE PLAZO + ABONO AMPLIACION share authorizationNumber="000000".
+// Before the fix, externalIdFor generated the same key for both rows causing
+// the second onConflictDoNothing to silently discard it. Both must land.
+describe("consolidateCycleFromStatement — refinanciación pair (auth=000000)", () => {
+  const REFINANCIACION_CYCLE = "2026-05";
+  const TAG2 = "STMT_REFIN_TEST";
+  let userId2!: number;
+  let accountId2!: number;
+
+  beforeAll(async () => {
+    userId2 = await createUser(`${TAG2.toLowerCase()}.${Date.now()}@test.local`);
+    accountId2 = await createTCAccount(userId2);
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId2);
+  });
+
+  it("inserts BOTH refinanciación rows despite sharing auth=000000", async () => {
+    const AMOUNT = BigInt(409952337);
+    const parsed = buildParsed(
+      [
+        // ABONO: credita el viejo saldo (extracto sign = negative)
+        row({
+          authorizationNumber: "000000",
+          merchant: "ABONO AMPLIACION DE PLA",
+          occurredAt: utcDate(2026, 3, 24),
+          amountCents: -AMOUNT,
+          installments: null,
+          rateEmX10k: null,
+        }),
+        // AMPLIACION: carga el nuevo plazo (extracto sign = positive)
+        row({
+          authorizationNumber: "000000",
+          merchant: "AMPLIACION DE PLAZO",
+          occurredAt: utcDate(2026, 3, 24),
+          amountCents: AMOUNT,
+          installments: { paid: 1, total: 60 },
+          rateEmX10k: 19110,
+        }),
+      ],
+      {
+        period: {
+          startDate: utcDate(2026, 5, 1),
+          endDate: utcDate(2026, 5, 31),
+          dueDate: utcDate(2026, 6, 16),
+        },
+      },
+    );
+
+    const report = await consolidateCycleFromStatement({
+      userId: userId2,
+      accountId: accountId2,
+      cycle: REFINANCIACION_CYCLE,
+      parsed,
+      fileHash: "refin".repeat(12).slice(0, 64),
+      dryRun: false,
+    });
+
+    expect(report.status).toBe("consolidated");
+    // Both rows must have been inserted — not 1.
+    expect(report.insertedTxIds).toHaveLength(2);
+
+    // Fetch only the two insertedTxIds from the report (not all user txs which
+    // may include a synthetic intereses row inserted by applyInteresesCausadosForCycle).
+    const [firstTx, secondTx] = await Promise.all(
+      report.insertedTxIds.map((id) =>
+        db
+          .select()
+          .from(transactions)
+          .where(eq(transactions.id, id))
+          .then((rows) => rows[0]),
+      ),
+    );
+    const insertedTxs = [firstTx, secondTx].filter(Boolean);
+    expect(insertedTxs).toHaveLength(2);
+
+    const merchants = insertedTxs.map((t) => t.merchant).sort();
+    expect(merchants).toEqual(["ABONO AMPLIACION DE PLA", "AMPLIACION DE PLAZO"].sort());
+
+    // AMPLIACION DE PLAZO: extracto +4M → ledger −4M (expense)
+    const ampliacion = insertedTxs.find((t) => t.merchant === "AMPLIACION DE PLAZO");
+    expect(ampliacion).toBeDefined();
+    expect(ampliacion!.amountCents).toBe(-AMOUNT);
+    expect(ampliacion!.installmentsTotal).toBe(60);
+    expect(ampliacion!.installmentRateEmX10k).toBe(19110);
+
+    // ABONO AMPLIACION: extracto −4M → ledger +4M (credit)
+    const abono = insertedTxs.find((t) => t.merchant === "ABONO AMPLIACION DE PLA");
+    expect(abono).toBeDefined();
+    expect(abono!.amountCents).toBe(AMOUNT);
+
+    // Both externalIds must be distinct (the whole point of the fix).
+    expect(ampliacion!.externalId).not.toBe(abono!.externalId);
+    expect(ampliacion!.externalId).toContain("000000");
+    expect(abono!.externalId).toContain("000000");
+  });
+});

--- a/src/lib/ingestion/bancolombia-statement/consolidate.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.ts
@@ -181,7 +181,43 @@ export function hashStatementBuffer(buffer: Buffer): string {
   return createHash("sha256").update(buffer).digest("hex");
 }
 
-function externalIdFor(accountId: number, cycle: string, authCode: string): string {
+// Bancolombia uses "000000" as a placeholder authorizationNumber for synthetic
+// bank operations (refinanciación, AMPLIACION DE PLAZO, ABONO AMPLIACION, etc.)
+// where no real merchant authorization was issued. Multiple such rows can appear
+// in the same cycle with inverse amounts — they must each get a unique externalId
+// so the onConflictDoNothing dedup in insertMissingRowInTx doesn't collapse the
+// second row into silence.
+//
+// For real auth codes (non-000000) we keep the auth-only key for dedup stability
+// (already in prod). For placeholder rows we extend the key with a normalized
+// merchant slug + amount so the pair (AMPLIACION/+4M) and (ABONO/-4M) never
+// share an externalId. The merchant slug is lowercased and stripped of
+// non-alphanumeric chars so minor extracto formatting differences don't produce
+// phantom duplicates across cycles.
+const PLACEHOLDER_AUTH = "000000";
+
+function normalizeMerchantSlug(merchant: string): string {
+  return merchant
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function externalIdFor(
+  accountId: number,
+  cycle: string,
+  authCode: string,
+  row: { merchant: string; amountCents: bigint },
+): string {
+  if (authCode === PLACEHOLDER_AUTH) {
+    const slug = normalizeMerchantSlug(row.merchant);
+    // Include the ledger-sign amount so AMPLIACION (+4M → ledger -4M) and
+    // ABONO (-4M → ledger +4M) produce distinct keys even on the same date.
+    const amount = row.amountCents.toString();
+    return `bancolombia-stmt:${accountId}:${cycle}:${authCode}:${slug}:${amount}`;
+  }
   return `bancolombia-stmt:${accountId}:${cycle}:${authCode}`;
 }
 
@@ -899,7 +935,7 @@ async function insertMissingRowInTx(
   txDb: Parameters<Parameters<DB["transaction"]>[0]>[0],
   { opts, account, row, statementImportId }: InsertMissingArgs,
 ): Promise<number | null> {
-  const external = externalIdFor(opts.accountId, opts.cycle, row.authorizationNumber!);
+  const external = externalIdFor(opts.accountId, opts.cycle, row.authorizationNumber!, row);
   const result = await txDb
     .insert(transactions)
     .values({

--- a/src/lib/ingestion/bancolombia-statement/match.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/match.test.ts
@@ -420,4 +420,39 @@ describe("matchStatementAgainstLedger — missing and unmatched", () => {
     expect(result.missingInLedger).toHaveLength(1);
     expect(result.missingInLedger[0].merchant).toBe("B");
   });
+
+  // Refinanciación pairs (AMPLIACION DE PLAZO + ABONO AMPLIACION) both carry
+  // authorizationNumber="000000" with INVERSE amounts. The matcher must not
+  // cross-match them against each other — they have different amounts in ledger
+  // sign (+4M and -4M) so the candidate filter naturally prevents a cross-match.
+  // Both must reach missingInLedger so consolidate.ts can insert them.
+  it("refinanciación pair with auth=000000 both reach missingInLedger (not matched to each other)", () => {
+    const REFINANCIACION_CENTS = BigInt(409952337);
+    const stmt = buildStatement([
+      // ABONO AMPLIACION DE PLAZO: credita el saldo (negative in extracto sign)
+      buildRow({
+        amountCents: -REFINANCIACION_CENTS,
+        occurredAt: utcDate(2026, 3, 24),
+        merchant: "ABONO AMPLIACION DE PLA",
+        authorizationNumber: "000000",
+        installments: null,
+        rateEmX10k: null,
+      }),
+      // AMPLIACION DE PLAZO: carga el nuevo plazo (positive in extracto sign)
+      buildRow({
+        amountCents: REFINANCIACION_CENTS,
+        occurredAt: utcDate(2026, 3, 24),
+        merchant: "AMPLIACION DE PLAZO",
+        authorizationNumber: "000000",
+        installments: { paid: 1, total: 60 },
+        rateEmX10k: 19110,
+      }),
+    ]);
+    // No existing txs — both rows must surface as missing.
+    const result = matchStatementAgainstLedger(stmt, []);
+    expect(result.matched).toHaveLength(0);
+    expect(result.missingInLedger).toHaveLength(2);
+    const merchants = result.missingInLedger.map((r) => r.merchant).sort();
+    expect(merchants).toEqual(["ABONO AMPLIACION DE PLA", "AMPLIACION DE PLAZO"].sort());
+  });
 });


### PR DESCRIPTION
## Summary

- **Root cause (H2, not H1)**: `externalIdFor()` generated identical `externalId` keys (`bancolombia-stmt:<accountId>:<cycle>:000000`) for both AMPLIACION DE PLAZO and ABONO AMPLIACION rows, since both share `authorizationNumber="000000"`. The `onConflictDoNothing` in `insertMissingRowInTx` silently discarded the second row.
- **Fix**: For placeholder auth `000000`, extend the key with a normalized merchant slug + raw statement amount, making each synthetic row's key unique within the cycle.
- **Matcher was clean**: H1 was ruled out — the two rows have inverse amounts (`+4M` and `−4M`), so the amount-equality filter in `matchStatementAgainstLedger` prevents them from ever cross-matching.

## Test plan

- [ ] `match.test.ts`: new test asserting both refinanciación rows (auth=000000, inverse amounts) reach `missingInLedger` without cross-matching
- [ ] `consolidate.test.ts`: new integration test inserting a synthetic ParsedStatement with the AMPLIACION/ABONO pair, asserting both txs land in `transactions` with correct amounts, installments, and distinct `externalId`s
- [ ] `bun run lint` — clean (pre-existing warning in reconcile/page.tsx, unrelated)
- [ ] `bunx tsc --noEmit` — clean
- [ ] `bun run test src/lib/ingestion/bancolombia-statement` — 74 tests pass
- [ ] Full pre-push hook (1697 tests, 134 files) — all passing

Closes #556