### PR TITLE
feat(infra): mount Bull-Board admin UI at /admin/queues (#588)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,9 @@
       "name": "personal-financial-dashboard",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
+        "@bull-board/api": "^7.0.0",
+        "@bull-board/express": "^7.0.0",
+        "@bull-board/ui": "^7.0.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -53,6 +56,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/bun": "^1.3.12",
+        "@types/express": "^5.0.6",
         "@types/node": "^25",
         "@types/node-cron": "^3.0.11",
         "@types/react": "^19",
@@ -156,6 +160,12 @@
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@bull-board/api": ["@bull-board/api@7.0.0", "", { "dependencies": { "redis-info": "^3.1.0" }, "peerDependencies": { "@bull-board/ui": "7.0.0" } }, "sha512-ISNspLHVmUWUSq/eLw+wd1FuBBUnqpLbYP2xUNmehpfKhS+NoZWMbBvqjUYVeE/HLfUkRcR1edzMKpl5n9zlSw=="],
+
+    "@bull-board/express": ["@bull-board/express@7.0.0", "", { "dependencies": { "@bull-board/api": "7.0.0", "@bull-board/ui": "7.0.0", "ejs": "^5.0.2", "express": "^5.2.1" } }, "sha512-3Tc/EyU5PQMTcTzcafFSrmRDiEbJBEU/EaVQ5OVYcuJ7DZCp5Pkvm0/2VtaCe2uywdtwn0ZaynlSIpB27FKX6A=="],
+
+    "@bull-board/ui": ["@bull-board/ui@7.0.0", "", { "dependencies": { "@bull-board/api": "7.0.0" } }, "sha512-AnKeklpDn0iMFgu4ukDU6uTNmw4oudl07G4k2Fh95SknKDrXSiWRV0N1TGUawMqyfG1Yi5P/W/8d7raBq/Uw6w=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
@@ -663,9 +673,13 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
 
@@ -693,7 +707,13 @@
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
+
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
@@ -707,9 +727,17 @@
 
     "@types/node-cron": ["@types/node-cron@3.0.11", "", {}, "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg=="],
 
+    "@types/qs": ["@types/qs@6.15.0", "", {}, "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
@@ -957,7 +985,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -1086,6 +1114,8 @@
     "eciesjs": ["eciesjs@0.4.18", "", { "dependencies": { "@ecies/ciphers": "^0.2.5", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.8.0" } }, "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "ejs": ["ejs@5.0.2", "", { "bin": { "ejs": "bin/cli.js" } }, "sha512-IpbUaI/CAW86l3f+T8zN0iggSc0LmMZLcIW5eRVStLVNCoTXkE0YlncbbH50fp8Cl6zHIky0sW2uUbhBqGw0Jw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.336", "", {}, "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ=="],
 
@@ -1549,6 +1579,8 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
     "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
 
     "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
@@ -1886,6 +1918,8 @@
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-info": ["redis-info@3.1.0", "", { "dependencies": { "lodash": "^4.17.11" } }, "sha512-ER4L9Sh/vm63DkIE0bkSjxluQlioBiBgf5w1UuldaW/3vPcecdljVDisZhmnCMvsxHNiARTTDDHGg9cGwTfrKg=="],
 
     "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
 
@@ -2335,8 +2369,6 @@
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
@@ -2348,6 +2380,8 @@
     "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "msw/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
+    "@bull-board/api": "^7.0.0",
+    "@bull-board/express": "^7.0.0",
+    "@bull-board/ui": "^7.0.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -91,6 +94,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/bun": "^1.3.12",
+    "@types/express": "^5.0.6",
     "@types/node": "^25",
     "@types/node-cron": "^3.0.11",
     "@types/react": "^19",

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -28,6 +28,12 @@ const LINKS = [
     description:
       "6 métricas agregadas cross-user (parse success, clasificación, dedup, onboarding, data loss, detection lag). Gatean Phase 8.",
   },
+  {
+    href: "/admin/queues",
+    title: "Queues",
+    description:
+      "Dashboard tipo Horizon para ver jobs activos, pendientes, completados y fallidos. Pausa, reintenta y monitorea las BullMQ queues en tiempo real.",
+  },
 ];
 
 export default async function AdminPage() {

--- a/src/app/(app)/admin/queues/[[...slug]]/page.tsx
+++ b/src/app/(app)/admin/queues/[[...slug]]/page.tsx
@@ -1,0 +1,23 @@
+/**
+ * /admin/queues/[[...slug]] — Bull-Board admin UI gateway.
+ *
+ * This server component calls requireAdmin() before rendering anything.
+ * On success it redirects to the actual Bull-Board Route Handler at
+ * /api/admin/queues, which serves the full SPA (HTML + static assets + JSON API).
+ *
+ * Why redirect instead of inline iframe:
+ *   - Bull-Board is a standalone SPA with its own HTML shell, CSS, and JS.
+ *   - Embedding it in an iframe would require additional CORS / frame-options work.
+ *   - A redirect is simpler and keeps the URL stable for bookmarks.
+ *
+ * Defense-in-depth: layout.tsx also enforces requireAdmin(), so even if
+ * this page is bypassed the layout blocks non-admins.
+ */
+
+import { redirect } from "next/navigation";
+import { requireAdmin } from "@/lib/auth/session";
+
+export default async function AdminQueuesPage() {
+  await requireAdmin();
+  redirect("/api/admin/queues");
+}

--- a/src/app/(app)/admin/queues/layout.tsx
+++ b/src/app/(app)/admin/queues/layout.tsx
@@ -1,0 +1,17 @@
+/**
+ * Defense-in-depth auth gate for /admin/queues/*.
+ *
+ * requireAdmin() is already called in page.tsx and in the Route Handler,
+ * but this layout provides an additional enforcement layer so that any
+ * future sub-routes added under /admin/queues/ are protected by default.
+ */
+
+import { notFound } from "next/navigation";
+import { getSessionUser } from "@/lib/auth/session";
+
+export default async function AdminQueuesLayout({ children }: { children: React.ReactNode }) {
+  const user = await getSessionUser();
+  if (user.role !== "admin") notFound();
+
+  return <>{children}</>;
+}

--- a/src/app/api/admin/queues/[[...slug]]/route.test.ts
+++ b/src/app/api/admin/queues/[[...slug]]/route.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Smoke tests for the Bull-Board route handler.
+ *
+ * Verifies auth enforcement without touching Redis or Express.
+ * All external dependencies (auth, bull-board app) are mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock requireAdmin — controls the auth gate
+// ---------------------------------------------------------------------------
+
+const mockRequireAdmin = vi.fn();
+
+vi.mock("@/lib/auth/session", () => ({
+  requireAdmin: mockRequireAdmin,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock getBullBoardApp — prevents Express + Redis from initializing in tests
+// ---------------------------------------------------------------------------
+
+const mockExpressApp = vi.fn().mockImplementation((_req: unknown, res: Record<string, unknown>) => {
+  // Simulate a minimal Express response for the success path.
+  // Express sets res.statusCode directly rather than calling writeHead,
+  // then calls res.end() to finish the response.
+  (res as { statusCode: number }).statusCode = 200;
+  if (typeof res.end === "function") {
+    (res.end as (body: string) => void)("<html><body>bull-board</body></html>");
+  }
+});
+
+vi.mock("@/lib/queue/bull-board", () => ({
+  getBullBoardApp: () => mockExpressApp,
+  BULL_BOARD_BASE_PATH: "/api/admin/queues",
+}));
+
+// ---------------------------------------------------------------------------
+// Import AFTER mocks are in place
+// ---------------------------------------------------------------------------
+
+const { GET } = await import("./route");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(path = "/api/admin/queues"): Request {
+  return new Request(`http://localhost${path}`, { method: "GET" });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Bull-Board route handler — auth gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 when requireAdmin throws FORBIDDEN", async () => {
+    mockRequireAdmin.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+
+    const body = await res.json();
+    expect(body).toMatchObject({ error: "Forbidden" });
+
+    // The Express app must NOT be called
+    expect(mockExpressApp).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when requireAdmin throws UNAUTHENTICATED", async () => {
+    mockRequireAdmin.mockRejectedValue(new Error("UNAUTHENTICATED"));
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toMatchObject({ error: "Unauthenticated" });
+
+    expect(mockExpressApp).not.toHaveBeenCalled();
+  });
+
+  it("calls the Express app when requireAdmin resolves (admin user)", async () => {
+    mockRequireAdmin.mockResolvedValue({
+      id: 1,
+      email: "admin@example.com",
+      role: "admin",
+      active: true,
+    });
+
+    const res = await GET(makeRequest());
+
+    // The Express bridge was invoked
+    expect(mockExpressApp).toHaveBeenCalledOnce();
+    // Status is whatever the mock Express app returned (200).
+    // If the bridge throws internally, the route returns 500 — debug if so.
+    const body = await res.json().catch(() => null);
+    expect({ status: res.status, body }).toMatchObject({ status: 200 });
+  });
+
+  it("does not expose the dashboard to non-admin role (FORBIDDEN path)", async () => {
+    mockRequireAdmin.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const res = await GET(makeRequest("/api/admin/queues/api/queues"));
+    expect(res.status).toBe(403);
+    expect(mockExpressApp).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/admin/queues/[[...slug]]/route.ts
+++ b/src/app/api/admin/queues/[[...slug]]/route.ts
@@ -1,0 +1,172 @@
+/**
+ * Route Handler: /api/admin/queues/[[...slug]]
+ *
+ * Serves the Bull-Board SPA (HTML entry + JSON API + static assets).
+ * Enforces requireAdmin() BEFORE the Express app ever sees the request.
+ *
+ * The [[...slug]] catch-all matches:
+ *   /api/admin/queues              → Bull-Board entry point
+ *   /api/admin/queues/static/*     → CSS / JS / images
+ *   /api/admin/queues/api/*        → Bull-Board JSON API
+ *   /api/admin/queues/queue/*      → queue detail SPA route
+ */
+
+import { type IncomingMessage, type ServerResponse } from "http";
+import { Readable } from "stream";
+import { requireAdmin } from "@/lib/auth/session";
+import { getBullBoardApp } from "@/lib/queue/bull-board";
+import { createLogger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const log = createLogger({ module: "bull-board-route" });
+
+// ---------------------------------------------------------------------------
+// Bridge: Next.js Request → Node.js IncomingMessage / ServerResponse
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a Fetch API `Request` into a Node.js `IncomingMessage`-compatible
+ * object and a mock `ServerResponse` that collects status, headers, and body.
+ * Returns a `Response` after Express finishes handling the request.
+ */
+async function bridgeToExpress(req: Request): Promise<Response> {
+  const app = getBullBoardApp();
+  const url = new URL(req.url);
+
+  // Strip the /api/admin/queues prefix so Express sees paths relative to "/"
+  const relPath = url.pathname.replace(/^\/api\/admin\/queues/, "") || "/";
+  const fullUrl = relPath + (url.search ?? "");
+
+  return new Promise<Response>((resolve, reject) => {
+    // --- Mock IncomingMessage ---
+    // Use a Readable stream so Express can pipe it without crashing.
+    const nodeReq = new Readable({
+      read() {
+        /* intentionally empty — body is pushed below */
+      },
+    }) as unknown as IncomingMessage;
+
+    (nodeReq as unknown as Record<string, unknown>).method = req.method;
+    (nodeReq as unknown as Record<string, unknown>).url = fullUrl;
+    (nodeReq as unknown as Record<string, unknown>).headers = Object.fromEntries(
+      req.headers.entries(),
+    );
+    (nodeReq as unknown as Record<string, unknown>).socket = {
+      remoteAddress: "127.0.0.1",
+      encrypted: false,
+    };
+
+    // Push request body into the stream
+    (async () => {
+      try {
+        if (req.body) {
+          const reader = req.body.getReader();
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            (nodeReq as unknown as Readable).push(value);
+          }
+        }
+        (nodeReq as unknown as Readable).push(null);
+      } catch (err) {
+        log.error({ err, event: "bridge_body_error" }, "error reading request body");
+        reject(err as Error);
+      }
+    })().catch(reject);
+
+    // --- Mock ServerResponse ---
+    let statusCode = 200;
+    const responseHeaders = new Headers();
+    const chunks: Buffer[] = [];
+
+    const nodeRes = new Proxy({} as ServerResponse, {
+      get(_target, prop: string) {
+        switch (prop) {
+          case "statusCode":
+            return statusCode;
+          case "setHeader":
+            return (name: string, value: string | string[]) => {
+              responseHeaders.set(name, Array.isArray(value) ? value.join(", ") : value);
+            };
+          case "getHeader":
+            return (name: string) => responseHeaders.get(name) ?? undefined;
+          case "removeHeader":
+            return (name: string) => responseHeaders.delete(name);
+          case "write":
+            return (chunk: Buffer | string) => {
+              chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+              return true;
+            };
+          case "end":
+            return (chunk?: Buffer | string) => {
+              if (chunk) {
+                chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+              }
+              resolve(
+                new Response(Buffer.concat(chunks), {
+                  status: statusCode,
+                  headers: responseHeaders,
+                }),
+              );
+            };
+          case "writeHead":
+            return (code: number, headers?: Record<string, string>) => {
+              statusCode = code;
+              if (headers) {
+                for (const [k, v] of Object.entries(headers)) {
+                  responseHeaders.set(k, v);
+                }
+              }
+            };
+          // Express inspects these on the response object
+          case "headersSent":
+            return false;
+          case "finished":
+            return false;
+          case "writable":
+            return true;
+          case "socket":
+            return { encrypted: false };
+          default:
+            return undefined;
+        }
+      },
+      set(_target, prop: string, value: unknown) {
+        if (prop === "statusCode") {
+          statusCode = value as number;
+        }
+        return true;
+      },
+    });
+
+    app(nodeReq, nodeRes as unknown as ServerResponse);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Route exports — all methods forwarded to the Express bridge
+// ---------------------------------------------------------------------------
+
+async function handler(req: Request): Promise<Response> {
+  try {
+    await requireAdmin();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg === "UNAUTHENTICATED") {
+      return Response.json({ error: "Unauthenticated" }, { status: 401 });
+    }
+    // FORBIDDEN or anything else
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    return await bridgeToExpress(req);
+  } catch (err) {
+    log.error({ err, event: "bull_board_handler_error" }, "bull-board handler error");
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export { handler as GET, handler as POST, handler as PUT, handler as PATCH, handler as DELETE };

--- a/src/lib/queue/bull-board.ts
+++ b/src/lib/queue/bull-board.ts
@@ -1,0 +1,71 @@
+/**
+ * Bull-Board singleton for Next.js App Router.
+ *
+ * Bull-Board has no official Next.js adapter — the issue's `@bull-board/nextjs`
+ * package does not exist on npm. We implement a thin custom adapter that wraps
+ * `@bull-board/api` and bridges it to Next.js Route Handlers.
+ *
+ * Architecture:
+ *   - `buildBullBoard()` creates a singleton (Express app via
+ *     `@bull-board/express`) that owns the EJS rendering + static-file serving.
+ *   - The Route Handler at `/api/admin/queues/[[...slug]]` bridges the incoming
+ *     Next.js `Request` into a Node.js `IncomingMessage` and pipes the Express
+ *     `ServerResponse` body back as a `NextResponse`.
+ *   - `requireAdmin()` is called at the top of the Route Handler, before Express
+ *     ever sees the request, so unauthorized traffic never hits the adapter.
+ */
+
+import express from "express";
+import path from "path";
+import { createBullBoard } from "@bull-board/api";
+import { BullMQAdapter } from "@bull-board/api/bullMQAdapter";
+import { ExpressAdapter } from "@bull-board/express";
+
+import { createLogger } from "@/lib/logger";
+import { getQueueRegistry } from "@/lib/queue";
+
+const log = createLogger({ module: "bull-board" });
+
+// ---------------------------------------------------------------------------
+// Singleton — the Express sub-app that owns Bull-Board's EJS + static files.
+// Initialized lazily on first request so it doesn't run at build time.
+// ---------------------------------------------------------------------------
+
+let _app: ReturnType<typeof express> | null = null;
+
+export const BULL_BOARD_BASE_PATH = "/api/admin/queues";
+
+export function getBullBoardApp(): ReturnType<typeof express> {
+  if (_app) return _app;
+
+  const serverAdapter = new ExpressAdapter();
+  serverAdapter.setBasePath(BULL_BOARD_BASE_PATH);
+
+  // Register every queue that was created via createQueue() before this call.
+  // Right now (before #589 lands) the registry is EMPTY — that's fine; the
+  // dashboard just shows an empty state.
+  const registry = getQueueRegistry();
+  const adapters = [...registry.values()].map((q) => new BullMQAdapter(q));
+
+  createBullBoard({
+    queues: adapters,
+    serverAdapter,
+    options: {
+      uiConfig: {
+        boardTitle: "Findash Queues",
+      },
+    },
+  });
+
+  const uiDistPath = path.dirname(require.resolve("@bull-board/ui/dist/index.ejs"));
+  serverAdapter.setViewsPath(uiDistPath);
+  serverAdapter.setStaticPath("/static", path.join(uiDistPath, "static"));
+
+  const app = express();
+  app.use("/", serverAdapter.getRouter());
+
+  log.info({ event: "bull_board_init", queueCount: registry.size }, "bull-board initialized");
+
+  _app = app;
+  return _app;
+}

--- a/src/lib/queue/bull-board.ts
+++ b/src/lib/queue/bull-board.ts
@@ -57,7 +57,11 @@ export function getBullBoardApp(): ReturnType<typeof express> {
     },
   });
 
-  const uiDistPath = path.dirname(require.resolve("@bull-board/ui/dist/index.ejs"));
+  // Resolve via package.json (a known JS-loadable file) instead of the .ejs
+  // template — Turbopack statically traces require.resolve() arguments and
+  // chokes on .ejs at build time. The dist folder lives next to package.json.
+  const uiPkgJson = require.resolve("@bull-board/ui/package.json");
+  const uiDistPath = path.join(path.dirname(uiPkgJson), "dist");
   serverAdapter.setViewsPath(uiDistPath);
   serverAdapter.setStaticPath("/static", path.join(uiDistPath, "static"));
 


### PR DESCRIPTION
Closes #588.
Part of #586.

## Summary

Self-hosted Bull-Board dashboard mounted at `/admin/queues`, gated by `requireAdmin()`. First piece of the Queue Infra epic that gives observability over BullMQ jobs.

## Implementation note

The original issue body listed `@bull-board/nextjs` as a dep — that package doesn't exist on npm. Used `@bull-board/express` + `@bull-board/api` + `@bull-board/ui` with a custom Next.js Route Handler bridge (Proxy-based ServerResponse mock) to convert between Next App Router and Express middleware.

## What's in the diff

- `src/lib/queue/bull-board.ts` — Express singleton, lazy-init, seeded from `getQueueRegistry()`
- `src/app/api/admin/queues/[[...slug]]/route.ts` — Route Handler with `requireAdmin()` gate
- `src/app/(app)/admin/queues/[[...slug]]/page.tsx` + `layout.tsx` — page + defense-in-depth auth
- `src/app/(app)/admin/page.tsx` — adds "Queues" admin card
- `src/app/api/admin/queues/[[...slug]]/route.test.ts` — 4 smoke tests (403 / 401 / 200 / deep-path-blocked)

New deps: `@bull-board/api`, `@bull-board/express`, `@bull-board/ui`, `@types/express`.

## Test plan

- [x] Local lint + typecheck clean
- [x] Local tests: 4/4 pass on new route, 1791/1792 pass on full suite
- [ ] CI green
- [ ] Smoke verify in dev: admin can access `/admin/queues`, non-admin 403