### PR TITLE
fix(infra): bull-board via internal http.Server + reverse proxy (#615)

### DIFF
--- a/src/app/api/admin/queues/[[...slug]]/route.test.ts
+++ b/src/app/api/admin/queues/[[...slug]]/route.test.ts
@@ -1,11 +1,13 @@
 /**
  * Smoke tests for the Bull-Board route handler.
  *
- * Verifies auth enforcement without touching Redis or Express.
- * All external dependencies (auth, bull-board app) are mocked.
+ * Verifies auth enforcement and the missing-port path. The success path
+ * (reverse proxy via fetch) is exercised end-to-end via local browser tests
+ * and prod smoke; mocking fetch + the internal http server here adds noise
+ * without catching real bugs.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Mock requireAdmin — controls the auth gate
@@ -15,25 +17,6 @@ const mockRequireAdmin = vi.fn();
 
 vi.mock("@/lib/auth/session", () => ({
   requireAdmin: mockRequireAdmin,
-}));
-
-// ---------------------------------------------------------------------------
-// Mock getBullBoardApp — prevents Express + Redis from initializing in tests
-// ---------------------------------------------------------------------------
-
-const mockExpressApp = vi.fn().mockImplementation((_req: unknown, res: Record<string, unknown>) => {
-  // Simulate a minimal Express response for the success path.
-  // Express sets res.statusCode directly rather than calling writeHead,
-  // then calls res.end() to finish the response.
-  (res as { statusCode: number }).statusCode = 200;
-  if (typeof res.end === "function") {
-    (res.end as (body: string) => void)("<html><body>bull-board</body></html>");
-  }
-});
-
-vi.mock("@/lib/queue/bull-board", () => ({
-  getBullBoardApp: () => mockExpressApp,
-  BULL_BOARD_BASE_PATH: "/api/admin/queues",
 }));
 
 // ---------------------------------------------------------------------------
@@ -49,6 +32,8 @@ const { GET } = await import("./route");
 function makeRequest(path = "/api/admin/queues"): Request {
   return new Request(`http://localhost${path}`, { method: "GET" });
 }
+
+type GlobalWithPort = typeof globalThis & { __findashBullBoardPort?: number };
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -67,9 +52,6 @@ describe("Bull-Board route handler — auth gate", () => {
 
     const body = await res.json();
     expect(body).toMatchObject({ error: "Forbidden" });
-
-    // The Express app must NOT be called
-    expect(mockExpressApp).not.toHaveBeenCalled();
   });
 
   it("returns 401 when requireAdmin throws UNAUTHENTICATED", async () => {
@@ -80,11 +62,33 @@ describe("Bull-Board route handler — auth gate", () => {
 
     const body = await res.json();
     expect(body).toMatchObject({ error: "Unauthenticated" });
-
-    expect(mockExpressApp).not.toHaveBeenCalled();
   });
 
-  it("calls the Express app when requireAdmin resolves (admin user)", async () => {
+  it("does not expose the dashboard to non-admin role on deep paths", async () => {
+    mockRequireAdmin.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const res = await GET(makeRequest("/api/admin/queues/api/queues"));
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("Bull-Board route handler — internal server availability", () => {
+  const originalPort = (globalThis as GlobalWithPort).__findashBullBoardPort;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete (globalThis as GlobalWithPort).__findashBullBoardPort;
+  });
+
+  afterEach(() => {
+    if (originalPort !== undefined) {
+      (globalThis as GlobalWithPort).__findashBullBoardPort = originalPort;
+    } else {
+      delete (globalThis as GlobalWithPort).__findashBullBoardPort;
+    }
+  });
+
+  it("returns 503 when the internal Bull-Board port is not set (instrumentation failed)", async () => {
     mockRequireAdmin.mockResolvedValue({
       id: 1,
       email: "admin@example.com",
@@ -93,20 +97,9 @@ describe("Bull-Board route handler — auth gate", () => {
     });
 
     const res = await GET(makeRequest());
+    expect(res.status).toBe(503);
 
-    // The Express bridge was invoked
-    expect(mockExpressApp).toHaveBeenCalledOnce();
-    // Status is whatever the mock Express app returned (200).
-    // If the bridge throws internally, the route returns 500 — debug if so.
-    const body = await res.json().catch(() => null);
-    expect({ status: res.status, body }).toMatchObject({ status: 200 });
-  });
-
-  it("does not expose the dashboard to non-admin role (FORBIDDEN path)", async () => {
-    mockRequireAdmin.mockRejectedValue(new Error("FORBIDDEN"));
-
-    const res = await GET(makeRequest("/api/admin/queues/api/queues"));
-    expect(res.status).toBe(403);
-    expect(mockExpressApp).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body).toMatchObject({ error: "Bull-Board not initialized" });
   });
 });

--- a/src/app/api/admin/queues/[[...slug]]/route.ts
+++ b/src/app/api/admin/queues/[[...slug]]/route.ts
@@ -1,183 +1,31 @@
 /**
  * Route Handler: /api/admin/queues/[[...slug]]
  *
- * Serves the Bull-Board SPA (HTML entry + JSON API + static assets).
- * Enforces requireAdmin() BEFORE the Express app ever sees the request.
+ * Authenticates via requireAdmin() then reverse-proxies the request to the
+ * internal http server that hosts Bull-Board (started in instrumentation.node.ts).
  *
- * The [[...slug]] catch-all matches:
- *   /api/admin/queues              → Bull-Board entry point
- *   /api/admin/queues/static/*     → CSS / JS / images
- *   /api/admin/queues/api/*        → Bull-Board JSON API
- *   /api/admin/queues/queue/*      → queue detail SPA route
+ * Why a reverse proxy instead of direct mounting: Bull-Board's
+ * @bull-board/express adapter relies on Express's res.render() (EJS) and
+ * streaming static-file responses, which need a real Node Writable Stream.
+ * The Web Fetch Request/Response pair Next.js Route Handlers expose can't
+ * be made stream-equivalent through Proxy mocking — every prior attempt
+ * (#608-#614) failed in subtle ways (res.render undefined, socket.destroy
+ * undefined, pipe hanging on backpressure). Spawning a real http.Server
+ * and proxying via fetch() lets Bull-Board run natively.
  */
 
-import { type IncomingMessage, type ServerResponse } from "http";
-import { Readable } from "stream";
 import { requireAdmin } from "@/lib/auth/session";
-import { getBullBoardApp } from "@/lib/queue/bull-board";
 import { createLogger } from "@/lib/logger";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const log = createLogger({ module: "bull-board-route" });
+const BASE_PATH = "/api/admin/queues";
 
-// ---------------------------------------------------------------------------
-// Bridge: Next.js Request → Node.js IncomingMessage / ServerResponse
-// ---------------------------------------------------------------------------
-
-/**
- * Converts a Fetch API `Request` into a Node.js `IncomingMessage`-compatible
- * object and a mock `ServerResponse` that collects status, headers, and body.
- * Returns a `Response` after Express finishes handling the request.
- */
-async function bridgeToExpress(req: Request): Promise<Response> {
-  const app = getBullBoardApp();
-  const url = new URL(req.url);
-
-  // Strip the /api/admin/queues prefix so Express sees paths relative to "/"
-  const relPath = url.pathname.replace(/^\/api\/admin\/queues/, "") || "/";
-  const fullUrl = relPath + (url.search ?? "");
-
-  return new Promise<Response>((resolve, reject) => {
-    // --- Mock IncomingMessage ---
-    // Use a Readable stream so Express can pipe it without crashing.
-    const nodeReq = new Readable({
-      read() {
-        /* intentionally empty — body is pushed below */
-      },
-    }) as unknown as IncomingMessage;
-
-    (nodeReq as unknown as Record<string, unknown>).method = req.method;
-    (nodeReq as unknown as Record<string, unknown>).url = fullUrl;
-    (nodeReq as unknown as Record<string, unknown>).headers = Object.fromEntries(
-      req.headers.entries(),
-    );
-    (nodeReq as unknown as Record<string, unknown>).socket = {
-      remoteAddress: "127.0.0.1",
-      encrypted: false,
-      destroy: () => {
-        /* Node's stream end-of-data path calls socket.destroy() during
-           cleanup. No-op on our mock (no real TCP socket to close). */
-      },
-    };
-
-    // Push request body into the stream
-    (async () => {
-      try {
-        if (req.body) {
-          const reader = req.body.getReader();
-          for (;;) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            (nodeReq as unknown as Readable).push(value);
-          }
-        }
-        (nodeReq as unknown as Readable).push(null);
-      } catch (err) {
-        log.error({ err, event: "bridge_body_error" }, "error reading request body");
-        reject(err as Error);
-      }
-    })().catch(reject);
-
-    // --- Mock ServerResponse ---
-    let statusCode = 200;
-    const responseHeaders = new Headers();
-    const chunks: Buffer[] = [];
-    // Backing store for properties Express attaches at runtime (res.render,
-    // res.app, res.req, res.locals, etc). Without this, our Proxy's set
-    // trap silently drops them and downstream calls like Bull-Board's
-    // `res.render(view, params)` blow up with "is not a function".
-    const dynamicProps = new Map<string | symbol, unknown>();
-
-    const nodeRes = new Proxy({} as ServerResponse, {
-      get(_target, prop: string | symbol) {
-        switch (prop) {
-          case "statusCode":
-            return statusCode;
-          case "setHeader":
-            return (name: string, value: string | string[]) => {
-              responseHeaders.set(name, Array.isArray(value) ? value.join(", ") : value);
-            };
-          case "getHeader":
-            return (name: string) => responseHeaders.get(name) ?? undefined;
-          case "removeHeader":
-            return (name: string) => responseHeaders.delete(name);
-          case "write":
-            return (chunk: Buffer | string) => {
-              chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
-              return true;
-            };
-          case "end":
-            return (chunk?: Buffer | string) => {
-              if (chunk) {
-                chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
-              }
-              resolve(
-                new Response(Buffer.concat(chunks), {
-                  status: statusCode,
-                  headers: responseHeaders,
-                }),
-              );
-            };
-          case "writeHead":
-            return (code: number, headers?: Record<string, string>) => {
-              statusCode = code;
-              if (headers) {
-                for (const [k, v] of Object.entries(headers)) {
-                  responseHeaders.set(k, v);
-                }
-              }
-            };
-          // Express inspects these on the response object
-          case "headersSent":
-            return false;
-          case "finished":
-            return false;
-          case "writable":
-            return true;
-          case "socket":
-            return {
-              encrypted: false,
-              destroy: () => {
-                /* Node's stream cleanup calls socket.destroy() — no-op on
-                   our mock (we don't have a real TCP socket to tear down). */
-              },
-            };
-          default:
-            // Fall through dynamicProps first (props Express attached via
-            // assignment), then to the target's prototype chain so methods
-            // Express adds via Object.setPrototypeOf (e.g. res.render,
-            // res.send, res.json) resolve correctly.
-            if (dynamicProps.has(prop)) return dynamicProps.get(prop);
-            return Reflect.get(_target, prop);
-        }
-      },
-      set(_target, prop: string | symbol, value: unknown) {
-        if (prop === "statusCode") {
-          statusCode = value as number;
-        } else {
-          dynamicProps.set(prop, value);
-        }
-        return true;
-      },
-    });
-
-    // Express may throw synchronously during middleware setup if our mock
-    // res/req objects are missing a property it expects. Without this
-    // try/catch the error escapes the Promise and is logged as a circular
-    // ref by Pino's err serializer.
-    try {
-      app(nodeReq, nodeRes as unknown as ServerResponse);
-    } catch (syncErr) {
-      reject(syncErr instanceof Error ? syncErr : new Error(String(syncErr)));
-    }
-  });
+function getInternalPort(): number | undefined {
+  return (globalThis as unknown as { __findashBullBoardPort?: number }).__findashBullBoardPort;
 }
-
-// ---------------------------------------------------------------------------
-// Route exports — all methods forwarded to the Express bridge
-// ---------------------------------------------------------------------------
 
 async function handler(req: Request): Promise<Response> {
   try {
@@ -187,30 +35,74 @@ async function handler(req: Request): Promise<Response> {
     if (msg === "UNAUTHENTICATED") {
       return Response.json({ error: "Unauthenticated" }, { status: 401 });
     }
-    // FORBIDDEN or anything else
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  const port = getInternalPort();
+  if (!port) {
+    log.error(
+      { event: "bull_board_port_missing" },
+      "bull-board internal server not initialized — instrumentation may have failed",
+    );
+    return Response.json({ error: "Bull-Board not initialized" }, { status: 503 });
+  }
+
+  const url = new URL(req.url);
+  const relPath = url.pathname.replace(new RegExp(`^${BASE_PATH}`), "") || "/";
+  const targetUrl = `http://127.0.0.1:${port}${relPath}${url.search}`;
+
+  // Strip Next.js / proxy / framework headers that don't make sense on the
+  // internal hop. Forward only the application-level ones Bull-Board cares
+  // about (cookies for any session work, accept-* for content negotiation).
+  const upstreamHeaders = new Headers();
+  for (const [key, value] of req.headers.entries()) {
+    const lower = key.toLowerCase();
+    if (lower === "host" || lower === "connection" || lower === "content-length") continue;
+    upstreamHeaders.set(key, value);
+  }
+
   try {
-    return await bridgeToExpress(req);
+    const upstream = await fetch(targetUrl, {
+      method: req.method,
+      headers: upstreamHeaders,
+      // Body only present for non-GET/HEAD methods; Bull-Board has POST/PATCH
+      // endpoints for retry/promote/clean.
+      body:
+        req.method === "GET" || req.method === "HEAD"
+          ? undefined
+          : Buffer.from(await req.arrayBuffer()),
+      redirect: "manual",
+    });
+
+    // Pass through status, headers, and body. Strip hop-by-hop headers per
+    // RFC 7230 (transfer-encoding, connection) — fetch handles them but
+    // Next.js may try to set them too.
+    const resHeaders = new Headers();
+    upstream.headers.forEach((value, key) => {
+      const lower = key.toLowerCase();
+      if (lower === "transfer-encoding" || lower === "connection") return;
+      resHeaders.set(key, value);
+    });
+
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: resHeaders,
+    });
   } catch (err) {
-    // Log error fields as plain strings — Pino's `err` serializer chokes on
-    // Express request/response cycles ("circular reference is too complex to
-    // analyze") and silently drops the actual error message + stack.
     if (err instanceof Error) {
       log.error(
         {
           errorName: err.name,
           errorMessage: err.message,
           errorStack: err.stack,
-          event: "bull_board_handler_error",
+          event: "bull_board_proxy_error",
         },
-        "bull-board handler error",
+        "bull-board reverse-proxy error",
       );
     } else {
       log.error(
-        { errorString: String(err), event: "bull_board_handler_error" },
-        "bull-board handler error",
+        { errorString: String(err), event: "bull_board_proxy_error" },
+        "bull-board reverse-proxy error",
       );
     }
     return Response.json({ error: "Internal server error" }, { status: 500 });

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -144,6 +144,33 @@ export async function registerNode() {
     "BullMQ workers registered: fx-refresh (15 6,18 * * *), recurring-gap (0 6 5 * *), health-snapshots (0 3 * * *), slo-alerts (*/30 * * * *), gmail-pull (*/5 * * * *) America/Bogota; classify-tx on-demand",
   );
 
+  // -------------------------------------------------------------------------
+  // Bull-Board internal http server
+  //
+  // Bull-Board's @bull-board/express adapter uses res.render() (EJS) and
+  // streaming static-file responses that need a real Node Writable Stream
+  // — not the Web Fetch Request/Response pair Next.js Route Handlers
+  // expose. So we spin up an internal http.Server on 127.0.0.1:0 (random
+  // port) and let the @bull-board/express app handle requests natively.
+  // The Next.js route at /api/admin/queues authenticates the user and
+  // reverse-proxies via fetch(). See #607, #615.
+  // -------------------------------------------------------------------------
+  const { getBullBoardApp } = await import("@/lib/queue/bull-board");
+  const http = await import("node:http");
+
+  const bullBoardApp = getBullBoardApp();
+  const bullBoardServer = http.createServer(bullBoardApp);
+  await new Promise<void>((resolve) => {
+    bullBoardServer.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = bullBoardServer.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+  (globalThis as unknown as { __findashBullBoardPort?: number }).__findashBullBoardPort = port;
+  log.info(
+    { event: "bull_board_server_started", port },
+    `bull-board internal http server listening on 127.0.0.1:${port}`,
+  );
+
   // Backfill on boot when the last known rate is stale (source=fallback,
   // never fetched, or fetchedAt > 12h ago). Without this, a fresh deploy or
   // a reboot after a long downtime shows `· fallback` in the Net Worth card

--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -6,6 +6,29 @@ import { createLogger } from "@/lib/logger";
 const log = createLogger({ module: "queue" });
 
 // ---------------------------------------------------------------------------
+// globalThis-backed singletons
+//
+// Next.js standalone bundles can duplicate module instances across route
+// chunks, so a plain module-scoped `let` Map ends up DIFFERENT in
+// instrumentation vs the bull-board route. Result: queues are registered
+// on instance A, Bull-Board reads from instance B (empty), dashboard shows
+// queueCount: 0. Pin everything to globalThis to share across instances.
+// Same pattern Vercel uses for Prisma in dev.
+// ---------------------------------------------------------------------------
+
+type GlobalQueueShared = {
+  __findashRedis?: IORedis;
+  __findashQueueRegistry?: Map<string, Queue>;
+  __findashWorkerRegistry?: Worker[];
+  __findashShutdownRegistered?: boolean;
+};
+
+const globalForQueue = globalThis as unknown as GlobalQueueShared;
+
+const queueRegistry = (globalForQueue.__findashQueueRegistry ??= new Map<string, Queue>());
+const workerRegistry = (globalForQueue.__findashWorkerRegistry ??= []);
+
+// ---------------------------------------------------------------------------
 // Redis connection singleton
 //
 // BullMQ requires maxRetriesPerRequest: null — without it ioredis will throw
@@ -16,36 +39,27 @@ function buildRedisUrl(): string {
   return process.env.REDIS_URL ?? "redis://localhost:6379";
 }
 
-let _redisConnection: IORedis | null = null;
-
 export function getRedisConnection(): IORedis {
-  if (!_redisConnection) {
+  if (!globalForQueue.__findashRedis) {
     const url = buildRedisUrl();
-    _redisConnection = new IORedis(url, {
+    const conn = new IORedis(url, {
       maxRetriesPerRequest: null,
       enableReadyCheck: false,
     });
 
-    _redisConnection.on("connect", () => {
+    conn.on("connect", () => {
       log.info({ event: "redis_connect", url }, "redis connected");
     });
 
-    _redisConnection.on("error", (err) => {
+    conn.on("error", (err) => {
       log.error({ event: "redis_error", err }, "redis connection error");
     });
+
+    globalForQueue.__findashRedis = conn;
   }
 
-  return _redisConnection;
+  return globalForQueue.__findashRedis;
 }
-
-// ---------------------------------------------------------------------------
-// Global queue registry
-//
-// Stored here so Bull-Board (#588) can iterate over all registered queues
-// without needing to know their names upfront.
-// ---------------------------------------------------------------------------
-
-const queueRegistry = new Map<string, Queue>();
 
 export function getQueueRegistry(): ReadonlyMap<string, Queue> {
   return queueRegistry;
@@ -78,12 +92,6 @@ export function createQueue<TData = unknown, TResult = unknown>(
   queueRegistry.set(name, queue as Queue);
   return queue;
 }
-
-// ---------------------------------------------------------------------------
-// Worker registry (for graceful shutdown)
-// ---------------------------------------------------------------------------
-
-const workerRegistry: Worker[] = [];
 
 // ---------------------------------------------------------------------------
 // Worker factory
@@ -124,11 +132,9 @@ export function createWorker<TData = unknown, TResult = unknown>(
 // this handler ensures they drain cleanly before the process exits.
 // ---------------------------------------------------------------------------
 
-let shutdownRegistered = false;
-
 export function registerGracefulShutdown(): void {
-  if (shutdownRegistered) return;
-  shutdownRegistered = true;
+  if (globalForQueue.__findashShutdownRegistered) return;
+  globalForQueue.__findashShutdownRegistered = true;
 
   process.on("SIGTERM", async () => {
     log.info(


### PR DESCRIPTION
**Verified end-to-end locally** (lesson learned from 6 prior fix-and-deploy roundtrips):

- HTML root → 200, 2KB
- Static JS asset (`main.a5746131.js`) → 200, 70KB, **77ms** (vs 100s timeout before)
- API queues list → 200, JSON with all 6 queues + counts

## What changes

- Route handler shrinks from ~210 LoC of Proxy mock to ~80 LoC of straight reverse proxy. `requireAdmin()` first, then `fetch('http://127.0.0.1:<port>')` and pipe the response through.
- `instrumentation.node.ts` starts an `http.Server` on `127.0.0.1:0` hosting the @bull-board/express app natively. Random port stashed in globalThis.
- `src/lib/queue/index.ts` registry pinned to globalThis (separate bug — Bull-Board reported queueCount:0 in prod because Next.js standalone duplicates module instances across route chunks; instrumentation populated registry A while the route read registry B).

## Why this is the right fix

The Proxy bridge could never work for static streaming because Express's `fs.createReadStream(path).pipe(res)` needs the response to be a real Stream/EventEmitter with backpressure (`on('drain')`, `emit('drain')`, etc). Web Fetch `Response` is none of those. Six prior fixes (#608-#614) all band-aided different symptoms of the same architectural mismatch.

Internal http.Server hosts the app natively; the proxy hop is just network bytes — no abstraction mismatch.

## Test plan
- [x] 4/4 unit tests pass (auth + 503 on missing port)
- [x] Local E2E: HTML, static JS, API JSON all 200
- [ ] CI green
- [ ] Deploy + browser smoke