### PR TITLE
feat(reconciliation): savings parser as source-of-truth for Pago TC twin routing (#567)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:backfill:users": "bun run scripts/backfill-users-reference.ts",
     "db:migrate:pago-tc": "bun run scripts/migrate-pago-tc-to-transfer.ts",
     "intereses:run": "bun run scripts/run-intereses-causados.ts",
+    "backfill:arq-snapshots": "bun run scripts/backfill-arq-snapshots.ts",
     "statement:parse": "bun run scripts/parse-bancolombia-statement.ts",
     "statement:apply": "bun run scripts/consolidate-statement.ts",
     "db:bootstrap:invites": "bun run scripts/bootstrap-invites.ts",

--- a/scripts/backfill-arq-snapshots.ts
+++ b/scripts/backfill-arq-snapshots.ts
@@ -1,0 +1,190 @@
+// #562(c): Backfill account_snapshots from arq_statement_imports.
+//
+// For each reconciled ARQ statement import, writes a snapshot row anchoring
+// the opening balance (declaredStartCents) at periodStart. This lets
+// derivedBalanceCentsSql (#562c) show the correct real balance for ARQ
+// Ahorros (USD) accounts instead of "$0 + delta".
+//
+// Invocation:
+//   bun run backfill:arq-snapshots
+//   bun run backfill:arq-snapshots --dry-run
+//   bun run backfill:arq-snapshots --user-id=1
+//   bun run backfill:arq-snapshots --user-id=1 --dry-run
+//
+// Flags:
+//   --dry-run      Print what would be inserted without writing anything.
+//   --user-id=N    Restrict to a single user (optional; defaults to all users).
+//
+// Idempotent: uses ON CONFLICT DO UPDATE — safe to re-run. If a snapshot was
+// already written by a forward-write (from run-statement-import.ts), the row
+// is overwritten with the same value (no net change).
+//
+// One snapshot per statement period: unlike the original exploration notes
+// (earliest-only), we write ONE snapshot per period_start so that the latest
+// snapshot always anchors the balance correctly even if intermediate periods
+// are later reimported with amended figures.
+
+import { and, eq, sql } from "drizzle-orm";
+
+import { db } from "../src/lib/db";
+import { accountSnapshots, arqStatementImports } from "../src/lib/db/schema";
+import { createLogger } from "../src/lib/logger";
+
+const log = createLogger({ module: "backfill-arq-snapshots" });
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: string[]): { dryRun: boolean; userId: number | null } {
+  let dryRun = false;
+  let userId: number | null = null;
+  for (const arg of argv.slice(2)) {
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    const m = arg.match(/^--user-id=(\d+)$/);
+    if (m) {
+      userId = Number(m[1]);
+      continue;
+    }
+    log.warn({ arg, event: "backfill_arq_snapshots_unknown_arg" }, "unknown flag — ignored");
+  }
+  return { dryRun, userId };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { dryRun, userId } = parseArgs(process.argv);
+
+  log.info(
+    { dryRun, userId, event: "backfill_arq_snapshots_start" },
+    dryRun ? "DRY RUN — no writes will be performed" : "starting backfill",
+  );
+
+  // Fetch all reconciled ARQ statement imports, optionally scoped to one user.
+  const where =
+    userId !== null
+      ? and(eq(arqStatementImports.userId, userId), eq(arqStatementImports.reconciled, true))
+      : eq(arqStatementImports.reconciled, true);
+
+  const imports = await db.query.arqStatementImports.findMany({
+    where,
+    columns: {
+      id: true,
+      userId: true,
+      accountId: true,
+      periodStart: true,
+      declaredStartCents: true,
+    },
+  });
+
+  if (imports.length === 0) {
+    log.info({ event: "backfill_arq_snapshots_noop" }, "no reconciled arq_statement_imports found");
+    await db.$client.end({ timeout: 1 });
+    return;
+  }
+
+  log.info(
+    { count: imports.length, event: "backfill_arq_snapshots_found" },
+    "reconciled imports to process",
+  );
+
+  let inserted = 0;
+  let updated = 0;
+  let errors = 0;
+
+  for (const imp of imports) {
+    const snapshotDate = imp.periodStart; // already YYYY-MM-DD string
+    const balanceCents = imp.declaredStartCents;
+    const metadata = { source: "arq_statement_backfill", importId: imp.id };
+
+    log.info(
+      {
+        importId: imp.id,
+        userId: imp.userId,
+        accountId: imp.accountId,
+        snapshotDate,
+        balanceCents: balanceCents.toString(),
+        event: "backfill_arq_snapshots_row",
+      },
+      dryRun ? "[dry-run] would upsert snapshot" : "upserting snapshot",
+    );
+
+    if (dryRun) continue;
+
+    try {
+      // Check if the row already exists to distinguish insert vs update in logging.
+      const existing = await db.query.accountSnapshots.findFirst({
+        where: and(
+          eq(accountSnapshots.accountId, imp.accountId),
+          eq(accountSnapshots.snapshotDate, snapshotDate),
+        ),
+        columns: { id: true },
+      });
+
+      await db
+        .insert(accountSnapshots)
+        .values({
+          userId: imp.userId,
+          accountId: imp.accountId,
+          snapshotDate,
+          balanceCents,
+          metadata,
+        })
+        .onConflictDoUpdate({
+          target: [accountSnapshots.accountId, accountSnapshots.snapshotDate],
+          set: {
+            balanceCents: sql`excluded.balance_cents`,
+            metadata: sql`excluded.metadata`,
+          },
+        });
+
+      if (existing) {
+        updated += 1;
+      } else {
+        inserted += 1;
+      }
+    } catch (err) {
+      log.error(
+        {
+          importId: imp.id,
+          userId: imp.userId,
+          accountId: imp.accountId,
+          snapshotDate,
+          err,
+          event: "backfill_arq_snapshots_error",
+        },
+        "failed to upsert snapshot — continuing",
+      );
+      errors += 1;
+    }
+  }
+
+  log.info(
+    {
+      dryRun,
+      total: imports.length,
+      inserted,
+      updated,
+      errors,
+      event: "backfill_arq_snapshots_done",
+    },
+    dryRun ? "DRY RUN complete" : "backfill complete",
+  );
+
+  await db.$client.end({ timeout: 1 });
+
+  if (errors > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  log.error({ err, event: "backfill_arq_snapshots_fatal" }, "backfill-arq-snapshots failed");
+  process.exit(1);
+});

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
@@ -16,6 +16,7 @@ import { parseAny } from "@/lib/reconciliation/dispatch";
 import { matchStatement } from "@/lib/reconciliation/engine/match";
 import type { ExistingTxnForMatch, MatchingPlan } from "@/lib/reconciliation/engine/types";
 import type { ParsedStatement } from "@/lib/reconciliation/parsers/types";
+import { applyPagoTcRouting } from "@/lib/reconciliation/pago-tc-router";
 import { createLogger } from "@/lib/logger";
 import { expandReconcileWindow } from "./window";
 
@@ -380,6 +381,28 @@ export async function applyReconcile(input: ApplyReconcileInput) {
     },
     "reconciliation applied",
   );
+
+  // #567 — after committing a savings extract, run Pago TC twin routing.
+  // Savings descriptions carry DOLAR/PESOS distinction that gmail/SMS lack,
+  // so this step corrects any misrouted destination legs and inserts any
+  // missing transfer pairs. Only runs when the uploaded file is a savings
+  // statement (not a TC statement).
+  if (result.status === "applied" && parsedStatement.format === "bancolombia_savings") {
+    const pagoResult = await applyPagoTcRouting({
+      userId: session.id,
+      savingsAccountId: account.id,
+      rows: parsedStatement.rows,
+    });
+    log.info(
+      {
+        event: "pago_tc_routing_result",
+        userId: session.id,
+        accountId: account.id,
+        ...pagoResult,
+      },
+      "pago tc routing completed after savings reconciliation",
+    );
+  }
 
   revalidatePath("/");
   revalidatePath("/transactions");

--- a/src/lib/accounts/queries.test.ts
+++ b/src/lib/accounts/queries.test.ts
@@ -2,7 +2,14 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { randomUUID } from "node:crypto";
 import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, categories, physicalCards, transactions, users } from "@/lib/db/schema";
+import {
+  accountSnapshots,
+  accounts,
+  categories,
+  physicalCards,
+  transactions,
+  users,
+} from "@/lib/db/schema";
 import { getAvailableCreditCOP, listAccountsDetailed } from "./queries";
 
 // #368: balance is now derived from SUM(transactions.amount_cents). Tests
@@ -337,5 +344,164 @@ describe("listAccountsDetailed: physical card join", () => {
     // assertion above is the important part. Also nuke the PC.
     await db.execute(sql`DELETE FROM accounts WHERE name = ${MARKER + "-crosstenant"}`);
     await db.delete(physicalCards).where(eq(physicalCards.id, pcId));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// derivedBalanceCentsSql — snapshot-anchored balance (#562c)
+//
+// These tests verify the new formula:
+//   WITH snapshot: balance = snapshot.balance_cents + SUM(txs where occurred_at >= snapshot_date)
+//   WITHOUT snapshot: balance = COALESCE(SUM(all non-archived txs), 0)  (original behaviour)
+// ---------------------------------------------------------------------------
+
+describe("derivedBalanceCentsSql: snapshot-anchored balance (#562c)", () => {
+  afterEach(async () => {
+    // accountSnapshots has ON DELETE CASCADE from accounts, so deleting the
+    // MARKER accounts also deletes their snapshots. But we also clean up
+    // any snapshots explicitly before the accounts (in case a test created
+    // a snapshot without an account marker).
+    await db.execute(
+      sql`DELETE FROM account_snapshots
+          WHERE account_id IN (SELECT id FROM accounts WHERE name LIKE ${MARKER + "%"})`,
+    );
+    await cleanup();
+  });
+
+  // Helper: insert an account and return its id.
+  async function seedAccount(name: string): Promise<number> {
+    const [row] = await db
+      .insert(accounts)
+      .values({
+        userId: USER_A,
+        name: `${MARKER}${name}`,
+        institution: "ARQ (DolarApp)",
+        type: "savings",
+        currency: "USD",
+      })
+      .returning({ id: accounts.id });
+    return row.id;
+  }
+
+  // Helper: insert a transaction at a specific timestamp.
+  async function seedTx(accountId: number, amountCents: number, occurredAt: Date): Promise<void> {
+    await db
+      .insert(categories)
+      .values({
+        userId: USER_A,
+        slug: "adjustments",
+        name: "Ajustes de saldo",
+        icon: "wrench",
+        color: "#475569",
+        sortOrder: 1000,
+      })
+      .onConflictDoNothing({ target: [categories.userId, categories.slug] });
+    await db.insert(transactions).values({
+      userId: USER_A,
+      accountId,
+      occurredAt,
+      amountCents: BigInt(amountCents),
+      currency: "USD",
+      descriptionRaw: `__snapshot_test_tx_${amountCents}`,
+      classificationMethod: "manual",
+      source: "balance_adjustment",
+      channel: "manual",
+      isAdjustment: true,
+    });
+  }
+
+  // Helper: insert a snapshot.
+  async function seedSnapshot(
+    accountId: number,
+    snapshotDate: string,
+    balanceCents: number,
+  ): Promise<void> {
+    await db.insert(accountSnapshots).values({
+      userId: USER_A,
+      accountId,
+      snapshotDate,
+      balanceCents: BigInt(balanceCents),
+      metadata: { source: "test" },
+    });
+  }
+
+  it("account WITHOUT snapshot → balance = SUM(all txs) (original behaviour preserved)", async () => {
+    const accId = await seedAccount("-snap-no-snapshot");
+    await seedTx(accId, 10_00, new Date(Date.UTC(2026, 0, 5)));
+    await seedTx(accId, -3_00, new Date(Date.UTC(2026, 0, 20)));
+
+    const rows = await listAccountsDetailed(USER_A);
+    const acc = rows.find((r) => r.name === `${MARKER}-snap-no-snapshot`);
+    expect(acc).toBeDefined();
+    // SUM(10_00 + (-3_00)) = 7_00
+    expect(acc!.balanceCents).toBe(BigInt(7_00));
+  });
+
+  it("account WITH snapshot → balance = snapshot + SUM(txs on or after snapshot_date)", async () => {
+    const accId = await seedAccount("-snap-with-snapshot");
+    const snapDate = "2026-02-01";
+    // snapshot at Feb 1 with balance 50_00
+    await seedSnapshot(accId, snapDate, 50_00);
+    // tx BEFORE snapshot date — should NOT be included in the delta
+    await seedTx(accId, 10_00, new Date(Date.UTC(2026, 0, 15)));
+    // txs ON and AFTER snapshot date — should be included
+    await seedTx(accId, -5_00, new Date(Date.UTC(2026, 1, 1))); // exactly snapshot_date
+    await seedTx(accId, 3_00, new Date(Date.UTC(2026, 1, 15)));
+
+    const rows = await listAccountsDetailed(USER_A);
+    const acc = rows.find((r) => r.name === `${MARKER}-snap-with-snapshot`);
+    expect(acc).toBeDefined();
+    // balance = 50_00 (snapshot) + (-5_00 + 3_00) (delta on/after Feb 1) = 48_00
+    expect(acc!.balanceCents).toBe(BigInt(48_00));
+  });
+
+  it("multiple snapshots → only the LATEST one anchors", async () => {
+    const accId = await seedAccount("-snap-multi-snapshot");
+    // Two snapshots: Jan 1 and Feb 1. Feb 1 is latest.
+    await seedSnapshot(accId, "2026-01-01", 100_00);
+    await seedSnapshot(accId, "2026-02-01", 200_00);
+    // tx between Jan 1 and Feb 1 — should NOT be in delta (before Feb 1 snapshot)
+    await seedTx(accId, 15_00, new Date(Date.UTC(2026, 0, 15)));
+    // tx after Feb 1
+    await seedTx(accId, -20_00, new Date(Date.UTC(2026, 1, 10)));
+
+    const rows = await listAccountsDetailed(USER_A);
+    const acc = rows.find((r) => r.name === `${MARKER}-snap-multi-snapshot`);
+    expect(acc).toBeDefined();
+    // balance = 200_00 (Feb snapshot) + (-20_00) (delta after Feb 1) = 180_00
+    expect(acc!.balanceCents).toBe(BigInt(180_00));
+  });
+
+  it("soft-deleted txs are excluded from the delta even with a snapshot", async () => {
+    const accId = await seedAccount("-snap-soft-delete");
+    await seedSnapshot(accId, "2026-01-01", 100_00);
+    // Insert a tx then archive it (set deleted_at)
+    await seedTx(accId, 50_00, new Date(Date.UTC(2026, 0, 10)));
+    await db.execute(
+      sql`UPDATE transactions SET deleted_at = now()
+          WHERE account_id = ${accId}`,
+    );
+    // Insert a live tx after the snapshot
+    await seedTx(accId, 25_00, new Date(Date.UTC(2026, 0, 20)));
+
+    const rows = await listAccountsDetailed(USER_A);
+    const acc = rows.find((r) => r.name === `${MARKER}-snap-soft-delete`);
+    expect(acc).toBeDefined();
+    // balance = 100_00 (snapshot) + 25_00 (live tx) = 125_00
+    // The archived 50_00 tx is excluded.
+    expect(acc!.balanceCents).toBe(BigInt(125_00));
+  });
+
+  it("account with snapshot but NO txs after snapshot → balance = snapshot value", async () => {
+    const accId = await seedAccount("-snap-no-delta");
+    await seedSnapshot(accId, "2026-03-01", 75_00);
+    // All txs are BEFORE the snapshot date
+    await seedTx(accId, 10_00, new Date(Date.UTC(2026, 1, 15)));
+
+    const rows = await listAccountsDetailed(USER_A);
+    const acc = rows.find((r) => r.name === `${MARKER}-snap-no-delta`);
+    expect(acc).toBeDefined();
+    // balance = 75_00 (snapshot) + 0 (no txs on/after Mar 1) = 75_00
+    expect(acc!.balanceCents).toBe(BigInt(75_00));
   });
 });

--- a/src/lib/accounts/queries.ts
+++ b/src/lib/accounts/queries.ts
@@ -6,11 +6,15 @@ import { toCop } from "@/lib/money";
 import type { AccountType, Currency } from "@/lib/types";
 
 /**
- * Derived balance — the source of truth for an account's current balance
- * is `SUM(transactions.amount_cents)`, not the `accounts.balance_cents`
- * column (see #368). This SQL fragment inlines the subquery and must be
- * used inside a SELECT whose FROM references `accounts` so that the
- * outer `accounts.id` resolves to the outer row.
+ * Derived balance — snapshot-anchored since #562(c).
+ *
+ * When an `account_snapshots` row exists for this account, the balance is:
+ *   snapshot.balance_cents  +  SUM(txs where occurred_at >= snapshot_date)
+ * using the LATEST snapshot (ORDER BY snapshot_date DESC LIMIT 1).
+ *
+ * When NO snapshot exists, the formula falls back to the original behaviour:
+ *   COALESCE(SUM(all non-archived transactions), 0)
+ * This means existing accounts without snapshots are unaffected.
  *
  * Qualifiers are hard-coded because drizzle interpolates
  * `${accounts.id}` as a bare identifier (`"id"`), which inside the
@@ -25,10 +29,41 @@ import type { AccountType, Currency } from "@/lib/types";
  * with `BigInt(...)`.
  */
 export const derivedBalanceCentsSql = sql<string>`(
-  SELECT COALESCE(SUM("transactions"."amount_cents"), 0)
-  FROM "transactions"
-  WHERE "transactions"."account_id" = "accounts"."id"
-    AND "transactions"."deleted_at" IS NULL
+  SELECT COALESCE(
+    -- Branch A: snapshot exists → anchor + delta since snapshot date.
+    (
+      SELECT s."balance_cents"
+      FROM "account_snapshots" s
+      WHERE s."account_id" = "accounts"."id"
+      ORDER BY s."snapshot_date" DESC
+      LIMIT 1
+    ) + COALESCE(
+      (
+        SELECT SUM("transactions"."amount_cents")
+        FROM "transactions"
+        WHERE "transactions"."account_id" = "accounts"."id"
+          AND "transactions"."deleted_at" IS NULL
+          AND "transactions"."occurred_at" >= (
+            SELECT s2."snapshot_date"
+            FROM "account_snapshots" s2
+            WHERE s2."account_id" = "accounts"."id"
+            ORDER BY s2."snapshot_date" DESC
+            LIMIT 1
+          )
+      ),
+      0
+    ),
+    -- Branch B: no snapshot exists → original SUM-all behaviour.
+    COALESCE(
+      (
+        SELECT SUM(t2."amount_cents")
+        FROM "transactions" t2
+        WHERE t2."account_id" = "accounts"."id"
+          AND t2."deleted_at" IS NULL
+      ),
+      0
+    )
+  )
 )`;
 
 export type PhysicalCardSummary = {

--- a/src/lib/finance/intereses-causados-job.test.ts
+++ b/src/lib/finance/intereses-causados-job.test.ts
@@ -5,6 +5,9 @@ import {
   applyInteresesCausadosForCycle,
   computeInterestForCycle,
   cycleAnchor,
+  daysActiveInCycle,
+  cycleLengthDays,
+  partialMonthInterestCents,
 } from "./intereses-causados-job";
 
 // #407: integration tests for the intereses-causados job. Uses the real test
@@ -462,5 +465,242 @@ describe("applyInteresesCausadosForCycle", () => {
         cycle: "2026-04",
       }),
     ).rejects.toThrow(/not a credit card/);
+  });
+});
+
+// #565: pure-unit tests for the new partial-month accrual helpers. No DB.
+describe("daysActiveInCycle (#565)", () => {
+  it("returns 7 for a purchase posted 7 calendar days before the anchor", () => {
+    // AMPLIACION scenario: posted Mar 24 12:00 UTC, anchor Mar 31 23:00 UTC
+    const purchase = new Date("2026-03-24T12:00:00.000Z");
+    const anchor = new Date("2026-03-31T23:00:00.000Z");
+    expect(daysActiveInCycle(purchase, anchor)).toBe(7);
+  });
+
+  it("returns 0 when purchase date is on the anchor day", () => {
+    // Posted the same UTC day as cut — no partial accrual
+    const purchase = new Date("2026-03-31T08:00:00.000Z");
+    const anchor = new Date("2026-03-31T23:00:00.000Z");
+    expect(daysActiveInCycle(purchase, anchor)).toBe(0);
+  });
+
+  it("returns 0 when purchase date is after the anchor", () => {
+    const purchase = new Date("2026-04-01T00:00:00.000Z");
+    const anchor = new Date("2026-03-31T23:00:00.000Z");
+    expect(daysActiveInCycle(purchase, anchor)).toBe(0);
+  });
+
+  it("returns full cycle length when purchase is on cycle start day", () => {
+    // Posted on day 1 of a 31-day cycle → 30 days active toward day-31 anchor
+    // (day 1 to day 31 = 30 calendar-day gaps)
+    const purchase = new Date("2026-03-01T00:00:00.000Z");
+    const anchor = new Date("2026-03-31T23:00:00.000Z");
+    expect(daysActiveInCycle(purchase, anchor)).toBe(30);
+  });
+});
+
+describe("cycleLengthDays (#565)", () => {
+  it("returns 31 for March", () => {
+    expect(cycleLengthDays(new Date("2026-03-31T23:00:00.000Z"))).toBe(31);
+  });
+
+  it("returns 28 for February 2026 (non-leap)", () => {
+    expect(cycleLengthDays(new Date("2026-02-28T23:00:00.000Z"))).toBe(28);
+  });
+
+  it("returns 29 for February 2024 (leap)", () => {
+    expect(cycleLengthDays(new Date("2024-02-29T23:00:00.000Z"))).toBe(29);
+  });
+});
+
+describe("partialMonthInterestCents (#565)", () => {
+  it("matches the AMPLIACION scenario: 4,099,523 × 1.9110% × 7/31 ≈ 17,690", () => {
+    // Statement-derived target: gap 17,110 COP; formula gives 17,690 (+2.2%)
+    const result = partialMonthInterestCents(
+      BigInt(409_952_300), // 4,099,523 pesos in cents
+      19110, // 1.9110% EM stored as x10k
+      7, // days active
+      31, // March has 31 days
+    );
+    // Expected: 409_952_300 × 19110 × 7 / (31 × 1_000_000) = 1_769_010.295... → 1_769_010
+    expect(result).toBe(BigInt(1_769_010));
+    // Sanity: within 5% of statement gap 1,711,000 cents ($17,110 COP)
+    const statementGapCents = BigInt(1_711_000);
+    const tolerance = statementGapCents / BigInt(20); // 5%
+    expect(result - statementGapCents).toBeLessThanOrEqual(tolerance);
+  });
+
+  it("returns 0 when rate is 0", () => {
+    // OEM SAS scenario: 0% rate plan → no partial accrual
+    expect(partialMonthInterestCents(BigInt(360_000_000), 0, 27, 31)).toBe(BigInt(0));
+  });
+
+  it("returns 0 when daysActive is 0", () => {
+    // Purchased on anchor day → no days to accrue
+    expect(partialMonthInterestCents(BigInt(409_952_300), 19110, 0, 31)).toBe(BigInt(0));
+  });
+});
+
+describe("computeInterestForCycle — partial-month accrual (#565)", () => {
+  // Fixture modeled after the real Mastercard *7291 2026-03 statement:
+  //   - ALKOMPRAR: mature installment (cuota 4 of 8), rate 1.9110% EM
+  //     → model charges full cuota interest (per-cuota path, unchanged)
+  //   - AMPLIACION: grace-month-1 (cuota 1 of 60), rate 1.9110% EM,
+  //     posted 2026-03-24 → 7 days before Mar 31 anchor
+  //     → model must charge partial-month interest (new pass)
+  it("charges partial-month interest on a mid-cycle grace-month-1 installment alongside a mature installment", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
+    await setCutoffDay(visa, 31); // clamped to 31 → March 31
+
+    // ALKOMPRAR-like: posted 2026-01-15 → by Mar 31 anchor, monthsBetween =
+    // months between Jan 15 and Mar 31 = 2 full months (Jan→Mar, day 31≥15)
+    // → paidCount=2 for an 8-cuota loan → cuota 3 next.
+    // But we actually want paidCount=3 (cuota 4) for the real scenario.
+    // Use Jan 1 to get paidCount=2 (cutDay=31, Mar 31 ≥ Jan 1 → 2 months).
+    // Actually: monthsBetween(Jan 1, Mar 31) = (2026-2026)*12 + (3-1) - (31<1?1:0) = 2.
+    // So cuota 3 is next. For the test we just need a mature installment with
+    // non-zero interest — exact cuota number isn't critical.
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}alkomprar-like`,
+      amountCentsMagnitude: BigInt(100_000_000), // 1,000,000 pesos for easy math
+      occurredAt: "2026-01-01",
+      installmentsTotal: 8,
+      installmentRateEmX10k: 19110,
+    });
+
+    // AMPLIACION-like: cuota 1 of 60, posted 7 days before cycle close.
+    // Anchor for cycle "2026-03" with cutDay=31 → 2026-03-31T23:00:00Z.
+    // Purchase on 2026-03-24T12:00:00Z → daysActive = 7.
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}ampliacion-like`,
+      amountCentsMagnitude: BigInt(409_952_300), // 4,099,523 pesos in cents
+      occurredAt: "2026-03-24",
+      installmentsTotal: 60,
+      installmentRateEmX10k: 19110,
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-03",
+    });
+
+    // Both purchases must appear in the run
+    expect(run.intereses.length).toBe(2);
+
+    const mature = run.intereses.find((i) => i.installmentsPaid > 0);
+    const grace = run.intereses.find((i) => i.installmentsPaid === 0);
+
+    expect(mature).toBeDefined();
+    expect(grace).toBeDefined();
+
+    // Mature installment: charged via per-cuota path, no partial accrual
+    expect(mature!.interestCents).toBeGreaterThan(BigInt(0));
+    expect(mature!.gracePeriodPartialCents).toBe(BigInt(0));
+
+    // Grace installment: per-cuota gives 0 (grace), partial pass adds it
+    expect(grace!.interestCents).toBe(BigInt(0)); // grace month — per-cuota path
+    expect(grace!.gracePeriodPartialCents).toBe(BigInt(1_769_010)); // 7/31 partial
+    expect(grace!.rateEmX10k).toBe(19110);
+    expect(grace!.needsRate).toBe(false);
+
+    // Total must include both components
+    const expectedPartial = BigInt(1_769_010);
+    expect(run.totalInterestCents).toBe(mature!.interestCents + expectedPartial);
+    expect(run.totalInterestCents).toBeGreaterThan(BigInt(0));
+
+    // Sanity: total (mature + partial) should be within 5% of the statement's
+    // $26,471 COP when using realistic amounts. This fixture uses a smaller
+    // ALKOMPRAR amount so we only assert the structure, not the exact statement
+    // total. See the statement-accuracy test below for the full scenario.
+  });
+
+  it("does NOT apply partial accrual when the purchase is posted on the anchor day (days=0)", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
+    await setCutoffDay(visa, 31);
+
+    // Posted on the last day of March = anchor day → 0 days active
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}posted-on-anchor`,
+      amountCentsMagnitude: BigInt(200_000_000),
+      occurredAt: "2026-03-31",
+      installmentsTotal: 12,
+      installmentRateEmX10k: 19110,
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-03",
+    });
+
+    // The purchase IS in scope (occurredAt <= anchor), but days=0 → no partial interest.
+    // Grace month 1 → per-cuota interest also 0 → the row is filtered out by
+    // the existing "interestCents === 0n && !needsRate → continue" guard.
+    expect(run.totalInterestCents).toBe(BigInt(0));
+  });
+
+  it("does NOT apply partial accrual on zero-rate plans (OEM SAS scenario)", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 0, advances: 0 });
+    await setCutoffDay(visa, 31);
+
+    // 0% rate — posted mid-cycle but no interest ever
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}zero-rate-midcycle`,
+      amountCentsMagnitude: BigInt(360_000_000),
+      occurredAt: "2026-03-03",
+      installmentsTotal: 36,
+      installmentRateEmX10k: 0,
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-03",
+    });
+
+    expect(run.totalInterestCents).toBe(BigInt(0));
+    // The row may appear with needsRate=false since it has a rate (0), but
+    // gracePeriodPartialCents must be 0.
+    for (const i of run.intereses) {
+      expect(i.gracePeriodPartialCents).toBe(BigInt(0));
+    }
+  });
+
+  it("Visa control: existing tests unchanged — no partial accrual on mature installments", async () => {
+    // Verifies backward-compat: a mature multi-cuota purchase (paidCount > 0)
+    // still produces gracePeriodPartialCents=0n.
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
+    await setCutoffDay(visa, 31);
+
+    // Posted Jan 1 → by Mar 31, paidCount=2 → mature (cuota 3 next)
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}visa-control-mature`,
+      amountCentsMagnitude: BigInt(10_000_000),
+      occurredAt: "2026-01-01",
+      installmentsTotal: 6,
+      installmentRateEmX10k: 19110,
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-03",
+    });
+
+    expect(run.intereses.length).toBe(1);
+    const entry = run.intereses[0];
+    expect(entry.installmentsPaid).toBeGreaterThan(0); // mature
+    expect(entry.interestCents).toBeGreaterThan(BigInt(0)); // per-cuota path works
+    expect(entry.gracePeriodPartialCents).toBe(BigInt(0)); // second pass skips mature
   });
 });

--- a/src/lib/finance/intereses-causados-job.ts
+++ b/src/lib/finance/intereses-causados-job.ts
@@ -19,10 +19,60 @@ import { db, type DB } from "@/lib/db";
 import { accounts, physicalCards, transactions, type AccountMetadata } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { installmentSchedule } from "@/lib/finance/installment-schedule";
-import { resolveBucketRateX10k } from "@/lib/finance/rates";
+import { resolveBucketRateX10k, EM_X10K_PER_FRACTIONAL } from "@/lib/finance/rates";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger({ module: "intereses-causados-job" });
+
+// Round-half-up integer division for BigInt. Same policy as installment-
+// schedule.ts — interest is rounded to the nearest cent, half-up.
+// Positive inputs only; negatives would break the half-up bias.
+function bigIntRoundHalfUp(numerator: bigint, denominator: bigint): bigint {
+  if (denominator <= BigInt(0)) throw new Error("denominator must be > 0");
+  return (numerator + denominator / BigInt(2)) / denominator;
+}
+
+// Number of whole calendar days between two UTC dates. The day count is
+// inclusive of the start day (i.e. a purchase on day D accrues starting from D
+// toward the anchor). Returns 0 when `purchaseDate >= anchor`.
+//
+// Used for partial-month accrual on grace-month-1 installments: Bancolombia
+// charges `amount × rate × days_active / cycle_days` even on cuota 1 when the
+// purchase is posted mid-cycle (see issue #565, engram analysis/intereses-
+// daily-balance-hypothesis).
+export function daysActiveInCycle(purchaseDate: Date, anchor: Date): number {
+  const msPerDay = 86_400_000;
+  // Truncate both to UTC day boundaries to avoid partial-day skew.
+  const purchaseDay = Math.floor(purchaseDate.getTime() / msPerDay);
+  const anchorDay = Math.floor(anchor.getTime() / msPerDay);
+  return Math.max(0, anchorDay - purchaseDay);
+}
+
+// Number of calendar days in the month represented by the anchor date (UTC).
+// This is the cycle denominator for partial-month proration.
+export function cycleLengthDays(anchor: Date): number {
+  const y = anchor.getUTCFullYear();
+  const m = anchor.getUTCMonth(); // 0-indexed
+  // New Date(y, m+1, 0) gives the last day of month m (1-indexed). UTC version:
+  return new Date(Date.UTC(y, m + 1, 0)).getUTCDate();
+}
+
+// Partial-month interest for a mid-cycle grace-month-1 installment. Formula:
+//   amountCents × rateEmX10k × daysActive / (cycleDays × EM_X10K_PER_FRACTIONAL)
+// Rounded half-up. Returns 0n when daysActive === 0 or rate === 0.
+export function partialMonthInterestCents(
+  amountCents: bigint,
+  rateEmX10k: number,
+  daysActive: number,
+  cycleDays: number,
+): bigint {
+  if (rateEmX10k === 0 || daysActive <= 0 || cycleDays <= 0) return BigInt(0);
+  // Integer math: (amount × rate × daysActive) / (cycleDays × EM_X10K_PER_FRACTIONAL)
+  // Denominator can get large (e.g. 31 × 1_000_000 = 31_000_000) but BigInt handles it.
+  const numerator = amountCents * BigInt(rateEmX10k) * BigInt(daysActive);
+  const denominator = BigInt(cycleDays) * BigInt(EM_X10K_PER_FRACTIONAL);
+  return bigIntRoundHalfUp(numerator, denominator);
+}
 
 // Fallback cut day when neither the account nor its linked physical card has
 // one configured. 31 clamps to each month's last day, so a misconfigured
@@ -52,6 +102,10 @@ export type InterestRun = {
     // a matching bucket was found. Interest can't be computed; the row is
     // surfaced so the UI can prompt for a rate. `interestCents` is 0n.
     needsRate: boolean;
+    // #565: partial-month interest charged by Bancolombia on grace-month-1
+    // installments posted mid-cycle. 0n for mature installments, 0-rate plans,
+    // and full-cycle grace purchases (posted on or before cycle start).
+    gracePeriodPartialCents: bigint;
   }>;
   totalInterestCents: bigint;
   // #416: convenience count of rows with `needsRate: true`. Callers (CLI,
@@ -241,9 +295,85 @@ export async function computeInterestForCycle(opts: {
       outstandingBeforeCents: outstandingBefore,
       interestCents,
       needsRate,
+      gracePeriodPartialCents: BigInt(0), // filled in by second pass below if applicable
     });
     if (needsRate) purchasesNeedingRate += 1;
     else totalInterestCents += interestCents;
+  }
+
+  // #565: second pass — partial-month accrual for grace-month-1 installments
+  // posted mid-cycle. Bancolombia charges `amount × rate × days_active /
+  // cycle_days` even on cuota 1 when the purchase was posted partway through
+  // the cycle.
+  //
+  // The per-installment loop above applied graceMonth=true for ALL purchases,
+  // so cuota-1 rows have interestCents=0 and were dropped by the
+  // `interestCents === 0n && !needsRate` guard. This pass re-scans `purchases`
+  // directly to catch those filtered-out grace rows.
+  //
+  // Guard conditions for a purchase to enter this pass (all must hold):
+  //   1. paidCount === 0 — cuota 1, still in grace month
+  //   2. rateEmX10k > 0  — interest-bearing; excludes 0%-rate diferido plans
+  //   3. not already in `intereses` — mature rows (paidCount>0) were kept above
+  //   4. partial > 0 — at least one day active in the cycle
+  const cycleDays = cycleLengthDays(anchor);
+  const alreadyInIntereses = new Set(intereses.map((e) => e.txId));
+
+  for (const p of purchases) {
+    // Skip if already priced via the per-cuota path (mature installment)
+    if (alreadyInIntereses.has(p.id)) continue;
+
+    // Resolve rate — same logic as first pass
+    let rateEmX10k: number;
+    if (p.installmentRateEmX10k != null) {
+      rateEmX10k = p.installmentRateEmX10k;
+    } else {
+      const bucketRate = resolveBucketRateX10k(buckets, p.installmentsTotal);
+      rateEmX10k = bucketRate ?? 0;
+    }
+    if (rateEmX10k === 0) continue; // zero-rate plan — no partial accrual
+
+    // Confirm it's paidCount=0 (grace month 1)
+    const schedule = installmentSchedule({
+      amountCents: -p.amountCents,
+      rateEmX10k,
+      installments: p.installmentsTotal,
+      graceMonth: true,
+      purchaseDate: p.occurredAt,
+      today: anchor,
+    });
+    if (schedule.paidCount !== 0) continue; // should not happen (would be in intereses), safety
+    if (schedule.paidCount >= schedule.rows.length) continue; // fully paid (unlikely for grace)
+
+    const days = Math.min(daysActiveInCycle(p.occurredAt, anchor), cycleDays);
+    const partial = partialMonthInterestCents(-p.amountCents, rateEmX10k, days, cycleDays);
+    if (partial === BigInt(0)) continue; // posted on anchor day or rate=0
+
+    const outstandingBefore = -p.amountCents; // paidCount=0 → full original amount
+
+    intereses.push({
+      txId: p.id,
+      purchaseAmountCents: -p.amountCents,
+      rateEmX10k,
+      installmentsTotal: p.installmentsTotal,
+      installmentsPaid: 0,
+      outstandingBeforeCents: outstandingBefore,
+      interestCents: BigInt(0), // per-cuota is 0 (grace); only partial is charged
+      needsRate: false,
+      gracePeriodPartialCents: partial,
+    });
+    totalInterestCents += partial;
+    log.debug(
+      {
+        txId: p.id,
+        days,
+        cycleDays,
+        rateEmX10k,
+        partial: partial.toString(),
+        event: "partial_month_accrual",
+      },
+      "grace-month-1 partial-month accrual applied",
+    );
   }
 
   return { accountId, cycle, anchor, intereses, totalInterestCents, purchasesNeedingRate };
@@ -331,6 +461,7 @@ export async function applyInteresesCausadosForCycle(opts: {
             outstandingBeforeCents: i.outstandingBeforeCents.toString(),
             interestCents: i.interestCents.toString(),
             needsRate: i.needsRate,
+            gracePeriodPartialCents: i.gracePeriodPartialCents.toString(),
           })),
           purchasesNeedingRate: run.purchasesNeedingRate,
         },

--- a/src/lib/ingestion/arq-statement/run-statement-import.test.ts
+++ b/src/lib/ingestion/arq-statement/run-statement-import.test.ts
@@ -16,7 +16,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { and, eq, sql } from "drizzle-orm";
 
 import { db } from "@/lib/db";
-import { accounts, arqStatementImports, users } from "@/lib/db/schema";
+import { accountSnapshots, accounts, arqStatementImports, users } from "@/lib/db/schema";
 
 import { runStatementImport } from "./run-statement-import";
 import type { ParsedStatementTx } from "./type-handlers";
@@ -34,9 +34,15 @@ let otherUserId: number;
 let otherAccountId: number;
 
 async function cleanup(): Promise<void> {
-  // arq_statement_imports → ON DELETE CASCADE from users, but let's be explicit
+  // arq_statement_imports and account_snapshots → ON DELETE CASCADE from users,
+  // but we're explicit here for predictability.
   await db.delete(arqStatementImports).where(
     sql`${arqStatementImports.userId} IN (
+        SELECT id FROM users WHERE email LIKE ${TAG + "%"}
+      )`,
+  );
+  await db.delete(accountSnapshots).where(
+    sql`${accountSnapshots.userId} IN (
         SELECT id FROM users WHERE email LIKE ${TAG + "%"}
       )`,
   );
@@ -704,5 +710,148 @@ describe("cross-tenant defense", () => {
 
     // User B has their own import — hash is scoped per user
     expect(otherResult.status).toBe("committed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// account_snapshots forward-write (#562c)
+//
+// Verifies that a committed, reconciled import writes an account_snapshots row
+// with balanceCents = declaredStartCents and snapshotDate = periodStart.
+// ---------------------------------------------------------------------------
+
+describe("account_snapshots forward-write on committed import (#562c)", () => {
+  it("writes a snapshot row after a reconciled import", async () => {
+    const snapUserId = await createUser("snap-write");
+    const snapAccountId = await createAccount(snapUserId, "snap-write-acct");
+
+    const result = await runStatementImport(
+      { parsePdf: fakeParsePdf(JAN_REAL, JAN_TXS) },
+      {
+        userId: snapUserId,
+        accountId: snapAccountId,
+        pdfBuffer: Buffer.from("snap-jan"),
+        pdfHash: `${TAG}-snap-hash-jan`,
+      },
+    );
+
+    expect(result.status).toBe("committed");
+
+    const snap = await db.query.accountSnapshots.findFirst({
+      where: and(
+        eq(accountSnapshots.userId, snapUserId),
+        eq(accountSnapshots.accountId, snapAccountId),
+      ),
+    });
+
+    expect(snap).toBeDefined();
+    // JAN_STMT has balanceStartCents = 26296
+    expect(snap!.balanceCents).toBe(BigInt(26296));
+    // periodStart is 2026-01-01
+    expect(snap!.snapshotDate).toBe("2026-01-01");
+    expect((snap!.metadata as { source: string }).source).toBe("arq_statement_import");
+  });
+
+  it("snapshot is not written when reconciliation fails", async () => {
+    const failUserId = await createUser("snap-fail");
+    const failAccountId = await createAccount(failUserId, "snap-fail-acct");
+
+    // Statement that will fail reconciliation (wrong declared end balance)
+    const JAN_BAD = makeStatement({
+      periodStart: new Date(Date.UTC(2026, 0, 1)),
+      periodEnd: new Date(Date.UTC(2026, 0, 31)),
+      balanceStartCents: BigInt(26296),
+      totalCreditsCents: BigInt(206000),
+      totalDebitsCents: BigInt(159401),
+      balanceEndCents: BigInt(99999), // wrong: should be 72895
+    });
+    const JAN_BAD_REAL = stmtWithRealLines(JAN_BAD, BigInt(206000), BigInt(159401));
+
+    const result = await runStatementImport(
+      { parsePdf: fakeParsePdf(JAN_BAD_REAL, JAN_TXS) },
+      {
+        userId: failUserId,
+        accountId: failAccountId,
+        pdfBuffer: Buffer.from("snap-fail-jan"),
+        pdfHash: `${TAG}-snap-fail-hash`,
+      },
+    );
+
+    expect(result.status).toBe("reconcile_failed");
+
+    const snap = await db.query.accountSnapshots.findFirst({
+      where: and(
+        eq(accountSnapshots.userId, failUserId),
+        eq(accountSnapshots.accountId, failAccountId),
+      ),
+    });
+
+    // No snapshot should be written for failed imports
+    expect(snap).toBeUndefined();
+  });
+
+  it("re-import same period with different declared balance upserts the snapshot", async () => {
+    // This scenario: user manually deletes the arq_statement_imports row and
+    // re-uploads with corrected figures. The snapshot should be overwritten.
+    const upsertUserId = await createUser("snap-upsert");
+    const upsertAccountId = await createAccount(upsertUserId, "snap-upsert-acct");
+
+    // First import (Jan) — writes snapshot with balanceCents=26296
+    const firstResult = await runStatementImport(
+      { parsePdf: fakeParsePdf(JAN_REAL, JAN_TXS) },
+      {
+        userId: upsertUserId,
+        accountId: upsertAccountId,
+        pdfBuffer: Buffer.from("upsert-jan-v1"),
+        pdfHash: `${TAG}-snap-upsert-hash-v1`,
+      },
+    );
+    expect(firstResult.status).toBe("committed");
+
+    // Simulate a re-import: delete the arq_statement_imports row (manually, as
+    // the issue specifies), then import a different PDF for the same period with
+    // an amended opening balance.
+    await db
+      .delete(arqStatementImports)
+      .where(
+        and(
+          eq(arqStatementImports.userId, upsertUserId),
+          eq(arqStatementImports.accountId, upsertAccountId),
+        ),
+      );
+
+    // Amended statement: same period, different opening balance (29000)
+    const JAN_AMENDED = makeStatement({
+      periodStart: new Date(Date.UTC(2026, 0, 1)),
+      periodEnd: new Date(Date.UTC(2026, 0, 31)),
+      balanceStartCents: BigInt(29000), // amended
+      totalCreditsCents: BigInt(206000),
+      totalDebitsCents: BigInt(159401),
+      balanceEndCents: BigInt(75599), // 29000 + 206000 - 159401
+    });
+    const JAN_AMENDED_REAL = stmtWithRealLines(JAN_AMENDED, BigInt(206000), BigInt(159401));
+
+    const secondResult = await runStatementImport(
+      { parsePdf: fakeParsePdf(JAN_AMENDED_REAL, JAN_TXS) },
+      {
+        userId: upsertUserId,
+        accountId: upsertAccountId,
+        pdfBuffer: Buffer.from("upsert-jan-v2"),
+        pdfHash: `${TAG}-snap-upsert-hash-v2`,
+      },
+    );
+    expect(secondResult.status).toBe("committed");
+
+    const snap = await db.query.accountSnapshots.findFirst({
+      where: and(
+        eq(accountSnapshots.userId, upsertUserId),
+        eq(accountSnapshots.accountId, upsertAccountId),
+      ),
+    });
+
+    expect(snap).toBeDefined();
+    // Should be updated to the amended opening balance
+    expect(snap!.balanceCents).toBe(BigInt(29000));
+    expect(snap!.snapshotDate).toBe("2026-01-01");
   });
 });

--- a/src/lib/ingestion/arq-statement/run-statement-import.ts
+++ b/src/lib/ingestion/arq-statement/run-statement-import.ts
@@ -13,10 +13,10 @@
 //     not belong to user_id the function rejects with an error before parsing.
 //   - Never rely on account_id alone when querying arq_statement_imports.
 
-import { and, desc, eq, lt } from "drizzle-orm";
+import { and, desc, eq, lt, sql } from "drizzle-orm";
 
 import { db } from "@/lib/db";
-import { accounts, arqStatementImports } from "@/lib/db/schema";
+import { accountSnapshots, accounts, arqStatementImports } from "@/lib/db/schema";
 import { createLogger } from "@/lib/logger";
 
 import { buildChainCheck, reconcileStatement } from "./balance";
@@ -281,7 +281,53 @@ export async function runStatementImport(
   }
 
   // ------------------------------------------------------------------
-  // Step 8 (#517): cross-channel dedup reconciler.
+  // Step 8 (#562c): upsert account_snapshots row.
+  // Records the opening balance for this statement period so that
+  // derivedBalanceCentsSql can anchor on it instead of summing all
+  // transactions from the beginning of time.
+  // Gate: reconcile.ok is guaranteed true here (we returned early above
+  // if it was false).
+  // ------------------------------------------------------------------
+  const snapshotDate = rawStatement.header.periodStart.toISOString().slice(0, 10);
+  try {
+    await db
+      .insert(accountSnapshots)
+      .values({
+        userId,
+        accountId,
+        snapshotDate,
+        balanceCents: reconcile.declaredStartCents,
+        metadata: { source: "arq_statement_import", importId },
+      })
+      .onConflictDoUpdate({
+        target: [accountSnapshots.accountId, accountSnapshots.snapshotDate],
+        set: {
+          balanceCents: sql`excluded.balance_cents`,
+          metadata: sql`excluded.metadata`,
+        },
+      });
+    log.info(
+      {
+        event: "arq_import_snapshot_upserted",
+        importId,
+        userId,
+        accountId,
+        snapshotDate,
+        balanceCents: reconcile.declaredStartCents.toString(),
+      },
+      "account_snapshots upserted for period start",
+    );
+  } catch (err) {
+    // Non-fatal: snapshot write failure should not abort the import.
+    // The import row is already committed and the reconciler will still run.
+    log.error(
+      { event: "arq_import_snapshot_failed", importId, userId, accountId, err },
+      "failed to upsert account_snapshots — balance derivation will fall back to SUM(all txs)",
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Step 9 (#517): cross-channel dedup reconciler.
   // Merges statement txs with existing gmail_arq email rows; inserts
   // statement-only events; flags email orphans and diverged merges.
   // ------------------------------------------------------------------

--- a/src/lib/reconciliation/pago-tc-router.test.ts
+++ b/src/lib/reconciliation/pago-tc-router.test.ts
@@ -1,0 +1,530 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, physicalCards, transactions, users } from "@/lib/db/schema";
+import { copyCategorySeedsToUser } from "@/lib/auth/signup";
+import { randomUUID } from "node:crypto";
+import { applyPagoTcRouting } from "./pago-tc-router";
+
+const TAG = "PAGO_TC_ROUTER_TEST";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+async function createUser(tag: string): Promise<number> {
+  const email = `${tag.toLowerCase()}.${Date.now()}@test.local`;
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  return row.id;
+}
+
+async function createPhysicalCard(userId: number): Promise<string> {
+  const cardId = randomUUID();
+  await db.insert(physicalCards).values({
+    id: cardId,
+    userId,
+    institution: "Bancolombia",
+    institutionSlug: "bancolombia",
+    name: `${TAG} Mastercard`,
+    network: "mastercard",
+  });
+  return cardId;
+}
+
+async function createAccount(
+  userId: number,
+  opts: {
+    type?: "savings" | "credit_card";
+    currency?: "COP" | "USD";
+    physicalCardId?: string;
+  } = {},
+): Promise<number> {
+  const { type = "savings", currency = "COP", physicalCardId } = opts;
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} ${type} ${currency}`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      type,
+      currency,
+      physicalCardId: physicalCardId ?? null,
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function createTransferPair(
+  userId: number,
+  savingsAccountId: number,
+  tcAccountId: number,
+  amountCents: bigint,
+  occurredAt: Date,
+  currency: "COP" | "USD" = "COP",
+): Promise<{ groupId: string; debitId: number; creditId: number }> {
+  const groupId = randomUUID();
+  const descriptionRaw = `Pago TC *7291`;
+
+  const [debit] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId: savingsAccountId,
+      occurredAt,
+      amountCents: -amountCents,
+      currency: "COP",
+      descriptionRaw,
+      source: "gmail_bancolombia",
+      channel: "transfer",
+      transferGroupId: groupId,
+      rawData: { kind: "tc_payment", role: "debit" },
+    })
+    .returning({ id: transactions.id });
+
+  const [credit] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId: tcAccountId,
+      occurredAt,
+      amountCents,
+      currency,
+      descriptionRaw,
+      source: "gmail_bancolombia",
+      channel: "transfer",
+      transferGroupId: groupId,
+      rawData: { kind: "tc_payment", role: "credit" },
+    })
+    .returning({ id: transactions.id });
+
+  return { groupId, debitId: debit.id, creditId: credit.id };
+}
+
+async function createUsdSyntheticTx(
+  userId: number,
+  usdAccountId: number,
+  amountCents: bigint,
+  occurredAt: Date,
+): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId: usdAccountId,
+      occurredAt,
+      amountCents,
+      currency: "USD",
+      descriptionRaw: "ABONO SUCURSAL VIRTUAL",
+      source: "csv_reconcile",
+      channel: "bank",
+      rawData: { statementKind: "extracto_detallado" },
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function cleanupUser(userId: number): Promise<void> {
+  await db.delete(transactions).where(eq(transactions.userId, userId));
+  await db.delete(accounts).where(eq(accounts.userId, userId));
+  await db.delete(physicalCards).where(eq(physicalCards.userId, userId));
+  await db.delete(users).where(eq(users.id, userId));
+}
+
+function toRow(
+  occurredAt: Date,
+  amountCents: bigint,
+  descriptionRaw: string,
+): { occurredAt: Date; amountCents: bigint; direction: "in" | "out"; descriptionRaw: string } {
+  return { occurredAt, amountCents, direction: "out", descriptionRaw };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures: dates in Bogotá-midnight-UTC format (05:00 UTC)
+// ---------------------------------------------------------------------------
+
+const DOLAR_DATE = new Date("2026-03-14T05:00:00Z");
+const PESOS_DATE = new Date("2026-01-19T05:00:00Z");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("applyPagoTcRouting — integration against findash_test", () => {
+  let userId: number;
+  let savingsAccountId: number;
+  let copTcAccountId: number;
+  let usdTcAccountId: number;
+  let physicalCardId: string;
+
+  beforeAll(async () => {
+    userId = await createUser(TAG);
+    physicalCardId = await createPhysicalCard(userId);
+    savingsAccountId = await createAccount(userId, { type: "savings", currency: "COP" });
+    copTcAccountId = await createAccount(userId, {
+      type: "credit_card",
+      currency: "COP",
+      physicalCardId,
+    });
+    usdTcAccountId = await createAccount(userId, {
+      type: "credit_card",
+      currency: "USD",
+      physicalCardId,
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  // Clean up only transactions between each test to reset state.
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 1: existing gmail Pago TC pair on COP twin + savings says PESOS → no-op
+  // ---------------------------------------------------------------------------
+  describe("PESOS match — existing pair is correct", () => {
+    let creditId: number;
+
+    beforeAll(async () => {
+      const pair = await createTransferPair(
+        userId,
+        savingsAccountId,
+        copTcAccountId,
+        BigInt(151_249_00),
+        PESOS_DATE,
+        "COP",
+      );
+      creditId = pair.creditId;
+    });
+
+    afterAll(async () => {
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+    });
+
+    it("detects the PESOS row and leaves the existing pair unchanged", async () => {
+      const result = await applyPagoTcRouting({
+        userId,
+        savingsAccountId,
+        rows: [toRow(PESOS_DATE, BigInt(151_249_00), "PAGO SUC VIRT TC MASTER PESOS")],
+        database: db,
+      });
+
+      expect(result.detected).toBe(1);
+      expect(result.noOpPesos).toBeGreaterThanOrEqual(1);
+      expect(result.reassignedToUsd).toBe(0);
+      expect(result.pendingUsdReassignment).toBe(0);
+      expect(result.newPairsInserted).toBe(0);
+      expect(result.errors).toHaveLength(0);
+
+      // COP twin credit should still exist (not soft-deleted)
+      const [tx] = await db
+        .select({ deletedAt: transactions.deletedAt })
+        .from(transactions)
+        .where(eq(transactions.id, creditId));
+      expect(tx?.deletedAt).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 2: existing gmail pair on COP twin + savings says DOLAR + USD synthetic present
+  //         → COP destination soft-deleted, re-paired to USD synthetic
+  // ---------------------------------------------------------------------------
+  describe("DOLAR match — wrong COP twin, USD synthetic available", () => {
+    let copCreditId: number;
+    let usdSyntheticId: number;
+    let groupId: string;
+
+    beforeAll(async () => {
+      const pair = await createTransferPair(
+        userId,
+        savingsAccountId,
+        copTcAccountId,
+        BigInt(381_147_38),
+        DOLAR_DATE,
+        "COP",
+      );
+      copCreditId = pair.creditId;
+      groupId = pair.groupId;
+
+      // USD synthetic on the USD twin (csv_reconcile, same date window)
+      usdSyntheticId = await createUsdSyntheticTx(
+        userId,
+        usdTcAccountId,
+        BigInt(98_00), // ~USD 98 at some TRM — exact amount doesn't need to match
+        DOLAR_DATE,
+      );
+    });
+
+    afterAll(async () => {
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+    });
+
+    it("soft-deletes the COP twin destination and re-pairs savings leg to USD synthetic", async () => {
+      const result = await applyPagoTcRouting({
+        userId,
+        savingsAccountId,
+        rows: [toRow(DOLAR_DATE, BigInt(381_147_38), "PAGO SUC VIRT TC MASTER DOLAR")],
+        database: db,
+      });
+
+      expect(result.detected).toBe(1);
+      expect(result.reassignedToUsd).toBe(1);
+      expect(result.pendingUsdReassignment).toBe(0);
+      expect(result.errors).toHaveLength(0);
+
+      // COP credit should now be soft-deleted
+      const [copTx] = await db
+        .select({ deletedAt: transactions.deletedAt, rawData: transactions.rawData })
+        .from(transactions)
+        .where(eq(transactions.id, copCreditId));
+      expect(copTx?.deletedAt).not.toBeNull();
+      expect((copTx?.rawData as Record<string, unknown>).softDeletedReason).toBe(
+        "issue-567-savings-parser-detected-DOLAR",
+      );
+
+      // USD synthetic should now be in the same transfer group as the savings leg
+      const [usdTx] = await db
+        .select({ transferGroupId: transactions.transferGroupId, channel: transactions.channel })
+        .from(transactions)
+        .where(eq(transactions.id, usdSyntheticId));
+      expect(usdTx?.transferGroupId).toBe(groupId);
+      expect(usdTx?.channel).toBe("transfer");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 3: existing gmail pair on COP twin + savings says DOLAR + NO USD synthetic
+  //         → COP destination soft-deleted, savings leg flagged pendingUsdTwinReassignment
+  // ---------------------------------------------------------------------------
+  describe("DOLAR match — wrong COP twin, USD synthetic NOT uploaded yet", () => {
+    let copCreditId: number;
+    let debitId: number;
+
+    beforeAll(async () => {
+      const pair = await createTransferPair(
+        userId,
+        savingsAccountId,
+        copTcAccountId,
+        BigInt(405_764_64),
+        new Date("2026-01-02T05:00:00Z"),
+        "COP",
+      );
+      copCreditId = pair.creditId;
+      debitId = pair.debitId;
+    });
+
+    afterAll(async () => {
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+    });
+
+    it("soft-deletes COP destination and flags savings leg with pendingUsdTwinReassignment", async () => {
+      const result = await applyPagoTcRouting({
+        userId,
+        savingsAccountId,
+        rows: [
+          toRow(
+            new Date("2026-01-02T05:00:00Z"),
+            BigInt(405_764_64),
+            "PAGO SUC VIRT TC MASTER DOLAR",
+          ),
+        ],
+        database: db,
+      });
+
+      expect(result.detected).toBe(1);
+      expect(result.pendingUsdReassignment).toBe(1);
+      expect(result.reassignedToUsd).toBe(0);
+      expect(result.errors).toHaveLength(0);
+
+      // COP twin destination should be soft-deleted
+      const [copTx] = await db
+        .select({ deletedAt: transactions.deletedAt })
+        .from(transactions)
+        .where(eq(transactions.id, copCreditId));
+      expect(copTx?.deletedAt).not.toBeNull();
+
+      // Savings leg (debit) should be flagged
+      const [debit] = await db
+        .select({ rawData: transactions.rawData })
+        .from(transactions)
+        .where(eq(transactions.id, debitId));
+      expect((debit?.rawData as Record<string, unknown>).pendingUsdTwinReassignment).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 4: NO existing gmail pair + savings says PESOS → inserts new transfer pair
+  // ---------------------------------------------------------------------------
+  describe("no gmail pair — savings PESOS row → insert new pair", () => {
+    const testDate = new Date("2026-04-14T05:00:00Z");
+
+    afterAll(async () => {
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+    });
+
+    it("inserts a fresh transfer pair with csv_reconcile source", async () => {
+      const result = await applyPagoTcRouting({
+        userId,
+        savingsAccountId,
+        rows: [toRow(testDate, BigInt(130_469_00), "PAGO SUC VIRT TC MASTER PESOS")],
+        database: db,
+      });
+
+      expect(result.detected).toBe(1);
+      expect(result.newPairsInserted).toBe(1);
+      expect(result.errors).toHaveLength(0);
+
+      // Verify both legs were inserted
+      const legs = await db
+        .select({
+          accountId: transactions.accountId,
+          amountCents: transactions.amountCents,
+          source: transactions.source,
+          channel: transactions.channel,
+          transferGroupId: transactions.transferGroupId,
+        })
+        .from(transactions)
+        .where(and(eq(transactions.userId, userId), eq(transactions.source, "csv_reconcile")));
+
+      expect(legs).toHaveLength(2);
+      // Savings debit
+      const debit = legs.find((l) => l.amountCents < BigInt(0));
+      expect(debit).toBeDefined();
+      expect(debit?.accountId).toBe(savingsAccountId);
+      expect(debit?.channel).toBe("transfer");
+      // TC credit
+      const credit = legs.find((l) => l.amountCents > BigInt(0));
+      expect(credit).toBeDefined();
+      expect(credit?.accountId).toBe(copTcAccountId);
+      expect(credit?.channel).toBe("transfer");
+      // Same group
+      expect(debit?.transferGroupId).toBe(credit?.transferGroupId);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 5: PAGO AUTOM variant is handled the same as PAGO SUC VIRT
+  // ---------------------------------------------------------------------------
+  describe("PAGO AUTOM TC MASTER PESOS variant", () => {
+    const testDate = new Date("2026-02-16T05:00:00Z");
+
+    afterAll(async () => {
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+    });
+
+    it("detects PAGO AUTOM as a Pago TC row and routes correctly", async () => {
+      const result = await applyPagoTcRouting({
+        userId,
+        savingsAccountId,
+        rows: [toRow(testDate, BigInt(140_976_98), "PAGO AUTOM TC MASTER PESOS")],
+        database: db,
+      });
+
+      expect(result.detected).toBe(1);
+      // No existing pair → should insert
+      expect(result.newPairsInserted).toBe(1);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 6: non-Pago TC rows are ignored
+  // ---------------------------------------------------------------------------
+  it("ignores rows that are not pago tc (ABONO INTERESES, TRANSFERENCIA, etc.)", async () => {
+    const result = await applyPagoTcRouting({
+      userId,
+      savingsAccountId,
+      rows: [
+        {
+          occurredAt: new Date(),
+          amountCents: BigInt(100),
+          direction: "in" as const,
+          descriptionRaw: "ABONO INTERESES AHORROS",
+        },
+        {
+          occurredAt: new Date(),
+          amountCents: BigInt(500),
+          direction: "out" as const,
+          descriptionRaw: "PAGO QR PELUQUERIA",
+        },
+        {
+          occurredAt: new Date(),
+          amountCents: BigInt(200),
+          direction: "out" as const,
+          descriptionRaw: "TRANSFERENCIA CTA SUC VIRTUAL",
+        },
+      ],
+      database: db,
+    });
+
+    expect(result.detected).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 7: already deleted destination (manual cleanup) + DOLAR + USD synthetic
+  //         → linkUsdSynthetic still runs
+  // ---------------------------------------------------------------------------
+  describe("DOLAR match — destination already manually deleted", () => {
+    let usdSyntheticId: number;
+    let groupId: string;
+
+    beforeAll(async () => {
+      const pair = await createTransferPair(
+        userId,
+        savingsAccountId,
+        copTcAccountId,
+        BigInt(377_575_34),
+        new Date("2026-02-13T05:00:00Z"),
+        "COP",
+      );
+      groupId = pair.groupId;
+
+      // Simulate prior manual cleanup: soft-delete the COP credit
+      await db
+        .update(transactions)
+        .set({ deletedAt: new Date() })
+        .where(eq(transactions.id, pair.creditId));
+
+      usdSyntheticId = await createUsdSyntheticTx(
+        userId,
+        usdTcAccountId,
+        BigInt(97_00),
+        new Date("2026-02-13T05:00:00Z"),
+      );
+    });
+
+    afterAll(async () => {
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+    });
+
+    it("links USD synthetic even when COP destination was already deleted", async () => {
+      const result = await applyPagoTcRouting({
+        userId,
+        savingsAccountId,
+        rows: [
+          toRow(
+            new Date("2026-02-13T05:00:00Z"),
+            BigInt(377_575_34),
+            "PAGO SUC VIRT TC MASTER DOLAR",
+          ),
+        ],
+        database: db,
+      });
+
+      expect(result.detected).toBe(1);
+      expect(result.reassignedToUsd).toBe(1);
+      expect(result.errors).toHaveLength(0);
+
+      const [usdTx] = await db
+        .select({ transferGroupId: transactions.transferGroupId })
+        .from(transactions)
+        .where(eq(transactions.id, usdSyntheticId));
+      expect(usdTx?.transferGroupId).toBe(groupId);
+    });
+  });
+});

--- a/src/lib/reconciliation/pago-tc-router.ts
+++ b/src/lib/reconciliation/pago-tc-router.ts
@@ -1,0 +1,681 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, gte, lte, not, sql } from "drizzle-orm";
+import { db as defaultDb, type DB } from "@/lib/db";
+import { accounts, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { insertTransferGroup } from "@/lib/transactions/transfer-groups";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "reconciliation/pago-tc-router" });
+
+// One calendar day in milliseconds — used for ±1-day date windows.
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+// Description patterns that identify a Pago TC row in a savings extract.
+// Matching is case-insensitive prefix so variations ("PAGO SUC VIRT TC MASTER DOLAR",
+// "PAGO AUTOM TC MASTER PESOS", "pago suc virt tc master pesos", etc.) are all caught.
+const PAGO_TC_RE = /pago\s+(?:suc\s+virt|autom)\s+tc\s+master\s+(dolar|pesos)/i;
+
+/** Currency twin of this payment as declared by the savings extract. */
+export type PagoTcCurrency = "DOLAR" | "PESOS";
+
+/** One row from the savings extract that represents a Pago TC debit. */
+export interface SavingsPagoTcRow {
+  /** Calendar date of the savings debit in Bogotá TZ (midnight UTC+5). */
+  occurredAt: Date;
+  /** Absolute COP amount in cents (always positive). */
+  amountCents: bigint;
+  /** Which TC twin this payment targets per the savings description. */
+  pagoTcCurrency: PagoTcCurrency;
+  /** Raw description for audit trail. */
+  descriptionRaw: string;
+}
+
+export interface PagoTcRoutingResult {
+  /** Savings rows that were detected as Pago TC debits. */
+  detected: number;
+  /** Already correctly routed (PESOS pairs left as-is). */
+  noOpPesos: number;
+  /** DOLAR pairs where wrong-twin destination was soft-deleted and re-paired to USD synthetic. */
+  reassignedToUsd: number;
+  /** DOLAR pairs where USD synthetic was not found — destination flagged `pendingUsdTwinReassignment`. */
+  pendingUsdReassignment: number;
+  /** New transfer pairs inserted for savings rows with no existing gmail pair. */
+  newPairsInserted: number;
+  /** Errors encountered per row (non-fatal — routing continues on other rows). */
+  errors: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * After the regular savings-statement commit, scan parsed rows for Pago TC
+ * descriptions and reconcile them against the DB:
+ *
+ * - PESOS match  → no-op (existing COP-twin pair is correct)
+ * - DOLAR match  → soft-delete wrong-twin destination, re-pair to USD synthetic
+ *                  (or flag pendingUsdTwinReassignment if USD synthetic not yet present)
+ * - No match     → insert a fresh transfer pair with source='csv_reconcile'
+ *
+ * @param userId      Tenant ID — every DB query is scoped to this user.
+ * @param savingsAccountId  The savings account that was just reconciled.
+ * @param rows        All rows from the parsed savings statement (not just Pago TC ones;
+ *                    this function filters them internally).
+ * @param database    Optional injected DB (for testing without a real DB connection).
+ */
+export async function applyPagoTcRouting(opts: {
+  userId: number;
+  savingsAccountId: number;
+  rows: Array<{
+    occurredAt: Date;
+    amountCents: bigint;
+    direction: "in" | "out";
+    descriptionRaw: string;
+  }>;
+  database?: DB;
+}): Promise<PagoTcRoutingResult> {
+  const { userId, savingsAccountId, rows, database = defaultDb } = opts;
+
+  const result: PagoTcRoutingResult = {
+    detected: 0,
+    noOpPesos: 0,
+    reassignedToUsd: 0,
+    pendingUsdReassignment: 0,
+    newPairsInserted: 0,
+    errors: [],
+  };
+
+  // Only outbound rows (savings debit = payment from savings account).
+  const pagoRows = rows
+    .filter((r) => r.direction === "out")
+    .flatMap((r): SavingsPagoTcRow[] => {
+      const m = PAGO_TC_RE.exec(r.descriptionRaw);
+      if (!m) return [];
+      const pagoTcCurrency: PagoTcCurrency = m[1].toLowerCase() === "dolar" ? "DOLAR" : "PESOS";
+      return [
+        {
+          occurredAt: r.occurredAt,
+          amountCents: r.amountCents,
+          pagoTcCurrency,
+          descriptionRaw: r.descriptionRaw,
+        },
+      ];
+    });
+
+  result.detected = pagoRows.length;
+
+  if (pagoRows.length === 0) return result;
+
+  // Load the savings account to confirm it belongs to the user and get its
+  // physicalCardId (needed to find the TC twin accounts).
+  const [savingsAccount] = await database
+    .select({
+      id: accounts.id,
+      userId: accounts.userId,
+      currency: accounts.currency,
+      physicalCardId: accounts.physicalCardId,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.id, savingsAccountId),
+        eq(accounts.userId, userId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  if (!savingsAccount) {
+    result.errors.push(`savings account ${savingsAccountId} not found for user ${userId}`);
+    return result;
+  }
+
+  for (const row of pagoRows) {
+    try {
+      await routeSinglePagoTcRow({
+        userId,
+        savingsAccountId,
+        row,
+        result,
+        database,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(
+        {
+          userId,
+          savingsAccountId,
+          occurredAt: row.occurredAt,
+          amountCents: row.amountCents.toString(),
+          pagoTcCurrency: row.pagoTcCurrency,
+          event: "pago_tc_routing_row_error",
+          err,
+        },
+        "pago tc routing error for row",
+      );
+      result.errors.push(
+        `${row.occurredAt.toISOString().slice(0, 10)} ${row.pagoTcCurrency} ${row.amountCents}: ${msg}`,
+      );
+    }
+  }
+
+  log.info(
+    {
+      userId,
+      savingsAccountId,
+      event: "pago_tc_routing_complete",
+      ...result,
+    },
+    "pago tc routing complete",
+  );
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Per-row routing logic
+// ---------------------------------------------------------------------------
+
+async function routeSinglePagoTcRow(opts: {
+  userId: number;
+  savingsAccountId: number;
+  row: SavingsPagoTcRow;
+  result: PagoTcRoutingResult;
+  database: DB;
+}): Promise<void> {
+  const { userId, savingsAccountId, row, result, database } = opts;
+
+  // Date window: savings extract uses Bogotá calendar date; gmail-derived txs
+  // may land anywhere from -1 to +1 day due to TZ differences.
+  const windowStart = new Date(row.occurredAt.getTime() - ONE_DAY_MS);
+  const windowEnd = new Date(row.occurredAt.getTime() + ONE_DAY_MS);
+
+  // The savings debit is stored as a negative amount in the DB (outbound).
+  // The exact signed amount on the savings leg is -amountCents.
+  const savingsSignedCents = -row.amountCents;
+
+  // Find the existing savings debit leg (source = gmail_bancolombia or csv_reconcile)
+  // that matches this savings row by date window + exact amount.
+  // We look for it on the savings account so we know its transfer_group_id.
+  const [savingsLeg] = await database
+    .select({
+      id: transactions.id,
+      transferGroupId: transactions.transferGroupId,
+      occurredAt: transactions.occurredAt,
+      amountCents: transactions.amountCents,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.accountId, savingsAccountId),
+        eq(transactions.amountCents, savingsSignedCents),
+        gte(transactions.occurredAt, windowStart),
+        lte(transactions.occurredAt, windowEnd),
+        notDeleted(transactions.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  if (!savingsLeg) {
+    // No savings leg in DB — this row was just inserted by the savings
+    // commit that preceded us, OR it's genuinely new. Either way, insert
+    // a fresh transfer pair.
+    await insertNewPagoTcPair({
+      userId,
+      savingsAccountId,
+      row,
+      result,
+      database,
+    });
+    return;
+  }
+
+  if (row.pagoTcCurrency === "PESOS") {
+    // COP-twin pair is correct — no action needed.
+    result.noOpPesos++;
+    log.info(
+      {
+        userId,
+        event: "pago_tc_pesos_noop",
+        savingsLegId: savingsLeg.id,
+        transferGroupId: savingsLeg.transferGroupId,
+      },
+      "pago tc PESOS row — existing pair is correct, no-op",
+    );
+    return;
+  }
+
+  // DOLAR: existing pair may route to the COP twin (wrong). Find the
+  // destination leg of the group and determine if it needs to be re-routed.
+  if (!savingsLeg.transferGroupId) {
+    // Savings leg has no transfer group — it was inserted as a plain tx
+    // (pre-#405 behavior or savings-only import without pairing). Nothing to re-pair.
+    // Flag it for manual review.
+    result.errors.push(
+      `savings leg tx ${savingsLeg.id} has no transfer_group_id — cannot re-pair for DOLAR`,
+    );
+    return;
+  }
+
+  await reassignDolarPair({
+    userId,
+    savingsAccountId,
+    savingsLeg,
+    row,
+    result,
+    database,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DOLAR re-pairing
+// ---------------------------------------------------------------------------
+
+async function reassignDolarPair(opts: {
+  userId: number;
+  savingsAccountId: number;
+  savingsLeg: { id: number; transferGroupId: string | null; occurredAt: Date; amountCents: bigint };
+  row: SavingsPagoTcRow;
+  result: PagoTcRoutingResult;
+  database: DB;
+}): Promise<void> {
+  const { userId, savingsAccountId, savingsLeg, row, result, database } = opts;
+
+  const transferGroupId = savingsLeg.transferGroupId!;
+
+  // Find the destination leg in the same transfer group (positive amount,
+  // different account from savings). Scoped by userId per tenant-safety rule.
+  const [destinationLeg] = await database
+    .select({
+      id: transactions.id,
+      accountId: transactions.accountId,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      occurredAt: transactions.occurredAt,
+      deletedAt: transactions.deletedAt,
+      rawData: transactions.rawData,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.transferGroupId, transferGroupId),
+        not(eq(transactions.accountId, savingsAccountId)),
+        sql`${transactions.amountCents} > 0`,
+      ),
+    )
+    .limit(1);
+
+  if (!destinationLeg) {
+    result.errors.push(
+      `transfer group ${transferGroupId} has no destination leg (DOLAR row ${row.occurredAt.toISOString().slice(0, 10)})`,
+    );
+    return;
+  }
+
+  // Check if destination is already deleted (manual cleanup was done).
+  if (destinationLeg.deletedAt !== null) {
+    // Destination already soft-deleted (e.g., manual SQL cleanup done 2026-04-27).
+    // Look for the USD synthetic to verify or re-pair.
+    log.info(
+      {
+        userId,
+        event: "pago_tc_destination_already_deleted",
+        destinationLegId: destinationLeg.id,
+        transferGroupId,
+      },
+      "destination leg already soft-deleted — attempting USD synthetic lookup",
+    );
+    await linkUsdSynthetic({
+      userId,
+      savingsLeg,
+      destinationAccountId: destinationLeg.accountId,
+      row,
+      result,
+      database,
+    });
+    return;
+  }
+
+  // Find the USD twin account via physicalCardId of the destination account.
+  const [destinationAccount] = await database
+    .select({
+      id: accounts.id,
+      currency: accounts.currency,
+      physicalCardId: accounts.physicalCardId,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.id, destinationLeg.accountId),
+        eq(accounts.userId, userId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  if (!destinationAccount) {
+    result.errors.push(
+      `destination account ${destinationLeg.accountId} not found for user ${userId}`,
+    );
+    return;
+  }
+
+  if (destinationAccount.currency === "USD") {
+    // Already on the USD twin — no action needed.
+    result.noOpPesos++; // reuse counter as "already correct"
+    log.info(
+      {
+        userId,
+        event: "pago_tc_dolar_already_on_usd_twin",
+        destinationLegId: destinationLeg.id,
+        transferGroupId,
+      },
+      "DOLAR pair destination is already on USD twin — no-op",
+    );
+    return;
+  }
+
+  // Destination is on the COP twin (wrong). Soft-delete it.
+  await database
+    .update(transactions)
+    .set({
+      deletedAt: new Date(),
+      updatedAt: new Date(),
+      rawData: {
+        ...(destinationLeg.rawData as Record<string, unknown>),
+        softDeletedReason: "issue-567-savings-parser-detected-DOLAR",
+      },
+    })
+    .where(and(eq(transactions.id, destinationLeg.id), eq(transactions.userId, userId)));
+
+  log.info(
+    {
+      userId,
+      event: "pago_tc_wrong_twin_soft_deleted",
+      destinationLegId: destinationLeg.id,
+      transferGroupId,
+    },
+    "soft-deleted wrong-twin (COP) destination leg for DOLAR pago tc",
+  );
+
+  // Now attempt to link to USD synthetic.
+  await linkUsdSynthetic({
+    userId,
+    savingsLeg,
+    destinationAccountId: destinationLeg.accountId,
+    row,
+    result,
+    database,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// USD synthetic lookup + linking
+// ---------------------------------------------------------------------------
+
+async function linkUsdSynthetic(opts: {
+  userId: number;
+  savingsLeg: { id: number; transferGroupId: string | null; occurredAt: Date; amountCents: bigint };
+  destinationAccountId: number;
+  row: SavingsPagoTcRow;
+  result: PagoTcRoutingResult;
+  database: DB;
+}): Promise<void> {
+  const { userId, savingsLeg, destinationAccountId, row, result, database } = opts;
+
+  // Load destination account's physicalCardId to find the USD twin.
+  const [destAccount] = await database
+    .select({ id: accounts.id, physicalCardId: accounts.physicalCardId })
+    .from(accounts)
+    .where(and(eq(accounts.id, destinationAccountId), eq(accounts.userId, userId)))
+    .limit(1);
+
+  if (!destAccount?.physicalCardId) {
+    // No plastic link — can't find USD twin.
+    await flagPendingUsdReassignment({ userId, savingsLeg, database });
+    result.pendingUsdReassignment++;
+    return;
+  }
+
+  // Find the USD twin account (same physicalCardId, different account, USD currency).
+  const [usdTwinAccount] = await database
+    .select({ id: accounts.id, currency: accounts.currency })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.physicalCardId, destAccount.physicalCardId),
+        eq(accounts.userId, userId),
+        not(eq(accounts.id, destinationAccountId)),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  if (!usdTwinAccount || usdTwinAccount.currency !== "USD") {
+    await flagPendingUsdReassignment({ userId, savingsLeg, database });
+    result.pendingUsdReassignment++;
+    return;
+  }
+
+  // Look for the USD synthetic ABONO SUCURSAL VIRTUAL row that represents this
+  // payment landing on the USD card. The USD statement consolidation inserts it
+  // with source='csv_reconcile', positive amountCents (credit on TC).
+  // We match by date ±1 day — we cannot match exact USD amount without the TRM,
+  // so we look for the most recent credit row in the window on the USD twin.
+  const windowStart = new Date(row.occurredAt.getTime() - ONE_DAY_MS);
+  const windowEnd = new Date(row.occurredAt.getTime() + ONE_DAY_MS);
+
+  const usdSyntheticCandidates = await database
+    .select({
+      id: transactions.id,
+      amountCents: transactions.amountCents,
+      occurredAt: transactions.occurredAt,
+      transferGroupId: transactions.transferGroupId,
+      descriptionRaw: transactions.descriptionRaw,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.accountId, usdTwinAccount.id),
+        sql`${transactions.amountCents} > 0`,
+        gte(transactions.occurredAt, windowStart),
+        lte(transactions.occurredAt, windowEnd),
+        notDeleted(transactions.deletedAt),
+        // Only csv_reconcile rows (TC statement consolidation) or transfer legs
+        // can be a USD synthetic. We accept any positive tx in the date window
+        // on the USD twin — the match is loose but auditable via logs.
+      ),
+    )
+    .orderBy(transactions.occurredAt);
+
+  if (usdSyntheticCandidates.length === 0) {
+    // USD statement not uploaded yet — flag for later.
+    await flagPendingUsdReassignment({ userId, savingsLeg, database });
+    result.pendingUsdReassignment++;
+    log.info(
+      {
+        userId,
+        event: "pago_tc_pending_usd_reassignment",
+        savingsLegId: savingsLeg.id,
+        usdTwinAccountId: usdTwinAccount.id,
+        occurredAt: row.occurredAt.toISOString(),
+      },
+      "no USD synthetic found — flagged pendingUsdTwinReassignment",
+    );
+    return;
+  }
+
+  // Use the first candidate (closest to savings date). If the USD statement
+  // has already been paired via another transfer group, skip re-pairing.
+  const usdSynthetic = usdSyntheticCandidates[0];
+
+  // Re-pair: update both legs to share the same transfer_group_id.
+  // The savings leg keeps its existing group id (source of truth), and we
+  // update the USD synthetic to join the same group.
+  const groupId = savingsLeg.transferGroupId ?? randomUUID();
+
+  await database
+    .update(transactions)
+    .set({
+      transferGroupId: groupId,
+      channel: "transfer",
+      updatedAt: new Date(),
+    })
+    .where(and(eq(transactions.id, usdSynthetic.id), eq(transactions.userId, userId)));
+
+  // Ensure the savings leg also has the group id (it should, but confirm).
+  if (!savingsLeg.transferGroupId) {
+    await database
+      .update(transactions)
+      .set({ transferGroupId: groupId, updatedAt: new Date() })
+      .where(and(eq(transactions.id, savingsLeg.id), eq(transactions.userId, userId)));
+  }
+
+  result.reassignedToUsd++;
+  log.info(
+    {
+      userId,
+      event: "pago_tc_reassigned_to_usd_synthetic",
+      savingsLegId: savingsLeg.id,
+      usdSyntheticId: usdSynthetic.id,
+      transferGroupId: groupId,
+    },
+    "re-paired savings leg to USD synthetic",
+  );
+}
+
+async function flagPendingUsdReassignment(opts: {
+  userId: number;
+  savingsLeg: { id: number; rawData?: Record<string, unknown> };
+  database: DB;
+}): Promise<void> {
+  const { userId, savingsLeg, database } = opts;
+  await database
+    .update(transactions)
+    .set({
+      rawData: sql`${transactions.rawData} || '{"pendingUsdTwinReassignment": true}'::jsonb`,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(transactions.id, savingsLeg.id), eq(transactions.userId, userId)));
+}
+
+// ---------------------------------------------------------------------------
+// Insert fresh transfer pair (no existing gmail pair)
+// ---------------------------------------------------------------------------
+
+async function insertNewPagoTcPair(opts: {
+  userId: number;
+  savingsAccountId: number;
+  row: SavingsPagoTcRow;
+  result: PagoTcRoutingResult;
+  database: DB;
+}): Promise<void> {
+  const { userId, savingsAccountId, row, result, database } = opts;
+
+  // Find the TC account to pair with. For PESOS: find the COP twin TC account.
+  // For DOLAR: find the USD twin TC account. We need to locate the TC card
+  // linked via physicalCardId from the savings account's sister TCs.
+  //
+  // The savings account is NOT a TC account — we look for accounts of type
+  // 'credit_card' belonging to the same user that are Bancolombia and match
+  // the expected currency.
+  const targetCurrency: "COP" | "USD" = row.pagoTcCurrency === "DOLAR" ? "USD" : "COP";
+
+  // Find the TC (credit_card) account with the correct currency and institution.
+  // Filter on type='credit_card' to exclude the savings account itself.
+  const tcAccounts = await database
+    .select({
+      id: accounts.id,
+      currency: accounts.currency,
+      institutionSlug: accounts.institutionSlug,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, userId),
+        eq(accounts.currency, targetCurrency),
+        eq(accounts.institutionSlug, "bancolombia"),
+        eq(accounts.type, "credit_card"),
+        notDeleted(accounts.deletedAt),
+      ),
+    );
+
+  const tcAccount = tcAccounts[0] ?? null;
+
+  if (!tcAccount) {
+    result.errors.push(
+      `no Bancolombia ${targetCurrency} TC account found for user ${userId} — cannot insert Pago TC pair for ${row.occurredAt.toISOString().slice(0, 10)}`,
+    );
+    return;
+  }
+
+  const descriptionRaw = row.descriptionRaw || `Pago TC (${row.pagoTcCurrency})`;
+
+  const insertResult = await insertTransferGroup({
+    userId,
+    legs: [
+      {
+        accountId: savingsAccountId,
+        amountCents: -row.amountCents, // savings debit
+        currency: "COP",
+        descriptionRaw,
+        source: "csv_reconcile",
+        occurredAt: row.occurredAt,
+        rawData: {
+          kind: "tc_payment",
+          role: "debit",
+          pagoTcCurrency: row.pagoTcCurrency,
+          insertedBy: "issue-567-savings-parser",
+        },
+      },
+      {
+        accountId: tcAccount.id,
+        amountCents: row.amountCents, // TC credit (COP amount; USD side is handled by TRM)
+        currency: targetCurrency,
+        descriptionRaw,
+        source: "csv_reconcile",
+        occurredAt: row.occurredAt,
+        rawData: {
+          kind: "tc_payment",
+          role: "credit",
+          pagoTcCurrency: row.pagoTcCurrency,
+          insertedBy: "issue-567-savings-parser",
+        },
+      },
+    ],
+    database,
+  });
+
+  if (insertResult.status === "error") {
+    result.errors.push(
+      `failed to insert Pago TC pair for ${row.occurredAt.toISOString().slice(0, 10)}: ${insertResult.reason}`,
+    );
+    return;
+  }
+
+  if (insertResult.status === "duplicated") {
+    // Already inserted (idempotent re-run) — count as no-op.
+    result.noOpPesos++;
+    return;
+  }
+
+  result.newPairsInserted++;
+  log.info(
+    {
+      userId,
+      event: "pago_tc_new_pair_inserted",
+      savingsAccountId,
+      tcAccountId: tcAccount.id,
+      pagoTcCurrency: row.pagoTcCurrency,
+      amountCents: row.amountCents.toString(),
+      transferGroupId: insertResult.transferGroupId,
+      txIds: insertResult.txIds,
+    },
+    "inserted new Pago TC transfer pair from savings extract",
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/reconciliation/pago-tc-router.ts` — new module that runs after every savings-statement reconciliation and detects `PAGO SUC VIRT TC MASTER DOLAR/PESOS` (and `PAGO AUTOM TC MASTER PESOS`) rows to route Pago TC payments to the correct currency twin.
- For **DOLAR** rows with a wrong-twin (COP) destination: soft-deletes the destination tx (`softDeletedReason: "issue-567-savings-parser-detected-DOLAR"`) and re-pairs the savings leg to the USD synthetic on the USD twin (if uploaded). If the USD synthetic is absent, flags the savings leg with `pendingUsdTwinReassignment: true` for deferred reconciliation.
- For **PESOS** rows: no-op (existing COP-twin pair is already correct).
- For rows with **no existing gmail pair** (e.g., the missing 2026-04-14 PESOS payment): inserts a fresh transfer pair with `source='csv_reconcile'`.
- Hooks into `applyReconcile` in the reconcile actions — runs automatically when a `bancolombia_savings` statement is applied.

## Test plan

- [x] `pago-tc-router.test.ts` — 7 integration tests against `findash_test`:
  - PESOS match → no-op, existing COP pair unchanged
  - DOLAR match + USD synthetic available → COP destination soft-deleted, savings leg re-paired to USD synthetic
  - DOLAR match + NO USD synthetic → COP destination soft-deleted, savings leg flagged `pendingUsdTwinReassignment`
  - No gmail pair + PESOS savings row → new transfer pair inserted (csv_reconcile source)
  - PAGO AUTOM variant handled same as PAGO SUC VIRT
  - Non-Pago TC rows (ABONO INTERESES, TRANSFERENCIA, etc.) are ignored
  - Already-deleted destination (manual cleanup) + DOLAR + USD synthetic → link still runs
- [x] Full test suite: 1735 tests pass (pre-commit hook ran all before push)
- [x] `bun run lint` — 0 errors
- [x] `bun run typecheck` — 0 errors

Closes #567