### PR TITLE
feat(reconciliation): support Bancolombia Extracto Mensual format (6-col with SALDO) (#572)

### DIFF
--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
@@ -60,7 +60,7 @@ interface SerializedParsedRow {
 
 interface SerializedParsed {
   bank: "bancolombia";
-  format: "bancolombia_savings" | "bancolombia_tc";
+  format: "bancolombia_savings" | "bancolombia_savings_extracto" | "bancolombia_tc";
   periodStart: string;
   periodEnd: string;
   rowCount: number;
@@ -385,9 +385,12 @@ export async function applyReconcile(input: ApplyReconcileInput) {
   // #567 — after committing a savings extract, run Pago TC twin routing.
   // Savings descriptions carry DOLAR/PESOS distinction that gmail/SMS lack,
   // so this step corrects any misrouted destination legs and inserts any
-  // missing transfer pairs. Only runs when the uploaded file is a savings
-  // statement (not a TC statement).
-  if (result.status === "applied" && parsedStatement.format === "bancolombia_savings") {
+  // missing transfer pairs. Runs for both savings formats (4-col Movimientos
+  // and 6-col Extracto Mensual) — both carry the same PAGO SUC VIRT TC rows.
+  const isSavingsFormat =
+    parsedStatement.format === "bancolombia_savings" ||
+    parsedStatement.format === "bancolombia_savings_extracto";
+  if (result.status === "applied" && isSavingsFormat) {
     const pagoResult = await applyPagoTcRouting({
       userId: session.id,
       savingsAccountId: account.id,

--- a/src/lib/reconciliation/dispatch.ts
+++ b/src/lib/reconciliation/dispatch.ts
@@ -1,5 +1,7 @@
 import * as XLSX from "xlsx";
 import { parseBancolombiaSavings } from "./parsers/bancolombia-savings";
+import { parseBancolombiaSavingsExtracto } from "./parsers/bancolombia-savings-extracto";
+import { findExtractoHeaderRow } from "./parsers/bancolombia-savings-extracto";
 import { parseBancolombiaTc } from "./parsers/bancolombia-tc";
 import { StatementParseError } from "./parsers/types";
 import type { ParsedStatement, StatementFormat, StatementBank } from "./parsers/types";
@@ -10,10 +12,16 @@ export interface DetectedFormat {
 }
 
 /**
- * Detects the Bancolombia export format by inspecting just the header row.
- * Column count + header text disambiguate:
- *   4 cols (Fecha | Descripción | Referencia | Valor) → savings
- *   6 cols (Fecha | Descripción | Fecha de corte | Valor | Tipo de moneda | Cuotas) → TC
+ * Detects the Bancolombia export format by inspecting the header row(s).
+ * Three formats are recognized:
+ *
+ *   Format A — 4-col Movimientos (header at row 1):
+ *     Fecha | Descripción | Referencia | Valor
+ *   Format B — 6-col Extracto Mensual (header at row ~15, scan first 30 rows):
+ *     FECHA | DESCRIPCIÓN | SUCURSAL | DCTO. | VALOR | SALDO
+ *   Format C — 6-col TC (header at row 1):
+ *     Fecha | Descripción | Fecha de corte | Valor | Tipo de moneda | Cuotas
+ *
  * Anything else → StatementParseError('format_mismatch').
  */
 export function detectFormat(buffer: Buffer | Uint8Array): DetectedFormat {
@@ -28,31 +36,38 @@ export function detectFormat(buffer: Buffer | Uint8Array): DetectedFormat {
   }
   const matrix = XLSX.utils.sheet_to_json<unknown[]>(sheet, {
     header: 1,
-    raw: true,
+    raw: false,
     defval: null,
   });
-  const header = matrix[0];
-  if (!Array.isArray(header)) {
-    throw new StatementParseError("format_mismatch", "no header row");
-  }
-  const headerNorm = header.map((c) => String(c ?? "").trim());
 
-  if (headerMatches(headerNorm, ["Fecha", "Descripción", "Referencia", "Valor"])) {
-    return { bank: "bancolombia", format: "bancolombia_savings" };
-  }
-  if (
-    headerMatches(headerNorm, [
-      "Fecha",
-      "Descripción",
-      "Fecha de corte",
-      "Valor",
-      "Tipo de moneda",
-      "Cuotas",
-    ])
-  ) {
-    return { bank: "bancolombia", format: "bancolombia_tc" };
+  // --- Format A: 4-col Movimientos (header at row 0) ---
+  const header0 = matrix[0];
+  if (Array.isArray(header0)) {
+    const headerNorm = header0.map((c) => String(c ?? "").trim());
+
+    if (headerMatches(headerNorm, ["Fecha", "Descripción", "Referencia", "Valor"])) {
+      return { bank: "bancolombia", format: "bancolombia_savings" };
+    }
+    if (
+      headerMatches(headerNorm, [
+        "Fecha",
+        "Descripción",
+        "Fecha de corte",
+        "Valor",
+        "Tipo de moneda",
+        "Cuotas",
+      ])
+    ) {
+      return { bank: "bancolombia", format: "bancolombia_tc" };
+    }
   }
 
+  // --- Format B: 6-col Extracto Mensual (header anywhere in first 30 rows) ---
+  if (findExtractoHeaderRow(matrix as unknown[][]) !== -1) {
+    return { bank: "bancolombia", format: "bancolombia_savings_extracto" };
+  }
+
+  const headerNorm = Array.isArray(header0) ? header0.map((c) => String(c ?? "").trim()) : [];
   throw new StatementParseError(
     "format_mismatch",
     `unrecognized header: [${headerNorm.join(", ")}]`,
@@ -74,6 +89,9 @@ export function parseAny(buffer: Buffer | Uint8Array): {
   const detected = detectFormat(buffer);
   if (detected.format === "bancolombia_savings") {
     return { detected, parsed: parseBancolombiaSavings(buffer) };
+  }
+  if (detected.format === "bancolombia_savings_extracto") {
+    return { detected, parsed: parseBancolombiaSavingsExtracto(buffer) };
   }
   return { detected, parsed: parseBancolombiaTc(buffer) };
 }

--- a/src/lib/reconciliation/parsers/bancolombia-savings-extracto.test.ts
+++ b/src/lib/reconciliation/parsers/bancolombia-savings-extracto.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it } from "vitest";
+import * as XLSX from "xlsx";
+import { parseBancolombiaSavingsExtracto } from "./bancolombia-savings-extracto";
+import { detectFormat, parseAny } from "../dispatch";
+import { StatementParseError } from "./types";
+
+// ---------------------------------------------------------------------------
+// Fixture builder helpers
+// ---------------------------------------------------------------------------
+
+type ExtractoRow = [
+  string | null, // FECHA  (D/MM or DD/MM)
+  string | null, // DESCRIPCIÓN
+  string | null, // SUCURSAL
+  string | null, // DCTO.
+  string | null, // VALOR  (Colombian-formatted string)
+  string | null, // SALDO  (Colombian-formatted string)
+];
+
+/**
+ * Builds a synthetic Extracto Mensual XLSX buffer in the real Bancolombia
+ * layout (title section rows 1-14, header at row 15, data from row 16 on).
+ *
+ * The period row uses `startDate` / `endDate` in "YYYY/MM/DD" format.
+ */
+function buildExtractoXlsx(
+  opts: {
+    startDate?: string; // e.g. "2025/12/31"
+    endDate?: string; // e.g. "2026/03/31"
+    rows?: ExtractoRow[];
+    appendSentinel?: boolean;
+  } = {},
+): Buffer {
+  const {
+    startDate = "2026/01/01",
+    endDate = "2026/03/31",
+    rows = [],
+    appendSentinel = true,
+  } = opts;
+
+  const titleSection: unknown[][] = [
+    // r1: blank
+    [null, null, null, null, null, null],
+    // r2: info header
+    ["Información Cliente:", null, null, null, null, null],
+    // r3: labels
+    ["CLIENTE", "DIRECCIÓN", "CIUDAD", null, null, null],
+    // r4: data
+    ["ALEJANDRO MARTINEZ", "CALLE 75 SUR 53 150", "ITAGUI ANTIOQUIA", null, null, null],
+    // r5: blank
+    [null, null, null, null, null, null],
+    // r6: info header
+    ["Información General:", null, null, null, null, null],
+    // r7: labels
+    ["DESDE", "HASTA", "TIPO CUENTA", "NRO CUENTA", "SUCURSAL", null],
+    // r8: period data — this is where we read the start year
+    [startDate, endDate, "CUENTA DE AHORROS", "9871936126", "SUCURSAL TEST", null],
+    // r9: blank
+    [null, null, null, null, null, null],
+    // r10: resumen header
+    ["Resumen:", null, null, null, null, null],
+    // r11: summary labels
+    ["SALDO ANTERIOR", "TOTAL ABONOS", "TOTAL CARGOS", "SALDO ACTUAL", null, null],
+    // r12: summary values
+    ["63,208.71", "28,882,641.87", "27,648,904.57", "1,296,946.01", null, null],
+    // r13: blank
+    [null, null, null, null, null, null],
+    // r14: movimientos header
+    ["Movimientos:", null, null, null, null, null],
+    // r15: column header — row index 14 in 0-based matrix
+    ["FECHA", "DESCRIPCIÓN", "SUCURSAL", "DCTO.", "VALOR", "SALDO"],
+  ];
+
+  const sentinel: unknown[][] = appendSentinel
+    ? [[null, "FIN ESTADO DE CUENTA", null, null, null, null]]
+    : [];
+
+  const all: unknown[][] = [...titleSection, ...rows, ...sentinel];
+
+  const ws = XLSX.utils.aoa_to_sheet(all);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "Extracto");
+  return XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+}
+
+// ---------------------------------------------------------------------------
+// detectFormat tests
+// ---------------------------------------------------------------------------
+
+describe("detectFormat — bancolombia_savings_extracto", () => {
+  it("recognizes the 6-col Extracto header at row 15", () => {
+    const buf = buildExtractoXlsx({
+      rows: [["1/01", "ABONO INTERESES", null, null, ".08", "1,000.00"]],
+    });
+    expect(detectFormat(buf)).toEqual({
+      bank: "bancolombia",
+      format: "bancolombia_savings_extracto",
+    });
+  });
+
+  it("recognizes the Extracto header even with garbage rows before it (header at row 18)", () => {
+    // Build a sheet where title section is extended with extra garbage rows
+    // so the header ends up later than row 15.
+    const extraGarbage: unknown[][] = [
+      ["Noise", null, null, null, null, null],
+      ["More noise", null, null, null, null, null],
+      [null, null, null, null, null, null],
+    ];
+    const titleSection: unknown[][] = [
+      [null, null, null, null, null, null],
+      ["Información Cliente:", null, null, null, null, null],
+      ["CLIENTE", "DIRECCIÓN", "CIUDAD", null, null, null],
+      ["ALEJANDRO", "CALLE", "ITAGUI", null, null, null],
+      [null, null, null, null, null, null],
+      ["Información General:", null, null, null, null, null],
+      ["DESDE", "HASTA", "TIPO CUENTA", "NRO CUENTA", "SUCURSAL", null],
+      ["2026/01/01", "2026/03/31", "CUENTA DE AHORROS", "6126", "SUCURSAL", null],
+      [null, null, null, null, null, null],
+      ["Resumen:", null, null, null, null, null],
+      ["SALDO ANTERIOR", "TOTAL ABONOS", null, null, null, null],
+      ["100.00", "200.00", null, null, null, null],
+      [null, null, null, null, null, null],
+      ["Movimientos:", null, null, null, null, null],
+      ...extraGarbage,
+      // header at row 18 (0-based index 17)
+      ["FECHA", "DESCRIPCIÓN", "SUCURSAL", "DCTO.", "VALOR", "SALDO"],
+      ["1/01", "ABONO INTERESES", null, null, ".08", "1,000.00"],
+      [null, "FIN ESTADO DE CUENTA", null, null, null, null],
+    ];
+    const ws = XLSX.utils.aoa_to_sheet(titleSection);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "Extracto");
+    const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+    expect(detectFormat(buf)).toEqual({
+      bank: "bancolombia",
+      format: "bancolombia_savings_extracto",
+    });
+  });
+
+  it("does NOT mistake the 4-col savings format for extracto", () => {
+    const ws = XLSX.utils.aoa_to_sheet([
+      ["Fecha", "Descripción", "Referencia", "Valor"],
+      [46127.20833, "x", null, 100],
+    ]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "Hoja 1");
+    const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+    expect(detectFormat(buf)).toEqual({ bank: "bancolombia", format: "bancolombia_savings" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBancolombiaSavingsExtracto tests
+// ---------------------------------------------------------------------------
+
+describe("parseBancolombiaSavingsExtracto", () => {
+  it("parses a basic fixture and returns the correct ParsedStatement shape", () => {
+    const buf = buildExtractoXlsx({
+      startDate: "2026/01/01",
+      endDate: "2026/03/31",
+      rows: [
+        ["2/01", "PAGO DE PROV PEXTO COLOMBIA", null, null, "100,000.00", "141,383.46"],
+        ["3/01", "COMPRA EN COLMEDICA", null, null, "-423,896.00", "5,716,868.66"],
+        ["5/02", "ABONO INTERESES AHORROS", null, null, ".14", "52,573.65"],
+      ],
+    });
+    const out = parseBancolombiaSavingsExtracto(buf);
+    expect(out.bank).toBe("bancolombia");
+    expect(out.format).toBe("bancolombia_savings_extracto");
+    expect(out.rowCount).toBe(3);
+    expect(out.rows.every((r) => r.currency === "COP")).toBe(true);
+    expect(out.rows.every((r) => r.isMetadata === false)).toBe(true);
+  });
+
+  it("correctly maps positive VALOR → direction='in', negative VALOR → direction='out'", () => {
+    const buf = buildExtractoXlsx({
+      rows: [
+        ["2/01", "INGRESO", null, null, "100,000.00", "200,000.00"],
+        ["3/01", "GASTO", null, null, "-50,000.00", "150,000.00"],
+        ["4/01", "MICRO INGRESO", null, null, ".14", "150,000.14"],
+        ["4/01", "MICRO GASTO", null, null, "-.07", "150,000.07"],
+      ],
+    });
+    const out = parseBancolombiaSavingsExtracto(buf);
+    expect(out.rows[0].direction).toBe("in");
+    expect(out.rows[0].amountCents).toBe(BigInt(10_000_000));
+    expect(out.rows[1].direction).toBe("out");
+    expect(out.rows[1].amountCents).toBe(BigInt(5_000_000));
+    expect(out.rows[2].direction).toBe("in");
+    expect(out.rows[2].amountCents).toBe(BigInt(14));
+    expect(out.rows[3].direction).toBe("out");
+    expect(out.rows[3].amountCents).toBe(BigInt(7));
+  });
+
+  it("derives the year from the DESDE campo and assigns it to all rows in a single-year file", () => {
+    const buf = buildExtractoXlsx({
+      startDate: "2026/01/01",
+      endDate: "2026/03/31",
+      rows: [
+        ["15/01", "TX 1", null, null, "1,000.00", "1,000.00"],
+        ["20/03", "TX 2", null, null, "2,000.00", "3,000.00"],
+      ],
+    });
+    const out = parseBancolombiaSavingsExtracto(buf);
+    expect(out.rows[0].occurredAt.getUTCFullYear()).toBe(2026);
+    expect(out.rows[0].occurredAt.getUTCMonth()).toBe(0); // January = 0
+    expect(out.rows[0].occurredAt.getUTCDate()).toBe(15);
+    expect(out.rows[1].occurredAt.getUTCFullYear()).toBe(2026);
+    expect(out.rows[1].occurredAt.getUTCMonth()).toBe(2); // March = 2
+    expect(out.rows[1].occurredAt.getUTCDate()).toBe(20);
+  });
+
+  it("advances the year when month wraps backward (Dec → Jan across year boundary)", () => {
+    const buf = buildExtractoXlsx({
+      startDate: "2025/12/31",
+      endDate: "2026/03/31",
+      rows: [
+        ["12/12", "MANEJO TARJETA DEB", null, null, "-11,175.00", "52,033.71"],
+        ["31/12", "AJUSTE INTERES AHORROS DB", null, null, "-.06", "41,383.41"],
+        ["1/01", "ABONO INTERESES AHORROS", null, null, ".08", "41,383.49"],
+        ["15/03", "PAGO QR NEWMEN", null, null, "-158,500.00", "56,573.51"],
+      ],
+    });
+    const out = parseBancolombiaSavingsExtracto(buf);
+    // Dec rows → 2025
+    expect(out.rows[0].occurredAt.getUTCFullYear()).toBe(2025);
+    expect(out.rows[0].occurredAt.getUTCMonth()).toBe(11); // December
+    expect(out.rows[1].occurredAt.getUTCFullYear()).toBe(2025);
+    expect(out.rows[1].occurredAt.getUTCMonth()).toBe(11); // December
+    // Jan rows → 2026
+    expect(out.rows[2].occurredAt.getUTCFullYear()).toBe(2026);
+    expect(out.rows[2].occurredAt.getUTCMonth()).toBe(0); // January
+    // March → 2026
+    expect(out.rows[3].occurredAt.getUTCFullYear()).toBe(2026);
+    expect(out.rows[3].occurredAt.getUTCMonth()).toBe(2); // March
+  });
+
+  it("sets occurredAt at midnight Bogotá (05:00 UTC)", () => {
+    const buf = buildExtractoXlsx({
+      rows: [["2/01", "TX", null, null, "1,000.00", "1,000.00"]],
+    });
+    const out = parseBancolombiaSavingsExtracto(buf);
+    expect(out.rows[0].occurredAt.getUTCHours()).toBe(5);
+    expect(out.rows[0].occurredAt.getUTCMinutes()).toBe(0);
+    expect(out.rows[0].occurredAt.getUTCSeconds()).toBe(0);
+  });
+
+  it("captures periodStart and periodEnd as min/max of row dates", () => {
+    const buf = buildExtractoXlsx({
+      startDate: "2026/01/01",
+      endDate: "2026/03/31",
+      rows: [
+        ["15/01", "NEWEST", null, null, "1,000.00", "1,000.00"],
+        ["2/01", "OLDEST", null, null, "2,000.00", "2,000.00"],
+        ["10/01", "MIDDLE", null, null, "3,000.00", "3,000.00"],
+      ],
+    });
+    const out = parseBancolombiaSavingsExtracto(buf);
+    expect(out.periodStart.getUTCDate()).toBe(2);
+    expect(out.periodEnd.getUTCDate()).toBe(15);
+  });
+
+  it("captures balanceAtEndCents from the last SALDO value", () => {
+    const buf = buildExtractoXlsx({
+      rows: [
+        ["2/01", "TX 1", null, null, "1,000.00", "100,000.00"],
+        ["3/01", "TX 2", null, null, "-500.00", "1,296,946.01"],
+      ],
+    });
+    const out = parseBancolombiaSavingsExtracto(buf);
+    // Last SALDO is "1,296,946.01" → 129694601 cents
+    expect(out.balanceAtEndCents).toBe(BigInt(129_694_601));
+  });
+
+  it("includes PAGO SUC VIRT TC MASTER DOLAR row with correct descriptionRaw", () => {
+    const buf = buildExtractoXlsx({
+      rows: [
+        ["2/01", "PAGO SUC VIRT TC MASTER DOLAR", null, null, "-405,764.64", "3,111,909.02"],
+        ["2/01", "PAGO SUC VIRT TC MASTER PESOS", null, null, "-2,199,195.00", "3,517,673.66"],
+      ],
+    });
+    const out = parseBancolombiaSavingsExtracto(buf);
+    expect(out.rows[0].descriptionRaw).toBe("PAGO SUC VIRT TC MASTER DOLAR");
+    expect(out.rows[0].direction).toBe("out");
+    expect(out.rows[0].amountCents).toBe(BigInt(40_576_464));
+    expect(out.rows[1].descriptionRaw).toBe("PAGO SUC VIRT TC MASTER PESOS");
+    expect(out.rows[1].direction).toBe("out");
+  });
+
+  it("stops at FIN ESTADO DE CUENTA sentinel and excludes it from rows", () => {
+    const buf = buildExtractoXlsx({
+      rows: [["2/01", "TX 1", null, null, "1,000.00", "1,000.00"]],
+      appendSentinel: true,
+    });
+    const out = parseBancolombiaSavingsExtracto(buf);
+    expect(out.rowCount).toBe(1);
+    expect(out.rows.every((r) => r.descriptionRaw !== "FIN ESTADO DE CUENTA")).toBe(true);
+  });
+
+  it("throws StatementParseError('empty') when there are no data rows", () => {
+    const buf = buildExtractoXlsx({ rows: [], appendSentinel: false });
+    expect(() => parseBancolombiaSavingsExtracto(buf)).toThrow(StatementParseError);
+    try {
+      parseBancolombiaSavingsExtracto(buf);
+    } catch (err) {
+      expect((err as StatementParseError).kind).toBe("empty");
+    }
+  });
+
+  it("throws StatementParseError('format_mismatch') when the Extracto header is missing", () => {
+    const ws = XLSX.utils.aoa_to_sheet([
+      ["RANDOM", "HEADERS", "HERE", null, null, null],
+      ["data", "data", "data", null, null, null],
+    ]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "Extracto");
+    const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+    expect(() => parseBancolombiaSavingsExtracto(buf)).toThrow(StatementParseError);
+    try {
+      parseBancolombiaSavingsExtracto(buf);
+    } catch (err) {
+      expect((err as StatementParseError).kind).toBe("format_mismatch");
+    }
+  });
+
+  it("throws StatementParseError('bad_row') on an invalid FECHA value", () => {
+    const buf = buildExtractoXlsx({
+      rows: [["NOT_A_DATE", "TX 1", null, null, "1,000.00", "1,000.00"]],
+      appendSentinel: false,
+    });
+    expect(() => parseBancolombiaSavingsExtracto(buf)).toThrow(StatementParseError);
+    try {
+      parseBancolombiaSavingsExtracto(buf);
+    } catch (err) {
+      expect((err as StatementParseError).kind).toBe("bad_row");
+    }
+  });
+
+  it("stores sucursal and dcto metadata in rawData", () => {
+    const buf = buildExtractoXlsx({
+      rows: [["5/01", "COMPRA EN TIENDA", "SUCURSAL NORTE", "TXN-001", "-50,000.00", "50,000.00"]],
+    });
+    const out = parseBancolombiaSavingsExtracto(buf);
+    expect(out.rows[0].rawData.sucursal).toBe("SUCURSAL NORTE");
+    expect(out.rows[0].rawData.dcto).toBe("TXN-001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAny integration tests
+// ---------------------------------------------------------------------------
+
+describe("parseAny — routes Extracto to extracto parser", () => {
+  it("routes Extracto buffer to bancolombia_savings_extracto parser", () => {
+    const buf = buildExtractoXlsx({
+      rows: [["2/01", "ABONO INTERESES", null, null, ".08", "1,000.00"]],
+    });
+    const { detected, parsed } = parseAny(buf);
+    expect(detected.format).toBe("bancolombia_savings_extracto");
+    expect(parsed.format).toBe("bancolombia_savings_extracto");
+    expect(parsed.bank).toBe("bancolombia");
+    expect(parsed.rowCount).toBe(1);
+  });
+
+  it("does not break existing 4-col savings routing", () => {
+    const ws = XLSX.utils.aoa_to_sheet([
+      ["Fecha", "Descripción", "Referencia", "Valor"],
+      [46127, "x", null, 100],
+    ]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "Hoja 1");
+    const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+    const { detected, parsed } = parseAny(buf);
+    expect(detected.format).toBe("bancolombia_savings");
+    expect(parsed.format).toBe("bancolombia_savings");
+  });
+});

--- a/src/lib/reconciliation/parsers/bancolombia-savings-extracto.ts
+++ b/src/lib/reconciliation/parsers/bancolombia-savings-extracto.ts
@@ -1,0 +1,278 @@
+import * as XLSX from "xlsx";
+import { StatementParseError, type ParsedStatement, type ParsedStatementRow } from "./types";
+
+/**
+ * Column header (normalized to uppercase) for the Bancolombia "Extracto Mensual"
+ * savings format. The header lives at ~row 15, not row 1.
+ */
+const EXTRACTO_HEADERS = ["FECHA", "DESCRIPCIÓN", "SUCURSAL", "DCTO.", "VALOR", "SALDO"] as const;
+
+/**
+ * Sentinel row that marks the end of data in the Extracto format.
+ * When FECHA is null and DESCRIPCIÓN equals this value, stop scanning.
+ */
+const END_SENTINEL = "FIN ESTADO DE CUENTA";
+
+/**
+ * Parses a Bancolombia savings-account "Extracto Mensual" statement
+ * (format B — 6 columns with running SALDO balance).
+ *
+ * Layout:
+ *   Row 1     blank
+ *   Row 2     "Información Cliente:"
+ *   Row 3     CLIENTE | DIRECCIÓN | CIUDAD (label row)
+ *   Row 4     <customer data>
+ *   Row 5     blank
+ *   Row 6     "Información General:"
+ *   Row 7     DESDE | HASTA | TIPO CUENTA | NRO CUENTA | SUCURSAL (label row)
+ *   Row 8     <period data: e.g. "2025/12/31" | "2026/03/31" | ...>
+ *   Row 9     blank
+ *   Row 10    "Resumen:"
+ *   Row 11-12 summary labels + values
+ *   Row 13    blank
+ *   Row 14    "Movimientos:"
+ *   Row 15    FECHA | DESCRIPCIÓN | SUCURSAL | DCTO. | VALOR | SALDO
+ *   Row 16+   data rows (FECHA as "DD/MM" or "D/MM" strings, no year per row)
+ *   Last row  null | "FIN ESTADO DE CUENTA" | ...
+ *
+ * Year derivation:
+ *   FECHA rows contain only day/month — no year. The period header at row 8
+ *   provides "DESDE" (start date, YYYY/MM/DD) and "HASTA" (end date, YYYY/MM/DD).
+ *   We start at the year of DESDE and advance the year whenever the month
+ *   decreases relative to the previous row (January after December = new year).
+ *
+ * Sign convention (NATIVE — same as the 4-col savings parser):
+ *   Positive VALOR → ingreso → direction='in'
+ *   Negative VALOR → gasto  → direction='out'
+ *   amountCents is always positive; semantics are in direction.
+ *
+ * VALOR is stored as a formatted COP string ("−11,175.00", "100,000.00", "-.07").
+ * We strip commas and parse as float, then convert to cents.
+ */
+export function parseBancolombiaSavingsExtracto(buffer: Buffer | Uint8Array): ParsedStatement {
+  const wb = XLSX.read(buffer, { type: "buffer" });
+  const sheetName = wb.SheetNames[0];
+  if (!sheetName) {
+    throw new StatementParseError("missing_sheet", "workbook has no sheets");
+  }
+  const ws = wb.Sheets[sheetName];
+  if (!ws) {
+    throw new StatementParseError("missing_sheet", `sheet "${sheetName}" not found`);
+  }
+
+  const matrix = XLSX.utils.sheet_to_json<unknown[]>(ws, {
+    header: 1,
+    raw: false, // read as formatted strings (VALOR/SALDO are stored as strings)
+    defval: null,
+  });
+
+  // -------------------------------------------------------------------------
+  // Step 1: Find the data header row (scan first 30 rows)
+  // -------------------------------------------------------------------------
+  const headerRowIndex = findHeaderRow(matrix);
+  if (headerRowIndex === -1) {
+    throw new StatementParseError(
+      "format_mismatch",
+      `Extracto header [${EXTRACTO_HEADERS.join(", ")}] not found in first 30 rows`,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 2: Extract the period start year from the title section (row 8 = index 7)
+  // -------------------------------------------------------------------------
+  const startYear = extractStartYear(matrix);
+
+  // -------------------------------------------------------------------------
+  // Step 3: Parse data rows
+  // -------------------------------------------------------------------------
+  const dataRows = matrix.slice(headerRowIndex + 1);
+  const rows: ParsedStatementRow[] = [];
+  let minMs = Number.POSITIVE_INFINITY;
+  let maxMs = Number.NEGATIVE_INFINITY;
+  let lastBalanceCents: bigint | null = null;
+
+  let currentYear = startYear;
+  let prevMonth: number | null = null;
+
+  for (let i = 0; i < dataRows.length; i++) {
+    const raw = dataRows[i];
+    if (!Array.isArray(raw)) continue;
+
+    const [fecha, descripcion, sucursal, dcto, valor, saldo] = raw as [
+      unknown,
+      unknown,
+      unknown,
+      unknown,
+      unknown,
+      unknown,
+    ];
+
+    // Sentinel: FECHA null + DESCRIPCIÓN = END_SENTINEL
+    if (fecha === null || fecha === undefined || fecha === "") {
+      const desc = String(descripcion ?? "").trim();
+      if (desc === END_SENTINEL || desc === "") break;
+      // Otherwise skip blank-fecha rows
+      continue;
+    }
+
+    const fechaStr = String(fecha).trim();
+    const parsed = parseFecha(fechaStr, currentYear, prevMonth);
+    if (!parsed) {
+      throw new StatementParseError(
+        "bad_row",
+        `row ${headerRowIndex + i + 2}: FECHA "${fechaStr}" is not a valid D/MM or DD/MM date`,
+      );
+    }
+
+    // Advance year if month wrapped backward (e.g. 12 → 1)
+    if (prevMonth !== null && parsed.month < prevMonth) {
+      currentYear++;
+      parsed.year = currentYear;
+    }
+    prevMonth = parsed.month;
+
+    const occurredAt = buildBogotaUtc(parsed.year, parsed.month, parsed.day);
+
+    const valorStr = String(valor ?? "").trim();
+    const valorNum = parseColombianNumber(valorStr);
+    if (!Number.isFinite(valorNum)) {
+      throw new StatementParseError(
+        "bad_row",
+        `row ${headerRowIndex + i + 2}: VALOR "${valorStr}" is not a valid number`,
+      );
+    }
+
+    const direction: "in" | "out" = valorNum < 0 ? "out" : "in";
+    const amountCents = BigInt(Math.round(Math.abs(valorNum) * 100));
+
+    const saldoStr = String(saldo ?? "").trim();
+    const saldoNum = parseColombianNumber(saldoStr);
+    if (Number.isFinite(saldoNum)) {
+      lastBalanceCents = BigInt(Math.round(saldoNum * 100));
+    }
+
+    const sucursalStr =
+      sucursal !== null && sucursal !== undefined ? String(sucursal).trim() : null;
+    const dctoStr = dcto !== null && dcto !== undefined ? String(dcto).trim() : null;
+
+    rows.push({
+      occurredAt,
+      amountCents,
+      currency: "COP",
+      direction,
+      descriptionRaw: String(descripcion ?? "").trim(),
+      rawData: {
+        sucursal: sucursalStr || null,
+        dcto: dctoStr || null,
+        saldo: saldoStr || null,
+      },
+      isMetadata: false,
+    });
+
+    const ms = occurredAt.getTime();
+    if (ms < minMs) minMs = ms;
+    if (ms > maxMs) maxMs = ms;
+  }
+
+  if (rows.length === 0) {
+    throw new StatementParseError("empty", "no valid data rows");
+  }
+
+  return {
+    bank: "bancolombia",
+    format: "bancolombia_savings_extracto",
+    periodStart: new Date(minMs),
+    periodEnd: new Date(maxMs),
+    rowCount: rows.length,
+    balanceAtEndCents: lastBalanceCents,
+    rows,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans the first 30 rows looking for the 6-column Extracto header.
+ * Returns the 0-based row index or -1 if not found.
+ */
+export function findExtractoHeaderRow(matrix: unknown[][]): number {
+  return findHeaderRow(matrix);
+}
+
+function findHeaderRow(matrix: unknown[][]): number {
+  const limit = Math.min(matrix.length, 30);
+  for (let i = 0; i < limit; i++) {
+    const row = matrix[i];
+    if (!Array.isArray(row) || row.length < EXTRACTO_HEADERS.length) continue;
+    const match = EXTRACTO_HEADERS.every(
+      (expected, col) =>
+        String(row[col] ?? "")
+          .trim()
+          .toUpperCase() === expected,
+    );
+    if (match) return i;
+  }
+  return -1;
+}
+
+/**
+ * Extracts the start year from the period info row.
+ * Looks for a row where the first cell looks like "YYYY/MM/DD" within the
+ * first 20 rows. Expects the DESDE date in column 1 (index 0).
+ *
+ * If not found, falls back to the current year (safe for same-year files).
+ */
+function extractStartYear(matrix: unknown[][]): number {
+  const limit = Math.min(matrix.length, 20);
+  for (let i = 0; i < limit; i++) {
+    const row = matrix[i];
+    if (!Array.isArray(row)) continue;
+    const cell = String(row[0] ?? "").trim();
+    // Match YYYY/MM/DD
+    const m = /^(\d{4})\/\d{2}\/\d{2}$/.exec(cell);
+    if (m) return parseInt(m[1], 10);
+  }
+  // Fallback: use current year (shouldn't happen with real Bancolombia exports)
+  return new Date().getUTCFullYear();
+}
+
+/**
+ * Parses a "D/MM" or "DD/MM" date string into day/month/year components.
+ * Returns null if parsing fails.
+ */
+function parseFecha(
+  s: string,
+  currentYear: number,
+  _prevMonth: number | null,
+): { day: number; month: number; year: number } | null {
+  const m = /^(\d{1,2})\/(\d{2})$/.exec(s);
+  if (!m) return null;
+  const day = parseInt(m[1], 10);
+  const month = parseInt(m[2], 10);
+  if (day < 1 || day > 31 || month < 1 || month > 12) return null;
+  return { day, month, year: currentYear };
+}
+
+/**
+ * Constructs a Date representing midnight Bogotá (UTC-5) for the given
+ * calendar date. Bogotá has no DST, so midnight Bogotá = 05:00 UTC.
+ */
+function buildBogotaUtc(year: number, month: number, day: number): Date {
+  // Date.UTC months are 0-indexed
+  const utcMidnightMs = Date.UTC(year, month - 1, day);
+  return new Date(utcMidnightMs + 5 * 60 * 60 * 1000);
+}
+
+/**
+ * Parses a Colombian-formatted number string.
+ * Examples: "100,000.00" → 100000, "-11,175.00" → -11175, "-.07" → -0.07, ".14" → 0.14.
+ * Strips thousands-separator commas before parsing.
+ */
+function parseColombianNumber(s: string): number {
+  if (!s) return NaN;
+  // Remove thousands-separator commas (but preserve decimal dots)
+  const normalized = s.replace(/,/g, "");
+  return parseFloat(normalized);
+}

--- a/src/lib/reconciliation/parsers/types.ts
+++ b/src/lib/reconciliation/parsers/types.ts
@@ -1,6 +1,9 @@
 export type ParseDirection = "in" | "out";
 
-export type StatementFormat = "bancolombia_tc" | "bancolombia_savings";
+export type StatementFormat =
+  | "bancolombia_tc"
+  | "bancolombia_savings"
+  | "bancolombia_savings_extracto";
 
 export type StatementBank = "bancolombia";
 


### PR DESCRIPTION
## Summary

- Adds `parseBancolombiaSavingsExtracto` parser for the Bancolombia "Estado de Cuenta → Generar Extracto" XLSX format (6-column with running SALDO balance, title section rows 1-14, header at row ~15)
- Extends `detectFormat()` to scan the first 30 rows for the Extracto header so files with title sections are recognized; existing 4-col savings and TC detection unchanged
- Wires Pago TC routing (`applyPagoTcRouting`) to also fire after Extracto uploads, so historical `PAGO SUC VIRT TC MASTER DOLAR/PESOS` rows in `Extracto_202603_Cuentas_de ahorro_6126.xlsx` are correctly routed

## Key design decisions

- **Year derivation**: The Extracto XLSX omits the year on every data row (dates are `D/MM` only). The period header in the title section (row 8) gives `DESDE`/`HASTA` as `YYYY/MM/DD`. Parser starts at `DESDE` year and advances by 1 whenever the month decreases — correctly handles multi-year files (Dec 2025 → Mar 2026).
- **VALOR parsing**: Values are COP-formatted strings (`"-11,175.00"`, `"-.07"`) — not numeric. Commas stripped, then `parseFloat`. Raw string comes from SheetJS with `raw: false`.
- **SALDO → `balanceAtEndCents`**: Last non-empty SALDO is captured (unlike the 4-col format which always returns `null`).
- **Sentinel**: Parser stops on `null FECHA + "FIN ESTADO DE CUENTA"` description, which Bancolombia appends as the final row.

## Test plan

- [x] `detectFormat` returns `bancolombia_savings_extracto` for an Extracto fixture
- [x] `detectFormat` recognizes the header even when it appears at row 18+ (garbage rows before it)
- [x] `detectFormat` does not misidentify the 4-col savings format
- [x] Sign convention: positive VALOR → `direction='in'`, negative → `direction='out'`, `amountCents` always positive
- [x] Year derivation for single-year files
- [x] Year derivation with Dec→Jan year boundary advance
- [x] `occurredAt` at midnight Bogotá (UTC+5 = 05:00 UTC)
- [x] `periodStart`/`periodEnd` as min/max of rows
- [x] `balanceAtEndCents` from last SALDO value
- [x] `PAGO SUC VIRT TC MASTER DOLAR/PESOS` rows round-trip with correct `descriptionRaw`
- [x] FIN ESTADO DE CUENTA sentinel excluded from rows
- [x] `empty` error when no data rows
- [x] `format_mismatch` when Extracto header not found
- [x] `bad_row` on invalid FECHA value
- [x] `sucursal` and `dcto` metadata in `rawData`
- [x] `parseAny` routes Extracto buffer to new parser (no regression on 4-col)
- [x] 18 new tests, 111 total in reconciliation suite (all passing)

Closes #572