### PR TITLE
fix(reconciliation): handle multi-section Bancolombia Extracto exports (#572)

### DIFF
--- a/src/lib/reconciliation/parsers/bancolombia-savings-extracto.test.ts
+++ b/src/lib/reconciliation/parsers/bancolombia-savings-extracto.test.ts
@@ -344,6 +344,85 @@ describe("parseBancolombiaSavingsExtracto", () => {
     expect(out.rows[0].rawData.sucursal).toBe("SUCURSAL NORTE");
     expect(out.rows[0].rawData.dcto).toBe("TXN-001");
   });
+
+  it("parses multi-section files where Bancolombia concatenates per-cycle blocks", () => {
+    // Real Bancolombia exports spanning multiple cycles concatenate one
+    // section per cycle, each starting with "Información Cliente:" → cliente
+    // → "Información General:" → period → "Movimientos:" → header → data.
+    // The parser must skip the section break and resume at the next header.
+    const titleSection: unknown[][] = [
+      [null, null, null, null, null, null],
+      ["Información Cliente:", null, null, null, null, null],
+      ["CLIENTE", "DIRECCIÓN", "CIUDAD", null, null, null],
+      ["ALEJANDRO MARTINEZ", "CALLE 75", "ITAGUI", null, null, null],
+      [null, null, null, null, null, null],
+      ["Información General:", null, null, null, null, null],
+      ["DESDE", "HASTA", "TIPO CUENTA", "NRO CUENTA", "SUCURSAL", null],
+      ["2026/01/01", "2026/03/31", "CUENTA DE AHORROS", "9871936126", "SUC TEST", null],
+      [null, null, null, null, null, null],
+      ["Resumen:", null, null, null, null, null],
+      ["SALDO ANT", "ABONOS", "CARGOS", "ACTUAL", null, null],
+      ["1000.00", "5000.00", "2000.00", "4000.00", null, null],
+      [null, null, null, null, null, null],
+      ["Movimientos:", null, null, null, null, null],
+      ["FECHA", "DESCRIPCIÓN", "SUCURSAL", "DCTO.", "VALOR", "SALDO"],
+    ];
+
+    const section1Data: unknown[][] = [
+      ["2/01", "TX A SECTION 1", null, null, "1,000.00", "1,000.00"],
+      ["3/01", "TX B SECTION 1", null, null, "-200.00", "800.00"],
+    ];
+
+    // Section break: same shape as a fresh section starting with cliente info
+    const sectionBreak: unknown[][] = [
+      ["Información Cliente:", null, null, null, null, null],
+      ["CLIENTE", "DIRECCIÓN", "CIUDAD", null, null, null],
+      ["ALEJANDRO MARTINEZ", "CALLE 75", "ITAGUI", null, null, null],
+      [null, null, null, null, null, null],
+      ["Información General:", null, null, null, null, null],
+      ["DESDE", "HASTA", "TIPO CUENTA", "NRO CUENTA", "SUCURSAL", null],
+      ["2026/02/01", "2026/02/28", "CUENTA DE AHORROS", "9871936126", "SUC TEST", null],
+      [null, null, null, null, null, null],
+      ["Movimientos:", null, null, null, null, null],
+      ["FECHA", "DESCRIPCIÓN", "SUCURSAL", "DCTO.", "VALOR", "SALDO"],
+    ];
+
+    const section2Data: unknown[][] = [
+      ["1/02", "TX C SECTION 2", null, null, "500.00", "1,300.00"],
+      ["14/03", "PAGO SUC VIRT TC MASTER DOLAR", null, null, "-381,147.38", "-379,847.38"],
+    ];
+
+    const all: unknown[][] = [
+      ...titleSection,
+      ...section1Data,
+      ...sectionBreak,
+      ...section2Data,
+      [null, "FIN ESTADO DE CUENTA", null, null, null, null],
+    ];
+
+    const ws = XLSX.utils.aoa_to_sheet(all);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "Extracto");
+    const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+
+    const out = parseBancolombiaSavingsExtracto(buf);
+
+    // Both sections' data rows present, section break excluded
+    expect(out.rowCount).toBe(4);
+    expect(out.rows.map((r) => r.descriptionRaw)).toEqual([
+      "TX A SECTION 1",
+      "TX B SECTION 1",
+      "TX C SECTION 2",
+      "PAGO SUC VIRT TC MASTER DOLAR",
+    ]);
+
+    // Section 2's PAGO row must be picked up correctly — this is the case
+    // that the prod Extracto file hit in 2026-04-27.
+    const pago = out.rows[3];
+    expect(pago.direction).toBe("out");
+    expect(pago.amountCents).toBe(BigInt(38_114_738));
+    expect(pago.occurredAt.toISOString()).toBe("2026-03-14T05:00:00.000Z");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/reconciliation/parsers/bancolombia-savings-extracto.ts
+++ b/src/lib/reconciliation/parsers/bancolombia-savings-extracto.ts
@@ -84,6 +84,13 @@ export function parseBancolombiaSavingsExtracto(buffer: Buffer | Uint8Array): Pa
 
   // -------------------------------------------------------------------------
   // Step 3: Parse data rows
+  //
+  // Multi-section robustness: Bancolombia "Estado de Cuenta" exports that
+  // span multiple cycles concatenate one section per cycle in the same sheet.
+  // Each section is structured as: "Información Cliente:" → cliente row →
+  // "Información General:" → period row → "Movimientos:" → header row → data.
+  // We can't just stop at the first non-date row — instead we recognize known
+  // section-break markers, scan forward for the next FECHA header, and resume.
   // -------------------------------------------------------------------------
   const dataRows = matrix.slice(headerRowIndex + 1);
   const rows: ParsedStatementRow[] = [];
@@ -110,12 +117,23 @@ export function parseBancolombiaSavingsExtracto(buffer: Buffer | Uint8Array): Pa
     // Sentinel: FECHA null + DESCRIPCIÓN = END_SENTINEL
     if (fecha === null || fecha === undefined || fecha === "") {
       const desc = String(descripcion ?? "").trim();
-      if (desc === END_SENTINEL || desc === "") break;
-      // Otherwise skip blank-fecha rows
+      if (desc === END_SENTINEL) break;
+      // Skip blank-fecha rows but don't end parsing — multi-section files
+      // have blank rows between sections.
       continue;
     }
 
     const fechaStr = String(fecha).trim();
+
+    // Section-break detection: when we see a known section title in the FECHA
+    // column, scan forward for the next FECHA header and resume from there.
+    if (isSectionBreakMarker(fechaStr)) {
+      const nextHeader = findNextHeaderRowIndex(dataRows, i);
+      if (nextHeader === -1) break; // no more sections
+      i = nextHeader; // loop's i++ moves past the header into the next section's first data row
+      continue;
+    }
+
     const parsed = parseFecha(fechaStr, currentYear, prevMonth);
     if (!parsed) {
       throw new StatementParseError(
@@ -275,4 +293,41 @@ function parseColombianNumber(s: string): number {
   // Remove thousands-separator commas (but preserve decimal dots)
   const normalized = s.replace(/,/g, "");
   return parseFloat(normalized);
+}
+
+/**
+ * Detects whether a string in the FECHA column looks like a section title
+ * from a multi-cycle Extracto export. Bancolombia repeats these labels at
+ * the start of each cycle's section.
+ */
+function isSectionBreakMarker(s: string): boolean {
+  const upper = s.toUpperCase();
+  return (
+    upper.startsWith("INFORMACIÓN") ||
+    upper.startsWith("INFORMACION") ||
+    upper === "MOVIMIENTOS:" ||
+    upper === "RESUMEN:" ||
+    upper === "CLIENTE" || // label row of "Información Cliente:" sub-table
+    upper === "DESDE" // label row of "Información General:" sub-table
+  );
+}
+
+/**
+ * Scans forward from `startIdx` looking for the next data table header row
+ * (FECHA | DESCRIPCIÓN | SUCURSAL | DCTO. | VALOR | SALDO). Returns its
+ * 0-based index relative to `dataRows`, or -1 if no further header exists.
+ */
+function findNextHeaderRowIndex(dataRows: unknown[][], startIdx: number): number {
+  for (let i = startIdx; i < dataRows.length; i++) {
+    const row = dataRows[i];
+    if (!Array.isArray(row) || row.length < EXTRACTO_HEADERS.length) continue;
+    const match = EXTRACTO_HEADERS.every(
+      (expected, col) =>
+        String(row[col] ?? "")
+          .trim()
+          .toUpperCase() === expected,
+    );
+    if (match) return i;
+  }
+  return -1;
 }


### PR DESCRIPTION
Real Bancolombia exports concatenate per-cycle sections in one XLSX. The initial parser shipped in PR #574 stopped at the first non-date FECHA value, throwing StatementParseError on real prod files like `Extracto_202603_Cuentas_de ahorro_6126.xlsx`. This PR teaches the parser to detect section breaks ("Información Cliente:", "Movimientos:", etc.) and resume at the next data header.

+1 test for a synthetic 2-section fixture matching the real file shape. 19 → 20 tests in this suite, all green.

Follow-up of #572.