### PR TITLE
fix(ingestion): insert missing before-period installment purchases during consolidation (#557)

### DIFF
--- a/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import { accounts, statementImports, transactions, users } from "@/lib/db/schema";
@@ -380,6 +380,272 @@ describe("consolidateCycleFromStatement — integration against findash_test", (
         dryRun: true,
       }),
     ).rejects.toThrow(/cycle must be YYYY-MM/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Before-period installment purchase insert (#557)
+// ---------------------------------------------------------------------------
+// When a before-period row is missing from the ledger AND it has
+// installments > 1 AND a rate, consolidate must insert it so the
+// intereses-causados job can price it in the current (and future) cycles.
+// The externalId is cycle-agnostic ("before" namespace) so consecutive
+// cycle consolidations don't insert the same purchase twice.
+describe("consolidateCycleFromStatement — before-period installment insert (#557)", () => {
+  const BEFORE_PERIOD_CYCLE = "2026-04";
+  const TAG3 = "STMT_BEFORE_TEST";
+  let userId3!: number;
+  let accountId3!: number;
+
+  beforeAll(async () => {
+    userId3 = await createUser(`${TAG3.toLowerCase()}.${Date.now()}@test.local`);
+    accountId3 = await createTCAccount(userId3);
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId3);
+  });
+
+  // Builds a ParsedStatement for `BEFORE_PERIOD_CYCLE` that includes one
+  // before-period multi-cuota row (ALKOMPRAR-like) and one during-period
+  // purchase so there's something to consolidate.
+  function buildBeforePeriodStatement(): import("./types").ParsedStatement {
+    return buildParsed(
+      [
+        // Before-period installment purchase — missing from ledger.
+        // Should be inserted by the fix.
+        row({
+          kind: "before-period",
+          authorizationNumber: "R06018",
+          merchant: "ALKOMPRAR MOLINOS",
+          occurredAt: utcDate(2025, 11, 16), // original purchase date
+          amountCents: BigInt(99905000), // extracto sign (+) = expense
+          installments: { paid: 4, total: 8 },
+          rateEmX10k: 18740,
+        }),
+        // During-period: a regular purchase, no installments.
+        row({
+          authorizationNumber: "ABC123",
+          merchant: "TIENDA LOCAL",
+          occurredAt: utcDate(2026, 4, 10),
+          amountCents: BigInt(5000000),
+        }),
+      ],
+      {
+        period: {
+          startDate: utcDate(2026, 3, 31),
+          endDate: utcDate(2026, 4, 30),
+          dueDate: utcDate(2026, 5, 16),
+        },
+      },
+    );
+  }
+
+  it("inserts the before-period installment purchase into the ledger", async () => {
+    const report = await consolidateCycleFromStatement({
+      userId: userId3,
+      accountId: accountId3,
+      cycle: BEFORE_PERIOD_CYCLE,
+      parsed: buildBeforePeriodStatement(),
+      fileHash: "before01".repeat(8),
+      dryRun: false,
+    });
+
+    expect(report.status).toBe("consolidated");
+    // insertedTxIds includes both the before-period row and the during-period row.
+    // (plus possibly a synthetic intereses tx via the job)
+    // The matchStats should reflect insertedMissing >= 2 (before+during), skippedMissingBefore=0.
+    expect(report.matchStats.skippedMissingBefore).toBe(0);
+
+    // Find the ALKOMPRAR tx — it must exist with correct fields.
+    const [alkTx] = await db.execute<{
+      id: number;
+      merchant: string;
+      amount_cents: string;
+      installments_total: number;
+      installment_rate_bps: number;
+      external_id: string;
+      occurred_at: string;
+    }>(sql`
+      SELECT id, merchant, amount_cents::text, installments_total,
+             installment_rate_bps, external_id, occurred_at::text
+      FROM transactions
+      WHERE user_id = ${userId3} AND account_id = ${accountId3}
+        AND merchant = 'ALKOMPRAR MOLINOS' AND deleted_at IS NULL
+      LIMIT 1
+    `);
+    expect(alkTx).toBeDefined();
+    expect(BigInt(alkTx.amount_cents)).toBe(-BigInt(99905000)); // ledger sign inverted
+    expect(alkTx.installments_total).toBe(8);
+    expect(alkTx.installment_rate_bps).toBe(18740);
+    // externalId must use the "before" namespace (cycle-agnostic).
+    expect(alkTx.external_id).toMatch(/bancolombia-stmt:\d+:before:R06018/);
+    // occurred_at must be the original purchase date from the statement.
+    expect(alkTx.occurred_at).toContain("2025-11-16");
+  });
+
+  it("does NOT insert a before-period row again when a second consecutive cycle consolidation runs (#557 idempotency)", async () => {
+    // First consolidation (BEFORE_PERIOD_CYCLE already ran above, but we
+    // need a fresh user to avoid the already-consolidated short-circuit).
+    const userId4 = await createUser(`${TAG3.toLowerCase()}.idem.${Date.now()}@test.local`);
+    const accountId4 = await createTCAccount(userId4);
+
+    try {
+      await consolidateCycleFromStatement({
+        userId: userId4,
+        accountId: accountId4,
+        cycle: BEFORE_PERIOD_CYCLE,
+        parsed: buildBeforePeriodStatement(),
+        fileHash: "before02".repeat(8),
+        dryRun: false,
+      });
+
+      // Second cycle: same ALKOMPRAR appears before-period again.
+      const NEXT_CYCLE = "2026-05";
+      const nextParsed = buildParsed(
+        [
+          row({
+            kind: "before-period",
+            authorizationNumber: "R06018",
+            merchant: "ALKOMPRAR MOLINOS",
+            occurredAt: utcDate(2025, 11, 16),
+            amountCents: BigInt(99905000),
+            installments: { paid: 5, total: 8 },
+            rateEmX10k: 18740,
+          }),
+        ],
+        {
+          period: {
+            startDate: utcDate(2026, 4, 30),
+            endDate: utcDate(2026, 5, 31),
+            dueDate: utcDate(2026, 6, 16),
+          },
+        },
+      );
+      await consolidateCycleFromStatement({
+        userId: userId4,
+        accountId: accountId4,
+        cycle: NEXT_CYCLE,
+        parsed: nextParsed,
+        fileHash: "before03".repeat(8),
+        dryRun: false,
+      });
+
+      // ALKOMPRAR must exist exactly once (not duplicated across the two cycles).
+      const rows = await db.execute<{ n: string }>(sql`
+        SELECT count(*)::text AS n FROM transactions
+        WHERE user_id = ${userId4} AND account_id = ${accountId4}
+          AND merchant = 'ALKOMPRAR MOLINOS' AND deleted_at IS NULL
+      `);
+      expect(rows[0].n).toBe("1");
+    } finally {
+      await cleanupUser(userId4);
+    }
+  });
+
+  it("does NOT insert a before-period row that has no rate (would produce needsRate=true anyway)", async () => {
+    const userId5 = await createUser(`${TAG3.toLowerCase()}.norate.${Date.now()}@test.local`);
+    const accountId5 = await createTCAccount(userId5);
+
+    try {
+      const parsed = buildParsed(
+        [
+          row({
+            kind: "before-period",
+            authorizationNumber: "Z99999",
+            merchant: "SOME INSTALLMENT NO RATE",
+            occurredAt: utcDate(2025, 10, 1),
+            amountCents: BigInt(50000000),
+            installments: { paid: 2, total: 12 },
+            rateEmX10k: null, // no rate — should NOT be inserted
+          }),
+        ],
+        {
+          period: {
+            startDate: utcDate(2026, 3, 31),
+            endDate: utcDate(2026, 4, 30),
+            dueDate: utcDate(2026, 5, 16),
+          },
+        },
+      );
+      const report = await consolidateCycleFromStatement({
+        userId: userId5,
+        accountId: accountId5,
+        cycle: BEFORE_PERIOD_CYCLE,
+        parsed,
+        fileHash: "before04".repeat(8),
+        dryRun: false,
+      });
+
+      // skippedMissingBefore=1 because it was not inserted.
+      expect(report.matchStats.skippedMissingBefore).toBe(1);
+
+      const rows = await db.execute<{ n: string }>(sql`
+        SELECT count(*)::text AS n FROM transactions
+        WHERE user_id = ${userId5} AND account_id = ${accountId5}
+          AND merchant = 'SOME INSTALLMENT NO RATE' AND deleted_at IS NULL
+      `);
+      expect(rows[0].n).toBe("0");
+    } finally {
+      await cleanupUser(userId5);
+    }
+  });
+
+  it("produces an intereses-causados tx when before-period installment purchase generates interest", async () => {
+    const userId6 = await createUser(`${TAG3.toLowerCase()}.intereses.${Date.now()}@test.local`);
+    const accountId6 = await createTCAccount(userId6);
+
+    try {
+      // Simulates the real scenario: a before-period purchase at 8 cuotas with
+      // rate=18740. Purchase date 2025-11-16 → by cycle 2026-04 (anchor Apr 30),
+      // monthsBetween(Nov 16, Apr 30) = 5 → paidCount=5 → month 6 has interest.
+      const parsed = buildParsed(
+        [
+          row({
+            kind: "before-period",
+            authorizationNumber: "R06018",
+            merchant: "ALKOMPRAR MOLINOS",
+            occurredAt: utcDate(2025, 11, 16),
+            amountCents: BigInt(99905000), // $999,050 COP
+            installments: { paid: 5, total: 8 },
+            rateEmX10k: 18740,
+          }),
+        ],
+        {
+          period: {
+            startDate: utcDate(2026, 3, 31),
+            endDate: utcDate(2026, 4, 30),
+            dueDate: utcDate(2026, 5, 16),
+          },
+        },
+      );
+      const report = await consolidateCycleFromStatement({
+        userId: userId6,
+        accountId: accountId6,
+        cycle: BEFORE_PERIOD_CYCLE,
+        parsed,
+        fileHash: "before05".repeat(8),
+        dryRun: false,
+      });
+
+      expect(report.status).toBe("consolidated");
+      // The intereses job runs after the before-period tx is committed.
+      // With paidCount>=1 and rate > 0, the job should produce a non-zero result.
+      expect(report.intereses.status).toBe("inserted");
+      if (report.intereses.status === "inserted") {
+        expect(BigInt(report.intereses.totalInterestCentsStr)).toBeGreaterThan(BigInt(0));
+
+        // Verify the synthetic tx was persisted.
+        const [synthetic] = await db
+          .select()
+          .from(transactions)
+          .where(eq(transactions.id, report.intereses.txId));
+        expect(synthetic.categorySlug).toBe("intereses-tc");
+        expect(synthetic.amountCents).toBeLessThan(BigInt(0)); // expense
+      }
+    } finally {
+      await cleanupUser(userId6);
+    }
   });
 });
 

--- a/src/lib/ingestion/bancolombia-statement/consolidate.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.ts
@@ -221,6 +221,44 @@ function externalIdFor(
   return `bancolombia-stmt:${accountId}:${cycle}:${authCode}`;
 }
 
+// Before-period installment purchases get a cycle-agnostic key so the same
+// purchase isn't inserted twice when multiple cycles are consolidated in
+// sequence (ENE→FEB→MAR: ALKOMPRAR MOLINOS appears before-period in all
+// three but should only enter the ledger once).
+//
+// The key omits `cycle` and uses a `before` namespace so it never collides
+// with the during-period keys above. Placeholder auth rows include the
+// normalized merchant slug + statement-sign amount to disambiguate pairs.
+function externalIdForBeforePeriod(
+  accountId: number,
+  authCode: string,
+  row: { merchant: string; amountCents: bigint },
+): string {
+  if (authCode === PLACEHOLDER_AUTH) {
+    const slug = normalizeMerchantSlug(row.merchant);
+    const amount = row.amountCents.toString();
+    return `bancolombia-stmt:${accountId}:before:${authCode}:${slug}:${amount}`;
+  }
+  return `bancolombia-stmt:${accountId}:before:${authCode}`;
+}
+
+// Returns true for before-period statement rows that should be inserted into
+// the ledger so the intereses-causados job can price them. Criteria:
+//   1. Multi-cuota (installments.total > 1) — 1-cuota purchases never accrue
+//      interest so inserting them doesn't help the job.
+//   2. Has a rate — the job needs it to compute interest. A row without a rate
+//      would become needsRate (interestCents=0), contributing nothing.
+//   3. Positive extracto amount — that's a purchase (expense). Negative rows
+//      are credits/abonos; inserting them as installment purchases would be wrong.
+//   4. Has a real authorizationNumber — required for a stable externalId.
+function isInsertableBeforePeriodRow(row: StatementRow): boolean {
+  if (row.authorizationNumber === null) return false;
+  if (row.amountCents <= BigInt(0)) return false;
+  if (row.installments === null || row.installments.total <= 1) return false;
+  if (row.rateEmX10k === null) return false;
+  return true;
+}
+
 function toIsoDate(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
@@ -608,12 +646,18 @@ async function loadExistingTxs(
   return rows;
 }
 
-function buildMatchStats(match: MatchResult): MatchStats {
+function buildMatchStats(match: MatchResult, insertedBeforePeriodCount = 0): MatchStats {
   const matchedWillChange = match.matched.filter((m) => m.willChange).length;
-  const insertedMissing = match.missingInLedger.filter((r) => r.kind === "during-period").length;
-  const skippedMissingBefore = match.missingInLedger.filter(
-    (r) => r.kind === "before-period",
-  ).length;
+  // `insertedMissing` counts during-period inserts + before-period installment
+  // inserts (added in #557) so the UI "Nuevas" stat reflects everything landed.
+  const insertedMissing =
+    match.missingInLedger.filter((r) => r.kind === "during-period").length +
+    insertedBeforePeriodCount;
+  // `skippedMissingBefore` = before-period rows that did NOT qualify for insert
+  // (1-cuota, missing rate, credit/abono, or no authCode).
+  const skippedMissingBefore =
+    match.missingInLedger.filter((r) => r.kind === "before-period").length -
+    insertedBeforePeriodCount;
   return {
     matched: match.matched.length,
     matchedWillChange,
@@ -770,73 +814,106 @@ export async function consolidateCycleFromStatement(
   // outside this tx avoids the drizzle DB-vs-Transaction type mismatch and
   // makes partial-failure semantics sane (ledger fix commits even if the
   // intereses job fails; user can retry).
-  const { imp, matchedIdsToUpdate, insertedTxIds } = await database.transaction(async (txDb) => {
-    const [imp] = await txDb
-      .insert(statementImports)
-      .values({
-        userId: opts.userId,
-        accountId: opts.accountId,
-        fileHash: opts.fileHash,
-        periodStart: toIsoDate(opts.parsed.period.startDate),
-        periodEnd: toIsoDate(opts.parsed.period.endDate),
-        txnCount: 0,
-        kind: "extracto_detallado",
-        cycle: opts.cycle,
-        report: null,
-      })
-      .returning({ id: statementImports.id });
-
-    const matchedIdsToUpdate: number[] = [];
-    for (const m of match.matched) {
-      if (!m.willChange) continue;
-      await txDb
-        .update(transactions)
-        .set({
-          installmentsTotal: m.diff.installmentsTotalAfter,
-          ...(m.diff.rateEmX10kAfter !== null && {
-            installmentRateEmX10k: m.diff.rateEmX10kAfter,
-          }),
-          reconciliationStatus: "matched",
-          reconciledAt: new Date(),
-          statementImportId: imp.id,
-          updatedAt: new Date(),
+  const { imp, matchedIdsToUpdate, insertedTxIds, insertedBeforePeriodCount } =
+    await database.transaction(async (txDb) => {
+      const [imp] = await txDb
+        .insert(statementImports)
+        .values({
+          userId: opts.userId,
+          accountId: opts.accountId,
+          fileHash: opts.fileHash,
+          periodStart: toIsoDate(opts.parsed.period.startDate),
+          periodEnd: toIsoDate(opts.parsed.period.endDate),
+          txnCount: 0,
+          kind: "extracto_detallado",
+          cycle: opts.cycle,
+          report: null,
         })
-        .where(and(eq(transactions.id, m.txId), eq(transactions.userId, opts.userId)));
-      matchedIdsToUpdate.push(m.txId);
-    }
+        .returning({ id: statementImports.id });
 
-    const insertedTxIds: number[] = [];
-    for (const row of match.missingInLedger) {
-      if (row.kind !== "during-period") continue;
-      if (isBankInterestRow(row)) continue;
-      if (row.authorizationNumber === null) {
-        log.warn(
-          {
-            accountId: opts.accountId,
-            cycle: opts.cycle,
-            merchant: row.merchant,
-            event: "missing_auth_skip",
-          },
-          "consolidate: skipping missing row without authorizationNumber",
-        );
-        continue;
+      const matchedIdsToUpdate: number[] = [];
+      for (const m of match.matched) {
+        if (!m.willChange) continue;
+        await txDb
+          .update(transactions)
+          .set({
+            installmentsTotal: m.diff.installmentsTotalAfter,
+            ...(m.diff.rateEmX10kAfter !== null && {
+              installmentRateEmX10k: m.diff.rateEmX10kAfter,
+            }),
+            reconciliationStatus: "matched",
+            reconciledAt: new Date(),
+            statementImportId: imp.id,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(transactions.id, m.txId), eq(transactions.userId, opts.userId)));
+        matchedIdsToUpdate.push(m.txId);
       }
-      const inserted = await insertMissingRowInTx(txDb, {
-        opts,
-        account,
-        row,
-        statementImportId: imp.id,
-      });
-      if (inserted !== null) insertedTxIds.push(inserted);
-    }
 
-    await txDb
-      .update(statementImports)
-      .set({ txnCount: matchedIdsToUpdate.length + insertedTxIds.length })
-      .where(eq(statementImports.id, imp.id));
+      const insertedTxIds: number[] = [];
+      let insertedBeforePeriodCount = 0;
+      for (const row of match.missingInLedger) {
+        if (row.kind === "before-period") {
+          // #557: insert missing before-period multi-cuota purchases so the
+          // intereses-causados job can price them in the current cycle.
+          // Non-qualifying rows (credits, 1-cuota, missing rate, no authCode)
+          // are skipped silently — they are either not installment purchases or
+          // already have no interest potential.
+          if (!isInsertableBeforePeriodRow(row)) continue;
+          const inserted = await insertMissingBeforePeriodRowInTx(txDb, {
+            opts,
+            account,
+            row,
+            statementImportId: imp.id,
+          });
+          if (inserted !== null) {
+            insertedTxIds.push(inserted);
+            insertedBeforePeriodCount += 1;
+            log.info(
+              {
+                accountId: opts.accountId,
+                cycle: opts.cycle,
+                merchant: row.merchant,
+                installmentsTotal: row.installments?.total,
+                rateEmX10k: row.rateEmX10k,
+                txId: inserted,
+                event: "before_period_installment_inserted",
+              },
+              "consolidate: inserted missing before-period installment purchase",
+            );
+          }
+          continue;
+        }
+        // during-period
+        if (isBankInterestRow(row)) continue;
+        if (row.authorizationNumber === null) {
+          log.warn(
+            {
+              accountId: opts.accountId,
+              cycle: opts.cycle,
+              merchant: row.merchant,
+              event: "missing_auth_skip",
+            },
+            "consolidate: skipping missing row without authorizationNumber",
+          );
+          continue;
+        }
+        const inserted = await insertMissingRowInTx(txDb, {
+          opts,
+          account,
+          row,
+          statementImportId: imp.id,
+        });
+        if (inserted !== null) insertedTxIds.push(inserted);
+      }
 
-    return { imp, matchedIdsToUpdate, insertedTxIds };
-  });
+      await txDb
+        .update(statementImports)
+        .set({ txnCount: matchedIdsToUpdate.length + insertedTxIds.length })
+        .where(eq(statementImports.id, imp.id));
+
+      return { imp, matchedIdsToUpdate, insertedTxIds, insertedBeforePeriodCount };
+    });
 
   const interesesResult = await applyInteresesCausadosForCycle({
     userId: opts.userId,
@@ -899,7 +976,7 @@ export async function consolidateCycleFromStatement(
     cycle: opts.cycle,
     dryRun: false,
     status: "consolidated",
-    matchStats: buildMatchStats(match),
+    matchStats: buildMatchStats(match, insertedBeforePeriodCount),
     matchedTxIds: matchedIdsToUpdate,
     insertedTxIds,
     matchedDiffs: serializeMatchedDiffs(match),
@@ -962,6 +1039,54 @@ async function insertMissingRowInTx(
         authorizationNumber: row.authorizationNumber,
         saldoPendingCents: row.saldoPendingCents.toString(),
         installmentValueCents: row.installmentValueCents?.toString() ?? null,
+      },
+    })
+    .onConflictDoNothing({
+      target: [transactions.accountId, transactions.externalId],
+      where: sql`${transactions.externalId} IS NOT NULL`,
+    })
+    .returning({ id: transactions.id });
+  return result[0]?.id ?? null;
+}
+
+// #557: insert a before-period installment purchase that was missing from the
+// ledger. Uses a cycle-agnostic externalId (`before` namespace) so the same
+// row isn't inserted twice when multiple consecutive cycles are consolidated.
+// The `onConflictDoNothing` on (accountId, externalId) is the guard.
+async function insertMissingBeforePeriodRowInTx(
+  txDb: Parameters<Parameters<DB["transaction"]>[0]>[0],
+  { opts, account, row, statementImportId }: InsertMissingArgs,
+): Promise<number | null> {
+  const external = externalIdForBeforePeriod(opts.accountId, row.authorizationNumber!, row);
+  const result = await txDb
+    .insert(transactions)
+    .values({
+      userId: opts.userId,
+      accountId: account.id,
+      occurredAt: row.occurredAt,
+      amountCents: statementAmountToLedger(row.amountCents),
+      currency: account.currency,
+      descriptionRaw: row.merchant,
+      merchant: row.merchant,
+      installmentsTotal: row.installments!.total,
+      installmentRateEmX10k: row.rateEmX10k,
+      source: "csv_reconcile",
+      channel: "bank",
+      reconciliationStatus: "imported_from_statement",
+      reconciledAt: new Date(),
+      statementImportId,
+      externalId: external,
+      rawData: {
+        statementKind: "extracto_detallado",
+        // `importedFromBeforePeriod` flags that the purchase date pre-dates
+        // the cycle being consolidated — useful for audit trails.
+        importedFromBeforePeriod: true,
+        cycle: opts.cycle,
+        authorizationNumber: row.authorizationNumber,
+        saldoPendingCents: row.saldoPendingCents.toString(),
+        installmentValueCents: row.installmentValueCents?.toString() ?? null,
+        installmentsPaid: row.installments!.paid,
+        installmentsTotal: row.installments!.total,
       },
     })
     .onConflictDoNothing({


### PR DESCRIPTION
## Summary

- Before-period multi-cuota statement rows that are **missing from the ledger** (e.g. ALKOMPRAR MOLINOS — a pre-existing installment loan that predates our tracking) are now inserted during consolidation so the `intereses-causados` job can price them.
- The root cause of #557: the `INTERESES CORRIENTES $26,470.92` declared on the MAR2026 statement is generated by installment purchases (like ALKOMPRAR MOLINOS 8-cuotas at 18740 bps) that appear as `before-period` rows but were never inserted into the ledger, leaving the job with nothing to compute interest on.
- Insertion is idempotent: a cycle-agnostic externalId (`bancolombia-stmt:N:before:AUTH`) prevents the same purchase from being inserted twice when consecutive cycles are consolidated (ENE→FEB→MAR).

## Path discovered

**Neither Path A nor Path B** from the issue hypothesis — it's **Path C**: the source purchases for the interest literally don't exist in the ledger. The fix enables them to be inserted during normal consolidation.

Investigation findings:
- OEM SAS (the gmail tx) already had `installment_rate_bps=19110` — Path A was not the bug for this specific tx.
- The job correctly returns `zero-interest` — Path B was not the bug either.
- ALKOMPRAR MOLINOS (8 cuotas, 18740 bps) appears as `before-period` in ENE and FEB statements but was never inserted. It's the primary source of COP interest in those cycles.
- The MAR2026 COP interest ($26,470.92) comes from before-period purchases that predated ingestion. Consolidating ENE2026 or FEB2026 with this fix will insert them; subsequent MAR2026 cycle interest will then be priceable.

## Criteria for inserting a before-period row

1. `installments.total > 1` (multi-cuota installment purchase)
2. `rateEmX10k !== null` (job needs it; without rate the row becomes `needsRate=true`)
3. `amountCents > 0` (positive statement sign = expense/purchase, not credit/abono)
4. `authorizationNumber !== null` (required for a stable externalId)

## Test delta (+4 new tests)

- **before-period installment row is inserted** with correct fields and cycle-agnostic externalId
- **idempotency**: second consecutive cycle sees the same before-period row but `onConflictDoNothing` prevents duplicate insert
- **non-qualifying rows skipped**: before-period row without rate → `skippedMissingBefore=1`, no insert
- **end-to-end**: before-period purchase insert → intereses job runs → `status=inserted` with `totalInterestCents > 0`

## Additional fixes for MAR2026 intereses

The user also needs to re-run ENE2026 and FEB2026 consolidation (those cycles were never imported). Once those run, ALKOMPRAR MOLINOS will be in the ledger and MAR2026's `$26,470.92` will be priceable. Note: the MAR2026 cycle is `already-consolidated` so re-running MAR2026 alone won't help — the user must run ENE or FEB first. This is tracked in task #6 (prod backfill).

Closes #557

## Test plan
- [x] `bun run lint` — clean (pre-existing unrelated warning only)
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test src/lib/finance src/lib/ingestion/bancolombia-statement` — 149 tests passed
- [x] Full suite on push — 1700 passing, 1 skipped, 134 test files