### PR TITLE
fix(infra): outputFileTracingIncludes for ejs in standalone (#607)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,16 @@ const nextConfig: NextConfig = {
   // rsync + run via `bun server.js` — no node_modules install on the droplet.
   output: "standalone",
   allowedDevOrigins: ["ia-server.tailcabcc8.ts.net"],
+  // Bull-Board's @bull-board/express adapter renders the dashboard via
+  // Express's res.render('index'), which lazy-requires ejs at request time.
+  // Turbopack's standalone tracer does NOT follow runtime require() calls,
+  // so ejs would otherwise be missing from prod's node_modules and every hit
+  // on /api/admin/queues throws 500 (#607). Glob keys are interpreted as
+  // patterns — `[[...slug]]` would parse as a character class, so we use
+  // the global `/*` key. ejs is ~50KB, overhead trivial.
+  outputFileTracingIncludes: {
+    "/*": ["./node_modules/ejs/**/*"],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Closes #607.

Follow-up to PR #608: `bun add ejs` was necessary but not sufficient. Next.js standalone tracer only copies deps it follows via static `import` chains. Adding `outputFileTracingIncludes` forces ejs into the standalone `node_modules/` so Express's runtime `require('ejs')` succeeds.

## Test plan
- [x] Verified locally: `.next/standalone/node_modules/ejs/package.json` present after build
- [ ] CI green
- [ ] Deploy + smoke: hit /api/admin/queues as admin, get HTML (not 500)