### PR TITLE
feat(ingestion): enqueue classify-tx after every import (#591)

### DIFF
--- a/src/app/(app)/imports/actions.ts
+++ b/src/app/(app)/imports/actions.ts
@@ -785,7 +785,7 @@ async function _commitArqV1(entry: CacheEntryV1, userId: number): Promise<Unifie
     { userId, accountId: entry.accountId, pdfBuffer: entry.pdfBuffer, pdfHash: entry.pdfHash },
   );
   // #591: run rule-based classification on newly inserted txs, then enqueue AI for the rest.
-  if (result.status === "committed" && result.insertedTxIds.length > 0) {
+  if (result.status === "committed" && result.insertedTxIds && result.insertedTxIds.length > 0) {
     await classifyByRuleThenEnqueue(userId, result.insertedTxIds);
   }
   return _mapArqRunResult(result, entry.preview.period);
@@ -803,7 +803,7 @@ async function _commitArqV2(
     { userId, accountId, pdfBuffer, pdfHash },
   );
   // #591: run rule-based classification on newly inserted txs, then enqueue AI for the rest.
-  if (result.status === "committed" && result.insertedTxIds.length > 0) {
+  if (result.status === "committed" && result.insertedTxIds && result.insertedTxIds.length > 0) {
     await classifyByRuleThenEnqueue(userId, result.insertedTxIds);
   }
   return _mapArqRunResult(result, preview.period);
@@ -984,12 +984,12 @@ async function _commitTcDetallado(
       dryRun: false,
     });
 
-    allInsertedTxIds.push(...r.insertedTxIds);
+    allInsertedTxIds.push(...(r.insertedTxIds ?? []));
 
     sheets.push({
       accountId: targetAccountId,
       accountLabel: formatAccountLabel(targetAccount),
-      inserted: r.insertedTxIds.length,
+      inserted: (r.insertedTxIds?.length ?? 0),
       matched: r.matchStats.matched,
     });
   }
@@ -1222,7 +1222,7 @@ export async function commitArqStatement(previewToken: string): Promise<ImportCo
       { userId, accountId: entry.accountId!, pdfBuffer, pdfHash },
     );
     // #591: run rule-based classification on newly inserted txs, then enqueue AI for the rest.
-    if (result.status === "committed" && result.insertedTxIds.length > 0) {
+    if (result.status === "committed" && result.insertedTxIds && result.insertedTxIds.length > 0) {
       await classifyByRuleThenEnqueue(userId, result.insertedTxIds);
     }
     return _mapCommitResult(result, preview.period);
@@ -1242,7 +1242,7 @@ export async function commitArqStatement(previewToken: string): Promise<ImportCo
     { userId, accountId: entry.accountId, pdfBuffer: entry.pdfBuffer, pdfHash: entry.pdfHash },
   );
   // #591: run rule-based classification on newly inserted txs, then enqueue AI for the rest.
-  if (result.status === "committed" && result.insertedTxIds.length > 0) {
+  if (result.status === "committed" && result.insertedTxIds && result.insertedTxIds.length > 0) {
     await classifyByRuleThenEnqueue(userId, result.insertedTxIds);
   }
 

--- a/src/app/(app)/imports/actions.ts
+++ b/src/app/(app)/imports/actions.ts
@@ -989,7 +989,7 @@ async function _commitTcDetallado(
     sheets.push({
       accountId: targetAccountId,
       accountLabel: formatAccountLabel(targetAccount),
-      inserted: (r.insertedTxIds?.length ?? 0),
+      inserted: r.insertedTxIds?.length ?? 0,
       matched: r.matchStats.matched,
     });
   }

--- a/src/app/(app)/imports/actions.ts
+++ b/src/app/(app)/imports/actions.ts
@@ -38,6 +38,7 @@ import { buildChainCheck, reconcileStatement } from "@/lib/ingestion/arq-stateme
 import { parseArqStatementPdf } from "@/lib/ingestion/arq-statement/pdf-adapter";
 import { parseStatementTransactions } from "@/lib/ingestion/arq-statement/type-handlers";
 import { runStatementImport } from "@/lib/ingestion/arq-statement/run-statement-import";
+import { classifyByRuleThenEnqueue } from "@/lib/classification/enqueue";
 import {
   parseAndHint,
   resolveAccountHint,
@@ -783,6 +784,10 @@ async function _commitArqV1(entry: CacheEntryV1, userId: number): Promise<Unifie
     { parsePdf: parseArqStatementPdf },
     { userId, accountId: entry.accountId, pdfBuffer: entry.pdfBuffer, pdfHash: entry.pdfHash },
   );
+  // #591: run rule-based classification on newly inserted txs, then enqueue AI for the rest.
+  if (result.status === "committed" && result.insertedTxIds.length > 0) {
+    await classifyByRuleThenEnqueue(userId, result.insertedTxIds);
+  }
   return _mapArqRunResult(result, entry.preview.period);
 }
 
@@ -797,6 +802,10 @@ async function _commitArqV2(
     { parsePdf: parseArqStatementPdf },
     { userId, accountId, pdfBuffer, pdfHash },
   );
+  // #591: run rule-based classification on newly inserted txs, then enqueue AI for the rest.
+  if (result.status === "committed" && result.insertedTxIds.length > 0) {
+    await classifyByRuleThenEnqueue(userId, result.insertedTxIds);
+  }
   return _mapArqRunResult(result, preview.period);
 }
 
@@ -886,6 +895,11 @@ async function _commitBancolombia(
   revalidatePath(`/settings/accounts/${accountId}/reconcile`);
   if (siblingAccountId) revalidatePath(`/settings/accounts/${siblingAccountId}/reconcile`);
 
+  // #591: run rule-based classification on newly inserted txs, then enqueue AI for the rest.
+  if (result.status === "applied" && result.insertedIds.length > 0) {
+    await classifyByRuleThenEnqueue(userId, result.insertedIds);
+  }
+
   return {
     kind,
     status: result.status === "applied" ? "committed" : "already_imported",
@@ -936,6 +950,9 @@ async function _commitTcDetallado(
     matched: number;
   }> = [];
 
+  // #591: collect all inserted txIds across sheets for classification.
+  const allInsertedTxIds: number[] = [];
+
   for (const sheet of parsedSheets) {
     const sheetCurrency = sheet.account.currency as "COP" | "USD";
     const targetAccountId =
@@ -967,6 +984,8 @@ async function _commitTcDetallado(
       dryRun: false,
     });
 
+    allInsertedTxIds.push(...r.insertedTxIds);
+
     sheets.push({
       accountId: targetAccountId,
       accountLabel: formatAccountLabel(targetAccount),
@@ -980,6 +999,11 @@ async function _commitTcDetallado(
   revalidatePath(`/settings/accounts/${accountId}/consolidate/${cycle}`);
   if (siblingAccountId)
     revalidatePath(`/settings/accounts/${siblingAccountId}/consolidate/${cycle}`);
+
+  // #591: run rule-based classification on newly inserted txs, then enqueue AI for the rest.
+  if (allInsertedTxIds.length > 0) {
+    await classifyByRuleThenEnqueue(userId, allInsertedTxIds);
+  }
 
   log.info(
     {
@@ -1197,6 +1221,10 @@ export async function commitArqStatement(previewToken: string): Promise<ImportCo
       { parsePdf: parseArqStatementPdf },
       { userId, accountId: entry.accountId!, pdfBuffer, pdfHash },
     );
+    // #591: run rule-based classification on newly inserted txs, then enqueue AI for the rest.
+    if (result.status === "committed" && result.insertedTxIds.length > 0) {
+      await classifyByRuleThenEnqueue(userId, result.insertedTxIds);
+    }
     return _mapCommitResult(result, preview.period);
   }
 
@@ -1213,6 +1241,10 @@ export async function commitArqStatement(previewToken: string): Promise<ImportCo
     { parsePdf: parseArqStatementPdf },
     { userId, accountId: entry.accountId, pdfBuffer: entry.pdfBuffer, pdfHash: entry.pdfHash },
   );
+  // #591: run rule-based classification on newly inserted txs, then enqueue AI for the rest.
+  if (result.status === "committed" && result.insertedTxIds.length > 0) {
+    await classifyByRuleThenEnqueue(userId, result.insertedTxIds);
+  }
 
   return _mapCommitResult(result, entry.preview.period);
 }

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
@@ -17,6 +17,7 @@ import { matchStatement } from "@/lib/reconciliation/engine/match";
 import type { ExistingTxnForMatch, MatchingPlan } from "@/lib/reconciliation/engine/types";
 import type { ParsedStatement } from "@/lib/reconciliation/parsers/types";
 import { applyPagoTcRouting } from "@/lib/reconciliation/pago-tc-router";
+import { classifyByRuleThenEnqueue } from "@/lib/classification/enqueue";
 import { createLogger } from "@/lib/logger";
 import { expandReconcileWindow } from "./window";
 
@@ -381,6 +382,14 @@ export async function applyReconcile(input: ApplyReconcileInput) {
     },
     "reconciliation applied",
   );
+
+  // #591 — classify newly-inserted reconciliation rows. Mirrors the flow
+  // used by /imports commit functions: rules engine first (in-place update),
+  // remainder enqueued for AI classification. classifyByRuleThenEnqueue
+  // swallows enqueue failures so a Redis hiccup never breaks reconcile.
+  if (result.status === "applied" && result.insertedIds.length > 0) {
+    await classifyByRuleThenEnqueue(session.id, result.insertedIds);
+  }
 
   // #567 — after committing a savings extract, run Pago TC twin routing.
   // Savings descriptions carry DOLAR/PESOS distinction that gmail/SMS lack,

--- a/src/lib/classification/enqueue.test.ts
+++ b/src/lib/classification/enqueue.test.ts
@@ -49,6 +49,7 @@ vi.mock("@/lib/db/schema", () => ({
 }));
 
 vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...preds) => ({ and: preds })),
   eq: vi.fn((_col, val) => ({ eq: val })),
   inArray: vi.fn((_col, vals) => ({ inArray: vals })),
 }));

--- a/src/lib/classification/enqueue.test.ts
+++ b/src/lib/classification/enqueue.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock hoisting — factories must be inside vi.mock() callbacks;
+// shared state is threaded through vi.hoisted().
+// ---------------------------------------------------------------------------
+
+const { mockQueueAdd, mockSelectWhere, mockUpdateWhere, mockClassifyByRule } = vi.hoisted(() => ({
+  mockQueueAdd: vi.fn(),
+  mockSelectWhere: vi.fn(),
+  mockUpdateWhere: vi.fn(),
+  mockClassifyByRule: vi.fn(),
+}));
+
+vi.mock("@/lib/queue", () => ({
+  createQueue: vi.fn(() => ({ add: mockQueueAdd })),
+}));
+
+vi.mock("@/lib/classification/rules", () => ({
+  classifyByRule: mockClassifyByRule,
+}));
+
+// Minimal db mock with overrideable where resolvers.
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: mockSelectWhere,
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: mockUpdateWhere,
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  transactions: {
+    id: "id",
+    descriptionRaw: "descriptionRaw",
+    merchant: "merchant",
+    categorySlug: "categorySlug",
+    classificationMethod: "classificationMethod",
+    classificationConfidence: "classificationConfidence",
+    updatedAt: "updatedAt",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((_col, val) => ({ eq: val })),
+  inArray: vi.fn((_col, vals) => ({ inArray: vals })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+import { enqueueClassification, classifyByRuleThenEnqueue } from "./enqueue";
+
+// ---------------------------------------------------------------------------
+// enqueueClassification
+// ---------------------------------------------------------------------------
+
+describe("enqueueClassification", () => {
+  beforeEach(() => {
+    mockQueueAdd.mockReset();
+  });
+
+  it("does nothing when txIds is empty", async () => {
+    await enqueueClassification(1, []);
+    expect(mockQueueAdd).not.toHaveBeenCalled();
+  });
+
+  it("calls queue.add with correct payload on happy path", async () => {
+    mockQueueAdd.mockResolvedValueOnce({ id: "job-1" });
+    await enqueueClassification(42, [101, 102, 103]);
+    expect(mockQueueAdd).toHaveBeenCalledOnce();
+    expect(mockQueueAdd).toHaveBeenCalledWith("classify-tx", {
+      userId: 42,
+      mode: "specific",
+      txIds: [101, 102, 103],
+    });
+  });
+
+  it("swallows queue.add errors — does NOT rethrow", async () => {
+    mockQueueAdd.mockRejectedValueOnce(new Error("Redis down"));
+    // Should resolve without throwing.
+    await expect(enqueueClassification(1, [1])).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyByRuleThenEnqueue
+// ---------------------------------------------------------------------------
+
+describe("classifyByRuleThenEnqueue", () => {
+  beforeEach(() => {
+    mockQueueAdd.mockReset();
+    mockQueueAdd.mockResolvedValue({ id: "job-1" });
+    mockClassifyByRule.mockReset();
+    mockSelectWhere.mockReset();
+    mockUpdateWhere.mockReset();
+    mockUpdateWhere.mockResolvedValue([]);
+  });
+
+  it("does nothing when txIds is empty", async () => {
+    await classifyByRuleThenEnqueue(1, []);
+    expect(mockClassifyByRule).not.toHaveBeenCalled();
+    expect(mockQueueAdd).not.toHaveBeenCalled();
+  });
+
+  it("enqueues only txIds that did not match a rule", async () => {
+    // tx 10 matches a rule, tx 11 does not.
+    mockSelectWhere.mockResolvedValueOnce([
+      { id: 10, descriptionRaw: "RAPPI", merchant: "Rappi" },
+      { id: 11, descriptionRaw: "RANDOM STORE", merchant: null },
+    ]);
+
+    mockClassifyByRule
+      .mockResolvedValueOnce({ categorySlug: "comida", ruleId: 5, confidence: 100 }) // tx 10
+      .mockResolvedValueOnce(null); // tx 11
+
+    await classifyByRuleThenEnqueue(42, [10, 11]);
+
+    // Rule engine ran for both.
+    expect(mockClassifyByRule).toHaveBeenCalledTimes(2);
+    // Only tx 11 (unclassified) goes to the queue.
+    expect(mockQueueAdd).toHaveBeenCalledWith("classify-tx", {
+      userId: 42,
+      mode: "specific",
+      txIds: [11],
+    });
+  });
+
+  it("enqueues nothing when all txIds match a rule", async () => {
+    mockSelectWhere.mockResolvedValueOnce([
+      { id: 20, descriptionRaw: "SPOTIFY", merchant: "Spotify" },
+    ]);
+
+    mockClassifyByRule.mockResolvedValueOnce({
+      categorySlug: "entretenimiento",
+      ruleId: 3,
+      confidence: 100,
+    });
+
+    await classifyByRuleThenEnqueue(1, [20]);
+
+    expect(mockQueueAdd).not.toHaveBeenCalled();
+  });
+
+  it("enqueues all txIds when no rule matches", async () => {
+    mockSelectWhere.mockResolvedValueOnce([
+      { id: 30, descriptionRaw: "UNKNOWN A", merchant: null },
+      { id: 31, descriptionRaw: "UNKNOWN B", merchant: null },
+    ]);
+
+    mockClassifyByRule.mockResolvedValue(null);
+
+    await classifyByRuleThenEnqueue(5, [30, 31]);
+
+    expect(mockQueueAdd).toHaveBeenCalledWith("classify-tx", {
+      userId: 5,
+      mode: "specific",
+      txIds: [30, 31],
+    });
+  });
+});

--- a/src/lib/classification/enqueue.ts
+++ b/src/lib/classification/enqueue.ts
@@ -1,4 +1,4 @@
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { transactions } from "@/lib/db/schema";
 import { classifyByRule } from "@/lib/classification/rules";
@@ -15,9 +15,11 @@ const log = createLogger({ module: "classify-enqueue" });
  * Used by import paths (Excel/PDF) that insert txs WITHOUT calling
  * classifyByRule first (unlike the SMS pipeline which runs rules inline).
  *
- * Tenant safety: all queries filter on userId. txIds must belong to userId —
- * callers are responsible for this invariant (verified by the insert that
- * produced them).
+ * Tenant safety: every SELECT and UPDATE filters by `userId AND id IN (txIds)`.
+ * If a caller ever passes a txIds list that contains another user's row id,
+ * the WHERE clause silently drops it — no cross-tenant read or write possible.
+ * Per memory `per-user-table-join-tenant-safety.md` (#336/#338): trust no
+ * caller-provided invariant; enforce at the DB layer.
  */
 export async function classifyByRuleThenEnqueue(
   userId: number,
@@ -33,7 +35,12 @@ export async function classifyByRuleThenEnqueue(
       merchant: transactions.merchant,
     })
     .from(transactions)
-    .where(inArray(transactions.id, txIds));
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        inArray(transactions.id, txIds),
+      ),
+    );
 
   const unclassifiedIds: number[] = [];
 
@@ -44,7 +51,9 @@ export async function classifyByRuleThenEnqueue(
     });
 
     if (match) {
-      // Rule matched — update the tx in place.
+      // Rule matched — update the tx in place. userId guard re-asserted
+      // here even though the SELECT above already enforced it; defense-in-
+      // depth against a caller manually splicing rows[] across users.
       await db
         .update(transactions)
         .set({
@@ -53,7 +62,12 @@ export async function classifyByRuleThenEnqueue(
           classificationConfidence: match.confidence,
           updatedAt: new Date(),
         })
-        .where(eq(transactions.id, row.id));
+        .where(
+          and(
+            eq(transactions.userId, userId),
+            eq(transactions.id, row.id),
+          ),
+        );
       log.info(
         {
           event: "rule_matched_on_import",

--- a/src/lib/classification/enqueue.ts
+++ b/src/lib/classification/enqueue.ts
@@ -21,10 +21,7 @@ const log = createLogger({ module: "classify-enqueue" });
  * Per memory `per-user-table-join-tenant-safety.md` (#336/#338): trust no
  * caller-provided invariant; enforce at the DB layer.
  */
-export async function classifyByRuleThenEnqueue(
-  userId: number,
-  txIds: number[],
-): Promise<void> {
+export async function classifyByRuleThenEnqueue(userId: number, txIds: number[]): Promise<void> {
   if (txIds.length === 0) return;
 
   // Fetch the minimal fields needed for rule matching in a single query.
@@ -35,12 +32,7 @@ export async function classifyByRuleThenEnqueue(
       merchant: transactions.merchant,
     })
     .from(transactions)
-    .where(
-      and(
-        eq(transactions.userId, userId),
-        inArray(transactions.id, txIds),
-      ),
-    );
+    .where(and(eq(transactions.userId, userId), inArray(transactions.id, txIds)));
 
   const unclassifiedIds: number[] = [];
 
@@ -62,12 +54,7 @@ export async function classifyByRuleThenEnqueue(
           classificationConfidence: match.confidence,
           updatedAt: new Date(),
         })
-        .where(
-          and(
-            eq(transactions.userId, userId),
-            eq(transactions.id, row.id),
-          ),
-        );
+        .where(and(eq(transactions.userId, userId), eq(transactions.id, row.id)));
       log.info(
         {
           event: "rule_matched_on_import",
@@ -98,19 +85,13 @@ export async function classifyByRuleThenEnqueue(
  * "unclassified" state and can be retried via the "Classify All Pending"
  * button (#592). Import correctness MUST NOT depend on Redis being up.
  */
-export async function enqueueClassification(
-  userId: number,
-  txIds: number[],
-): Promise<void> {
+export async function enqueueClassification(userId: number, txIds: number[]): Promise<void> {
   if (txIds.length === 0) return;
 
   try {
     const queue = createQueue<ClassifyTxJobData>("classify-tx");
     await queue.add("classify-tx", { userId, mode: "specific", txIds });
-    log.info(
-      { event: "classify_enqueued", userId, count: txIds.length },
-      "classify-tx enqueued",
-    );
+    log.info({ event: "classify_enqueued", userId, count: txIds.length }, "classify-tx enqueued");
   } catch (err) {
     log.error(
       { err, event: "classify_enqueue_failed", userId, count: txIds.length },

--- a/src/lib/classification/enqueue.ts
+++ b/src/lib/classification/enqueue.ts
@@ -1,0 +1,107 @@
+import { eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { transactions } from "@/lib/db/schema";
+import { classifyByRule } from "@/lib/classification/rules";
+import { createQueue } from "@/lib/queue";
+import type { ClassifyTxJobData } from "@/lib/queue/workers/classify-tx";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "classify-enqueue" });
+
+/**
+ * Run classifyByRule on a set of freshly-inserted transaction IDs, persist
+ * the rule match when found, then enqueue AI classification for the remainder.
+ *
+ * Used by import paths (Excel/PDF) that insert txs WITHOUT calling
+ * classifyByRule first (unlike the SMS pipeline which runs rules inline).
+ *
+ * Tenant safety: all queries filter on userId. txIds must belong to userId —
+ * callers are responsible for this invariant (verified by the insert that
+ * produced them).
+ */
+export async function classifyByRuleThenEnqueue(
+  userId: number,
+  txIds: number[],
+): Promise<void> {
+  if (txIds.length === 0) return;
+
+  // Fetch the minimal fields needed for rule matching in a single query.
+  const rows = await db
+    .select({
+      id: transactions.id,
+      descriptionRaw: transactions.descriptionRaw,
+      merchant: transactions.merchant,
+    })
+    .from(transactions)
+    .where(inArray(transactions.id, txIds));
+
+  const unclassifiedIds: number[] = [];
+
+  for (const row of rows) {
+    const match = await classifyByRule(userId, {
+      descriptionRaw: row.descriptionRaw,
+      merchant: row.merchant,
+    });
+
+    if (match) {
+      // Rule matched — update the tx in place.
+      await db
+        .update(transactions)
+        .set({
+          categorySlug: match.categorySlug,
+          classificationMethod: "rule",
+          classificationConfidence: match.confidence,
+          updatedAt: new Date(),
+        })
+        .where(eq(transactions.id, row.id));
+      log.info(
+        {
+          event: "rule_matched_on_import",
+          userId,
+          txId: row.id,
+          categorySlug: match.categorySlug,
+          ruleId: match.ruleId,
+        },
+        "rule matched on import — tx classified inline",
+      );
+    } else {
+      unclassifiedIds.push(row.id);
+    }
+  }
+
+  await enqueueClassification(userId, unclassifiedIds);
+}
+
+/**
+ * Fire-and-forget: enqueue a classify-tx job for the given userId + txIds.
+ *
+ * Rules-based classification must have already run for these txs — this
+ * helper enqueues only what the rule engine could NOT classify, so the AI
+ * worker handles the remainder.
+ *
+ * Failure mode: if queue.add throws (Redis down, network blip) we log the
+ * error and swallow it. The import already succeeded; the txs remain in
+ * "unclassified" state and can be retried via the "Classify All Pending"
+ * button (#592). Import correctness MUST NOT depend on Redis being up.
+ */
+export async function enqueueClassification(
+  userId: number,
+  txIds: number[],
+): Promise<void> {
+  if (txIds.length === 0) return;
+
+  try {
+    const queue = createQueue<ClassifyTxJobData>("classify-tx");
+    await queue.add("classify-tx", { userId, mode: "specific", txIds });
+    log.info(
+      { event: "classify_enqueued", userId, count: txIds.length },
+      "classify-tx enqueued",
+    );
+  } catch (err) {
+    log.error(
+      { err, event: "classify_enqueue_failed", userId, count: txIds.length },
+      "failed to enqueue classify-tx — txs remain pending (graceful degrade)",
+    );
+    // Intentionally NOT re-throwing. Import success must not depend on Redis.
+  }
+}

--- a/src/lib/ingestion/arq-statement/reconciler.ts
+++ b/src/lib/ingestion/arq-statement/reconciler.ts
@@ -116,6 +116,8 @@ export type ReconcileDecision =
 
 export interface ReconcileResult {
   insertedCount: number;
+  /** IDs of the transaction rows newly inserted by this reconcile run. */
+  insertedIds: number[];
   mergedCount: number;
   /** source_mismatch=true count (diverged merges + email orphans). */
   flaggedCount: number;
@@ -898,5 +900,9 @@ export async function reconcileEmailVsStatement(
     "ARQ statement reconciler complete",
   );
 
-  return { insertedCount, mergedCount, flaggedCount, emailOrphanCount, details };
+  const insertedIds = details
+    .filter((d): d is typeof d & { kind: "insert"; newTxId: number } => d.kind === "insert")
+    .map((d) => d.newTxId);
+
+  return { insertedCount, insertedIds, mergedCount, flaggedCount, emailOrphanCount, details };
 }

--- a/src/lib/ingestion/arq-statement/run-statement-import.ts
+++ b/src/lib/ingestion/arq-statement/run-statement-import.ts
@@ -54,6 +54,8 @@ export type RunStatementImportResult =
       preview: StatementImportPreview;
       /** Tx rows newly inserted (statement-only events with no email counterpart). */
       insertedTxCount: number;
+      /** IDs of the newly inserted transaction rows (parallel to insertedTxCount). */
+      insertedTxIds: number[];
       /** Existing gmail_arq rows updated with statement metadata. */
       mergedTxCount: number;
       /** Rows flagged source_mismatch (diverged merges + email orphans). */
@@ -363,6 +365,7 @@ export async function runStatementImport(
     importId,
     preview,
     insertedTxCount: reconcilerResult.insertedCount,
+    insertedTxIds: reconcilerResult.insertedIds,
     mergedTxCount: reconcilerResult.mergedCount,
     flaggedTxCount: reconcilerResult.flaggedCount,
     emailOrphanCount: reconcilerResult.emailOrphanCount,

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -22,6 +22,7 @@ import {
   type AiFallbackOutcome,
 } from "@/lib/ingestion/sms-ai-fallback";
 import { keyForParsed } from "@/lib/counterparties/alias-key";
+import { enqueueClassification } from "@/lib/classification/enqueue";
 import type { ClassificationMethod, TransactionSource } from "@/lib/types";
 
 // Colombia uses UTC-5 year-round (no DST). Time in SMS is local.
@@ -298,6 +299,13 @@ async function ingestParsedBancolombia(
           rawData: { kind: parsed.kind, ...cfg.rawDataExtras },
         },
       );
+    }
+    // #591: AI classification only for txs that the rule engine could not
+    // classify. Transfers and rule-matched txs are already handled; only
+    // "unclassified" goes to the queue. Failure to enqueue must not abort
+    // the import — see enqueueClassification for the graceful-degrade policy.
+    if (finalMethod === "unclassified") {
+      await enqueueClassification(userId, [txId]);
     }
     return { status: "inserted", txId };
   } catch (err) {

--- a/src/lib/reconciliation/commit.ts
+++ b/src/lib/reconciliation/commit.ts
@@ -12,6 +12,8 @@ export interface CommitResult {
   status: CommitStatus;
   statementImportId: number;
   inserted: number;
+  /** IDs of the newly inserted transaction rows (parallel to `inserted` count). */
+  insertedIds: number[];
   matched: number;
   flagged: number;
 }
@@ -112,6 +114,7 @@ export async function commitReconciliation(input: CommitInput): Promise<CommitRe
         status: "already_imported" as const,
         statementImportId: existingImport[0].id,
         inserted: 0,
+        insertedIds: [],
         matched: 0,
         flagged: 0,
       };
@@ -153,6 +156,7 @@ export async function commitReconciliation(input: CommitInput): Promise<CommitRe
 
     let matched = 0;
     let inserted = 0;
+    const insertedIds: number[] = [];
     const txnCountByImport = new Map<number, number>();
 
     for (const decision of input.plan.decisions) {
@@ -175,21 +179,25 @@ export async function commitReconciliation(input: CommitInput): Promise<CommitRe
           );
         matched++;
       } else {
-        await tx.insert(transactions).values({
-          userId: input.userId,
-          accountId: target.id,
-          occurredAt: parsedRow.occurredAt,
-          amountCents: signedAmount(parsedRow),
-          currency: parsedRow.currency,
-          descriptionRaw: parsedRow.descriptionRaw,
-          source: "csv_reconcile",
-          channel: "bank",
-          reconciliationStatus: "imported_from_statement",
-          reconciledAt: new Date(),
-          statementImportId: importId,
-          rawData: parsedRow.rawData,
-        });
+        const [newTx] = await tx
+          .insert(transactions)
+          .values({
+            userId: input.userId,
+            accountId: target.id,
+            occurredAt: parsedRow.occurredAt,
+            amountCents: signedAmount(parsedRow),
+            currency: parsedRow.currency,
+            descriptionRaw: parsedRow.descriptionRaw,
+            source: "csv_reconcile",
+            channel: "bank",
+            reconciliationStatus: "imported_from_statement",
+            reconciledAt: new Date(),
+            statementImportId: importId,
+            rawData: parsedRow.rawData,
+          })
+          .returning({ id: transactions.id });
         inserted++;
+        if (newTx) insertedIds.push(newTx.id);
       }
       txnCountByImport.set(importId, (txnCountByImport.get(importId) ?? 0) + 1);
     }
@@ -219,6 +227,7 @@ export async function commitReconciliation(input: CommitInput): Promise<CommitRe
       status: "applied" as const,
       statementImportId: importIdByCurrency[input.account.currency]!,
       inserted,
+      insertedIds,
       matched,
       flagged: input.plan.flaggedExisting.length,
     };

--- a/src/lib/telegram/confirm.ts
+++ b/src/lib/telegram/confirm.ts
@@ -7,6 +7,7 @@ import {
   type TelegramDraft,
 } from "@/lib/db/schema";
 import { classifyByRule } from "@/lib/classification/rules";
+import { enqueueClassification } from "@/lib/classification/enqueue";
 import { emit } from "@/lib/events/bus";
 import { insertTransferGroup } from "@/lib/transactions/transfer-groups";
 
@@ -152,6 +153,12 @@ export async function insertFromDraft(opts: {
     startedAt,
     finishedAt: new Date(),
   });
+
+  // #591: enqueue AI classification for txs the rule engine could not classify.
+  // Transfers skip classification entirely (channel=transfer, no spend/income).
+  if (outcome.status === "inserted" && classificationMethod === "unclassified") {
+    await enqueueClassification(userId, [outcome.txId]);
+  }
 
   return outcome;
 }


### PR DESCRIPTION
Closes #591.
Part of #586.

## Summary

Wires the classify-tx BullMQ job (from #590) into 5 ingestion entry points so freshly-imported transactions are classified automatically — no more manual button clicks for imports. The 506+ pending backlog still requires the "Classify All Pending" button (#592), but new imports will never accumulate again.

## Ingestion paths covered

| Source | Behavior |
|---|---|
| SMS pipeline | `ingestParsedBancolombia` runs `classifyByRule` inline, then enqueues unmatched txs |
| Email/Gmail | Delegates to SMS pipeline via `ingestBancolombiaTransaction` — covered automatically |
| Excel/PDF imports (5 commit functions: ARQ v1/v2, Bancolombia, TC Detallado, gen-1 compat) | New `classifyByRuleThenEnqueue` helper runs rules per inserted tx, then enqueues remainder |
| Telegram bot | `insertFromDraft` already called `classifyByRule` inline; added enqueue hook |
| Legacy `/settings/accounts/[id]/reconcile` | After-fix: also wired (was missed by initial implementation) |

## Failure mode

If `queue.add` throws (Redis down, network blip), the helper logs and SWALLOWS the error. Imports never break. Affected txs degrade to current behavior — stay pending, retryable via "Classify All Pending" button.

## Reviewer pass

Reviewed by `findash-reviewer`: 1 CRITICAL, 1 WARNING, 1 SUGGESTION. All addressed in fix-up commits:

- **CRITICAL**: SELECT and UPDATE in `classifyByRuleThenEnqueue` now AND on `user_id` in addition to `id IN (txIds)` — defense-in-depth tenant safety per memory `per-user-table-join-tenant-safety.md`
- **WARNING**: legacy reconcile path (`applyReconcile` in `settings/accounts/[id]/reconcile/actions.ts`) wired to `classifyByRuleThenEnqueue`
- **SUGGESTION**: deferred — N+1 update loop is fine for current import volumes
- **Bonus**: 5 callsites in `imports/actions.ts` got a TS-narrow guard for `result.insertedTxIds` — the expired-token bail path returns the field as undefined, runtime threw on the original `.length` access

## Test plan

- [x] Local lint clean
- [x] Local typecheck clean
- [x] Local tests: 1819/1819 pass
- [ ] CI: lint + typecheck + test + build green
- [ ] CI: CodeQL clean