### PR TITLE
feat(ingestion): cross-twin reassignment for international TC purchases (#555)

### DIFF
--- a/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { db } from "@/lib/db";
-import { accounts, statementImports, transactions, users } from "@/lib/db/schema";
+import { accounts, physicalCards, statementImports, transactions, users } from "@/lib/db/schema";
 import { copyCategorySeedsToUser } from "@/lib/auth/signup";
 
 import { consolidateCycleFromStatement } from "./consolidate";
@@ -748,5 +748,552 @@ describe("consolidateCycleFromStatement — refinanciación pair (auth=000000)",
     expect(ampliacion!.externalId).not.toBe(abono!.externalId);
     expect(ampliacion!.externalId).toContain("000000");
     expect(abono!.externalId).toContain("000000");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-twin reconciliation (#555)
+// ---------------------------------------------------------------------------
+// International TC purchases arrive via gmail_bancolombia as COP amounts on
+// the COP twin. When the USD statement is consolidated, the matching COP tx
+// must be re-assigned to the USD account with the real USD amount.
+describe("consolidateCycleFromStatement — cross-twin reconciliation (#555)", () => {
+  const CROSS_TWIN_CYCLE = "2026-03";
+  const TAG_CT = "STMT_CROSSTWIN_TEST";
+  let userIdCT!: number;
+  let copAccountId!: number;
+  let usdAccountId!: number;
+  let physicalCardUUID!: string;
+
+  beforeAll(async () => {
+    userIdCT = await createUser(`${TAG_CT.toLowerCase()}.${Date.now()}@test.local`);
+
+    // Insert a physical_card so both accounts can be linked.
+    physicalCardUUID = crypto.randomUUID();
+    await db.insert(physicalCards).values({
+      id: physicalCardUUID,
+      userId: userIdCT,
+      institution: "Bancolombia",
+      network: "mastercard",
+      last4: "7291",
+      creditLimitCents: BigInt(15_000_000_00),
+    });
+
+    // COP twin account
+    const [copRow] = await db
+      .insert(accounts)
+      .values({
+        userId: userIdCT,
+        name: `${TAG_CT} MC COP`,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        type: "credit_card",
+        currency: "COP",
+        physicalCardId: physicalCardUUID,
+        metadata: { last4s: ["7291"], cutoffDay: 15 },
+      })
+      .returning({ id: accounts.id });
+    copAccountId = copRow.id;
+
+    // USD twin account
+    const [usdRow] = await db
+      .insert(accounts)
+      .values({
+        userId: userIdCT,
+        name: `${TAG_CT} MC USD`,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        type: "credit_card",
+        currency: "USD",
+        physicalCardId: physicalCardUUID,
+        metadata: { last4s: ["7291"], cutoffDay: 15 },
+      })
+      .returning({ id: accounts.id });
+    usdAccountId = usdRow.id;
+  });
+
+  afterAll(async () => {
+    await db.delete(transactions).where(eq(transactions.userId, userIdCT));
+    await db.delete(statementImports).where(eq(statementImports.userId, userIdCT));
+    await db.delete(accounts).where(eq(accounts.userId, userIdCT));
+    await db.delete(physicalCards).where(eq(physicalCards.id, physicalCardUUID));
+    await db.delete(users).where(eq(users.id, userIdCT));
+  });
+
+  it("reassigns a COP gmail tx to the USD account when the USD statement matches it", async () => {
+    // Seed a gmail_bancolombia tx on the COP account (how AIRBNB lands today).
+    const [airbnbRow] = await db
+      .insert(transactions)
+      .values({
+        userId: userIdCT,
+        accountId: copAccountId,
+        occurredAt: utcDate(2026, 3, 10),
+        amountCents: BigInt(-181479701), // -$1,814,797.01 COP (ledger sign)
+        currency: "COP",
+        descriptionRaw: "AIRBNB * HMA245HENE",
+        merchant: "AIRBNB * HMA245HENE",
+        source: "gmail_bancolombia",
+        channel: "bank",
+      })
+      .returning({ id: transactions.id });
+    const airbnbTxId = airbnbRow.id;
+
+    // USD statement has the real charge: $484.55 USD.
+    const usdStatement = buildParsed(
+      [
+        row({
+          authorizationNumber: "123456",
+          merchant: "AIRBNB",
+          occurredAt: utcDate(2026, 3, 10),
+          amountCents: BigInt(48455), // extracto sign: 484.55 USD
+        }),
+      ],
+      {
+        account: { last4: "7291", currency: "USD" },
+        period: {
+          startDate: utcDate(2026, 2, 28),
+          endDate: utcDate(2026, 3, 31),
+          dueDate: utcDate(2026, 4, 16),
+        },
+      },
+    );
+
+    const report = await consolidateCycleFromStatement({
+      userId: userIdCT,
+      accountId: usdAccountId,
+      cycle: CROSS_TWIN_CYCLE,
+      parsed: usdStatement,
+      fileHash: "ct-airbnb-01".repeat(5).slice(0, 64),
+      dryRun: false,
+    });
+
+    expect(report.status).toBe("consolidated");
+    expect(report.matchStats.crossTwinReassigned).toBe(1);
+    // Cross-twin reassigned rows are not counted as inserts.
+    expect(report.matchStats.insertedMissing).toBe(0);
+
+    // The AIRBNB tx must now live on the USD account.
+    const [updatedAirbnb] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, airbnbTxId));
+    expect(updatedAirbnb.accountId).toBe(usdAccountId);
+    expect(updatedAirbnb.currency).toBe("USD");
+    expect(updatedAirbnb.amountCents).toBe(BigInt(-48455)); // ledger-sign
+    expect(updatedAirbnb.reconciliationStatus).toBe("matched");
+    expect(updatedAirbnb.statementImportId).toBe(report.statementImportId);
+    expect(updatedAirbnb.sourceMismatch).toBe(true);
+
+    // sourceMismatchDetails must record the divergence.
+    const diffs = updatedAirbnb.sourceMismatchDetails?.diffs ?? [];
+    const accountDiff = diffs.find((d) => d.field === "accountId");
+    const currencyDiff = diffs.find((d) => d.field === "currency");
+    const amountDiff = diffs.find((d) => d.field === "amountCents");
+    expect(accountDiff?.fromValue).toBe(String(copAccountId));
+    expect(accountDiff?.toValue).toBe(String(usdAccountId));
+    expect(currencyDiff?.fromValue).toBe("COP");
+    expect(currencyDiff?.toValue).toBe("USD");
+    expect(amountDiff?.fromValue).toBe(BigInt(-181479701).toString());
+    expect(amountDiff?.toValue).toBe(BigInt(-48455).toString());
+  });
+
+  it("skips the cross-twin pass when account has no physicalCardId (single-currency TC)", async () => {
+    const userIdSingle = await createUser(
+      `${TAG_CT.toLowerCase()}.single.${Date.now()}@test.local`,
+    );
+    const accountIdSingle = await createTCAccount(userIdSingle);
+
+    try {
+      // Seed a gmail tx on the same account (no sibling to look in).
+      await db.insert(transactions).values({
+        userId: userIdSingle,
+        accountId: accountIdSingle,
+        occurredAt: utcDate(2026, 3, 10),
+        amountCents: BigInt(-181479701),
+        currency: "COP",
+        descriptionRaw: "AIRBNB * HMA245HENE",
+        merchant: "AIRBNB * HMA245HENE",
+        source: "gmail_bancolombia",
+        channel: "bank",
+      });
+
+      // A COP statement for the single-currency account — cross-twin must not error.
+      const parsed = buildParsed([
+        row({
+          authorizationNumber: "SINGLETEST",
+          merchant: "TIENDA LOCAL",
+          occurredAt: utcDate(2026, 3, 20),
+          amountCents: BigInt(5000000),
+        }),
+      ]);
+
+      const report = await consolidateCycleFromStatement({
+        userId: userIdSingle,
+        accountId: accountIdSingle,
+        cycle: CROSS_TWIN_CYCLE,
+        parsed,
+        fileHash: "ct-single-01".repeat(5).slice(0, 64),
+        dryRun: false,
+      });
+
+      expect(report.status).toBe("consolidated");
+      expect(report.matchStats.crossTwinReassigned).toBe(0);
+      // The AIRBNB tx stays on the COP account (no sibling).
+      const [airbnbTx] = await db
+        .select()
+        .from(transactions)
+        .where(
+          and(
+            eq(transactions.userId, userIdSingle),
+            eq(transactions.accountId, accountIdSingle),
+            eq(transactions.source, "gmail_bancolombia"),
+          ),
+        );
+      expect(airbnbTx.accountId).toBe(accountIdSingle);
+    } finally {
+      await cleanupUser(userIdSingle);
+    }
+  });
+
+  it("does NOT reassign when merchantSimilarity is at or below the threshold (no false positives)", async () => {
+    const userIdLow = await createUser(`${TAG_CT.toLowerCase()}.low.${Date.now()}@test.local`);
+
+    const physicalCardLowUUID = crypto.randomUUID();
+    await db.insert(physicalCards).values({
+      id: physicalCardLowUUID,
+      userId: userIdLow,
+      institution: "Bancolombia",
+      creditLimitCents: BigInt(10_000_000_00),
+    });
+
+    const [copLow] = await db
+      .insert(accounts)
+      .values({
+        userId: userIdLow,
+        name: `${TAG_CT} Low COP`,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        type: "credit_card",
+        currency: "COP",
+        physicalCardId: physicalCardLowUUID,
+        metadata: {},
+      })
+      .returning({ id: accounts.id });
+
+    const [usdLow] = await db
+      .insert(accounts)
+      .values({
+        userId: userIdLow,
+        name: `${TAG_CT} Low USD`,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        type: "credit_card",
+        currency: "USD",
+        physicalCardId: physicalCardLowUUID,
+        metadata: {},
+      })
+      .returning({ id: accounts.id });
+
+    try {
+      // COP tx: completely different merchant name — similarity will be 0.
+      const [genericTxRow] = await db
+        .insert(transactions)
+        .values({
+          userId: userIdLow,
+          accountId: copLow.id,
+          occurredAt: utcDate(2026, 3, 10),
+          amountCents: BigInt(-500000),
+          currency: "COP",
+          descriptionRaw: "SUPERMERCADO XYZ",
+          merchant: "SUPERMERCADO XYZ",
+          source: "gmail_bancolombia",
+          channel: "bank",
+        })
+        .returning({ id: transactions.id });
+      const genericTxId = genericTxRow.id;
+
+      // USD statement row with a completely different merchant.
+      const usdStatement = buildParsed(
+        [
+          row({
+            authorizationNumber: "LOW001",
+            merchant: "AMAZON WEB SERVICES",
+            occurredAt: utcDate(2026, 3, 10),
+            amountCents: BigInt(9999),
+          }),
+        ],
+        {
+          account: { last4: "7291", currency: "USD" },
+          period: {
+            startDate: utcDate(2026, 2, 28),
+            endDate: utcDate(2026, 3, 31),
+            dueDate: utcDate(2026, 4, 16),
+          },
+        },
+      );
+
+      const report = await consolidateCycleFromStatement({
+        userId: userIdLow,
+        accountId: usdLow.id,
+        cycle: CROSS_TWIN_CYCLE,
+        parsed: usdStatement,
+        fileHash: "ct-low-01".repeat(5).slice(0, 64),
+        dryRun: false,
+      });
+
+      expect(report.matchStats.crossTwinReassigned).toBe(0);
+      // The unmatched USD row must be inserted as a new tx.
+      expect(report.matchStats.insertedMissing).toBe(1);
+
+      // The COP generic tx must remain untouched on the COP account.
+      const [unchanged] = await db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, genericTxId));
+      expect(unchanged.accountId).toBe(copLow.id);
+      expect(unchanged.currency).toBe("COP");
+    } finally {
+      await db.delete(transactions).where(eq(transactions.userId, userIdLow));
+      await db.delete(statementImports).where(eq(statementImports.userId, userIdLow));
+      await db.delete(accounts).where(eq(accounts.userId, userIdLow));
+      await db.delete(physicalCards).where(eq(physicalCards.id, physicalCardLowUUID));
+      await db.delete(users).where(eq(users.id, userIdLow));
+    }
+  });
+
+  it("pickBestCandidate: with two same-day sibling candidates picks the one with higher merchant similarity", async () => {
+    const userIdPick = await createUser(`${TAG_CT.toLowerCase()}.pick.${Date.now()}@test.local`);
+
+    const physicalCardPickUUID = crypto.randomUUID();
+    await db.insert(physicalCards).values({
+      id: physicalCardPickUUID,
+      userId: userIdPick,
+      institution: "Bancolombia",
+      creditLimitCents: BigInt(10_000_000_00),
+    });
+
+    const [copPick] = await db
+      .insert(accounts)
+      .values({
+        userId: userIdPick,
+        name: `${TAG_CT} Pick COP`,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        type: "credit_card",
+        currency: "COP",
+        physicalCardId: physicalCardPickUUID,
+        metadata: {},
+      })
+      .returning({ id: accounts.id });
+
+    const [usdPick] = await db
+      .insert(accounts)
+      .values({
+        userId: userIdPick,
+        name: `${TAG_CT} Pick USD`,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        type: "credit_card",
+        currency: "USD",
+        physicalCardId: physicalCardPickUUID,
+        metadata: {},
+      })
+      .returning({ id: accounts.id });
+
+    try {
+      // Two COP candidates on the same day — one matches "AIRBNB" well, the
+      // other is a generic "COMIDA" (low similarity).
+      const [airbnbCopRow] = await db
+        .insert(transactions)
+        .values({
+          userId: userIdPick,
+          accountId: copPick.id,
+          occurredAt: utcDate(2026, 3, 10),
+          amountCents: BigInt(-181479701),
+          currency: "COP",
+          descriptionRaw: "AIRBNB * HMA245HENE",
+          merchant: "AIRBNB * HMA245HENE",
+          source: "gmail_bancolombia",
+          channel: "bank",
+        })
+        .returning({ id: transactions.id });
+
+      const [comidaCopRow] = await db
+        .insert(transactions)
+        .values({
+          userId: userIdPick,
+          accountId: copPick.id,
+          occurredAt: utcDate(2026, 3, 10),
+          amountCents: BigInt(-50000),
+          currency: "COP",
+          descriptionRaw: "COMIDA RAPIDA",
+          merchant: "COMIDA RAPIDA",
+          source: "gmail_bancolombia",
+          channel: "bank",
+        })
+        .returning({ id: transactions.id });
+
+      // USD statement row for AIRBNB.
+      const usdStatement = buildParsed(
+        [
+          row({
+            authorizationNumber: "PICK001",
+            merchant: "AIRBNB",
+            occurredAt: utcDate(2026, 3, 10),
+            amountCents: BigInt(48455),
+          }),
+        ],
+        {
+          account: { last4: "7291", currency: "USD" },
+          period: {
+            startDate: utcDate(2026, 2, 28),
+            endDate: utcDate(2026, 3, 31),
+            dueDate: utcDate(2026, 4, 16),
+          },
+        },
+      );
+
+      const report = await consolidateCycleFromStatement({
+        userId: userIdPick,
+        accountId: usdPick.id,
+        cycle: CROSS_TWIN_CYCLE,
+        parsed: usdStatement,
+        fileHash: "ct-pick-01".repeat(5).slice(0, 64),
+        dryRun: false,
+      });
+
+      expect(report.matchStats.crossTwinReassigned).toBe(1);
+
+      // The AIRBNB tx (higher similarity) must be moved, not the COMIDA tx.
+      const [movedAirbnb] = await db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, airbnbCopRow.id));
+      expect(movedAirbnb.accountId).toBe(usdPick.id);
+
+      const [untouchedComida] = await db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, comidaCopRow.id));
+      expect(untouchedComida.accountId).toBe(copPick.id);
+    } finally {
+      await db.delete(transactions).where(eq(transactions.userId, userIdPick));
+      await db.delete(statementImports).where(eq(statementImports.userId, userIdPick));
+      await db.delete(accounts).where(eq(accounts.userId, userIdPick));
+      await db.delete(physicalCards).where(eq(physicalCards.id, physicalCardPickUUID));
+      await db.delete(users).where(eq(users.id, userIdPick));
+    }
+  });
+
+  it("idempotency: running consolidate twice does NOT double-reassign the tx", async () => {
+    const userIdIdem = await createUser(`${TAG_CT.toLowerCase()}.idem2.${Date.now()}@test.local`);
+
+    const physicalCardIdemUUID = crypto.randomUUID();
+    await db.insert(physicalCards).values({
+      id: physicalCardIdemUUID,
+      userId: userIdIdem,
+      institution: "Bancolombia",
+      creditLimitCents: BigInt(10_000_000_00),
+    });
+
+    const [copIdem] = await db
+      .insert(accounts)
+      .values({
+        userId: userIdIdem,
+        name: `${TAG_CT} Idem COP`,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        type: "credit_card",
+        currency: "COP",
+        physicalCardId: physicalCardIdemUUID,
+        metadata: {},
+      })
+      .returning({ id: accounts.id });
+
+    const [usdIdem] = await db
+      .insert(accounts)
+      .values({
+        userId: userIdIdem,
+        name: `${TAG_CT} Idem USD`,
+        institution: "Bancolombia",
+        institutionSlug: "bancolombia",
+        type: "credit_card",
+        currency: "USD",
+        physicalCardId: physicalCardIdemUUID,
+        metadata: {},
+      })
+      .returning({ id: accounts.id });
+
+    try {
+      await db.insert(transactions).values({
+        userId: userIdIdem,
+        accountId: copIdem.id,
+        occurredAt: utcDate(2026, 3, 10),
+        amountCents: BigInt(-181479701),
+        currency: "COP",
+        descriptionRaw: "AIRBNB IDEM",
+        merchant: "AIRBNB IDEM",
+        source: "gmail_bancolombia",
+        channel: "bank",
+      });
+
+      const usdStatement = buildParsed(
+        [
+          row({
+            authorizationNumber: "IDEM001",
+            merchant: "AIRBNB IDEM",
+            occurredAt: utcDate(2026, 3, 10),
+            amountCents: BigInt(48455),
+          }),
+        ],
+        {
+          account: { last4: "7291", currency: "USD" },
+          period: {
+            startDate: utcDate(2026, 2, 28),
+            endDate: utcDate(2026, 3, 31),
+            dueDate: utcDate(2026, 4, 16),
+          },
+        },
+      );
+
+      // First run — should reassign.
+      const report1 = await consolidateCycleFromStatement({
+        userId: userIdIdem,
+        accountId: usdIdem.id,
+        cycle: CROSS_TWIN_CYCLE,
+        parsed: usdStatement,
+        fileHash: "ct-idem-01".repeat(5).slice(0, 64),
+        dryRun: false,
+      });
+      expect(report1.status).toBe("consolidated");
+      expect(report1.matchStats.crossTwinReassigned).toBe(1);
+
+      // Second run — already-consolidated short-circuit kicks in.
+      const report2 = await consolidateCycleFromStatement({
+        userId: userIdIdem,
+        accountId: usdIdem.id,
+        cycle: CROSS_TWIN_CYCLE,
+        parsed: usdStatement,
+        fileHash: "ct-idem-01".repeat(5).slice(0, 64),
+        dryRun: false,
+      });
+      expect(report2.status).toBe("already-consolidated");
+
+      // Only 1 tx should exist (no phantom insert on second run).
+      const allTxs = await db
+        .select()
+        .from(transactions)
+        .where(and(eq(transactions.userId, userIdIdem), eq(transactions.accountId, usdIdem.id)));
+      // The reassigned tx + possibly a synthetic intereses tx (but definitely no duplicate).
+      // The intereses synthetic uses categorySlug="intereses-tc"; filter it out.
+      const nonInteresesTxs = allTxs.filter((t) => t.categorySlug !== "intereses-tc");
+      expect(nonInteresesTxs).toHaveLength(1);
+    } finally {
+      await db.delete(transactions).where(eq(transactions.userId, userIdIdem));
+      await db.delete(statementImports).where(eq(statementImports.userId, userIdIdem));
+      await db.delete(accounts).where(eq(accounts.userId, userIdIdem));
+      await db.delete(physicalCards).where(eq(physicalCards.id, physicalCardIdemUUID));
+      await db.delete(users).where(eq(users.id, userIdIdem));
+    }
   });
 });

--- a/src/lib/ingestion/bancolombia-statement/consolidate.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.ts
@@ -26,6 +26,7 @@ const ADJUSTMENTS_CATEGORY_SLUG = "adjustments";
 import {
   isBankInterestRow,
   matchStatementAgainstLedger,
+  merchantSimilarity,
   statementAmountToLedger,
   type MatchResult,
   type TxRowForMatch,
@@ -55,6 +56,10 @@ export type MatchStats = {
   insertedMissing: number;
   skippedMissingBefore: number;
   unmatchedInLedger: number;
+  // #555 — how many COP-twin txs were reassigned to this (USD) account
+  // because the USD statement matched them via merchantSimilarity + date window.
+  // Zero on accounts without a physicalCardId sibling.
+  crossTwinReassigned: number;
 };
 
 // #432 — projection of how the account's saldo disponible will change when
@@ -280,9 +285,13 @@ async function loadAccount(
   database: DB,
   userId: number,
   accountId: number,
-): Promise<{ id: number; currency: "COP" | "USD" }> {
+): Promise<{ id: number; currency: "COP" | "USD"; physicalCardId: string | null }> {
   const [row] = await database
-    .select({ id: accounts.id, currency: accounts.currency })
+    .select({
+      id: accounts.id,
+      currency: accounts.currency,
+      physicalCardId: accounts.physicalCardId,
+    })
     .from(accounts)
     .where(
       and(eq(accounts.userId, userId), eq(accounts.id, accountId), notDeleted(accounts.deletedAt)),
@@ -294,6 +303,72 @@ async function loadAccount(
     );
   }
   return row;
+}
+
+// #555 — if the account being consolidated has a physicalCardId, find the
+// sibling account (same physicalCardId, same user, different currency, not
+// soft-deleted). Returns null when no sibling exists (single-currency TC or no
+// physicalCardId). Used by the cross-twin reconciliation pass.
+async function loadSiblingTwinAccount(
+  database: DB,
+  userId: number,
+  physicalCardId: string,
+  excludeAccountId: number,
+): Promise<{ id: number; currency: "COP" | "USD" } | null> {
+  const [row] = await database
+    .select({ id: accounts.id, currency: accounts.currency })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, userId),
+        eq(accounts.physicalCardId, physicalCardId),
+        sql`${accounts.id} != ${excludeAccountId}`,
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+// #555 — shape of sibling twin txs fetched for cross-twin candidate matching.
+// We only load txs with sources that a gmail/sms parser would have created —
+// never csv_reconcile (those are already statement-sourced, no need to move them).
+export type SiblingTxForCrossTwin = {
+  id: number;
+  occurredAt: Date;
+  amountCents: bigint;
+  currency: "COP" | "USD";
+  merchant: string | null;
+  descriptionRaw: string;
+};
+
+async function loadSiblingTxsForCrossTwin(
+  database: DB,
+  userId: number,
+  siblingAccountId: number,
+  fromDate: Date,
+  toDate: Date,
+): Promise<SiblingTxForCrossTwin[]> {
+  return database
+    .select({
+      id: transactions.id,
+      occurredAt: transactions.occurredAt,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      merchant: transactions.merchant,
+      descriptionRaw: transactions.descriptionRaw,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.accountId, siblingAccountId),
+        gte(transactions.occurredAt, fromDate),
+        lte(transactions.occurredAt, toDate),
+        notDeleted(transactions.deletedAt),
+        sql`${transactions.source} IN ('gmail_bancolombia', 'sms')`,
+      ),
+    );
 }
 
 // #432 — inputs for BalanceProjection. Split out so tests can unit-feed the
@@ -646,12 +721,18 @@ async function loadExistingTxs(
   return rows;
 }
 
-function buildMatchStats(match: MatchResult, insertedBeforePeriodCount = 0): MatchStats {
+function buildMatchStats(
+  match: MatchResult,
+  insertedBeforePeriodCount = 0,
+  crossTwinReassigned = 0,
+): MatchStats {
   const matchedWillChange = match.matched.filter((m) => m.willChange).length;
   // `insertedMissing` counts during-period inserts + before-period installment
   // inserts (added in #557) so the UI "Nuevas" stat reflects everything landed.
+  // Cross-twin reassigned rows are NOT counted here — they are moves, not inserts.
   const insertedMissing =
-    match.missingInLedger.filter((r) => r.kind === "during-period").length +
+    match.missingInLedger.filter((r) => r.kind === "during-period").length -
+    crossTwinReassigned +
     insertedBeforePeriodCount;
   // `skippedMissingBefore` = before-period rows that did NOT qualify for insert
   // (1-cuota, missing rate, credit/abono, or no authCode).
@@ -664,6 +745,7 @@ function buildMatchStats(match: MatchResult, insertedBeforePeriodCount = 0): Mat
     insertedMissing,
     skippedMissingBefore,
     unmatchedInLedger: match.unmatchedInLedger.length,
+    crossTwinReassigned,
   };
 }
 
@@ -765,10 +847,28 @@ export async function consolidateCycleFromStatement(
   }
 
   const earliest = minRowDate(opts.parsed);
-  const fromDate = earliest ? addDays(earliest, -2) : addDays(opts.parsed.period.startDate, -2);
-  const toDate = addDays(opts.parsed.period.endDate, 2);
+  // #555: cross-twin window is ±3 Bogota days — wider than the same-account
+  // window (±1 day) because the email is ingested in real-time with a slight
+  // timezone skew vs. the statement's calendar date. The same fromDate/toDate
+  // expansion is re-used for both the same-account and cross-twin tx loads.
+  const CROSS_TWIN_DAYS = 3;
+  const fromDate = earliest
+    ? addDays(earliest, -CROSS_TWIN_DAYS)
+    : addDays(opts.parsed.period.startDate, -CROSS_TWIN_DAYS);
+  const toDate = addDays(opts.parsed.period.endDate, CROSS_TWIN_DAYS);
   const txs = await loadExistingTxs(database, opts.userId, opts.accountId, fromDate, toDate);
   const match = matchStatementAgainstLedger(opts.parsed, txs);
+
+  // #555 — load sibling twin account + its ledger txs for cross-twin pass.
+  // Both are null when the account has no physicalCardId (single-currency TC).
+  const siblingAccount =
+    account.physicalCardId !== null
+      ? await loadSiblingTwinAccount(database, opts.userId, account.physicalCardId, opts.accountId)
+      : null;
+  const siblingTxs: SiblingTxForCrossTwin[] =
+    siblingAccount !== null
+      ? await loadSiblingTxsForCrossTwin(database, opts.userId, siblingAccount.id, fromDate, toDate)
+      : [];
 
   // #432 — snapshot saldo + plugs BEFORE any mutation so the projection
   // reflects the pre-commit state in both dry-run and commit paths.
@@ -814,106 +914,275 @@ export async function consolidateCycleFromStatement(
   // outside this tx avoids the drizzle DB-vs-Transaction type mismatch and
   // makes partial-failure semantics sane (ledger fix commits even if the
   // intereses job fails; user can retry).
-  const { imp, matchedIdsToUpdate, insertedTxIds, insertedBeforePeriodCount } =
-    await database.transaction(async (txDb) => {
-      const [imp] = await txDb
-        .insert(statementImports)
-        .values({
-          userId: opts.userId,
-          accountId: opts.accountId,
-          fileHash: opts.fileHash,
-          periodStart: toIsoDate(opts.parsed.period.startDate),
-          periodEnd: toIsoDate(opts.parsed.period.endDate),
-          txnCount: 0,
-          kind: "extracto_detallado",
-          cycle: opts.cycle,
-          report: null,
-        })
-        .returning({ id: statementImports.id });
+  const {
+    imp,
+    matchedIdsToUpdate,
+    insertedTxIds,
+    insertedBeforePeriodCount,
+    crossTwinReassignedIds,
+  } = await database.transaction(async (txDb) => {
+    const [imp] = await txDb
+      .insert(statementImports)
+      .values({
+        userId: opts.userId,
+        accountId: opts.accountId,
+        fileHash: opts.fileHash,
+        periodStart: toIsoDate(opts.parsed.period.startDate),
+        periodEnd: toIsoDate(opts.parsed.period.endDate),
+        txnCount: 0,
+        kind: "extracto_detallado",
+        cycle: opts.cycle,
+        report: null,
+      })
+      .returning({ id: statementImports.id });
 
-      const matchedIdsToUpdate: number[] = [];
-      for (const m of match.matched) {
-        if (!m.willChange) continue;
+    const matchedIdsToUpdate: number[] = [];
+    for (const m of match.matched) {
+      if (!m.willChange) continue;
+      await txDb
+        .update(transactions)
+        .set({
+          installmentsTotal: m.diff.installmentsTotalAfter,
+          ...(m.diff.rateEmX10kAfter !== null && {
+            installmentRateEmX10k: m.diff.rateEmX10kAfter,
+          }),
+          reconciliationStatus: "matched",
+          reconciledAt: new Date(),
+          statementImportId: imp.id,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(transactions.id, m.txId), eq(transactions.userId, opts.userId)));
+      matchedIdsToUpdate.push(m.txId);
+    }
+
+    // #555 — cross-twin reconciliation pass.
+    // For each during-period row that is missing from this account's ledger,
+    // look in the sibling twin (COP) account for a gmail_bancolombia/sms tx
+    // that matches on merchant similarity + date proximity. When found, move
+    // the tx to this (USD) account with the statement amount/currency, marking
+    // source_mismatch so the divergence is auditable.
+    //
+    // This runs AFTER the same-account match loop so that txs already matched
+    // within the same account are never considered for cross-twin.
+    //
+    // Security: every query in this block is scoped by opts.userId — the
+    // sibling query (loadSiblingTwinAccount) also filters by userId, so a
+    // different user's physicalCardId would never be reachable.
+    const crossTwinReassignedIds: number[] = [];
+    const crossTwinReassignedRowIndices = new Set<number>();
+    const CROSS_TWIN_SIMILARITY_THRESHOLD = 0.3;
+    const CROSS_TWIN_DATE_TOLERANCE_DAYS = 3;
+
+    if (siblingAccount !== null && siblingTxs.length > 0) {
+      // Build a mutable pool of sibling candidates so each tx is picked at
+      // most once (prevents double-reassignment if two statement rows happen
+      // to match the same sibling tx).
+      const siblingPool = new Map<number, SiblingTxForCrossTwin>(siblingTxs.map((t) => [t.id, t]));
+
+      for (let rowIdx = 0; rowIdx < match.missingInLedger.length; rowIdx++) {
+        const row = match.missingInLedger[rowIdx];
+        if (row.kind !== "during-period") continue;
+        if (isBankInterestRow(row)) continue;
+        if (row.authorizationNumber === null) continue;
+
+        // The statement row uses extracto sign (compra = positive). We want
+        // to find a sibling tx that represents the same expenditure regardless
+        // of the amount — the COP tx and the USD statement row will have
+        // completely different magnitudes, so we do NOT filter by amount.
+        // We rely solely on merchant similarity + date proximity.
+        const candidates = Array.from(siblingPool.values()).filter((sibling) => {
+          const dateDelta = Math.abs(
+            Math.floor(
+              (sibling.occurredAt.getTime() - 5 * 60 * 60 * 1000) / (24 * 60 * 60 * 1000),
+            ) - Math.floor((row.occurredAt.getTime() - 5 * 60 * 60 * 1000) / (24 * 60 * 60 * 1000)),
+          );
+          if (dateDelta > CROSS_TWIN_DATE_TOLERANCE_DAYS) return false;
+          const label = sibling.merchant ?? sibling.descriptionRaw;
+          return merchantSimilarity(row.merchant, label) > CROSS_TWIN_SIMILARITY_THRESHOLD;
+        });
+
+        if (candidates.length === 0) continue;
+
+        // Among candidates, pick by: smallest date delta → highest merchant
+        // similarity → smallest tx id (same tiebreak as pickBestCandidate in
+        // match.ts, adapted for SiblingTxForCrossTwin shape).
+        const best = candidates
+          .map((sibling) => {
+            const label = sibling.merchant ?? sibling.descriptionRaw;
+            return {
+              sibling,
+              dateDelta: Math.abs(
+                Math.floor(
+                  (sibling.occurredAt.getTime() - 5 * 60 * 60 * 1000) / (24 * 60 * 60 * 1000),
+                ) -
+                  Math.floor(
+                    (row.occurredAt.getTime() - 5 * 60 * 60 * 1000) / (24 * 60 * 60 * 1000),
+                  ),
+              ),
+              similarity: merchantSimilarity(row.merchant, label),
+            };
+          })
+          .sort((a, b) => {
+            if (a.dateDelta !== b.dateDelta) return a.dateDelta - b.dateDelta;
+            if (a.similarity !== b.similarity) return b.similarity - a.similarity;
+            return a.sibling.id - b.sibling.id;
+          })[0].sibling;
+
+        siblingPool.delete(best.id);
+
+        const originalAmountCents = best.amountCents;
+        const originalCurrency = best.currency;
+        const originalAccountId = siblingAccount.id;
+        const newAmountCents = statementAmountToLedger(row.amountCents);
+        const impliedTrm =
+          row.amountCents > BigInt(0) && newAmountCents !== BigInt(0)
+            ? (
+                Number(
+                  originalAmountCents < BigInt(0) ? -originalAmountCents : originalAmountCents,
+                ) / Number(newAmountCents < BigInt(0) ? -newAmountCents : newAmountCents)
+              ).toFixed(2)
+            : null;
+
         await txDb
           .update(transactions)
           .set({
-            installmentsTotal: m.diff.installmentsTotalAfter,
-            ...(m.diff.rateEmX10kAfter !== null && {
-              installmentRateEmX10k: m.diff.rateEmX10kAfter,
-            }),
+            accountId: opts.accountId,
+            currency: account.currency,
+            amountCents: newAmountCents,
             reconciliationStatus: "matched",
             reconciledAt: new Date(),
             statementImportId: imp.id,
+            sourceMismatch: true,
+            sourceMismatchDetails: {
+              fromSource: "gmail_bancolombia",
+              toSource: "csv_reconcile",
+              diffs: [
+                {
+                  field: "accountId",
+                  fromValue: String(originalAccountId),
+                  toValue: String(opts.accountId),
+                },
+                {
+                  field: "amountCents",
+                  fromValue: originalAmountCents.toString(),
+                  toValue: newAmountCents.toString(),
+                },
+                {
+                  field: "currency",
+                  fromValue: originalCurrency,
+                  toValue: account.currency,
+                },
+                {
+                  field: "impliedTrm",
+                  fromValue: null,
+                  toValue: impliedTrm,
+                },
+              ],
+            },
             updatedAt: new Date(),
           })
-          .where(and(eq(transactions.id, m.txId), eq(transactions.userId, opts.userId)));
-        matchedIdsToUpdate.push(m.txId);
-      }
+          // Tenant-safety: must match BOTH id AND userId — never rely on id alone.
+          .where(and(eq(transactions.id, best.id), eq(transactions.userId, opts.userId)));
 
-      const insertedTxIds: number[] = [];
-      let insertedBeforePeriodCount = 0;
-      for (const row of match.missingInLedger) {
-        if (row.kind === "before-period") {
-          // #557: insert missing before-period multi-cuota purchases so the
-          // intereses-causados job can price them in the current cycle.
-          // Non-qualifying rows (credits, 1-cuota, missing rate, no authCode)
-          // are skipped silently — they are either not installment purchases or
-          // already have no interest potential.
-          if (!isInsertableBeforePeriodRow(row)) continue;
-          const inserted = await insertMissingBeforePeriodRowInTx(txDb, {
-            opts,
-            account,
-            row,
-            statementImportId: imp.id,
-          });
-          if (inserted !== null) {
-            insertedTxIds.push(inserted);
-            insertedBeforePeriodCount += 1;
-            log.info(
-              {
-                accountId: opts.accountId,
-                cycle: opts.cycle,
-                merchant: row.merchant,
-                installmentsTotal: row.installments?.total,
-                rateEmX10k: row.rateEmX10k,
-                txId: inserted,
-                event: "before_period_installment_inserted",
-              },
-              "consolidate: inserted missing before-period installment purchase",
-            );
-          }
-          continue;
-        }
-        // during-period
-        if (isBankInterestRow(row)) continue;
-        if (row.authorizationNumber === null) {
-          log.warn(
-            {
-              accountId: opts.accountId,
-              cycle: opts.cycle,
-              merchant: row.merchant,
-              event: "missing_auth_skip",
-            },
-            "consolidate: skipping missing row without authorizationNumber",
-          );
-          continue;
-        }
-        const inserted = await insertMissingRowInTx(txDb, {
+        crossTwinReassignedIds.push(best.id);
+        crossTwinReassignedRowIndices.add(rowIdx);
+
+        log.info(
+          {
+            userId: opts.userId,
+            accountId: opts.accountId,
+            cycle: opts.cycle,
+            siblingAccountId: originalAccountId,
+            txId: best.id,
+            merchant: row.merchant,
+            originalAmountCents: originalAmountCents.toString(),
+            newAmountCents: newAmountCents.toString(),
+            originalCurrency,
+            newCurrency: account.currency,
+            impliedTrm,
+            event: "cross_twin_reassigned",
+          },
+          "consolidate: cross-twin reassignment — moved tx from COP sibling to USD account",
+        );
+      }
+    }
+
+    const insertedTxIds: number[] = [];
+    let insertedBeforePeriodCount = 0;
+    for (let rowIdx = 0; rowIdx < match.missingInLedger.length; rowIdx++) {
+      const row = match.missingInLedger[rowIdx];
+      // #555 — skip rows already handled by the cross-twin pass above.
+      if (crossTwinReassignedRowIndices.has(rowIdx)) continue;
+
+      if (row.kind === "before-period") {
+        // #557: insert missing before-period multi-cuota purchases so the
+        // intereses-causados job can price them in the current cycle.
+        // Non-qualifying rows (credits, 1-cuota, missing rate, no authCode)
+        // are skipped silently — they are either not installment purchases or
+        // already have no interest potential.
+        if (!isInsertableBeforePeriodRow(row)) continue;
+        const inserted = await insertMissingBeforePeriodRowInTx(txDb, {
           opts,
           account,
           row,
           statementImportId: imp.id,
         });
-        if (inserted !== null) insertedTxIds.push(inserted);
+        if (inserted !== null) {
+          insertedTxIds.push(inserted);
+          insertedBeforePeriodCount += 1;
+          log.info(
+            {
+              accountId: opts.accountId,
+              cycle: opts.cycle,
+              merchant: row.merchant,
+              installmentsTotal: row.installments?.total,
+              rateEmX10k: row.rateEmX10k,
+              txId: inserted,
+              event: "before_period_installment_inserted",
+            },
+            "consolidate: inserted missing before-period installment purchase",
+          );
+        }
+        continue;
       }
+      // during-period
+      if (isBankInterestRow(row)) continue;
+      if (row.authorizationNumber === null) {
+        log.warn(
+          {
+            accountId: opts.accountId,
+            cycle: opts.cycle,
+            merchant: row.merchant,
+            event: "missing_auth_skip",
+          },
+          "consolidate: skipping missing row without authorizationNumber",
+        );
+        continue;
+      }
+      const inserted = await insertMissingRowInTx(txDb, {
+        opts,
+        account,
+        row,
+        statementImportId: imp.id,
+      });
+      if (inserted !== null) insertedTxIds.push(inserted);
+    }
 
-      await txDb
-        .update(statementImports)
-        .set({ txnCount: matchedIdsToUpdate.length + insertedTxIds.length })
-        .where(eq(statementImports.id, imp.id));
+    await txDb
+      .update(statementImports)
+      .set({
+        txnCount: matchedIdsToUpdate.length + insertedTxIds.length + crossTwinReassignedIds.length,
+      })
+      .where(eq(statementImports.id, imp.id));
 
-      return { imp, matchedIdsToUpdate, insertedTxIds, insertedBeforePeriodCount };
-    });
+    return {
+      imp,
+      matchedIdsToUpdate,
+      insertedTxIds,
+      insertedBeforePeriodCount,
+      crossTwinReassignedIds,
+    };
+  });
 
   const interesesResult = await applyInteresesCausadosForCycle({
     userId: opts.userId,
@@ -976,7 +1245,7 @@ export async function consolidateCycleFromStatement(
     cycle: opts.cycle,
     dryRun: false,
     status: "consolidated",
-    matchStats: buildMatchStats(match, insertedBeforePeriodCount),
+    matchStats: buildMatchStats(match, insertedBeforePeriodCount, crossTwinReassignedIds.length),
     matchedTxIds: matchedIdsToUpdate,
     insertedTxIds,
     matchedDiffs: serializeMatchedDiffs(match),


### PR DESCRIPTION
## Summary

- Adds a **cross-twin reconciliation pass** to `consolidateCycleFromStatement`: when the USD extracto_detallado is processed, any during-period statement row missing from the USD account is now matched against the sibling COP twin account (linked via `physical_card_id`) for `gmail_bancolombia` / `sms` sourced txs within ±3 Bogota days and `merchantSimilarity > 0.3`
- On a match, the COP tx is moved to the USD account with the real USD amount/currency from the statement, `reconciliation_status=matched`, and `source_mismatch_details` recording the original COP amount, the new USD amount, and the implied TRM for auditability
- Accounts without `physicalCardId` (single-currency TCs) skip the pass entirely — zero overhead on the common path
- `MatchStats` gains `crossTwinReassigned: number` (additive, non-breaking)
- Concretely fixes: AIRBNB 2026-03-10 tx id 1081 — after importing the MAR USD statement, it will land on account_id=7 as −$484.55 USD instead of staying as −$1,814,797 COP on account_id=6

## Test plan

- [x] Happy path: COP gmail tx → USD account after USD statement consolidation (amount, currency, accountId, reconciliationStatus, sourceMismatchDetails all verified)
- [x] No-sibling skip: account without `physicalCardId` → `crossTwinReassigned=0`, no errors
- [x] Low-similarity gate: `merchantSimilarity ≤ 0.3` → no reassignment, unmatched row inserted as new tx instead
- [x] `pickBestCandidate` determinism: two same-day candidates → higher-similarity tx wins
- [x] Idempotency: running consolidate twice → second call hits `already-consolidated`, no double-reassignment
- [x] Full test suite passes (1705 tests via pre-push hook)

Closes #555
Completes epic #558 (last sub-issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)