### PR TITLE
fix(infra): resolve bull-board UI dist via process.cwd() (#607)

### DIFF
--- a/src/lib/queue/bull-board.ts
+++ b/src/lib/queue/bull-board.ts
@@ -57,11 +57,16 @@ export function getBullBoardApp(): ReturnType<typeof express> {
     },
   });
 
-  // Resolve via package.json (a known JS-loadable file) instead of the .ejs
-  // template — Turbopack statically traces require.resolve() arguments and
-  // chokes on .ejs at build time. The dist folder lives next to package.json.
-  const uiPkgJson = require.resolve("@bull-board/ui/package.json");
-  const uiDistPath = path.join(path.dirname(uiPkgJson), "dist");
+  // Resolve the UI dist via process.cwd() — NOT require.resolve.
+  //
+  // Turbopack rewrites require.resolve() at build time to use its own module
+  // map. The map handles JS modules but does NOT expose package.json (or any
+  // non-bundled file) at runtime, so `require.resolve("@bull-board/ui/...")`
+  // throws ResolveMessage at runtime. We tried .ejs (build-time fail), then
+  // package.json (runtime fail). process.cwd() is stable: findash starts from
+  // the release dir where node_modules lives (in dev `bun run dev` runs from
+  // the project root). See memory `nextjs16/bull-board-turbopack`.
+  const uiDistPath = path.resolve(process.cwd(), "node_modules/@bull-board/ui/dist");
   serverAdapter.setViewsPath(uiDistPath);
   serverAdapter.setStaticPath("/static", path.join(uiDistPath, "static"));
 


### PR DESCRIPTION
Third attempt on the same root cause — Turbopack does NOT preserve `require.resolve()` semantics at runtime.

## What changes

```diff
- const uiPkgJson = require.resolve('@bull-board/ui/package.json');
- const uiDistPath = path.join(path.dirname(uiPkgJson), 'dist');
+ const uiDistPath = path.resolve(process.cwd(), 'node_modules/@bull-board/ui/dist');
```

## Why earlier attempts failed

- Original `require.resolve('@bull-board/ui/dist/index.ejs')` — Turbopack chokes at BUILD time on `.ejs` (unknown module type)
- `require.resolve('@bull-board/ui/package.json')` — Turbopack rewrites the call to use its own module map, which doesn't expose package.json paths at runtime → `ResolveMessage: Cannot find module`
- `process.cwd()` is stable: findash always starts from a dir where `node_modules` lives (release dir in prod, project root in dev)

## Test plan
- [x] 4/4 route tests pass
- [ ] CI green
- [ ] Deploy + admin curl: dashboard renders, no 500