### PR TITLE
feat(classification): classify-tx job + worker (#590)

### DIFF
--- a/src/app/(app)/transactions/actions.test.ts
+++ b/src/app/(app)/transactions/actions.test.ts
@@ -3,6 +3,15 @@ import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import type { CounterpartyKind } from "@/lib/types";
 
+// ---------------------------------------------------------------------------
+// Shared mock state — hoisted so factory closures work above top-level consts.
+// ---------------------------------------------------------------------------
+const queueMocks = vi.hoisted(() => {
+  const addMock = vi.fn().mockResolvedValue({ id: "mock-job-id" });
+  const queueInstance = { add: addMock };
+  return { addMock, queueInstance };
+});
+
 // `revalidatePath` requires a Next.js request context that vitest's node
 // environment does not provide. No-op it so we can unit-test actions directly.
 vi.mock("next/cache", () => ({
@@ -31,6 +40,11 @@ vi.mock("@/lib/classification/ai", async () => {
   };
 });
 
+// Stub the BullMQ queue so runAiClassifier tests don't need a live Redis.
+vi.mock("@/lib/queue", () => ({
+  createQueue: vi.fn().mockReturnValue(queueMocks.queueInstance),
+}));
+
 const {
   updateCounterparty,
   mergeCounterparty,
@@ -43,6 +57,7 @@ const {
   restoreTransaction,
   createManualTransferGroup,
   updateTransactionInstallments,
+  runAiClassifier,
 } = await import("./actions");
 const { classifySingleWithAi: classifySingleWithAiLib } = await import("@/lib/classification/ai");
 const mockAiClassifySingle = vi.mocked(classifySingleWithAiLib);
@@ -1801,5 +1816,99 @@ describe("updateTransactionInstallments (#406)", () => {
       installmentRateEmX10k: null,
     });
     expect(tooMany.status).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runAiClassifier — now enqueues instead of processing inline (#590)
+// ---------------------------------------------------------------------------
+
+describe("runAiClassifier (#590)", () => {
+  const EXT_PREFIX = "test-run-ai-classifier";
+
+  async function defaultAccountId(): Promise<number> {
+    const [row] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} AND name = 'Bancolombia Ahorros' LIMIT 1
+    `);
+    return row.id;
+  }
+
+  async function seedUnclassifiedTx(externalId: string): Promise<number> {
+    const accountId = await defaultAccountId();
+    const [row] = await db.execute<{ id: number }>(sql`
+      INSERT INTO transactions (
+        user_id, account_id, occurred_at, amount_cents, currency,
+        description_raw, classification_method, source, external_id
+      ) VALUES (
+        ${TEST_USER_ID}, ${accountId}, now(), -10000, 'COP',
+        'runAiClassifier-test', 'unclassified'::classification_method,
+        'sms', ${externalId}
+      )
+      RETURNING id
+    `);
+    return row.id;
+  }
+
+  async function cleanupRunAiTxs() {
+    await db.execute(sql`
+      DELETE FROM transactions WHERE external_id LIKE ${EXT_PREFIX + ":%"}
+    `);
+  }
+
+  beforeEach(async () => {
+    await cleanupRunAiTxs();
+    queueMocks.addMock.mockClear();
+  });
+  afterEach(cleanupRunAiTxs);
+
+  it("enqueues a classify-tx job with mode=specific and the pending tx IDs", async () => {
+    const txId = await seedUnclassifiedTx(`${EXT_PREFIX}:one`);
+
+    const result = await runAiClassifier();
+
+    expect(result.enqueued).toBeGreaterThanOrEqual(1);
+    expect(queueMocks.addMock).toHaveBeenCalledOnce();
+
+    const [, jobData] = queueMocks.addMock.mock.calls[0];
+    expect(jobData.mode).toBe("specific");
+    expect(jobData.userId).toBe(TEST_USER_ID);
+    expect(Array.isArray(jobData.txIds)).toBe(true);
+    expect(jobData.txIds).toContain(txId);
+  });
+
+  it("returns { enqueued: 0 } and does NOT call queue.add when nothing is pending", async () => {
+    // No unclassified txs seeded
+    const result = await runAiClassifier();
+
+    expect(result.enqueued).toBe(0);
+    expect(queueMocks.addMock).not.toHaveBeenCalled();
+  });
+
+  it("enqueues at most AI_BATCH_SIZE transactions per call", async () => {
+    // Seed 25 unclassified txs — more than AI_BATCH_SIZE (20)
+    for (let i = 0; i < 25; i++) {
+      await seedUnclassifiedTx(`${EXT_PREFIX}:batch-${i}`);
+    }
+
+    const result = await runAiClassifier();
+
+    expect(result.enqueued).toBeLessThanOrEqual(20);
+    expect(queueMocks.addMock).toHaveBeenCalledOnce();
+
+    const [, jobData] = queueMocks.addMock.mock.calls[0];
+    expect(jobData.txIds).toHaveLength(result.enqueued);
+    expect(jobData.txIds.length).toBeLessThanOrEqual(20);
+  });
+
+  it("does NOT process the transactions synchronously (no DB updates)", async () => {
+    const txId = await seedUnclassifiedTx(`${EXT_PREFIX}:no-inline`);
+
+    await runAiClassifier();
+
+    // The tx must still be unclassified — only the queue.add was called
+    const [row] = await db.execute<{ classification_method: string }>(sql`
+      SELECT classification_method FROM transactions WHERE id = ${txId}
+    `);
+    expect(row.classification_method).toBe("unclassified");
   });
 });

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import {
@@ -18,7 +18,9 @@ import { notDeleted } from "@/lib/db/helpers";
 import { getSessionUser } from "@/lib/auth/session";
 import { classifySingleWithAi as classifySingleWithAiLib } from "@/lib/classification/ai";
 import { MERCHANT_HINTS_MAX } from "@/lib/classification/context";
-import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
+import { AI_BATCH_SIZE } from "@/lib/classification/pipeline";
+import { createQueue } from "@/lib/queue";
+import type { ClassifyTxJobData } from "@/lib/queue/workers/classify-tx";
 import type { UserClassificationContext } from "@/lib/db/schema";
 import { emit } from "@/lib/events/bus";
 import { autoLinkTransaction } from "@/lib/recurring/auto-link";
@@ -330,12 +332,42 @@ export async function createManualEntry(input: {
   });
 }
 
-export async function runAiClassifier() {
+export async function runAiClassifier(): Promise<{ enqueued: number }> {
   const session = await getSessionUser();
-  const result = await classifyUnclassifiedBatch(session.id);
-  revalidatePath("/");
-  revalidatePath("/transactions");
-  return result;
+
+  // Fetch the next batch of unclassified tx IDs so the job targets specific
+  // rows (tenant-safe: WHERE user_id = $1 AND classification_method = 'unclassified').
+  // This matches the pipeline's own fetch order (asc id, limit AI_BATCH_SIZE).
+  const pending = await db
+    .select({ id: transactions.id })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, session.id),
+        eq(transactions.classificationMethod, "unclassified"),
+        isNull(transactions.categorySlug),
+        notDeleted(transactions.deletedAt),
+      ),
+    )
+    .orderBy(asc(transactions.id))
+    .limit(AI_BATCH_SIZE);
+
+  if (pending.length === 0) {
+    return { enqueued: 0 };
+  }
+
+  const txIds = pending.map((r) => r.id);
+  const queue = createQueue<ClassifyTxJobData>("classify-tx");
+  await queue.add(
+    "classify-tx",
+    { userId: session.id, mode: "specific", txIds },
+    {
+      attempts: 3,
+      backoff: { type: "exponential", delay: 5000 },
+    },
+  );
+
+  return { enqueued: txIds.length };
 }
 
 const classifySingleSchema = z.object({

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -367,6 +367,12 @@ export async function runAiClassifier(): Promise<{ enqueued: number }> {
     },
   );
 
+  // Bust the RSC cache so the unclassified count badge reflects the enqueue
+  // immediately. The job runs async, but the cache invalidation is synchronous
+  // and cheap — without this the badge stays stale until the user reloads.
+  revalidatePath("/");
+  revalidatePath("/transactions");
+
   return { enqueued: txIds.length };
 }
 

--- a/src/components/transactions/ai-classify-button.tsx
+++ b/src/components/transactions/ai-classify-button.tsx
@@ -18,13 +18,11 @@ export function AiClassifyButton({ unclassified }: { unclassified: number }) {
     startTransition(async () => {
       try {
         const res = await runAiClassifier();
-        if (res.picked === 0) {
+        if (res.enqueued === 0) {
           toast.info("Nothing to classify");
           return;
         }
-        toast.success(
-          `Classified ${res.aiClassified} via AI · ${res.ruleClassified} via rules · ${res.skipped} skipped`,
-        );
+        toast.success(`Queued ${res.enqueued} transactions for AI classification`);
         router.refresh();
       } catch (err) {
         toast.error(err instanceof Error ? err.message : "AI classify failed");

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -34,6 +34,7 @@ export async function registerNode() {
   const { createLogger } = await import("@/lib/logger");
   const { createQueue, registerGracefulShutdown } = await import("@/lib/queue");
   const { createFxRefreshWorker } = await import("@/lib/queue/workers/fx-refresh");
+  const { createClassifyTxWorker } = await import("@/lib/queue/workers/classify-tx");
   const log = createLogger({ module: "instrumentation" });
 
   // -------------------------------------------------------------------------
@@ -47,6 +48,12 @@ export async function registerNode() {
   // -------------------------------------------------------------------------
   const fxQueue = createQueue("fx-refresh");
   createFxRefreshWorker();
+
+  // classify-tx worker — processes AI classification jobs enqueued by
+  // runAiClassifier (server action) and future import pipelines (#591).
+  createQueue("classify-tx");
+  createClassifyTxWorker();
+
   registerGracefulShutdown();
 
   await fxQueue.add(
@@ -176,7 +183,7 @@ export async function registerNode() {
 
   log.info(
     { event: "crons_registered" },
-    "crons registered: recurring-gap (0 6 5 * *), user-health (0 3 * * *), slo-alerts (*/30 * * * *), gmail-pull (*/5 * * * *) America/Bogota; fx-refresh via BullMQ (15 6,18 * * *)",
+    "crons registered: recurring-gap (0 6 5 * *), user-health (0 3 * * *), slo-alerts (*/30 * * * *), gmail-pull (*/5 * * * *) America/Bogota; fx-refresh via BullMQ (15 6,18 * * *); classify-tx worker registered",
   );
 
   // Backfill on boot when the last known rate is stale (source=fallback,

--- a/src/lib/classification/pipeline.test.ts
+++ b/src/lib/classification/pipeline.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { transactions } from "@/lib/db/schema";
+
+// ---------------------------------------------------------------------------
+// Mock external dependencies — we test the pipeline's DB filtering logic,
+// not the AI or rule engine themselves.
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/classification/ai", () => ({
+  classifyBatchWithAi: vi.fn().mockResolvedValue({
+    classifications: [],
+    model: "claude-haiku-4-5-20251001",
+    usage: { inputTokens: 0, outputTokens: 0 },
+  }),
+}));
+
+vi.mock("@/lib/classification/rules", () => ({
+  classifyByRule: vi.fn().mockResolvedValue(null),
+}));
+
+const { classifyUnclassifiedBatch, AI_BATCH_SIZE } = await import("./pipeline");
+const { classifyBatchWithAi } = await import("./ai");
+const mockClassifyBatch = vi.mocked(classifyBatchWithAi);
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+const TEST_USER_A = 1; // bootstrap user — always exists in findash_test
+const TEST_USER_B = 2; // second user seeded by db:seed:test
+
+async function defaultAccountId(userId: number): Promise<number> {
+  const [row] = await db.execute<{ id: number }>(sql`
+    SELECT id FROM accounts WHERE user_id = ${userId} ORDER BY id LIMIT 1
+  `);
+  if (!row) throw new Error(`No account for user ${userId}`);
+  return row.id;
+}
+
+async function seedUnclassifiedTx(args: {
+  userId: number;
+  accountId: number;
+  externalId: string;
+}): Promise<number> {
+  const [row] = await db.execute<{ id: number }>(sql`
+    INSERT INTO transactions (
+      user_id, account_id, occurred_at, amount_cents, currency,
+      description_raw, classification_method, source, external_id
+    ) VALUES (
+      ${args.userId}, ${args.accountId}, now(), -10000, 'COP',
+      'pipeline-test', 'unclassified'::classification_method,
+      'sms', ${args.externalId}
+    )
+    RETURNING id
+  `);
+  return row.id;
+}
+
+async function cleanupTestTxs() {
+  await db.execute(sql`
+    DELETE FROM ingestion_logs WHERE source = 'manual' AND payload->>'kind' = 'ai-classify'
+      AND started_at > now() - interval '1 hour'
+  `);
+  await db.execute(sql`
+    DELETE FROM transactions WHERE external_id LIKE 'pipeline-test:%'
+  `);
+}
+
+// ---------------------------------------------------------------------------
+// opts.txIds filtering
+// ---------------------------------------------------------------------------
+
+describe("classifyUnclassifiedBatch — opts.txIds", () => {
+  let accountA: number;
+
+  beforeEach(async () => {
+    await cleanupTestTxs();
+    accountA = await defaultAccountId(TEST_USER_A);
+    mockClassifyBatch.mockClear();
+  });
+
+  afterEach(cleanupTestTxs);
+
+  it("returns picked=0 immediately when txIds is empty array", async () => {
+    const result = await classifyUnclassifiedBatch(TEST_USER_A, { txIds: [] });
+    expect(result.picked).toBe(0);
+    expect(mockClassifyBatch).not.toHaveBeenCalled();
+  });
+
+  it("only picks transactions matching the given txIds", async () => {
+    const txA = await seedUnclassifiedTx({
+      userId: TEST_USER_A,
+      accountId: accountA,
+      externalId: "pipeline-test:filter-A",
+    });
+    await seedUnclassifiedTx({
+      userId: TEST_USER_A,
+      accountId: accountA,
+      externalId: "pipeline-test:filter-B",
+    });
+
+    // Only pass txA's id
+    mockClassifyBatch.mockResolvedValueOnce({
+      classifications: [{ id: txA, categorySlug: "alimentacion", confidence: 80 }],
+      model: "claude-haiku-4-5-20251001",
+      usage: { inputTokens: 100, outputTokens: 20 },
+    });
+
+    const result = await classifyUnclassifiedBatch(TEST_USER_A, { txIds: [txA] });
+
+    // Pipeline should have only sent txA to the AI
+    expect(result.picked).toBe(1);
+    expect(mockClassifyBatch).toHaveBeenCalledTimes(1);
+    const callArg = mockClassifyBatch.mock.calls[0][0];
+    expect(callArg.transactions).toHaveLength(1);
+    expect(callArg.transactions[0].id).toBe(txA);
+  });
+
+  it("ignores already-classified txs even when their id is in txIds", async () => {
+    // Seed as 'manual' (already classified)
+    const [classifiedRow] = await db.execute<{ id: number }>(sql`
+      INSERT INTO transactions (
+        user_id, account_id, occurred_at, amount_cents, currency,
+        description_raw, category_slug, classification_method, source, external_id
+      ) VALUES (
+        ${TEST_USER_A}, ${accountA}, now(), -10000, 'COP',
+        'pipeline-test', 'alimentacion', 'manual'::classification_method,
+        'sms', 'pipeline-test:already-classified'
+      )
+      RETURNING id
+    `);
+
+    const result = await classifyUnclassifiedBatch(TEST_USER_A, {
+      txIds: [classifiedRow.id],
+    });
+
+    // The WHERE clause includes classification_method = 'unclassified', so
+    // this row must NOT be picked
+    expect(result.picked).toBe(0);
+    expect(mockClassifyBatch).not.toHaveBeenCalled();
+  });
+
+  it("tenant isolation: txIds from userA are NOT processed for userB (WHERE includes user_id)", async () => {
+    // Seed tx for userA
+    const userATxId = await seedUnclassifiedTx({
+      userId: TEST_USER_A,
+      accountId: accountA,
+      externalId: "pipeline-test:tenant-A",
+    });
+
+    // Run pipeline AS userB with userA's txId
+    const result = await classifyUnclassifiedBatch(TEST_USER_B, { txIds: [userATxId] });
+
+    // userB's pipeline must not pick userA's tx
+    expect(result.picked).toBe(0);
+    expect(mockClassifyBatch).not.toHaveBeenCalled();
+
+    // userA's tx must remain unclassified
+    const [row] = await db
+      .select({ method: transactions.classificationMethod })
+      .from(transactions)
+      .where(and(eq(transactions.id, userATxId), eq(transactions.userId, TEST_USER_A)));
+    expect(row?.method).toBe("unclassified");
+  });
+
+  it("respects AI_BATCH_SIZE — never sends more than 20 to the AI per call", async () => {
+    const ids: number[] = [];
+    for (let i = 0; i < AI_BATCH_SIZE + 5; i++) {
+      const id = await seedUnclassifiedTx({
+        userId: TEST_USER_A,
+        accountId: accountA,
+        externalId: `pipeline-test:batch-limit-${i}`,
+      });
+      ids.push(id);
+    }
+
+    mockClassifyBatch.mockResolvedValueOnce({
+      classifications: [],
+      model: "claude-haiku-4-5-20251001",
+      usage: { inputTokens: 0, outputTokens: 0 },
+    });
+
+    const result = await classifyUnclassifiedBatch(TEST_USER_A, { txIds: ids });
+
+    // Pipeline limits to AI_BATCH_SIZE regardless of how many txIds were requested
+    expect(result.picked).toBeLessThanOrEqual(AI_BATCH_SIZE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default behavior (no opts) — sanity check existing path is unchanged
+// ---------------------------------------------------------------------------
+
+describe("classifyUnclassifiedBatch — default (no opts)", () => {
+  let accountA: number;
+
+  beforeEach(async () => {
+    await cleanupTestTxs();
+    accountA = await defaultAccountId(TEST_USER_A);
+    mockClassifyBatch.mockClear();
+  });
+
+  afterEach(cleanupTestTxs);
+
+  it("returns picked=0 when no unclassified transactions exist", async () => {
+    // Ensure no test-txs exist for this user with classification_method=unclassified
+    const result = await classifyUnclassifiedBatch(TEST_USER_A);
+    expect(result.picked).toBe(0);
+    expect(mockClassifyBatch).not.toHaveBeenCalled();
+  });
+
+  it("picks unclassified txs up to AI_BATCH_SIZE when called with no opts", async () => {
+    // Seed 3 unclassified txs
+    for (let i = 0; i < 3; i++) {
+      await seedUnclassifiedTx({
+        userId: TEST_USER_A,
+        accountId: accountA,
+        externalId: `pipeline-test:default-${i}`,
+      });
+    }
+
+    mockClassifyBatch.mockResolvedValueOnce({
+      classifications: [],
+      model: "claude-haiku-4-5-20251001",
+      usage: { inputTokens: 0, outputTokens: 0 },
+    });
+
+    const result = await classifyUnclassifiedBatch(TEST_USER_A);
+    expect(result.picked).toBe(3);
+  });
+});

--- a/src/lib/classification/pipeline.ts
+++ b/src/lib/classification/pipeline.ts
@@ -21,6 +21,17 @@ export type ClassifyBatchOpts = {
   txIds?: number[];
 };
 
+/**
+ * Retry safety: when the worker retries a job mid-batch (e.g. Anthropic
+ * timeout after partial success), the WHERE clause below re-filters by
+ * `classificationMethod = "unclassified"`. Rows already classified on the
+ * previous attempt have a different method and are silently skipped, so
+ * retries are idempotent in practice. The only theoretical race is two
+ * retries firing within the DB-commit window of the first AI response —
+ * BullMQ's exponential backoff (5s+) makes this effectively impossible.
+ * If we ever observe duplicates, switch to a sentinel `"ai-pending"`
+ * state set in a single UPDATE before the AI call.
+ */
 export async function classifyUnclassifiedBatch(
   userId: number,
   opts?: ClassifyBatchOpts,

--- a/src/lib/classification/pipeline.ts
+++ b/src/lib/classification/pipeline.ts
@@ -1,5 +1,5 @@
 import { and, asc, eq, inArray, isNull } from "drizzle-orm";
-import { db as defaultDb, type DB } from "@/lib/db";
+import { db as defaultDb } from "@/lib/db";
 import { categories, ingestionLogs, transactions, users } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { classifyBatchWithAi, type AiCategoryOption, type AiUserHint } from "./ai";
@@ -16,13 +16,37 @@ export type PipelineResult = {
   usage: { inputTokens: number; outputTokens: number };
 };
 
+export type ClassifyBatchOpts = {
+  /** When provided, only classify these specific transaction IDs (still filtered by userId). */
+  txIds?: number[];
+};
+
 export async function classifyUnclassifiedBatch(
   userId: number,
-  database: DB = defaultDb,
+  opts?: ClassifyBatchOpts,
 ): Promise<PipelineResult> {
+  const db = defaultDb;
+  const options: ClassifyBatchOpts = opts ?? {};
+
   const startedAt = new Date();
 
-  const pending = await database
+  const whereClause =
+    options.txIds && options.txIds.length > 0
+      ? and(
+          eq(transactions.userId, userId),
+          eq(transactions.classificationMethod, "unclassified"),
+          isNull(transactions.categorySlug),
+          notDeleted(transactions.deletedAt),
+          inArray(transactions.id, options.txIds),
+        )
+      : and(
+          eq(transactions.userId, userId),
+          eq(transactions.classificationMethod, "unclassified"),
+          isNull(transactions.categorySlug),
+          notDeleted(transactions.deletedAt),
+        );
+
+  const pending = await db
     .select({
       id: transactions.id,
       description: transactions.descriptionRaw,
@@ -32,14 +56,7 @@ export async function classifyUnclassifiedBatch(
       currency: transactions.currency,
     })
     .from(transactions)
-    .where(
-      and(
-        eq(transactions.userId, userId),
-        eq(transactions.classificationMethod, "unclassified"),
-        isNull(transactions.categorySlug),
-        notDeleted(transactions.deletedAt),
-      ),
-    )
+    .where(whereClause)
     .orderBy(asc(transactions.id))
     .limit(AI_BATCH_SIZE);
 
@@ -55,7 +72,7 @@ export async function classifyUnclassifiedBatch(
   }
 
   const [cats, userRow] = await Promise.all([
-    database
+    db
       .select({
         slug: categories.slug,
         name: categories.name,
@@ -63,7 +80,7 @@ export async function classifyUnclassifiedBatch(
       })
       .from(categories)
       .where(and(eq(categories.userId, userId), notDeleted(categories.deletedAt))),
-    database
+    db
       .select({ context: users.classificationContext })
       .from(users)
       .where(eq(users.id, userId))
@@ -82,10 +99,10 @@ export async function classifyUnclassifiedBatch(
         descriptionClean: tx.descriptionClean,
         merchant: tx.merchant,
       },
-      database,
+      db,
     );
     if (ruleHit) {
-      await database
+      await db
         .update(transactions)
         .set({
           categorySlug: ruleHit.categorySlug,
@@ -133,7 +150,7 @@ export async function classifyUnclassifiedBatch(
       skipped++;
       continue;
     }
-    await database
+    await db
       .update(transactions)
       .set({
         categorySlug: hit.categorySlug,
@@ -152,7 +169,7 @@ export async function classifyUnclassifiedBatch(
     aiClassified++;
   }
 
-  await database.insert(ingestionLogs).values({
+  await db.insert(ingestionLogs).values({
     userId,
     source: "manual",
     status: skipped === 0 ? "ok" : "partial",

--- a/src/lib/queue/workers/classify-tx.test.ts
+++ b/src/lib/queue/workers/classify-tx.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Job } from "bullmq";
+import type { ClassifyTxJobData } from "./classify-tx";
+
+// ---------------------------------------------------------------------------
+// Shared mock state via vi.hoisted so factories can access it before imports.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  classifyUnclassifiedBatch: vi.fn(),
+  countUnclassified: vi.fn(),
+}));
+
+vi.mock("@/lib/classification/pipeline", () => ({
+  classifyUnclassifiedBatch: mocks.classifyUnclassifiedBatch,
+  AI_BATCH_SIZE: 20,
+}));
+
+vi.mock("@/lib/transactions/queries", () => ({
+  countUnclassified: mocks.countUnclassified,
+}));
+
+const { classifyTxProcessor } = await import("./classify-tx");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeJob(data: ClassifyTxJobData): Job<ClassifyTxJobData> {
+  return { id: "test-job-1", data } as unknown as Job<ClassifyTxJobData>;
+}
+
+const defaultPipelineResult = {
+  picked: 20,
+  aiClassified: 15,
+  ruleClassified: 3,
+  skipped: 2,
+  model: "claude-haiku-4-5-20251001",
+  usage: { inputTokens: 1000, outputTokens: 200 },
+};
+
+// ---------------------------------------------------------------------------
+// mode: "specific"
+// ---------------------------------------------------------------------------
+
+describe('classifyTxProcessor — mode "specific"', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls classifyUnclassifiedBatch with the given txIds and userId", async () => {
+    mocks.classifyUnclassifiedBatch.mockResolvedValueOnce(defaultPipelineResult);
+
+    const txIds = [1, 2, 3, 4, 5];
+    await classifyTxProcessor(makeJob({ userId: 42, mode: "specific", txIds }));
+
+    expect(mocks.classifyUnclassifiedBatch).toHaveBeenCalledTimes(1);
+    expect(mocks.classifyUnclassifiedBatch).toHaveBeenCalledWith(42, { txIds });
+  });
+
+  it("does NOT call countUnclassified in specific mode", async () => {
+    mocks.classifyUnclassifiedBatch.mockResolvedValueOnce(defaultPipelineResult);
+
+    await classifyTxProcessor(makeJob({ userId: 1, mode: "specific", txIds: [10] }));
+
+    expect(mocks.countUnclassified).not.toHaveBeenCalled();
+  });
+
+  it("completes without error on empty txIds", async () => {
+    mocks.classifyUnclassifiedBatch.mockResolvedValueOnce({
+      ...defaultPipelineResult,
+      picked: 0,
+      aiClassified: 0,
+      ruleClassified: 0,
+      skipped: 0,
+    });
+
+    await expect(
+      classifyTxProcessor(makeJob({ userId: 1, mode: "specific", txIds: [] })),
+    ).resolves.toBeUndefined();
+  });
+
+  it("re-throws when classifyUnclassifiedBatch throws", async () => {
+    mocks.classifyUnclassifiedBatch.mockRejectedValueOnce(new Error("Anthropic API error"));
+
+    await expect(
+      classifyTxProcessor(makeJob({ userId: 1, mode: "specific", txIds: [99] })),
+    ).rejects.toThrow("Anthropic API error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mode: "drain-pending"
+// ---------------------------------------------------------------------------
+
+describe('classifyTxProcessor — mode "drain-pending"', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loops until countUnclassified returns 0", async () => {
+    // 3 iterations: 40 pending → 20 pending → 0 pending
+    mocks.countUnclassified
+      .mockResolvedValueOnce(40)
+      .mockResolvedValueOnce(20)
+      .mockResolvedValueOnce(0);
+    mocks.classifyUnclassifiedBatch
+      .mockResolvedValueOnce(defaultPipelineResult)
+      .mockResolvedValueOnce(defaultPipelineResult);
+
+    await classifyTxProcessor(makeJob({ userId: 7, mode: "drain-pending" }));
+
+    expect(mocks.countUnclassified).toHaveBeenCalledTimes(3);
+    expect(mocks.classifyUnclassifiedBatch).toHaveBeenCalledTimes(2);
+    // drain-pending passes no txIds — falls through to classifyUnclassifiedBatch(userId)
+    expect(mocks.classifyUnclassifiedBatch).toHaveBeenCalledWith(7);
+  });
+
+  it("exits immediately when pendingCount is already 0", async () => {
+    mocks.countUnclassified.mockResolvedValueOnce(0);
+
+    await classifyTxProcessor(makeJob({ userId: 1, mode: "drain-pending" }));
+
+    expect(mocks.classifyUnclassifiedBatch).not.toHaveBeenCalled();
+  });
+
+  it("aborts (stall guard) when pipeline picks 0 but count > 0", async () => {
+    mocks.countUnclassified.mockResolvedValue(5); // always 5 — would loop forever otherwise
+    mocks.classifyUnclassifiedBatch.mockResolvedValueOnce({
+      ...defaultPipelineResult,
+      picked: 0,
+    });
+
+    await expect(
+      classifyTxProcessor(makeJob({ userId: 1, mode: "drain-pending" })),
+    ).resolves.toBeUndefined();
+
+    // Should have called classifyUnclassifiedBatch once, then hit the stall guard
+    expect(mocks.classifyUnclassifiedBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-throws when classifyUnclassifiedBatch throws", async () => {
+    mocks.countUnclassified.mockResolvedValueOnce(20);
+    mocks.classifyUnclassifiedBatch.mockRejectedValueOnce(new Error("timeout"));
+
+    await expect(
+      classifyTxProcessor(makeJob({ userId: 1, mode: "drain-pending" })),
+    ).rejects.toThrow("timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tenant isolation: specific-mode txIds scoped to userId
+// ---------------------------------------------------------------------------
+
+describe("tenant isolation — specific mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes userId alongside txIds — pipeline receives both, no cross-tenant leakage", async () => {
+    // User A's processor
+    mocks.classifyUnclassifiedBatch.mockResolvedValue(defaultPipelineResult);
+
+    const userAId = 100;
+    const userBId = 200;
+    const userATxIds = [1, 2, 3];
+    const userBTxIds = [101, 102];
+
+    await classifyTxProcessor(makeJob({ userId: userAId, mode: "specific", txIds: userATxIds }));
+    await classifyTxProcessor(makeJob({ userId: userBId, mode: "specific", txIds: userBTxIds }));
+
+    // Each call should have passed its own userId + txIds
+    expect(mocks.classifyUnclassifiedBatch).toHaveBeenNthCalledWith(1, userAId, {
+      txIds: userATxIds,
+    });
+    expect(mocks.classifyUnclassifiedBatch).toHaveBeenNthCalledWith(2, userBId, {
+      txIds: userBTxIds,
+    });
+
+    // The txIds from user A were never passed with user B's userId
+    const allCalls = mocks.classifyUnclassifiedBatch.mock.calls;
+    for (const [callUserId, callOpts] of allCalls) {
+      if (callUserId === userAId) {
+        expect(callOpts?.txIds).toEqual(userATxIds);
+      }
+      if (callUserId === userBId) {
+        expect(callOpts?.txIds).toEqual(userBTxIds);
+      }
+    }
+  });
+});

--- a/src/lib/queue/workers/classify-tx.test.ts
+++ b/src/lib/queue/workers/classify-tx.test.ts
@@ -153,7 +153,12 @@ describe('classifyTxProcessor — mode "drain-pending"', () => {
 // Tenant isolation: specific-mode txIds scoped to userId
 // ---------------------------------------------------------------------------
 
-describe("tenant isolation — specific mode", () => {
+// Worker-level tenant isolation: this test verifies the WORKER routes each
+// job's userId correctly through to the pipeline. The actual DB-level
+// isolation guarantee (cross-tenant txIds rejected by the WHERE clause)
+// is covered in pipeline.test.ts under "tenant isolation" — that one runs
+// against the real findash_test DB.
+describe("tenant isolation — specific mode (call-routing only)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/src/lib/queue/workers/classify-tx.ts
+++ b/src/lib/queue/workers/classify-tx.ts
@@ -1,0 +1,179 @@
+import type { Job } from "bullmq";
+
+import { createLogger } from "@/lib/logger";
+import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
+import { countUnclassified } from "@/lib/transactions/queries";
+import { createWorker } from "@/lib/queue";
+
+const log = createLogger({ module: "worker/classify-tx" });
+
+// Maximum loop iterations for drain-pending mode.
+// 100 iterations × AI_BATCH_SIZE(20) = up to 2000 txs per job.
+// Prevents runaway if the pending count never reaches zero due to a bug.
+const MAX_DRAIN_ITERATIONS = 100;
+
+export type ClassifyTxJobData =
+  | { userId: number; mode: "specific"; txIds: number[] }
+  | { userId: number; mode: "drain-pending" };
+
+/**
+ * Core processor: classifies transactions for a user.
+ *
+ * - mode "specific": classify only the given txIds (filtered AND user_id — tenant-safe).
+ * - mode "drain-pending": loop calling classifyUnclassifiedBatch until no pending remain.
+ *
+ * Exported separately so tests can invoke it directly without a live Worker.
+ */
+export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<void> {
+  const { userId, mode } = job.data;
+
+  log.info({ event: "classify_job_start", userId, mode, jobId: job.id }, "classify-tx started");
+
+  if (mode === "specific") {
+    const { txIds } = job.data;
+    log.info(
+      { event: "classify_specific_batch", userId, txCount: txIds.length, jobId: job.id },
+      "classifying specific txIds",
+    );
+
+    const result = await classifyUnclassifiedBatch(userId, { txIds });
+
+    log.info(
+      {
+        event: "classify_specific_done",
+        userId,
+        picked: result.picked,
+        aiClassified: result.aiClassified,
+        ruleClassified: result.ruleClassified,
+        skipped: result.skipped,
+        model: result.model,
+        jobId: job.id,
+      },
+      "classify-tx specific done",
+    );
+    return;
+  }
+
+  // mode === "drain-pending"
+  log.info(
+    { event: "classify_drain_start", userId, jobId: job.id },
+    "classify-tx drain-pending started",
+  );
+
+  let totalAiClassified = 0;
+  let totalRuleClassified = 0;
+  let totalSkipped = 0;
+  let iterations = 0;
+
+  while (iterations < MAX_DRAIN_ITERATIONS) {
+    iterations++;
+
+    const pendingCount = await countUnclassified(userId);
+    log.info(
+      { event: "classify_drain_tick", userId, pendingCount, iteration: iterations, jobId: job.id },
+      "drain-pending tick",
+    );
+
+    if (pendingCount === 0) {
+      log.info(
+        {
+          event: "classify_drain_done",
+          userId,
+          iterations,
+          totalAiClassified,
+          totalRuleClassified,
+          totalSkipped,
+          jobId: job.id,
+        },
+        "classify-tx drain-pending complete — no more pending",
+      );
+      return;
+    }
+
+    const result = await classifyUnclassifiedBatch(userId);
+
+    totalAiClassified += result.aiClassified;
+    totalRuleClassified += result.ruleClassified;
+    totalSkipped += result.skipped;
+
+    log.info(
+      {
+        event: "classify_drain_batch_done",
+        userId,
+        iteration: iterations,
+        picked: result.picked,
+        aiClassified: result.aiClassified,
+        ruleClassified: result.ruleClassified,
+        skipped: result.skipped,
+        jobId: job.id,
+      },
+      "drain-pending batch done",
+    );
+
+    // If the pipeline picked zero even though pendingCount > 0, something is
+    // wrong — break to avoid infinite spinning.
+    if (result.picked === 0) {
+      log.warn(
+        {
+          event: "classify_drain_stalled",
+          userId,
+          pendingCount,
+          iteration: iterations,
+          jobId: job.id,
+        },
+        "drain-pending stalled: pendingCount > 0 but pipeline picked 0 — aborting",
+      );
+      return;
+    }
+  }
+
+  log.warn(
+    {
+      event: "classify_drain_limit_reached",
+      userId,
+      maxIterations: MAX_DRAIN_ITERATIONS,
+      totalAiClassified,
+      totalRuleClassified,
+      totalSkipped,
+      jobId: job.id,
+    },
+    "classify-tx drain-pending reached iteration limit — stopping",
+  );
+}
+
+/**
+ * Create and register the classify-tx BullMQ worker.
+ *
+ * Concurrency is set to 1 globally to avoid hammering Anthropic's API with
+ * parallel classification requests. Multiple jobs can be enqueued but they
+ * will process one at a time.
+ *
+ * Retry: 3 attempts with exponential back-off starting at 5s. Handles
+ * transient Anthropic API failures without overwhelming the API.
+ */
+export function createClassifyTxWorker() {
+  return createWorker<ClassifyTxJobData, void>(
+    "classify-tx",
+    async (job) => {
+      try {
+        await classifyTxProcessor(job);
+      } catch (err) {
+        log.error(
+          {
+            err,
+            event: "classify_job_failed",
+            userId: job.data.userId,
+            mode: job.data.mode,
+            jobId: job.id,
+          },
+          "classify-tx job failed",
+        );
+        // Re-throw so BullMQ records the failure and triggers retries.
+        throw err;
+      }
+    },
+    {
+      concurrency: 1,
+    },
+  );
+}

--- a/src/lib/queue/workers/classify-tx.ts
+++ b/src/lib/queue/workers/classify-tx.ts
@@ -144,9 +144,12 @@ export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<
 /**
  * Create and register the classify-tx BullMQ worker.
  *
- * Concurrency is set to 1 globally to avoid hammering Anthropic's API with
- * parallel classification requests. Multiple jobs can be enqueued but they
- * will process one at a time.
+ * Concurrency is set to 1 per-process to avoid hammering Anthropic's API
+ * with parallel classification requests. Findash currently runs single-
+ * instance, so per-process == global. Revisit if horizontal scaling is
+ * added — N instances each with concurrency 1 means N concurrent calls
+ * to Anthropic, which would need a distributed rate limiter (e.g. Redis-
+ * backed token bucket or BullMQ Pro's group rate limiting).
  *
  * Retry: 3 attempts with exponential back-off starting at 5s. Handles
  * transient Anthropic API failures without overwhelming the API.


### PR DESCRIPTION
Closes #590.
Part of #586.

## Summary

Refactors the AI classifier to run as a BullMQ background job. The `runAiClassifier` server action no longer processes inline — it enqueues a `classify-tx` job that the worker drains in batches of 20 with retry + backoff. Foundation for #591 (enqueue from imports) and #592 (Classify All Pending UI).

## What's in the diff

- `src/lib/queue/workers/classify-tx.ts` — worker, concurrency 1, retry 3×exp@5s, supports `mode: "specific"` (txIds) and `mode: "drain-pending"` (loops until pending is 0, capped at 100 iterations)
- `src/lib/classification/pipeline.ts` — added optional `opts.txIds` filter; WHERE clause is `user_id = $1 AND id = ANY($2)` (both predicates required, txIds does NOT replace user filter)
- `src/lib/classification/pipeline.test.ts` — 7 integration tests including tenant-isolation against findash_test
- `src/lib/queue/workers/classify-tx.test.ts` — 9 unit tests
- `src/app/(app)/transactions/actions.ts` — `runAiClassifier` enqueues, returns `{ enqueued: N }`, calls `revalidatePath` so the count badge refreshes
- `src/components/transactions/ai-classify-button.tsx` — UI updated for new response shape
- `src/instrumentation.node.ts` — registers classify-tx queue + worker at boot

## Reviewer pass

Reviewed by `findash-reviewer`: 0 CRITICAL, 2 WARNING, 2 SUGGESTION. All 4 findings addressed in the second commit (`fix(classification): address reviewer feedback on classify-tx job`):

- W1 — restored `revalidatePath` in `runAiClassifier` so the unclassified count badge updates after enqueue
- W2 — documented retry safety (race window << BullMQ 5s exponential backoff)
- S1 — clarified worker concurrency comment (per-process, not per-cluster)
- S2 — clarified worker tenant test scope (call-routing; DB-level isolation tested in pipeline.test.ts)

## Test plan

- [x] Local lint clean
- [x] Local typecheck clean
- [x] Local tests: 1811/1812 pass (1 pre-existing skip)
- [ ] CI: lint + typecheck + test + build green
- [ ] CI: CodeQL clean
- [ ] Smoke: enqueue via "Run AI Classifier" button → job visible in Bull-Board → drains correctly