### PR TITLE
fix(infra): bull-board proxy allow dynamic prop assignment (#607)

### DIFF
--- a/src/app/api/admin/queues/[[...slug]]/route.ts
+++ b/src/app/api/admin/queues/[[...slug]]/route.ts
@@ -80,9 +80,14 @@ async function bridgeToExpress(req: Request): Promise<Response> {
     let statusCode = 200;
     const responseHeaders = new Headers();
     const chunks: Buffer[] = [];
+    // Backing store for properties Express attaches at runtime (res.render,
+    // res.app, res.req, res.locals, etc). Without this, our Proxy's set
+    // trap silently drops them and downstream calls like Bull-Board's
+    // `res.render(view, params)` blow up with "is not a function".
+    const dynamicProps = new Map<string | symbol, unknown>();
 
     const nodeRes = new Proxy({} as ServerResponse, {
-      get(_target, prop: string) {
+      get(_target, prop: string | symbol) {
         switch (prop) {
           case "statusCode":
             return statusCode;
@@ -130,12 +135,14 @@ async function bridgeToExpress(req: Request): Promise<Response> {
           case "socket":
             return { encrypted: false };
           default:
-            return undefined;
+            return dynamicProps.get(prop);
         }
       },
-      set(_target, prop: string, value: unknown) {
+      set(_target, prop: string | symbol, value: unknown) {
         if (prop === "statusCode") {
           statusCode = value as number;
+        } else {
+          dynamicProps.set(prop, value);
         }
         return true;
       },


### PR DESCRIPTION
**The real error** uncovered after externalizing the @bull-board packages:

```
TypeError: res.render is not a function
    at viewHandler (@bull-board/express/dist/ExpressAdapter.js:104:17)
```

Express attaches `res.render`, `res.app`, `res.req`, `res.locals` etc. to the response at request time. Our Proxy's `set` trap only handled `statusCode` and dropped everything else — so Bull-Board's `res.render(view, params)` got undefined.

Fix: route unknown set/get through a backing Map.

## Test plan
- [x] 4/4 route tests pass
- [x] Typecheck clean
- [ ] CI green
- [ ] Deploy + admin GET /api/admin/queues → renders Bull-Board HTML, no 500