### PR TITLE
feat(ingestion): unified dispatcher with kind detection + account/cycle hints (#582)

### DIFF
--- a/src/lib/ingestion/bancolombia-statement/xlsx.ts
+++ b/src/lib/ingestion/bancolombia-statement/xlsx.ts
@@ -482,6 +482,63 @@ export type ParseStatementOptions = {
   sheet?: StatementSheetName;
 };
 
+/**
+ * Cheap structural probe: returns true when the buffer looks like a
+ * Bancolombia TC Extracto Detallado (the multi-sheet PESOS+DOLARES format used
+ * by parseBancolombiaStatementAllSheets).
+ *
+ * Detection criteria (ANY of these is sufficient):
+ *   1. Workbook has both a "PESOS" and a "DOLARES" sheet (multi-currency twin).
+ *   2. First ~10 rows of any sheet contain the text "TARJETA" or
+ *      "Estado de Cuenta" in any cell (TC extracto header marker).
+ *
+ * Returns false — does NOT throw — when the buffer is not a valid XLSX or
+ * does not match the criteria. This keeps the unified dispatcher clean.
+ */
+export function tryDetectTcDetallado(buffer: Buffer): boolean {
+  let wb: XLSX.WorkBook;
+  try {
+    wb = XLSX.read(buffer, { type: "buffer", raw: false, cellDates: false });
+  } catch {
+    return false;
+  }
+
+  if (!wb.SheetNames.length) return false;
+
+  // Criterion 1: both PESOS and DOLARES sheets present.
+  const upperNames = wb.SheetNames.map((n) => n.toUpperCase());
+  if (upperNames.includes("PESOS") && upperNames.includes("DOLARES")) {
+    return true;
+  }
+
+  // Criterion 2: any of the first ~10 rows in any sheet contains the
+  // "TARJETA" or "Estado de Cuenta" header text (case-insensitive).
+  const TC_MARKERS = ["tarjeta", "estado de cuenta"];
+  for (const sheetName of wb.SheetNames) {
+    const sheet = wb.Sheets[sheetName];
+    if (!sheet) continue;
+    const rows = XLSX.utils.sheet_to_json<unknown[]>(sheet, {
+      header: 1,
+      raw: false,
+      defval: null,
+    }) as unknown[][];
+    const scanLimit = Math.min(10, rows.length);
+    for (let i = 0; i < scanLimit; i++) {
+      const row = rows[i];
+      if (!Array.isArray(row)) continue;
+      for (const cell of row) {
+        if (cell == null) continue;
+        const text = String(cell).toLowerCase();
+        if (TC_MARKERS.some((m) => text.includes(m))) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
 function parseSheetRows(rows: SheetRows): ParsedStatement {
   const account = extractAccount(rows);
   const period = extractPeriod(rows);

--- a/src/lib/ingestion/dispatch-types.ts
+++ b/src/lib/ingestion/dispatch-types.ts
@@ -1,0 +1,93 @@
+// Unified ingestion dispatcher — shared types.
+//
+// NO "use server" directive: this file exports only types/interfaces, which are
+// non-async by definition. Next.js 16 server-action files reject non-async
+// exports, so all types must live in sibling files like this one.
+// (Memory: nextjs16-server-action-types-split)
+
+import type { RawStatement } from "./arq-statement/types";
+// The savings/extracto/tc-legacy parsers live in reconciliation/parsers and
+// return their own ParsedStatement (bank, format, periodStart, rowCount, rows).
+import type { ParsedStatement as ReconciliationParsedStatement } from "@/lib/reconciliation/parsers/types";
+// The tc-detallado parser lives in bancolombia-statement and returns a
+// richer ParsedStatement that includes account metadata and period dates.
+import type { ParsedStatement as BancolombiaStatementParsed } from "./bancolombia-statement/types";
+
+// ---------------------------------------------------------------------------
+// IngestionKind
+// ---------------------------------------------------------------------------
+
+export type IngestionKind =
+  | "arq-pdf"
+  | "bancolombia-savings" // 4-col Movimientos
+  | "bancolombia-extracto" // 6-col Extracto Mensual with SALDO column
+  | "bancolombia-tc-legacy" // 6-col TC (legacy reconcile path)
+  | "bancolombia-tc-detallado"; // PESOS+DOLARES sheets, consolidate path
+
+// ---------------------------------------------------------------------------
+// Hint types
+// ---------------------------------------------------------------------------
+
+export interface AccountHint {
+  accountId: number;
+  /** How the hint was derived — used for logging and UI annotation. */
+  source: "file-header" | "query-string" | "user-override";
+}
+
+export interface CycleHint {
+  /** YYYY-MM format, derived from the file's parsed period. */
+  cycle: string;
+  source: "file-period" | "query-string" | "user-override";
+}
+
+// ---------------------------------------------------------------------------
+// DispatchResult — discriminated union by kind
+// ---------------------------------------------------------------------------
+//
+// Each branch carries:
+//   - kind: the detected IngestionKind
+//   - accountHint: resolved from file-internal metadata (null if not found)
+//   - cycleHint: only for tc-detallado (the only kind with a meaningful cycle)
+//   - format-specific parsed payload ready for the commit pipeline
+//
+// "format_unknown" is a sentinel: XLSX read succeeded but no format matched.
+// The UI presents a manual kind-picker; it is NOT part of IngestionKind because
+// it represents the absence of a detected kind, not a known ingestion format.
+
+export type DispatchResult =
+  | {
+      kind: "arq-pdf";
+      rawStatement: RawStatement;
+      accountHint: AccountHint | null;
+    }
+  | {
+      kind: "bancolombia-savings";
+      /** ParsedStatement from reconciliation/parsers/bancolombia-savings */
+      parsed: ReconciliationParsedStatement;
+      accountHint: AccountHint | null;
+    }
+  | {
+      kind: "bancolombia-extracto";
+      /** ParsedStatement from reconciliation/parsers/bancolombia-savings-extracto */
+      parsed: ReconciliationParsedStatement;
+      accountHint: AccountHint | null;
+    }
+  | {
+      kind: "bancolombia-tc-legacy";
+      /** ParsedStatement from reconciliation/parsers/bancolombia-tc */
+      parsed: ReconciliationParsedStatement;
+      accountHint: AccountHint | null;
+    }
+  | {
+      kind: "bancolombia-tc-detallado";
+      /** ParsedStatements from bancolombia-statement/xlsx — COP first, USD second. */
+      parsedSheets: BancolombiaStatementParsed[];
+      /** True when both PESOS and DOLARES sheets were present in the workbook. */
+      multiCurrencySheets: boolean;
+      cycleHint: CycleHint;
+      accountHint: AccountHint | null;
+    }
+  | { kind: "format_unknown" };
+
+// Re-export for callers that need to reference these types alongside DispatchResult.
+export type { RawStatement, ReconciliationParsedStatement, BancolombiaStatementParsed };

--- a/src/lib/ingestion/dispatch.test.ts
+++ b/src/lib/ingestion/dispatch.test.ts
@@ -1,0 +1,521 @@
+// dispatch.test.ts — unified ingestion dispatcher tests
+//
+// Unit tests (cases 1-8): use synthetic buffers — no real fixture files.
+// Integration test (resolveAccountHint cross-tenant): hits findash_test DB.
+// Default vitest env is "node" — no jsdom override needed.
+
+import { describe, expect, it } from "vitest";
+import * as XLSX from "xlsx";
+
+import { detectKind, parseAndHint, resolveAccountHint, UnsupportedFileKindError } from "./dispatch";
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal valid PDF buffer (starts with %PDF magic). */
+function makePdfBuffer(sizeBytes = 100): Buffer {
+  const buf = Buffer.alloc(sizeBytes, 0);
+  buf.write("%PDF-1.4\n", 0, "utf8");
+  return buf;
+}
+
+/** Build an XLSX with the 4-col savings header (bancolombia-savings). */
+function buildSavingsXlsx(): Buffer {
+  const ws = XLSX.utils.aoa_to_sheet([
+    ["Fecha", "Descripción", "Referencia", "Valor"],
+    [46127.20833, "ABONO INTERESES", "0012345", 100],
+  ]);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "Hoja 1");
+  return XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+}
+
+/** Build an XLSX in the Extracto Mensual 6-col format (bancolombia-extracto). */
+function buildExtractoXlsx(): Buffer {
+  const titleSection: unknown[][] = [
+    [null, null, null, null, null, null],
+    ["Información Cliente:", null, null, null, null, null],
+    ["CLIENTE", "DIRECCIÓN", "CIUDAD", null, null, null],
+    ["TEST USER", "CALLE 1", "MEDELLIN", null, null, null],
+    [null, null, null, null, null, null],
+    ["Información General:", null, null, null, null, null],
+    ["DESDE", "HASTA", "TIPO CUENTA", "NRO CUENTA", "SUCURSAL", null],
+    ["2026/01/01", "2026/03/31", "CUENTA DE AHORROS", "9871936126", "SUCURSAL TEST", null],
+    [null, null, null, null, null, null],
+    ["Resumen:", null, null, null, null, null],
+    ["SALDO ANTERIOR", "TOTAL ABONOS", "TOTAL CARGOS", "SALDO ACTUAL", null, null],
+    ["100.000,00", "50.000,00", "30.000,00", "120.000,00", null, null],
+    [null, null, null, null, null, null],
+    ["Movimientos:", null, null, null, null, null],
+    ["FECHA", "DESCRIPCIÓN", "SUCURSAL", "DCTO.", "VALOR", "SALDO"],
+    ["1/01", "ABONO INTERESES", null, null, "100,00", "120.100,00"],
+    [null, "FIN ESTADO DE CUENTA", null, null, null, null],
+  ];
+  const ws = XLSX.utils.aoa_to_sheet(titleSection);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "Extracto");
+  return XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+}
+
+/** Build an XLSX with the TC legacy 6-col header (bancolombia-tc-legacy). */
+function buildTcLegacyXlsx(): Buffer {
+  const ws = XLSX.utils.aoa_to_sheet([
+    ["Fecha", "Descripción", "Fecha de corte", "Valor", "Tipo de moneda", "Cuotas"],
+    [46127, "COMPRA TIENDA", 46130, 50000, "COP", "1"],
+  ]);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "Hoja 1");
+  return XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+}
+
+type SyntheticTcOptions = {
+  last4?: string;
+  moneda?: string;
+};
+
+function buildSyntheticTcAoa(opts: SyntheticTcOptions = {}): (string | number | null)[][] {
+  const last4 = opts.last4 ?? "9999";
+  const moneda = opts.moneda ?? "PESOS";
+  const isUsd = /USD|DOLAR/i.test(moneda);
+  const rateRows: (string | number | null)[][] = isUsd
+    ? [
+        [
+          "Compra Internacional",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Saldo anterior",
+          "300.000,00",
+          "Cuota transacciones",
+          "50.000,00",
+        ],
+        [
+          "Avance Internacional",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Compras del mes",
+          "250.000,00",
+          "Cuota Transacciones anteriores",
+          "0,00",
+        ],
+        ["Mora", "1.9110 %", "25.5026 %", "+ Intereses de mora", "0,00", "Cuota avances", "0,00"],
+        [null, null, null, "+ Intereses corrientes", "5.000,00", "+ Intereses de mora", "0,00"],
+        [null, null, null, "+ Avances", "0,00", "+ Intereses corrientes", "5.000,00"],
+      ]
+    : [
+        [
+          "Compra un mes",
+          "0.0000 %",
+          "0.0000 %",
+          "+ Saldo anterior",
+          "300.000,00",
+          "Cuota transacciones",
+          "50.000,00",
+        ],
+        [
+          "Compra 2 - 36 meses",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Compras del mes",
+          "250.000,00",
+          "Cuota Transacciones anteriores",
+          "0,00",
+        ],
+        [
+          "Impuestos",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Intereses de mora",
+          "0,00",
+          "Cuota avances",
+          "0,00",
+        ],
+        [
+          "Avances",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Intereses corrientes",
+          "5.000,00",
+          "+ Intereses de mora",
+          "0,00",
+        ],
+        [
+          "Mora",
+          "1.9110 %",
+          "25.5026 %",
+          "+ Avances",
+          "0,00",
+          "+ Intereses corrientes",
+          "5.000,00",
+        ],
+      ];
+  return [
+    ["Información Cliente:"],
+    ["Cliente", null, "Dirección", "Ciudad", "Departamento"],
+    ["TEST USER", null, "CALLE 1", "MEDELLIN", "ANTIOQUIA"],
+    [],
+    ["Información de la Tarjeta", `************${last4}`],
+    ["Moneda: ", moneda],
+    [],
+    ["Periodo facturado: ", "01 ene", "31 ene. 2026"],
+    ["Pagar antes de: ", "feb. 15, 2026"],
+    ["Pago mínimo", "100.000,00"],
+    ["Pago total", "500.000,00"],
+    ["Cupo total: ", "1.000.000,00"],
+    ["Cupo disponible: ", "500.000,00"],
+    [],
+    [],
+    [
+      "Tasas de interés vigente",
+      "Tasa Mes Vencido",
+      "Tasa Efectivo Anual",
+      "Resumen Saldo Total",
+      "",
+      "Resumen Pago Mínimo",
+    ],
+    [],
+    ...rateRows,
+    [null, null, null, "+ Otros cargos", "0,00"],
+    [null, null, null, "Cargos", "555.000,00"],
+    [null, null, null, "(-) Pagos / abonos", "100.000,00"],
+    [null, null, null, "(-) Saldo a favor", "0,00"],
+    [null, null, null, "Abono", "100.000,00"],
+    [],
+    [],
+    ["Movimientos durante el periodo"],
+    [
+      "Número de autorización",
+      "Fecha",
+      "Movimientos",
+      "Valor Movimiento",
+      "Número de cuotas",
+      "Valor cuota/abono",
+      "Interés mensual (%)",
+      "Interés anual (%)",
+      "Saldo pendiente",
+    ],
+    ["", "31/01/2026", "INTERESES CORRIENTES", "5.000,00", "", "5.000,00", "", "", "0,00"],
+    [
+      "111111",
+      "20/01/2026",
+      "TEST MERCHANT A",
+      "50.000,00",
+      "1/1",
+      "50.000,00",
+      "0,0000",
+      "00,0000",
+      "0,00",
+    ],
+  ];
+}
+
+/** Build a TC Detallado XLSX with PESOS+DOLARES sheets (bancolombia-tc-detallado). */
+function buildTcDetalladoXlsx(): Buffer {
+  const wb = XLSX.utils.book_new();
+  const pesos = XLSX.utils.aoa_to_sheet(buildSyntheticTcAoa({ last4: "8888", moneda: "PESOS" }));
+  const dolares = XLSX.utils.aoa_to_sheet(buildSyntheticTcAoa({ last4: "8888", moneda: "USD" }));
+  XLSX.utils.book_append_sheet(wb, pesos, "PESOS");
+  XLSX.utils.book_append_sheet(wb, dolares, "DOLARES");
+  return XLSX.write(wb, { bookType: "xlsx", type: "buffer" }) as Buffer;
+}
+
+/** Build garbage bytes that are neither PDF nor XLSX. */
+function makeGarbageBuffer(): Buffer {
+  return Buffer.from([0x00, 0x01, 0x02, 0x03, 0xde, 0xad, 0xbe, 0xef]);
+}
+
+/** Build an XLSX that has no recognized header (format_unknown). */
+function buildUnrecognizedXlsx(): Buffer {
+  const ws = XLSX.utils.aoa_to_sheet([["Random", "Columns", "Here", "NotBancolombia"]]);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "Sheet1");
+  return XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+}
+
+// ---------------------------------------------------------------------------
+// detectKind unit tests
+// ---------------------------------------------------------------------------
+
+describe("detectKind", () => {
+  it("1. %PDF buffer → kind: arq-pdf", () => {
+    const buf = makePdfBuffer();
+    expect(detectKind(buf)).toBe("arq-pdf");
+  });
+
+  it("2. 4-col Movimientos XLSX → kind: bancolombia-savings", () => {
+    const buf = buildSavingsXlsx();
+    expect(detectKind(buf)).toBe("bancolombia-savings");
+  });
+
+  it("3. 6-col SALDO XLSX → kind: bancolombia-extracto", () => {
+    const buf = buildExtractoXlsx();
+    expect(detectKind(buf)).toBe("bancolombia-extracto");
+  });
+
+  it("4. TC legacy 6-col XLSX → kind: bancolombia-tc-legacy", () => {
+    const buf = buildTcLegacyXlsx();
+    expect(detectKind(buf)).toBe("bancolombia-tc-legacy");
+  });
+
+  it("5. TC detallado PESOS+DOLARES XLSX → kind: bancolombia-tc-detallado", () => {
+    const buf = buildTcDetalladoXlsx();
+    expect(detectKind(buf)).toBe("bancolombia-tc-detallado");
+  });
+
+  it("6. Garbage bytes → returns format_unknown (does NOT throw)", () => {
+    // Garbage starts with 0x00 — not PDF or XLSX magic
+    const buf = makeGarbageBuffer();
+    expect(() => detectKind(buf)).toThrow(UnsupportedFileKindError);
+    expect(() => detectKind(buf)).toThrow(/Tipo de archivo no soportado/);
+  });
+
+  it("6b. Unrecognized XLSX → returns format_unknown (does NOT throw)", () => {
+    const buf = buildUnrecognizedXlsx();
+    expect(detectKind(buf)).toBe("format_unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAndHint unit tests
+// ---------------------------------------------------------------------------
+
+describe("parseAndHint", () => {
+  it("7. ARQ PDF >10MB → throws UnsupportedFileKindError with MB in message", async () => {
+    // Craft a buffer that starts with %PDF but is > 10 MB
+    const oversizePdf = Buffer.alloc(10 * 1024 * 1024 + 1, 0x20);
+    oversizePdf.write("%PDF-1.4\n", 0, "utf8");
+
+    await expect(parseAndHint(oversizePdf)).rejects.toThrow(UnsupportedFileKindError);
+    await expect(parseAndHint(oversizePdf)).rejects.toThrow(/10 MB/);
+  });
+
+  it("8. XLSX >5MB → throws UnsupportedFileKindError with MB in message", async () => {
+    // Craft a buffer that starts with XLSX ZIP magic but is > 5 MB
+    const oversizeXlsx = Buffer.alloc(5 * 1024 * 1024 + 1, 0x20);
+    // PK\x03\x04 = XLSX magic
+    oversizeXlsx[0] = 0x50;
+    oversizeXlsx[1] = 0x4b;
+    oversizeXlsx[2] = 0x03;
+    oversizeXlsx[3] = 0x04;
+
+    await expect(parseAndHint(oversizeXlsx)).rejects.toThrow(UnsupportedFileKindError);
+    await expect(parseAndHint(oversizeXlsx)).rejects.toThrow(/5 MB/);
+  });
+
+  it("6. Garbage bytes → parseAndHint throws UnsupportedFileKindError", async () => {
+    const buf = makeGarbageBuffer();
+    await expect(parseAndHint(buf)).rejects.toThrow(UnsupportedFileKindError);
+    await expect(parseAndHint(buf)).rejects.toThrow(/Tipo de archivo no soportado/);
+  });
+
+  it("5b. TC detallado XLSX → kind: bancolombia-tc-detallado, multiCurrencySheets true", async () => {
+    const buf = buildTcDetalladoXlsx();
+    const result = await parseAndHint(buf);
+    expect(result.kind).toBe("bancolombia-tc-detallado");
+    if (result.kind === "bancolombia-tc-detallado") {
+      expect(result.multiCurrencySheets).toBe(true);
+      expect(result.parsedSheets).toHaveLength(2);
+      expect(result.cycleHint.source).toBe("file-period");
+      expect(result.cycleHint.cycle).toMatch(/^\d{4}-\d{2}$/);
+    }
+  });
+
+  it("unrecognized XLSX → kind: format_unknown (does NOT throw)", async () => {
+    const buf = buildUnrecognizedXlsx();
+    const result = await parseAndHint(buf);
+    expect(result.kind).toBe("format_unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tryDetectTcDetallado unit tests (T1.2 acceptance)
+// ---------------------------------------------------------------------------
+
+import { tryDetectTcDetallado } from "./bancolombia-statement/xlsx";
+
+describe("tryDetectTcDetallado (T1.2)", () => {
+  it("returns true for a PESOS+DOLARES workbook (multi-currency twin marker)", () => {
+    const buf = buildTcDetalladoXlsx();
+    expect(tryDetectTcDetallado(buf)).toBe(true);
+  });
+
+  it("returns false for a savings 4-col workbook", () => {
+    const buf = buildSavingsXlsx();
+    expect(tryDetectTcDetallado(buf)).toBe(false);
+  });
+
+  it("returns false for non-XLSX bytes (does NOT throw)", () => {
+    const buf = makeGarbageBuffer();
+    expect(tryDetectTcDetallado(buf)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAccountHint — cross-tenant integration test
+//
+// Runs against findash_test DB (forced by vitest.setup.ts).
+// Seeds 2 users with the same accountNumber to prove no cross-tenant leakage.
+// ---------------------------------------------------------------------------
+
+import { db } from "@/lib/db";
+import { accounts, users } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+// Helpers to seed test data and clean up
+async function seedTestUser(email: string): Promise<number> {
+  const [u] = await db
+    .insert(users)
+    .values({
+      email,
+      name: `Test ${email}`,
+      role: "user",
+    })
+    .returning({ id: users.id });
+  if (!u) throw new Error(`Failed to seed user ${email}`);
+  return u.id;
+}
+
+async function seedArqAccount(userId: number, accountNumber: string): Promise<number> {
+  const [a] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: "ARQ Account",
+      institution: "ARQ",
+      institutionSlug: "other",
+      type: "savings",
+      currency: "USD",
+      active: true,
+      metadata: { accountNumber } as Record<string, unknown>,
+    })
+    .returning({ id: accounts.id });
+  if (!a) throw new Error(`Failed to seed account for user ${userId}`);
+  return a.id;
+}
+
+async function seedTcDetalladoAccount(userId: number, last4: string): Promise<number> {
+  const [a] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: "TC Detallado Account",
+      institution: "bancolombia",
+      institutionSlug: "bancolombia",
+      type: "credit_card",
+      currency: "COP",
+      active: true,
+      metadata: { last4s: [last4] } as Record<string, unknown>,
+    })
+    .returning({ id: accounts.id });
+  if (!a) throw new Error(`Failed to seed tc account for user ${userId}`);
+  return a.id;
+}
+
+async function cleanupUsers(emails: string[]): Promise<void> {
+  for (const email of emails) {
+    // Cascades to accounts via FK
+    await db.delete(users).where(eq(users.email, email));
+  }
+}
+
+describe("resolveAccountHint — cross-tenant isolation (integration)", () => {
+  // Use unique emails to avoid conflicts across test runs
+  const EMAIL_A = `dispatch-test-a-${Date.now()}@test.findash`;
+  const EMAIL_B = `dispatch-test-b-${Date.now()}@test.findash`;
+  const SHARED_ACCOUNT_NUMBER = `ACCT-${Date.now()}`;
+  const SHARED_LAST4 = String(Date.now()).slice(-4);
+
+  let userAId: number;
+  let userBId: number;
+  let accountAId: number;
+  let accountBId: number;
+
+  // Setup — runs once before all tests in this describe
+  // (using individual it() with db calls; no beforeAll to keep it flat)
+
+  it("AC-5: seeds two users + accounts and confirms resolveAccountHint does not leak", async () => {
+    // Seed
+    userAId = await seedTestUser(EMAIL_A);
+    userBId = await seedTestUser(EMAIL_B);
+    accountAId = await seedArqAccount(userAId, SHARED_ACCOUNT_NUMBER);
+    accountBId = await seedArqAccount(userBId, SHARED_ACCOUNT_NUMBER); // same accountNumber, different user
+    // Also seed a TC account for user A (validates multi-account users don't bleed)
+    await seedTcDetalladoAccount(userAId, SHARED_LAST4);
+
+    // Build a minimal ARQ DispatchResult (arq-pdf) without actually parsing a PDF.
+    // We manually construct the result shape that resolveAccountHint accepts.
+    const arqResult = {
+      kind: "arq-pdf" as const,
+      rawStatement: {
+        header: {
+          accountNumber: SHARED_ACCOUNT_NUMBER,
+          accountHolder: "Test",
+          routingNumber: "000000000",
+          periodStart: new Date(),
+          periodEnd: new Date(),
+          durationDays: 30,
+          summary: {
+            balanceStartCents: BigInt(0),
+            totalCreditsCents: BigInt(0),
+            totalDebitsCents: BigInt(0),
+            balanceEndCents: BigInt(0),
+          },
+        },
+        transactions: [],
+      },
+      accountHint: null,
+    };
+
+    // User A resolves to their own account
+    const hintA = await resolveAccountHint(userAId, arqResult);
+    expect(hintA).not.toBeNull();
+    expect(hintA!.accountId).toBe(accountAId);
+
+    // User B resolves to their own account (NOT user A's)
+    const hintB = await resolveAccountHint(userBId, arqResult);
+    expect(hintB).not.toBeNull();
+    expect(hintB!.accountId).toBe(accountBId);
+    expect(hintB!.accountId).not.toBe(accountAId); // key isolation assertion
+
+    // Cleanup
+    await cleanupUsers([EMAIL_A, EMAIL_B]);
+  });
+
+  it("AC-5b: tc-detallado last4 resolves to correct user account, not the other user's", async () => {
+    // Re-seed for isolation from the previous test
+    const EMAIL_C = `dispatch-test-c-${Date.now()}@test.findash`;
+    const EMAIL_D = `dispatch-test-d-${Date.now()}@test.findash`;
+    const last4 = String(Date.now()).slice(-4);
+
+    const userCId = await seedTestUser(EMAIL_C);
+    const userDId = await seedTestUser(EMAIL_D);
+    const tcAcctC = await seedTcDetalladoAccount(userCId, last4);
+    await seedTcDetalladoAccount(userDId, last4); // same last4, different user
+
+    // Build synthetic TC with the test-specific last4 so account resolution matches.
+    // (The default buildTcDetalladoXlsx uses "8888" which won't match our seeded last4.)
+    const wb2 = XLSX.utils.book_new();
+    const pesosRows = buildSyntheticTcAoa({ last4, moneda: "PESOS" });
+    const dolaresRows = buildSyntheticTcAoa({ last4, moneda: "USD" });
+    const pesosSheet = XLSX.utils.aoa_to_sheet(pesosRows);
+    const dolaresSheet = XLSX.utils.aoa_to_sheet(dolaresRows);
+    XLSX.utils.book_append_sheet(wb2, pesosSheet, "PESOS");
+    XLSX.utils.book_append_sheet(wb2, dolaresSheet, "DOLARES");
+    const buf = XLSX.write(wb2, { bookType: "xlsx", type: "buffer" }) as Buffer;
+
+    const result = await parseAndHint(buf);
+    expect(result.kind).toBe("bancolombia-tc-detallado");
+
+    // User C resolves to their account
+    const hintC = await resolveAccountHint(userCId, result);
+    expect(hintC).not.toBeNull();
+    expect(hintC!.accountId).toBe(tcAcctC);
+
+    // User D resolves to their own account, NOT user C's
+    const hintD = await resolveAccountHint(userDId, result);
+    expect(hintD).not.toBeNull();
+    expect(hintD!.accountId).not.toBe(tcAcctC);
+
+    await cleanupUsers([EMAIL_C, EMAIL_D]);
+  });
+});

--- a/src/lib/ingestion/dispatch.ts
+++ b/src/lib/ingestion/dispatch.ts
@@ -1,0 +1,387 @@
+// Unified ingestion dispatcher — format detection + parsing façade.
+//
+// Entry points:
+//   detectKind(buffer)         — cheap sniff, returns IngestionKind or
+//                                "format_unknown". Never throws (unless file
+//                                is neither PDF nor XLSX → UnsupportedFileKindError).
+//   parseAndHint(buffer, opts) — detect + parse + derive hints in one call.
+//   resolveAccountHint(userId, result) — DB-side helper: finds the user's
+//                                account whose metadata matches the parsed
+//                                file header. Multi-tenant safe.
+//
+// Sniff order (design Decision #3 — locked):
+//   1. First 4 bytes == "%PDF" magic → arq-pdf
+//   2. First 4 bytes == "PK\x03\x04" (XLSX ZIP magic) → XLSX.read, then:
+//      a. tryDetectTcDetallado → bancolombia-tc-detallado
+//      b. tryDetectFormat     → bancolombia-savings | extracto | tc-legacy
+//      c. fall through        → format_unknown (does NOT throw)
+//   3. Anything else          → throws UnsupportedFileKindError
+//
+// File size limits are enforced HERE, before any parse attempt.
+//
+// Logging: Pino only — import createLogger. Zero console.* calls.
+// Multi-tenant: resolveAccountHint always filters by userId. (Memory:
+// per-user-table-join-tenant-safety)
+
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { accounts } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { createLogger } from "@/lib/logger";
+import { parseArqStatementPdf } from "./arq-statement/pdf-adapter";
+import { tryDetectFormat } from "@/lib/reconciliation/dispatch";
+import { tryDetectTcDetallado } from "./bancolombia-statement/xlsx";
+import { parseBancolombiaSavings } from "@/lib/reconciliation/parsers/bancolombia-savings";
+import { parseBancolombiaSavingsExtracto } from "@/lib/reconciliation/parsers/bancolombia-savings-extracto";
+import { parseBancolombiaTc } from "@/lib/reconciliation/parsers/bancolombia-tc";
+import { parseBancolombiaStatementAllSheets } from "./bancolombia-statement/xlsx";
+
+import type { AccountHint, CycleHint, DispatchResult, IngestionKind } from "./dispatch-types";
+
+const log = createLogger({ module: "ingestion/dispatch" });
+
+// ---------------------------------------------------------------------------
+// File size limits (enforced before any parse attempt)
+// ---------------------------------------------------------------------------
+
+const MAX_ARQ_PDF_BYTES = 10 * 1024 * 1024; // 10 MB
+const MAX_XLSX_BYTES = 5 * 1024 * 1024; // 5 MB
+
+// ---------------------------------------------------------------------------
+// Magic bytes
+// ---------------------------------------------------------------------------
+
+/** "%PDF" as a byte pattern */
+const PDF_MAGIC = Buffer.from([0x25, 0x50, 0x44, 0x46]);
+
+/** "PK\x03\x04" — ZIP local-file header that XLSX uses */
+const XLSX_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+
+// ---------------------------------------------------------------------------
+// UnsupportedFileKindError
+// ---------------------------------------------------------------------------
+
+export class UnsupportedFileKindError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedFileKindError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// detectKind
+// ---------------------------------------------------------------------------
+
+/**
+ * Sniff-only detector. Returns IngestionKind or "format_unknown".
+ *
+ * "format_unknown" means: valid XLSX but no header matched.
+ * Throws UnsupportedFileKindError when first 4 bytes are neither PDF nor XLSX.
+ */
+export function detectKind(buffer: Buffer): IngestionKind | "format_unknown" {
+  const magic = buffer.subarray(0, 4);
+
+  // --- Step 1: PDF magic ---
+  if (magic.compare(PDF_MAGIC) === 0) {
+    return "arq-pdf";
+  }
+
+  // --- Step 2: XLSX ZIP magic ---
+  if (magic.compare(XLSX_MAGIC) === 0) {
+    // a. TC detallado probe (most distinctive structural signature)
+    if (tryDetectTcDetallado(buffer)) {
+      return "bancolombia-tc-detallado";
+    }
+
+    // b. Reconciliation format probe
+    const detected = tryDetectFormat(buffer);
+    if (detected) {
+      switch (detected.format) {
+        case "bancolombia_savings":
+          return "bancolombia-savings";
+        case "bancolombia_savings_extracto":
+          return "bancolombia-extracto";
+        case "bancolombia_tc":
+          return "bancolombia-tc-legacy";
+      }
+    }
+
+    // c. Fall through — valid XLSX but no format matched
+    return "format_unknown";
+  }
+
+  // --- Step 3: Unsupported file kind ---
+  throw new UnsupportedFileKindError("Tipo de archivo no soportado.");
+}
+
+// ---------------------------------------------------------------------------
+// parseAndHint
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect + parse + derive hints in one call. Returns a DispatchResult.
+ *
+ * File size limits are enforced here before any parse attempt.
+ * opts.userId is used only for logging; account resolution happens separately
+ * via resolveAccountHint().
+ */
+export async function parseAndHint(
+  buffer: Buffer,
+  opts?: { userId?: number },
+): Promise<DispatchResult> {
+  const userId = opts?.userId;
+  const magic = buffer.subarray(0, 4);
+
+  // --- Step 1: PDF ---
+  if (magic.compare(PDF_MAGIC) === 0) {
+    const mbActual = (buffer.byteLength / 1_048_576).toFixed(1);
+    if (buffer.byteLength > MAX_ARQ_PDF_BYTES) {
+      log.warn(
+        { event: "ingestion_file_too_large", kind: "arq-pdf", bytes: buffer.byteLength, userId },
+        "pdf file exceeds size limit",
+      );
+      throw new UnsupportedFileKindError(
+        `El archivo supera el límite de 10 MB (${mbActual} MB actual).`,
+      );
+    }
+
+    log.debug({ event: "ingestion_parse_start", kind: "arq-pdf", userId }, "parsing arq pdf");
+    let rawStatement;
+    try {
+      rawStatement = await parseArqStatementPdf(buffer);
+    } catch (err) {
+      log.error({ err, event: "parse_failed", kind: "arq-pdf", userId }, "arq pdf parse failed");
+      throw err;
+    }
+
+    // Derive accountHint from header.accountNumber — resolved later against DB
+    // by resolveAccountHint; here we can only record the raw accountNumber so
+    // the caller can pass it to resolveAccountHint.
+    // We return null here; the caller must call resolveAccountHint separately.
+    return {
+      kind: "arq-pdf",
+      rawStatement,
+      accountHint: null,
+    };
+  }
+
+  // --- Step 2: XLSX ---
+  if (magic.compare(XLSX_MAGIC) === 0) {
+    const mbActual = (buffer.byteLength / 1_048_576).toFixed(1);
+    if (buffer.byteLength > MAX_XLSX_BYTES) {
+      log.warn(
+        { event: "ingestion_file_too_large", kind: "xlsx", bytes: buffer.byteLength, userId },
+        "xlsx file exceeds size limit",
+      );
+      throw new UnsupportedFileKindError(
+        `El archivo supera el límite de 5 MB (${mbActual} MB actual).`,
+      );
+    }
+
+    // a. TC detallado
+    if (tryDetectTcDetallado(buffer)) {
+      log.debug(
+        { event: "ingestion_parse_start", kind: "bancolombia-tc-detallado", userId },
+        "parsing bancolombia tc detallado",
+      );
+      let parsedSheets;
+      try {
+        parsedSheets = parseBancolombiaStatementAllSheets(buffer);
+      } catch (err) {
+        log.error(
+          { err, event: "parse_failed", kind: "bancolombia-tc-detallado", userId },
+          "tc detallado parse failed",
+        );
+        throw err;
+      }
+
+      const multiCurrencySheets = parsedSheets.length >= 2;
+      const firstSheet = parsedSheets[0];
+      // Derive cycleHint from the first (COP) sheet's period start.
+      const periodStart = firstSheet?.period.startDate;
+      const cycleHint: CycleHint = {
+        cycle: periodStart
+          ? `${periodStart.getUTCFullYear()}-${String(periodStart.getUTCMonth() + 1).padStart(2, "0")}`
+          : "",
+        source: "file-period",
+      };
+
+      return {
+        kind: "bancolombia-tc-detallado",
+        parsedSheets,
+        multiCurrencySheets,
+        cycleHint,
+        accountHint: null,
+      };
+    }
+
+    // b. Reconciliation format probe
+    const detected = tryDetectFormat(buffer);
+    if (detected) {
+      if (detected.format === "bancolombia_savings") {
+        log.debug(
+          { event: "ingestion_parse_start", kind: "bancolombia-savings", userId },
+          "parsing bancolombia savings",
+        );
+        let parsed;
+        try {
+          parsed = parseBancolombiaSavings(buffer);
+        } catch (err) {
+          log.error(
+            { err, event: "parse_failed", kind: "bancolombia-savings", userId },
+            "bancolombia savings parse failed",
+          );
+          throw err;
+        }
+        return { kind: "bancolombia-savings", parsed, accountHint: null };
+      }
+
+      if (detected.format === "bancolombia_savings_extracto") {
+        log.debug(
+          { event: "ingestion_parse_start", kind: "bancolombia-extracto", userId },
+          "parsing bancolombia extracto mensual",
+        );
+        let parsed;
+        try {
+          parsed = parseBancolombiaSavingsExtracto(buffer);
+        } catch (err) {
+          log.error(
+            { err, event: "parse_failed", kind: "bancolombia-extracto", userId },
+            "bancolombia extracto parse failed",
+          );
+          throw err;
+        }
+        return { kind: "bancolombia-extracto", parsed, accountHint: null };
+      }
+
+      if (detected.format === "bancolombia_tc") {
+        log.debug(
+          { event: "ingestion_parse_start", kind: "bancolombia-tc-legacy", userId },
+          "parsing bancolombia tc legacy",
+        );
+        let parsed;
+        try {
+          parsed = parseBancolombiaTc(buffer);
+        } catch (err) {
+          log.error(
+            { err, event: "parse_failed", kind: "bancolombia-tc-legacy", userId },
+            "bancolombia tc legacy parse failed",
+          );
+          throw err;
+        }
+        return { kind: "bancolombia-tc-legacy", parsed, accountHint: null };
+      }
+    }
+
+    // c. Fall through — valid XLSX but no format matched
+    log.info({ event: "ingestion_format_unknown", userId }, "xlsx did not match any known format");
+    return { kind: "format_unknown" };
+  }
+
+  // --- Step 3: Unsupported ---
+  log.warn(
+    {
+      event: "ingestion_unsupported_file_kind",
+      userId,
+      magicHex: magic.toString("hex"),
+    },
+    "unsupported file kind",
+  );
+  throw new UnsupportedFileKindError("Tipo de archivo no soportado.");
+}
+
+// ---------------------------------------------------------------------------
+// resolveAccountHint
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the user's account that matches the parsed file's header metadata.
+ *
+ * Multi-tenant safe: ALWAYS filters `accounts.userId = userId` (query #1
+ * first — memory: per-user-table-join-tenant-safety). Returns null (does NOT
+ * throw) when no match is found so the caller can fall through to manual picker.
+ *
+ * Matching strategy per kind:
+ *   arq-pdf              → `metadata.accountNumber` OR institution heuristic
+ *                          (matches accounts.institution ILIKE arq/dolarapp).
+ *   bancolombia-savings  → `metadata.last4s` contains parsed account's last4.
+ *   bancolombia-extracto → same as savings.
+ *   bancolombia-tc-legacy→ same as savings.
+ *   bancolombia-tc-detallado → `metadata.last4s` contains the COP sheet's
+ *                          card last4.
+ *   format_unknown       → always returns null.
+ */
+export async function resolveAccountHint(
+  userId: number,
+  result: DispatchResult,
+): Promise<AccountHint | null> {
+  if (result.kind === "format_unknown") return null;
+
+  // Fetch all non-deleted accounts for this user (single query #1 — tenant-safe).
+  const userAccounts = await db
+    .select({
+      id: accounts.id,
+      institution: accounts.institution,
+      metadata: accounts.metadata,
+      currency: accounts.currency,
+    })
+    .from(accounts)
+    .where(and(eq(accounts.userId, userId), notDeleted(accounts.deletedAt)));
+
+  if (result.kind === "arq-pdf") {
+    const accountNumber = result.rawStatement.header.accountNumber;
+    const match = userAccounts.find((a) => {
+      const meta = a.metadata as Record<string, unknown> | null;
+      if (meta?.accountNumber && String(meta.accountNumber) === accountNumber) return true;
+      if (meta?.routingNumber) return true; // ARQ-specific marker
+      if (a.institution && /arq|dolarapp/i.test(a.institution)) return true;
+      return false;
+    });
+    if (!match) {
+      log.info(
+        { event: "account_hint_not_resolved", kind: "arq-pdf", userId, accountNumber },
+        "no account matched arq accountNumber",
+      );
+      return null;
+    }
+    return { accountId: match.id, source: "file-header" };
+  }
+
+  if (
+    result.kind === "bancolombia-savings" ||
+    result.kind === "bancolombia-extracto" ||
+    result.kind === "bancolombia-tc-legacy"
+  ) {
+    // The reconciliation ParsedStatement doesn't carry a last4 directly —
+    // those parsers don't extract account metadata from the XLSX. Account
+    // resolution for these kinds relies on the query-string hint from the
+    // calling page. Return null to let the UI fall back to manual picker.
+    log.debug(
+      { event: "account_hint_not_resolved_savings", kind: result.kind, userId },
+      "savings/extracto/tc-legacy account hint requires url query-string; returning null",
+    );
+    return null;
+  }
+
+  if (result.kind === "bancolombia-tc-detallado") {
+    const firstSheet = result.parsedSheets[0];
+    if (!firstSheet) return null;
+    const last4 = firstSheet.account.last4;
+    const match = userAccounts.find((a) => {
+      const meta = a.metadata as Record<string, unknown> | null;
+      const last4s = (meta?.last4s as string[] | undefined) ?? [];
+      return last4s.includes(last4);
+    });
+    if (!match) {
+      log.info(
+        { event: "account_hint_not_resolved", kind: "bancolombia-tc-detallado", userId, last4 },
+        "no account matched tc detallado card last4",
+      );
+      return null;
+    }
+    return { accountId: match.id, source: "file-header" };
+  }
+
+  return null;
+}

--- a/src/lib/reconciliation/dispatch.ts
+++ b/src/lib/reconciliation/dispatch.ts
@@ -12,6 +12,26 @@ export interface DetectedFormat {
 }
 
 /**
+ * Non-throwing variant of detectFormat. Returns null when no format matches
+ * instead of throwing StatementParseError('format_mismatch').
+ *
+ * Used by the unified ingestion dispatcher to probe XLSX files without a
+ * try/catch ladder. Callers that need an explicit error should use
+ * detectFormat() instead.
+ */
+export function tryDetectFormat(buffer: Buffer | Uint8Array): DetectedFormat | null {
+  try {
+    return detectFormat(buffer);
+  } catch (err) {
+    if (err instanceof StatementParseError && err.kind === "format_mismatch") {
+      return null;
+    }
+    // Re-throw unexpected errors (missing_sheet, bad_row, etc.)
+    throw err;
+  }
+}
+
+/**
  * Detects the Bancolombia export format by inspecting the header row(s).
  * Three formats are recognized:
  *


### PR DESCRIPTION
Closes #582

## Summary

- Adds `dispatch-types.ts` with `IngestionKind`, `AccountHint`, `CycleHint`, and `DispatchResult` discriminated union — the shared vocabulary for all ingestion paths
- Adds `dispatch.ts` with `detectKind`, `parseAndHint`, `resolveAccountHint`, and `UnsupportedFileKindError` — single entry point that routes any uploaded file to the correct parser and returns normalized hints
- Adds `tryDetectFormat` (non-throwing) on the reconciliation dispatcher and `tryDetectTcDetallado` export on the xlsx ingestion path — both used internally by the new dispatcher

## Test plan

- [x] `bun run lint` clean (0 errors; 1 pre-existing warning in unrelated file)
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (1775 specs pass, 1 pre-existing skip)
- [x] 17 new specs in `dispatch.test.ts` covering all `IngestionKind` branches + cross-tenant integration
- [ ] manual smoke: backend-only — no UI surface to exercise; integration covered by test suite

This is Phase 1 of the #573 unification plan. Phase 2 (`/imports` UI) unblocks after this merges.