### PR TITLE
fix(infra): externalize + trace-include @bull-board packages (#607)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,15 +5,24 @@ const nextConfig: NextConfig = {
   // rsync + run via `bun server.js` — no node_modules install on the droplet.
   output: "standalone",
   allowedDevOrigins: ["ia-server.tailcabcc8.ts.net"],
-  // Bull-Board's @bull-board/express adapter renders the dashboard via
-  // Express's res.render('index'), which lazy-requires ejs at request time.
-  // Turbopack's standalone tracer does NOT follow runtime require() calls,
-  // so ejs would otherwise be missing from prod's node_modules and every hit
-  // on /api/admin/queues throws 500 (#607). Glob keys are interpreted as
-  // patterns — `[[...slug]]` would parse as a character class, so we use
-  // the global `/*` key. ejs is ~50KB, overhead trivial.
+  // Bull-Board can't be bundled by Turbopack — @bull-board/express does
+  // require('@bull-board/ui/package.json') and require.resolve() tricks
+  // internally to find its UI dist. Turbopack's bundled chunks don't
+  // satisfy those runtime require() calls, throwing
+  // `ResolveMessage: Cannot find module '@bull-board/ui/package.json'`
+  // on every request.
+  //
+  // Fix: externalize the 3 @bull-board packages so Node's normal resolver
+  // handles them at runtime, AND copy them (plus ejs) into the standalone
+  // bundle so they exist on disk in prod. (#607)
+  serverExternalPackages: ["@bull-board/api", "@bull-board/express", "@bull-board/ui"],
   outputFileTracingIncludes: {
-    "/*": ["./node_modules/ejs/**/*"],
+    "/*": [
+      "./node_modules/ejs/**/*",
+      "./node_modules/@bull-board/api/**/*",
+      "./node_modules/@bull-board/express/**/*",
+      "./node_modules/@bull-board/ui/**/*",
+    ],
   },
 };
 


### PR DESCRIPTION
Root cause: @bull-board/express internally does require('@bull-board/ui/package.json'). Turbopack bundled the chunk but the package.json doesn't exist on disk in prod — only dist/ was copied (because Turbopack saw .ejs / static references, not the dir root).

Verified on prod: `ls .../node_modules/@bull-board/ui/package.json` → No such file or directory.

## Fix
- `serverExternalPackages` for the 3 @bull-board packages → Node resolves them natively
- `outputFileTracingIncludes` with **/* globs → entire package tree copied to standalone

## Test plan
- [x] Local typecheck clean (after .next cache rm)
- [ ] CI green
- [ ] Deploy + verify @bull-board/ui/package.json on disk
- [ ] curl admin URL → no 500