### PR TITLE
fix(ingestion): persist balance_at_end_cents from statement summary (#563)

### DIFF
--- a/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
@@ -84,6 +84,7 @@ function buildParsed(
       paymentsCents: BigInt(0),
       minPaymentCents: BigInt(0),
       totalPaymentCents: BigInt(0),
+      currentBalanceCents: BigInt(0),
     },
     currentRates: { oneMonth: 0, months2to36: 19110, advances: 19110 },
     rows,
@@ -335,6 +336,9 @@ describe("consolidateCycleFromStatement — integration against findash_test", (
       expect(imp.syntheticTxId).toBe(report.intereses.txId);
     }
     expect(imp.txnCount).toBe(4); // 3 UPDATEd + 1 INSERTed.
+    // #563 — balance_at_end_cents must be persisted from summary.currentBalanceCents.
+    // buildParsed uses totalPaymentCents=0 so the fixture yields 0 here.
+    expect(imp.balanceAtEndCents).toBe(BigInt(0));
 
     // The ghost tx stays untouched but surfaces as unmatched in the report.
     expect(report.unmatchedInLedgerIds).toContain(txUnmatched);
@@ -1295,5 +1299,77 @@ describe("consolidateCycleFromStatement — cross-twin reconciliation (#555)", (
       await db.delete(physicalCards).where(eq(physicalCards.id, physicalCardIdemUUID));
       await db.delete(users).where(eq(users.id, userIdIdem));
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// balance_at_end_cents persistence (#563)
+// ---------------------------------------------------------------------------
+// Verifies that consolidate writes parsed.summary.currentBalanceCents to the
+// statement_imports.balance_at_end_cents column on first consolidation.
+describe("consolidateCycleFromStatement — balance_at_end_cents persistence (#563)", () => {
+  const BALANCE_CYCLE = "2026-06";
+  const TAG_BAL = "STMT_BAL_TEST";
+  let userIdBal!: number;
+  let accountIdBal!: number;
+
+  beforeAll(async () => {
+    userIdBal = await createUser(`${TAG_BAL.toLowerCase()}.${Date.now()}@test.local`);
+    accountIdBal = await createTCAccount(userIdBal);
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userIdBal);
+  });
+
+  it("persists a non-zero currentBalanceCents as balance_at_end_cents on statement_imports", async () => {
+    // Simulate a cycle-end balance of $7,744,665 COP (real value from 2575_MAR2026).
+    const CURRENT_BALANCE = BigInt(774466500); // cents
+
+    const parsed = buildParsed(
+      [
+        row({
+          authorizationNumber: "BALTEST1",
+          merchant: "BALANCE TEST MERCHANT",
+          occurredAt: utcDate(2026, 6, 15),
+          amountCents: BigInt(100000),
+        }),
+      ],
+      {
+        period: {
+          startDate: utcDate(2026, 6, 1),
+          endDate: utcDate(2026, 6, 30),
+          dueDate: utcDate(2026, 7, 16),
+        },
+        summary: {
+          previousBalanceCents: BigInt(0),
+          purchasesCents: BigInt(100000),
+          interestCorrientesCents: BigInt(0),
+          paymentsCents: BigInt(0),
+          minPaymentCents: BigInt(0),
+          totalPaymentCents: CURRENT_BALANCE,
+          currentBalanceCents: CURRENT_BALANCE,
+        },
+      },
+    );
+
+    const report = await consolidateCycleFromStatement({
+      userId: userIdBal,
+      accountId: accountIdBal,
+      cycle: BALANCE_CYCLE,
+      parsed,
+      fileHash: "bal563".repeat(10).slice(0, 64),
+      dryRun: false,
+    });
+
+    expect(report.status).toBe("consolidated");
+    expect(report.statementImportId).not.toBeNull();
+
+    const [imp] = await db
+      .select()
+      .from(statementImports)
+      .where(eq(statementImports.id, report.statementImportId!));
+    // Round-trip: balance_at_end_cents must equal the parsed summary value.
+    expect(imp.balanceAtEndCents).toBe(CURRENT_BALANCE);
   });
 });

--- a/src/lib/ingestion/bancolombia-statement/consolidate.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.ts
@@ -932,6 +932,10 @@ export async function consolidateCycleFromStatement(
         txnCount: 0,
         kind: "extracto_detallado",
         cycle: opts.cycle,
+        // #563 — persist the cycle-end balance from the extracto summary so
+        // the snapshot backfill (#562) can use it as an opening-balance anchor.
+        // currentBalanceCents = "Pago total" = what the bank says you owe.
+        balanceAtEndCents: opts.parsed.summary.currentBalanceCents,
         report: null,
       })
       .returning({ id: statementImports.id });

--- a/src/lib/ingestion/bancolombia-statement/match.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/match.test.ts
@@ -27,6 +27,7 @@ function buildStatement(rows: StatementRow[]): ParsedStatement {
       paymentsCents: BigInt(0),
       minPaymentCents: BigInt(0),
       totalPaymentCents: BigInt(0),
+      currentBalanceCents: BigInt(0),
     },
     currentRates: { oneMonth: 0, months2to36: 19110, advances: 19110 },
     rows,

--- a/src/lib/ingestion/bancolombia-statement/types.ts
+++ b/src/lib/ingestion/bancolombia-statement/types.ts
@@ -29,6 +29,11 @@ export type StatementSummary = {
   paymentsCents: bigint;
   minPaymentCents: bigint;
   totalPaymentCents: bigint;
+  // Cycle-end balance ("Pago total" on the XLSX — the amount the bank says
+  // you owe at end of cycle). Equals totalPaymentCents in the Bancolombia
+  // extracto format (both come from the same "Pago total" row). Persisted
+  // as balance_at_end_cents on statement_imports for backfill use (#562).
+  currentBalanceCents: bigint;
 };
 
 // Rates are stored as EM (mes vencido) × 10_000 per project convention

--- a/src/lib/ingestion/bancolombia-statement/xlsx.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/xlsx.test.ts
@@ -362,6 +362,10 @@ describe("parseBancolombiaStatement (synthetic fixture)", () => {
     expect(parsed.summary.paymentsCents).toBe(BigInt(10000000));
     expect(parsed.summary.minPaymentCents).toBe(BigInt(10000000));
     expect(parsed.summary.totalPaymentCents).toBe(BigInt(50000000));
+    // #563 — currentBalanceCents = "Pago total" (cycle-end balance).
+    // Bancolombia XLSX has no separate "Nuevo saldo" row; pago total IS the
+    // current balance. Verified against 7291+2575 MAR2026 real extractos.
+    expect(parsed.summary.currentBalanceCents).toBe(BigInt(50000000));
   });
 
   it("extracts current rates", () => {
@@ -493,6 +497,8 @@ describeIfFixture("parseBancolombiaStatement (real fixture 202603 Visa 2575)", (
     expect(parsed.summary.purchasesCents).toBe(BigInt(360129100));
     expect(parsed.summary.minPaymentCents).toBe(BigInt(435143100));
     expect(parsed.summary.totalPaymentCents).toBe(BigInt(774466500));
+    // #563 — currentBalanceCents mirrors totalPaymentCents (same XLSX row).
+    expect(parsed.summary.currentBalanceCents).toBe(BigInt(774466500));
   });
 
   it("matches acceptance rate (2-36 meses === 19110)", () => {

--- a/src/lib/ingestion/bancolombia-statement/xlsx.ts
+++ b/src/lib/ingestion/bancolombia-statement/xlsx.ts
@@ -344,13 +344,22 @@ function extractSummary(rows: SheetRows): StatementSummary {
   const interestRaw = findSummaryValueByLabel(rows, "intereses corrientes", 3, 4);
   const paymentsRaw = findSummaryValueByLabel(rows, "pagos / abonos", 3, 4);
 
+  // "Pago total" (col A / col B header row) is what the bank declares as the
+  // cycle-end balance — the amount you owe. No separate "Nuevo saldo" / "Saldo
+  // nuevo" label exists in Bancolombia XLSX extractos (verified against
+  // 7291_MAR2026 PESOS+DOLARES and 2575_MAR2026 PESOS — issue #563).
+  // currentBalanceCents is an alias for totalPaymentCents; both use the same
+  // source row so they are always equal. The separate field exists for semantic
+  // clarity when writing balance_at_end_cents on statement_imports.
+  const totalPayCents = parseCopAmount(totalPayRaw);
   return {
     previousBalanceCents: parseCopAmount(previousRaw),
     purchasesCents: parseCopAmount(purchasesRaw),
     interestCorrientesCents: parseCopAmount(interestRaw),
     paymentsCents: parseCopAmount(paymentsRaw),
     minPaymentCents: parseCopAmount(minPayRaw),
-    totalPaymentCents: parseCopAmount(totalPayRaw),
+    totalPaymentCents: totalPayCents,
+    currentBalanceCents: totalPayCents,
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `currentBalanceCents: bigint` to `StatementSummary` in `types.ts`
- Populates it from the "Pago total" header row in `extractSummary()` — Bancolombia XLSX extractos have **no** "Nuevo saldo"/"Saldo nuevo" label; "Pago total" IS the cycle-end balance (verified against 7291_MAR2026 PESOS+DOLARES and 2575_MAR2026 PESOS)
- Wires `balanceAtEndCents: parsed.summary.currentBalanceCents` into the `statement_imports` INSERT in `consolidate.ts`
- All 7 prod rows with `balance_at_end_cents = NULL` can now be backfilled by #562 part c

## XLSX discovery

No `Nuevo saldo`/`Saldo nuevo` row exists in any sheet inspected. The summary section ends at `Abono` (r=27). The balance = `Cargos - Abono` = "Pago total" (r=11 col B), which `extractSummary` already reads as `totalPaymentCents`. `currentBalanceCents` is a semantic alias for the same parsed value.

## Test plan

- `xlsx.test.ts`: updated existing "extracts summary values" assertions + real-fixture assertion to include `currentBalanceCents`
- `consolidate.test.ts`: existing commit test asserts `imp.balanceAtEndCents === BigInt(0)`; new dedicated `describe` block ("balance_at_end_cents persistence #563") proves round-trip with a non-zero value (`BigInt(774466500)` — real value from 2575_MAR2026)
- `match.test.ts`: `StatementSummary` fixture updated to include `currentBalanceCents`
- Full suite: 1706 tests, 134 files, all passing before push

Closes #563
Part of #562 (bundled backfill — part b)