### PR TITLE
fix(infra): drop DEBIAN_FRONTEND from apt-get in deploy.yml (#605)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,11 +141,15 @@ jobs:
             infra/systemd/redis.service "$DEPLOY_USER@$DEPLOY_HOST:/tmp/redis-findash.service"
           ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" '
             set -eu
-            # Install redis-server package only if missing.
+            # Install redis-server package only if missing. -y -qq is enough
+            # for the no-interaction case (no debconf prompts on this package);
+            # passing DEBIAN_FRONTEND through sudo would require an env_keep
+            # entry the deploy user does not have, and would fail on a fresh
+            # droplet (#605).
             if ! command -v redis-server >/dev/null 2>&1; then
               echo "installing redis-server..."
-              sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -qq
-              sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -qq redis-server
+              sudo -n apt-get update -qq
+              sudo -n apt-get install -y -qq redis-server
             fi
             # Disable the Ubuntu default unit if it ever became enabled.
             sudo -n systemctl disable --now redis-server.service 2>/dev/null || true


### PR DESCRIPTION
Closes #605.

Dormant bug from #604 — sudo rejects DEBIAN_FRONTEND env var on the command line because it's not in the deploy user's env_keep. Currently masked because redis-server is already installed on prod (manually via #603 remediation), so the apt-get branch never executes. Would surface on a fresh droplet rebuild.

Fix: drop DEBIAN_FRONTEND entirely. `apt-get install -y -qq redis-server` doesn't need it — no debconf prompts on this package.

## Test plan
- [x] Local diff is just 2 lines (+ a comment)
- [ ] CI green
- [ ] Next deploy passes (will skip apt path on existing droplet, idempotent)