### PR TITLE
fix(reconciliation): allow ±$1 tolerance on Pago TC matcher (#567)

### DIFF
--- a/src/lib/reconciliation/pago-tc-router.test.ts
+++ b/src/lib/reconciliation/pago-tc-router.test.ts
@@ -300,6 +300,71 @@ describe("applyPagoTcRouting — integration against findash_test", () => {
   // Test 3: existing gmail pair on COP twin + savings says DOLAR + NO USD synthetic
   //         → COP destination soft-deleted, savings leg flagged pendingUsdTwinReassignment
   // ---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Test 2b: gmail/SMS round to whole pesos, savings extract has cents
+  //          (e.g. gmail tx amount=-$381,147 vs savings extract row=-$381,147.38)
+  //          The matcher must tolerate ±$1 difference.
+  // ---------------------------------------------------------------------------
+  describe("DOLAR match — gmail rounds to whole pesos, savings has cents", () => {
+    let copCreditId: number;
+    let usdSyntheticId: number;
+    let groupId: string;
+    const ROUNDED_DATE = new Date("2026-03-14T05:00:00Z");
+
+    beforeAll(async () => {
+      // Gmail-derived pair WITHOUT decimal cents (matches what Bancolombia
+      // emails actually carry: "Pagaste $381,147 ...")
+      const pair = await createTransferPair(
+        userId,
+        savingsAccountId,
+        copTcAccountId,
+        BigInt(381_147_00), // -$381,147.00 in DB (gmail truncated)
+        ROUNDED_DATE,
+        "COP",
+      );
+      copCreditId = pair.creditId;
+      groupId = pair.groupId;
+
+      usdSyntheticId = await createUsdSyntheticTx(
+        userId,
+        usdTcAccountId,
+        BigInt(103_00),
+        ROUNDED_DATE,
+      );
+    });
+
+    afterAll(async () => {
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+    });
+
+    it("matches a savings row whose amount has cents that the gmail leg lacks (within ±$1)", async () => {
+      // Savings extract has the precise amount with cents
+      const result = await applyPagoTcRouting({
+        userId,
+        savingsAccountId,
+        rows: [toRow(ROUNDED_DATE, BigInt(381_147_38), "PAGO SUC VIRT TC MASTER DOLAR")],
+        database: db,
+      });
+
+      // Expectation: tolerance kicks in, savings row is matched to the rounded
+      // gmail leg, COP destination is soft-deleted, USD synthetic re-paired.
+      expect(result.detected).toBe(1);
+      expect(result.reassignedToUsd).toBe(1);
+
+      const [copTx] = await db
+        .select({ deletedAt: transactions.deletedAt })
+        .from(transactions)
+        .where(eq(transactions.id, copCreditId));
+      expect(copTx?.deletedAt).not.toBeNull();
+
+      const [usdTx] = await db
+        .select({ transferGroupId: transactions.transferGroupId })
+        .from(transactions)
+        .where(eq(transactions.id, usdSyntheticId));
+      expect(usdTx?.transferGroupId).toBe(groupId);
+    });
+  });
+
   describe("DOLAR match — wrong COP twin, USD synthetic NOT uploaded yet", () => {
     let copCreditId: number;
     let debitId: number;

--- a/src/lib/reconciliation/pago-tc-router.ts
+++ b/src/lib/reconciliation/pago-tc-router.ts
@@ -11,6 +11,14 @@ const log = createLogger({ module: "reconciliation/pago-tc-router" });
 // One calendar day in milliseconds — used for ±1-day date windows.
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
+// Bancolombia gmail/SMS Pago TC notifications round to whole pesos
+// ("Pagaste $381,147 ...") while the savings extract carries cents
+// ("$-381,147.38"). When matching the savings row to its existing gmail
+// debit leg we allow ±100 cents (= ±$1 COP) of difference. This is wide
+// enough to absorb the rounding gap without risking false positives —
+// real Pago TC pairs never differ by more than $0.99 in practice.
+const AMOUNT_TOLERANCE_CENTS = BigInt(100);
+
 // Description patterns that identify a Pago TC row in a savings extract.
 // Matching is case-insensitive prefix so variations ("PAGO SUC VIRT TC MASTER DOLAR",
 // "PAGO AUTOM TC MASTER PESOS", "pago suc virt tc master pesos", etc.) are all caught.
@@ -195,9 +203,13 @@ async function routeSinglePagoTcRow(opts: {
   // The savings debit is stored as a negative amount in the DB (outbound).
   // The exact signed amount on the savings leg is -amountCents.
   const savingsSignedCents = -row.amountCents;
+  // Range with ±AMOUNT_TOLERANCE_CENTS to absorb gmail/SMS whole-peso rounding.
+  // Both bounds are negative (savings debit). Lower = more negative.
+  const lowerBound = savingsSignedCents - AMOUNT_TOLERANCE_CENTS;
+  const upperBound = savingsSignedCents + AMOUNT_TOLERANCE_CENTS;
 
   // Find the existing savings debit leg (source = gmail_bancolombia or csv_reconcile)
-  // that matches this savings row by date window + exact amount.
+  // that matches this savings row by date window + amount-within-tolerance.
   // We look for it on the savings account so we know its transfer_group_id.
   const [savingsLeg] = await database
     .select({
@@ -211,7 +223,8 @@ async function routeSinglePagoTcRow(opts: {
       and(
         eq(transactions.userId, userId),
         eq(transactions.accountId, savingsAccountId),
-        eq(transactions.amountCents, savingsSignedCents),
+        gte(transactions.amountCents, lowerBound),
+        lte(transactions.amountCents, upperBound),
         gte(transactions.occurredAt, windowStart),
         lte(transactions.occurredAt, windowEnd),
         notDeleted(transactions.deletedAt),


### PR DESCRIPTION
Bancolombia gmail/SMS rounds to whole pesos; savings extract has cents. Exact-match in applyPagoTcRouting failed for 4/5 historical Pago TC pairs. Fix: match savings_signed_cents within ±100 cents.

+1 test (8 total in pago-tc-router suite, all green).