### PR TITLE
feat(ui): "Classify All Pending" button drains queue (#592)

### DIFF
--- a/src/app/(app)/transactions/actions.test.ts
+++ b/src/app/(app)/transactions/actions.test.ts
@@ -58,6 +58,7 @@ const {
   createManualTransferGroup,
   updateTransactionInstallments,
   runAiClassifier,
+  enqueueClassifyAllPending,
 } = await import("./actions");
 const { classifySingleWithAi: classifySingleWithAiLib } = await import("@/lib/classification/ai");
 const mockAiClassifySingle = vi.mocked(classifySingleWithAiLib);
@@ -1906,6 +1907,108 @@ describe("runAiClassifier (#590)", () => {
     await runAiClassifier();
 
     // The tx must still be unclassified — only the queue.add was called
+    const [row] = await db.execute<{ classification_method: string }>(sql`
+      SELECT classification_method FROM transactions WHERE id = ${txId}
+    `);
+    expect(row.classification_method).toBe("unclassified");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enqueueClassifyAllPending — enqueues ONE drain-pending job (#592)
+// ---------------------------------------------------------------------------
+
+describe("enqueueClassifyAllPending (#592)", () => {
+  const EXT_PREFIX = "test-drain-all-pending";
+
+  async function defaultAccountId(): Promise<number> {
+    const [row] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} AND name = 'Bancolombia Ahorros' LIMIT 1
+    `);
+    return row.id;
+  }
+
+  async function seedUnclassifiedTx(externalId: string): Promise<number> {
+    const accountId = await defaultAccountId();
+    const [row] = await db.execute<{ id: number }>(sql`
+      INSERT INTO transactions (
+        user_id, account_id, occurred_at, amount_cents, currency,
+        description_raw, classification_method, source, external_id
+      ) VALUES (
+        ${TEST_USER_ID}, ${accountId}, now(), -10000, 'COP',
+        'drain-all-test', 'unclassified'::classification_method,
+        'sms', ${externalId}
+      )
+      RETURNING id
+    `);
+    return row.id;
+  }
+
+  async function cleanupDrainTxs() {
+    await db.execute(sql`
+      DELETE FROM transactions WHERE external_id LIKE ${EXT_PREFIX + ":%"}
+    `);
+  }
+
+  beforeEach(async () => {
+    await cleanupDrainTxs();
+    queueMocks.addMock.mockClear();
+  });
+  afterEach(cleanupDrainTxs);
+
+  it("returns { enqueued: 0 } and does NOT call queue.add when nothing is pending", async () => {
+    // No unclassified txs seeded for this user (cleanup ran above)
+    const result = await enqueueClassifyAllPending();
+
+    expect(result.enqueued).toBe(0);
+    expect(queueMocks.addMock).not.toHaveBeenCalled();
+  });
+
+  it("enqueues a classify-tx job with mode=drain-pending when there are pending txs", async () => {
+    await seedUnclassifiedTx(`${EXT_PREFIX}:one`);
+
+    const result = await enqueueClassifyAllPending();
+
+    expect(result.enqueued).toBeGreaterThanOrEqual(1);
+    expect(queueMocks.addMock).toHaveBeenCalledOnce();
+
+    const [, jobData, jobOpts] = queueMocks.addMock.mock.calls[0];
+    expect(jobData.mode).toBe("drain-pending");
+    expect(jobData.userId).toBe(TEST_USER_ID);
+    // drain-pending carries no txIds — the worker fetches them incrementally
+    expect("txIds" in jobData).toBe(false);
+    // Idempotent jobId
+    expect(jobOpts.jobId).toBe(`drain-${TEST_USER_ID}`);
+  });
+
+  it("returns the total pending count (not capped at batch size)", async () => {
+    // Seed 25 txs — more than AI_BATCH_SIZE (20); drain-all should report ALL
+    for (let i = 0; i < 25; i++) {
+      await seedUnclassifiedTx(`${EXT_PREFIX}:batch-${i}`);
+    }
+
+    const result = await enqueueClassifyAllPending();
+
+    // enqueued = total pending, which is at least our 25 seeded rows
+    expect(result.enqueued).toBeGreaterThanOrEqual(25);
+    // Only one job added regardless of pending count
+    expect(queueMocks.addMock).toHaveBeenCalledOnce();
+  });
+
+  it("uses a per-user idempotent jobId (drain-<userId>)", async () => {
+    await seedUnclassifiedTx(`${EXT_PREFIX}:idem`);
+
+    await enqueueClassifyAllPending();
+
+    const [, , opts] = queueMocks.addMock.mock.calls[0];
+    expect(opts.jobId).toBe(`drain-${TEST_USER_ID}`);
+  });
+
+  it("does NOT update any transaction rows synchronously", async () => {
+    const txId = await seedUnclassifiedTx(`${EXT_PREFIX}:no-inline`);
+
+    await enqueueClassifyAllPending();
+
     const [row] = await db.execute<{ classification_method: string }>(sql`
       SELECT classification_method FROM transactions WHERE id = ${txId}
     `);

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -33,6 +33,7 @@ import {
   type TransferLeg,
 } from "@/lib/transactions/transfer-groups";
 import { validateInstallmentRate, rateValidationMessage } from "@/lib/finance/rates";
+import { countUnclassified } from "@/lib/transactions/queries";
 import type { CounterpartyKind, CounterpartyType } from "@/lib/types";
 
 const updateSchema = z.object({
@@ -330,6 +331,43 @@ export async function createManualEntry(input: {
     source: "manual",
     timestamp: Date.now(),
   });
+}
+
+/**
+ * Enqueue a single drain-pending job that classifies ALL pending transactions
+ * for the session user — the worker loops until the queue is empty (capped at
+ * 100 iterations × AI_BATCH_SIZE = 2000 max txs, per classify-tx worker).
+ *
+ * The `jobId` is deterministic per-user (`drain-<userId>`) so duplicate
+ * clicks or rapid re-submissions are idempotent at the BullMQ level — BullMQ
+ * deduplicates by jobId and the second add is a no-op.
+ */
+export async function enqueueClassifyAllPending(): Promise<{ enqueued: number }> {
+  const session = await getSessionUser();
+
+  // Count pending so the toast can tell the user how many are queued.
+  // `countUnclassified` already filters by userId + notDeleted.
+  const pendingCount = await countUnclassified(session.id);
+
+  if (pendingCount === 0) return { enqueued: 0 };
+
+  const queue = createQueue<ClassifyTxJobData>("classify-tx");
+  await queue.add(
+    "classify-tx",
+    { userId: session.id, mode: "drain-pending" },
+    {
+      // Idempotent per user — a second click while the drain is running
+      // simply finds the existing job and is silently dropped by BullMQ.
+      jobId: `drain-${session.id}`,
+      attempts: 3,
+      backoff: { type: "exponential", delay: 5000 },
+    },
+  );
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+
+  return { enqueued: pendingCount };
 }
 
 export async function runAiClassifier(): Promise<{ enqueued: number }> {

--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -1,7 +1,10 @@
 import Link from "next/link";
 import { AlertTriangleIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { AiClassifyButton } from "@/components/transactions/ai-classify-button";
+import {
+  AiClassifyButton,
+  DrainAllPendingButton,
+} from "@/components/transactions/ai-classify-button";
 import { Filters } from "@/components/transactions/filters";
 import { TransactionTable } from "@/components/transactions/transaction-table";
 import { TransferGroupDialog } from "@/components/transactions/transfer-group-dialog";
@@ -144,6 +147,7 @@ export default async function TransactionsPage({ searchParams }: { searchParams:
         <div className="flex items-center gap-2">
           <TransferGroupDialog accounts={accounts} />
           <AiClassifyButton unclassified={unclassified} />
+          <DrainAllPendingButton unclassified={unclassified} />
         </div>
       </header>
 

--- a/src/components/transactions/ai-classify-button.tsx
+++ b/src/components/transactions/ai-classify-button.tsx
@@ -5,10 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Sparkles, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  runAiClassifier,
-  enqueueClassifyAllPending,
-} from "@/app/(app)/transactions/actions";
+import { runAiClassifier, enqueueClassifyAllPending } from "@/app/(app)/transactions/actions";
 
 export function AiClassifyButton({ unclassified }: { unclassified: number }) {
   const router = useRouter();
@@ -68,9 +65,7 @@ export function DrainAllPendingButton({ unclassified }: { unclassified: number }
           toast.info("No pending transactions to classify");
           return;
         }
-        toast.success(
-          `Encolados ${res.enqueued.toLocaleString()} — te aviso cuando termine`,
-        );
+        toast.success(`Encolados ${res.enqueued.toLocaleString()} — te aviso cuando termine`);
         router.refresh();
       } catch (err) {
         toast.error(err instanceof Error ? err.message : "Failed to enqueue drain job");

--- a/src/components/transactions/ai-classify-button.tsx
+++ b/src/components/transactions/ai-classify-button.tsx
@@ -3,9 +3,12 @@
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Sparkles } from "lucide-react";
+import { Sparkles, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { runAiClassifier } from "@/app/(app)/transactions/actions";
+import {
+  runAiClassifier,
+  enqueueClassifyAllPending,
+} from "@/app/(app)/transactions/actions";
 
 export function AiClassifyButton({ unclassified }: { unclassified: number }) {
   const router = useRouter();
@@ -38,6 +41,51 @@ export function AiClassifyButton({ unclassified }: { unclassified: number }) {
         : unclassified === 0
           ? "All classified"
           : `Classify ${batchSize} with AI${unclassified > 20 ? ` (${unclassified} pending)` : ""}`}
+    </Button>
+  );
+}
+
+/**
+ * Enqueues a single drain-pending job that drains ALL pending transactions for
+ * the session user. The worker runs until empty (capped at 2000 txs).
+ *
+ * Note on idempotency: BullMQ deduplicates by jobId (`drain-<userId>`), so
+ * multiple clicks while a drain is already running are no-ops at the queue
+ * level. The button has no local "is draining" state — relying on this server-
+ * side dedup avoids polling the job status from the client.
+ */
+export function DrainAllPendingButton({ unclassified }: { unclassified: number }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  const disabled = pending || unclassified === 0;
+
+  function onClick() {
+    startTransition(async () => {
+      try {
+        const res = await enqueueClassifyAllPending();
+        if (res.enqueued === 0) {
+          toast.info("No pending transactions to classify");
+          return;
+        }
+        toast.success(
+          `Encolados ${res.enqueued.toLocaleString()} — te aviso cuando termine`,
+        );
+        router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to enqueue drain job");
+      }
+    });
+  }
+
+  return (
+    <Button variant="outline" size="sm" onClick={onClick} disabled={disabled}>
+      <Zap className="size-4" />
+      {pending
+        ? "Enqueuing…"
+        : unclassified === 0
+          ? "All classified"
+          : `Classify All Pending (${unclassified.toLocaleString()})`}
     </Button>
   );
 }


### PR DESCRIPTION
Closes #592

Part of #586

## Summary

- Adds `enqueueClassifyAllPending()` server action that enqueues a single BullMQ job with `mode: "drain-pending"` and an idempotent job ID (`drain-${session.id}`) so rapid double-clicks are safe
- Adds `DrainAllPendingButton` component alongside the existing `AiClassifyButton`; placed in the transactions page header toolbar
- Existing 20-at-a-time classify button kept as a power-user option (additive change); no schema changes

## Test plan

- [x] `bun run lint` clean (pre-existing `console.log` failures in `public/widgets/scriptable/findash-widget.js` are not from this PR)
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` clean — 72/72 specs passed
- [ ] manual smoke: open `/transactions`, click "Classify All Pending", verify job enqueued in Bull-Board and pending rows are drained