### PR TITLE
fix(infra): provision Redis on every deploy (#603)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,43 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
 
+      - name: Provision Redis (idempotent)
+        # Every BullMQ worker registered at boot (fx-refresh, classify-tx,
+        # gmail-pull, etc — see src/instrumentation.node.ts) needs Redis up
+        # before findash.service starts. This step ensures the droplet has
+        # redis-server installed and our hardened unit at /etc/systemd/system/
+        # redis.service. Idempotent: a healthy droplet hits the no-op path.
+        run: |
+          set -eu
+          scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new \
+            infra/systemd/redis.service "$DEPLOY_USER@$DEPLOY_HOST:/tmp/redis-findash.service"
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" '
+            set -eu
+            # Install redis-server package only if missing.
+            if ! command -v redis-server >/dev/null 2>&1; then
+              echo "installing redis-server..."
+              sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -qq
+              sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -qq redis-server
+            fi
+            # Disable the Ubuntu default unit if it ever became enabled.
+            sudo -n systemctl disable --now redis-server.service 2>/dev/null || true
+            # Replace our unit only if the on-disk copy differs from the repo.
+            # Avoids gratuitous redis restarts on every deploy.
+            if ! sudo -n diff -q /tmp/redis-findash.service /etc/systemd/system/redis.service >/dev/null 2>&1; then
+              echo "redis unit changed — installing"
+              sudo -n mv /tmp/redis-findash.service /etc/systemd/system/redis.service
+              sudo -n systemctl daemon-reload
+              sudo -n systemctl enable redis.service
+              sudo -n systemctl restart redis.service
+            else
+              rm -f /tmp/redis-findash.service
+            fi
+            # Ensure active (covers fresh-install case + crash recovery).
+            sudo -n systemctl is-active --quiet redis.service || sudo -n systemctl start redis.service
+            # Verify reachable.
+            redis-cli ping
+          '
+
       - name: Upload tarball
         env:
           GIT_SHA: ${{ steps.sha.outputs.sha }}


### PR DESCRIPTION
Closes #603.

## Summary

Adds a **Provision Redis** step to `deploy.yml` that runs between Setup SSH and Upload tarball. The step is idempotent — a droplet with Redis already correctly installed hits the no-op path.

## Why now

Epic #586 (Queue Infra) added BullMQ workers that all need Redis at boot. The repo had `infra/systemd/redis.service` but the deploy never copied it to the droplet — every deploy from #589 onward failed health probe until manual `apt-get install redis-server` + systemd unit copy was run on prod (already done; prod is healthy on `01c9634`).

This PR makes the provisioning automatic so:
- A fresh droplet works out of the box
- Future Redis unit edits in the repo land on prod via the next deploy

## How the step is idempotent

| Action | Idempotency mechanism |
|---|---|
| `apt-get install redis-server` | Skip if `command -v redis-server` succeeds |
| Disable `redis-server.service` (Ubuntu default) | `\|\| true` so a no-op disable doesn't fail the step |
| Copy unit file | `diff -q` first; `mv` + `daemon-reload` + `restart` only on change |
| Ensure active | `is-active --quiet \|\| start` — only acts when not already running |

The `redis-cli ping` at the end is the verification gate — fails the deploy fast if anything's wrong.

## Test plan

- [x] Manually verified equivalent commands work on prod (already applied)
- [ ] CI green
- [ ] Next deploy run uses the new step and passes