### PR TITLE
fix(ui): show 6 TC cycles instead of 3 to surface older months (#580)

### DIFF
--- a/src/app/(app)/settings/accounts/tc-consolidation-status.tsx
+++ b/src/app/(app)/settings/accounts/tc-consolidation-status.tsx
@@ -107,7 +107,7 @@ export async function TcConsolidationStatus({ userId }: { userId: number }) {
         accountId: a.id,
         userId,
         metadata: a.metadata,
-        count: 3,
+        count: 6,
       }),
     })),
   );

--- a/src/lib/accounts/cycles.test.ts
+++ b/src/lib/accounts/cycles.test.ts
@@ -172,6 +172,27 @@ describe("recentCycles — integration", () => {
     expect(cycles[3].status).toBe("pending");
   });
 
+  it("returns 6 cycles when count=6 (covers #580 UI fix)", async () => {
+    const cycles = await recentCycles({
+      accountId,
+      userId,
+      metadata: { cutoffDay: 30 },
+      count: 6,
+      now: utcDate(2026, 4, 15),
+    });
+    expect(cycles).toHaveLength(6);
+    expect(cycles.map((c) => c.cycle)).toEqual([
+      "2026-04",
+      "2026-03",
+      "2026-02",
+      "2026-01",
+      "2025-12",
+      "2025-11",
+    ]);
+    expect(cycles[0].status).toBe("in-progress");
+    expect(cycles[1].status).toBe("consolidated");
+  });
+
   it("overdueCyclesForUser flags cycles past threshold", async () => {
     const overdue = await overdueCyclesForUser(
       userId,


### PR DESCRIPTION
Closes #580

## Summary
- Bumps `recentCycles` count from 3 to 6 in `tc-consolidation-status.tsx` so the card surfaces January and other months beyond the prior 3-month window
- Adds a test covering the 6-cycle boundary in `src/lib/accounts/cycles.test.ts`

## Test plan
- [x] `bun run lint` clean (0 errors)
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (136 files, 1758 specs passed)
- [ ] manual smoke: visit `/settings/accounts` — TC consolidation status card should now show up to 6 months including January 2026

Note: E2E screenshots skipped — this change is a 1-char constant fix; no visual layout change expected.