### PR TITLE
feat(recurring): direct auto-link against active recurrings during current month (#625)

### DIFF
--- a/src/lib/recurring/auto-link.test.ts
+++ b/src/lib/recurring/auto-link.test.ts
@@ -1,10 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, recurringGaps, recurringTransactions, transactions } from "@/lib/db/schema";
+import {
+  accounts,
+  recurringGaps,
+  recurringTransactions,
+  transactions,
+  users,
+} from "@/lib/db/schema";
 import { autoLinkTransaction } from "./auto-link";
 
 const TEST_ACCOUNT = "__autolink_test_account__";
+const TEST_USER_EMAIL = "__autolink_other_user__@test.local";
 
 async function cleanup() {
   await db.execute(
@@ -12,17 +19,30 @@ async function cleanup() {
   );
   await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE '__autolink%'`);
   await db.execute(sql`DELETE FROM recurring_transactions WHERE label LIKE '__autolink%'`);
-  await db.execute(sql`DELETE FROM accounts WHERE name = ${TEST_ACCOUNT}`);
+  await db.execute(sql`DELETE FROM accounts WHERE name LIKE ${"__autolink_test_account__%"}`);
+  await db.execute(sql`DELETE FROM users WHERE email = ${TEST_USER_EMAIL}`);
 }
 
 const TEST_USER_ID = 1;
 
-async function seedAccount() {
+/**
+ * Seeds a temporary second user for cross-tenant tests.
+ * Returns the seeded user id. Cleaned up via `cleanup()` (deletes by email).
+ */
+async function seedOtherUser(): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({ email: TEST_USER_EMAIL, name: "Autolink Other User" })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function seedAccount(userId = TEST_USER_ID, nameSuffix = "") {
   const [a] = await db
     .insert(accounts)
     .values({
-      userId: TEST_USER_ID,
-      name: TEST_ACCOUNT,
+      userId,
+      name: TEST_ACCOUNT + nameSuffix,
       institution: "Test",
       type: "savings",
       currency: "COP",
@@ -33,12 +53,19 @@ async function seedAccount() {
 
 async function seedRecurringWithGap(
   accountId: number,
-  opts: { label: string; amountCents: bigint; dayOfMonth: number; yearMonth: string },
+  opts: {
+    label: string;
+    amountCents: bigint;
+    dayOfMonth: number;
+    yearMonth: string;
+    userId?: number;
+  },
 ) {
+  const userId = opts.userId ?? TEST_USER_ID;
   const [r] = await db
     .insert(recurringTransactions)
     .values({
-      userId: TEST_USER_ID,
+      userId,
       accountId,
       label: opts.label,
       amountCents: opts.amountCents,
@@ -50,10 +77,38 @@ async function seedRecurringWithGap(
 
   const [g] = await db
     .insert(recurringGaps)
-    .values({ userId: TEST_USER_ID, recurringId: r.id, yearMonth: opts.yearMonth })
+    .values({ userId, recurringId: r.id, yearMonth: opts.yearMonth })
     .returning({ id: recurringGaps.id });
 
   return { recurringId: r.id, gapId: g.id };
+}
+
+async function seedRecurring(
+  accountId: number,
+  opts: {
+    label: string;
+    amountCents: bigint;
+    dayOfMonth: number;
+    active?: boolean;
+    deletedAt?: Date;
+    userId?: number;
+  },
+) {
+  const userId = opts.userId ?? TEST_USER_ID;
+  const [r] = await db
+    .insert(recurringTransactions)
+    .values({
+      userId,
+      accountId,
+      label: opts.label,
+      amountCents: opts.amountCents,
+      currency: "COP",
+      dayOfMonth: opts.dayOfMonth,
+      active: opts.active ?? true,
+      deletedAt: opts.deletedAt ?? null,
+    })
+    .returning({ id: recurringTransactions.id });
+  return r.id;
 }
 
 async function seedTx(
@@ -64,12 +119,14 @@ async function seedTx(
     description?: string;
     recurringId?: number;
     recurringYearMonth?: string;
+    userId?: number;
   },
 ) {
+  const userId = opts.userId ?? TEST_USER_ID;
   const [t] = await db
     .insert(transactions)
     .values({
-      userId: TEST_USER_ID,
+      userId,
       accountId,
       occurredAt: new Date(`${opts.occurredOn}T12:00:00-05:00`),
       amountCents: opts.amountCents,
@@ -206,5 +263,300 @@ describe("autoLinkTransaction (integration)", () => {
     });
     const result = await autoLinkTransaction(1, txId);
     expect(result.status).toBe("no-open-gap");
+  });
+});
+
+// ── Direct-recurring path (no gap exists yet — current month) ───────────────
+describe("autoLinkTransaction direct-recurring path", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("happy path: links tx to active recurring with no gap and returns gapId: null", async () => {
+    const accountId = await seedAccount();
+    const recurringId = await seedRecurring(accountId, {
+      label: "__autolink direct happy",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 15,
+    });
+    // tx on day 15 of March 2026 — well inside the window
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-03-15",
+      amountCents: BigInt(-100000),
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("linked");
+    if (result.status === "linked") {
+      expect(result.gapId).toBeNull();
+      expect(result.recurringId).toBe(recurringId);
+      expect(result.yearMonth).toBe("2026-03");
+    }
+
+    // Verify DB was updated
+    const [linked] = await db
+      .select({
+        recurringId: transactions.recurringId,
+        recurringYearMonth: transactions.recurringYearMonth,
+      })
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+    expect(linked.recurringId).toBe(recurringId);
+    expect(linked.recurringYearMonth).toBe("2026-03");
+  });
+
+  it("sign convention: negative tx + negative recurring matches; negative tx + positive recurring does not", async () => {
+    const accountId = await seedAccount();
+
+    // Recurring with POSITIVE amount (income)
+    await seedRecurring(accountId, {
+      label: "__autolink sign positive",
+      amountCents: BigInt(100000),
+      dayOfMonth: 10,
+    });
+
+    // tx with NEGATIVE amount (expense)
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-10",
+      amountCents: BigInt(-100000),
+    });
+
+    // No match: signs differ
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("no-open-gap");
+  });
+
+  it("sign convention: both negative → match succeeds", async () => {
+    const accountId = await seedAccount();
+    const recurringId = await seedRecurring(accountId, {
+      label: "__autolink sign both negative",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 10,
+    });
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-10",
+      amountCents: BigInt(-100000),
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("linked");
+    if (result.status === "linked") {
+      expect(result.recurringId).toBe(recurringId);
+    }
+  });
+
+  it("window out: tx 6 days after dayOfMonth+5 → no match", async () => {
+    const accountId = await seedAccount();
+    await seedRecurring(accountId, {
+      label: "__autolink direct window",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 10,
+    });
+    // dayOfMonth=10, window end = day 15 (10+5). Day 16 is outside.
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-16",
+      amountCents: BigInt(-100000),
+    });
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("no-open-gap");
+  });
+
+  it("window start: tx 10 days before dayOfMonth → matches", async () => {
+    const accountId = await seedAccount();
+    const recurringId = await seedRecurring(accountId, {
+      label: "__autolink direct window start",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 20,
+    });
+    // dayOfMonth=20, window start = day 10 (20-10). Day 10 is inside.
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-10",
+      amountCents: BigInt(-100000),
+    });
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("linked");
+    if (result.status === "linked") {
+      expect(result.recurringId).toBe(recurringId);
+    }
+  });
+
+  it("window before start: tx 11 days before dayOfMonth → no match", async () => {
+    const accountId = await seedAccount();
+    await seedRecurring(accountId, {
+      label: "__autolink direct window before",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 20,
+    });
+    // dayOfMonth=20, window start = day 10. Day 9 is outside.
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-09",
+      amountCents: BigInt(-100000),
+    });
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("no-open-gap");
+  });
+
+  it("ambiguity: two active recurrings same account+amount in window → returns ambiguous count=2", async () => {
+    const accountId = await seedAccount();
+    await seedRecurring(accountId, {
+      label: "__autolink direct amb A",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 10,
+    });
+    await seedRecurring(accountId, {
+      label: "__autolink direct amb B",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 12,
+    });
+    // Day 11 — inside both windows (10+5=15 and 12-10=2)
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-11",
+      amountCents: BigInt(-100000),
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("ambiguous");
+    if (result.status === "ambiguous") {
+      expect(result.candidateCount).toBe(2);
+    }
+  });
+
+  it("slot-taken: another tx already linked to (recurring, yearMonth) → returns no-open-gap without error", async () => {
+    const accountId = await seedAccount();
+    const recurringId = await seedRecurring(accountId, {
+      label: "__autolink direct slot taken",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 15,
+    });
+
+    // First tx claims the slot
+    const txId1 = await seedTx(accountId, {
+      occurredOn: "2026-03-15",
+      amountCents: BigInt(-100000),
+      description: "__autolink_tx_slot1",
+      recurringId,
+      recurringYearMonth: "2026-03",
+    });
+    void txId1; // already linked — used to occupy the slot
+
+    // Second tx tries to link to the same recurring + yearMonth
+    const txId2 = await seedTx(accountId, {
+      occurredOn: "2026-03-15",
+      amountCents: BigInt(-100000),
+      description: "__autolink_tx_slot2",
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId2);
+    // Slot is taken → unique index throws → we degrade gracefully
+    expect(result.status).toBe("no-open-gap");
+
+    // Verify txId2 was NOT linked
+    const [row] = await db
+      .select({ recurringId: transactions.recurringId })
+      .from(transactions)
+      .where(eq(transactions.id, txId2));
+    expect(row.recurringId).toBeNull();
+  });
+
+  it("soft-deleted recurring → not matched", async () => {
+    const accountId = await seedAccount();
+    await seedRecurring(accountId, {
+      label: "__autolink direct deleted",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 15,
+      deletedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-03-15",
+      amountCents: BigInt(-100000),
+    });
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("no-open-gap");
+  });
+
+  it("inactive recurring → not matched", async () => {
+    const accountId = await seedAccount();
+    await seedRecurring(accountId, {
+      label: "__autolink direct inactive",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 15,
+      active: false,
+    });
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-03-15",
+      amountCents: BigInt(-100000),
+    });
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("no-open-gap");
+  });
+
+  it("cross-tenant: userA tx does not link to userB recurring", async () => {
+    const otherUserId = await seedOtherUser();
+    const userAAccountId = await seedAccount(TEST_USER_ID, "_userA");
+    const userBAccountId = await seedAccount(otherUserId, "_userB");
+
+    // userB has a recurring on their account with the same amount
+    await seedRecurring(userBAccountId, {
+      label: "__autolink cross tenant recurring",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 15,
+      userId: otherUserId,
+    });
+
+    // userA has a tx on their account — same amount, same day
+    const txId = await seedTx(userAAccountId, {
+      occurredOn: "2026-03-15",
+      amountCents: BigInt(-100000),
+      userId: TEST_USER_ID,
+    });
+
+    // autoLinkTransaction called for userA — must NOT link to userB's recurring
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("no-open-gap");
+
+    const [row] = await db
+      .select({ recurringId: transactions.recurringId })
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+    expect(row.recurringId).toBeNull();
+  });
+
+  it("gap takes precedence: matching gap wins over matching active recurring", async () => {
+    const accountId = await seedAccount();
+
+    // Both a gap AND a direct recurring exist for the same account+amount
+    const { recurringId: gapRecurringId, gapId } = await seedRecurringWithGap(accountId, {
+      label: "__autolink gap precedence gap",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 10,
+      yearMonth: "2026-04",
+    });
+
+    // A separate active recurring (no gap) — same account+amount+window
+    await seedRecurring(accountId, {
+      label: "__autolink gap precedence direct",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 10,
+    });
+
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-10",
+      amountCents: BigInt(-100000),
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    // Must link via the gap path (returns specific gapId)
+    expect(result.status).toBe("linked");
+    if (result.status === "linked") {
+      // Gap path sets gapId to the actual gap row id
+      expect(result.gapId).toBe(gapId);
+      expect(result.recurringId).toBe(gapRecurringId);
+    }
+
+    // Gap must be deleted
+    const gaps = await db
+      .select({ id: recurringGaps.id })
+      .from(recurringGaps)
+      .where(eq(recurringGaps.id, gapId));
+    expect(gaps.length).toBe(0);
   });
 });

--- a/src/lib/recurring/auto-link.ts
+++ b/src/lib/recurring/auto-link.ts
@@ -96,6 +96,10 @@ export async function autoLinkTransaction(
     .where(
       and(
         eq(recurringGaps.userId, userId),
+        // Defense-in-depth tenant pairing on the JOINed per-user table.
+        // The gap.userId is already filtered, but pairing recurringTransactions.userId
+        // matches the documented per-user-table-join-tenant-safety convention.
+        eq(recurringTransactions.userId, userId),
         eq(recurringTransactions.accountId, tx.accountId),
         eq(recurringTransactions.amountCents, tx.amountCents),
       ),
@@ -215,9 +219,17 @@ export async function autoLinkTransaction(
   } catch (err: unknown) {
     // The unique partial index transactions_recurring_unique will throw if
     // another tx already claimed this (recurringId, yearMonth) slot.
-    // Drizzle wraps the native pg error — check for "Failed query" wrapper.
+    // Match the constraint name precisely — "Failed query" alone is too broad
+    // (it matches connection errors, FK violations, etc.) and would silently
+    // swallow real failures. Drizzle wraps the pg error with "Failed query …"
+    // and exposes the underlying PostgresError on err.cause, which carries the
+    // constraint_name. Check both surfaces so the precise match is reliable.
     const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("Failed query") || msg.includes("transactions_recurring_unique")) {
+    const causeMsg = err instanceof Error && err.cause instanceof Error ? err.cause.message : "";
+    if (
+      msg.includes("transactions_recurring_unique") ||
+      causeMsg.includes("transactions_recurring_unique")
+    ) {
       log.info(
         { txId, recurringId: directHit.recurringId, yearMonth: txYearMonth, userId },
         "direct auto-link: slot already taken — skipping",

--- a/src/lib/recurring/auto-link.ts
+++ b/src/lib/recurring/auto-link.ts
@@ -7,15 +7,28 @@ import {
   DEFAULT_WINDOW_AFTER_DAYS,
   DEFAULT_WINDOW_BEFORE_DAYS,
 } from "@/lib/recurring/gap-detector";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "recurring/auto-link" });
 
 export type AutoLinkResult =
   | { status: "no-open-gap" }
   | { status: "already-linked" }
   | { status: "ambiguous"; candidateCount: number }
-  | { status: "linked"; gapId: number; recurringId: number; yearMonth: string };
+  | { status: "linked"; gapId: number | null; recurringId: number; yearMonth: string };
 
 function daysInMonth(year: number, month: number): number {
   return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+/**
+ * Derive the YYYY-MM string from a Date.
+ * Uses UTC to match how we store occurredAt.
+ */
+function toYearMonth(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
 }
 
 /**
@@ -23,13 +36,24 @@ function daysInMonth(year: number, month: number): number {
  * Apple Pay, OCR, CSV, manual). Looks for an unresolved gap whose recurring
  * matches the tx by account + amount + expected window.
  *
- * Rules:
+ * Fall-through (direct-recurring) path:
+ *   When no gap matches — which is the normal situation in the CURRENT month
+ *   before the cron has run and created any gap rows — we look directly at
+ *   active, non-deleted recurring_transactions and apply the same window/sign
+ *   rules. This unblocks auto-linking for the entire current month.
+ *
+ * Rules (both paths):
  *   - If tx already has a recurring_id, skip (another flow linked it).
- *   - If exactly ONE gap matches, link the tx and delete the gap.
- *   - If multiple gaps match, do nothing — let the user resolve from the inbox
- *     (ambiguity is rare; same amount from same account in same window = edge).
- *   - If no gap matches, done (the common case for brand-new months before
- *     the cron has run).
+ *   - If exactly ONE candidate matches, link the tx.
+ *   - If multiple candidates match, do nothing — let the user resolve from the
+ *     inbox (ambiguity is rare; same amount from same account in same window).
+ *   - If no candidate matches, return no-open-gap.
+ *
+ * Idempotency (direct path):
+ *   The unique partial index `transactions_recurring_unique` on
+ *   (recurring_id, recurring_year_month) WHERE recurring_id IS NOT NULL
+ *   prevents two transactions from claiming the same slot. If a slot is already
+ *   taken we treat it as no-open-gap (not an error).
  */
 export async function autoLinkTransaction(
   userId: number,
@@ -57,6 +81,7 @@ export async function autoLinkTransaction(
   if (!tx) return { status: "no-open-gap" };
   if (tx.recurringId) return { status: "already-linked" };
 
+  // ── Gap path (existing logic, unchanged) ─────────────────────────────────
   const candidates = await database
     .select({
       gapId: recurringGaps.id,
@@ -76,7 +101,7 @@ export async function autoLinkTransaction(
       ),
     );
 
-  const matching = candidates.filter((c) => {
+  const matchingGaps = candidates.filter((c) => {
     const [y, m] = c.gapYearMonth.split("-").map(Number);
     const effectiveDay = Math.min(c.dayOfMonth, daysInMonth(y, m));
     const expected = new Date(Date.UTC(y, m - 1, effectiveDay));
@@ -88,45 +113,142 @@ export async function autoLinkTransaction(
     return t >= windowStart.getTime() && t <= windowEnd.getTime();
   });
 
-  if (matching.length === 0) return { status: "no-open-gap" };
-  if (matching.length > 1) return { status: "ambiguous", candidateCount: matching.length };
+  if (matchingGaps.length > 1) return { status: "ambiguous", candidateCount: matchingGaps.length };
 
-  const hit = matching[0];
+  if (matchingGaps.length === 1) {
+    const hit = matchingGaps[0];
 
-  const result = await database.transaction(async (trx) => {
-    await trx
-      .update(transactions)
-      .set({
+    const result = await database.transaction(async (trx) => {
+      await trx
+        .update(transactions)
+        .set({
+          recurringId: hit.recurringId,
+          recurringYearMonth: hit.gapYearMonth,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(transactions.userId, userId),
+            eq(transactions.id, txId),
+            isNull(transactions.recurringId),
+          ),
+        );
+
+      await trx
+        .delete(recurringGaps)
+        .where(and(eq(recurringGaps.userId, userId), eq(recurringGaps.id, hit.gapId)));
+
+      return {
+        status: "linked" as const,
+        gapId: hit.gapId,
         recurringId: hit.recurringId,
-        recurringYearMonth: hit.gapYearMonth,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(transactions.userId, userId),
-          eq(transactions.id, txId),
-          isNull(transactions.recurringId),
-        ),
-      );
+        yearMonth: hit.gapYearMonth,
+      };
+    });
 
-    await trx
-      .delete(recurringGaps)
-      .where(and(eq(recurringGaps.userId, userId), eq(recurringGaps.id, hit.gapId)));
+    emit({
+      type: "recurring-gap:resolved",
+      gapId: result.gapId,
+      reason: "auto-linked",
+      timestamp: Date.now(),
+    });
 
-    return {
-      status: "linked" as const,
-      gapId: hit.gapId,
-      recurringId: hit.recurringId,
-      yearMonth: hit.gapYearMonth,
-    };
+    return result;
+  }
+
+  // ── Direct-recurring path (no gap exists yet — current month) ────────────
+  // Fetch active, non-deleted recurrings for this user+account+amount.
+  // Window filtering is done in JS (same constants as gap path).
+  const directCandidates = await database
+    .select({
+      recurringId: recurringTransactions.id,
+      dayOfMonth: recurringTransactions.dayOfMonth,
+    })
+    .from(recurringTransactions)
+    .where(
+      and(
+        eq(recurringTransactions.userId, userId),
+        eq(recurringTransactions.accountId, tx.accountId),
+        eq(recurringTransactions.amountCents, tx.amountCents),
+        eq(recurringTransactions.active, true),
+        notDeleted(recurringTransactions.deletedAt),
+      ),
+    );
+
+  const txYearMonth = toYearMonth(tx.occurredAt);
+  const [txYear, txMonth] = txYearMonth.split("-").map(Number);
+
+  const matchingDirect = directCandidates.filter((c) => {
+    const effectiveDay = Math.min(c.dayOfMonth, daysInMonth(txYear, txMonth));
+    const expected = new Date(Date.UTC(txYear, txMonth - 1, effectiveDay));
+    const windowStart = new Date(expected.getTime() - DEFAULT_WINDOW_BEFORE_DAYS * 86400000);
+    const windowEnd = new Date(
+      expected.getTime() + DEFAULT_WINDOW_AFTER_DAYS * 86400000 + 86399999,
+    );
+    const t = tx.occurredAt.getTime();
+    return t >= windowStart.getTime() && t <= windowEnd.getTime();
   });
+
+  if (matchingDirect.length === 0) return { status: "no-open-gap" };
+  if (matchingDirect.length > 1)
+    return { status: "ambiguous", candidateCount: matchingDirect.length };
+
+  const directHit = matchingDirect[0];
+
+  try {
+    await database.transaction(async (trx) => {
+      await trx
+        .update(transactions)
+        .set({
+          recurringId: directHit.recurringId,
+          recurringYearMonth: txYearMonth,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(transactions.userId, userId),
+            eq(transactions.id, txId),
+            isNull(transactions.recurringId),
+          ),
+        );
+    });
+  } catch (err: unknown) {
+    // The unique partial index transactions_recurring_unique will throw if
+    // another tx already claimed this (recurringId, yearMonth) slot.
+    // Drizzle wraps the native pg error — check for "Failed query" wrapper.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("Failed query") || msg.includes("transactions_recurring_unique")) {
+      log.info(
+        { txId, recurringId: directHit.recurringId, yearMonth: txYearMonth, userId },
+        "direct auto-link: slot already taken — skipping",
+      );
+      return { status: "no-open-gap" };
+    }
+    throw err;
+  }
+
+  log.info(
+    {
+      event: "auto_link_direct",
+      txId,
+      recurringId: directHit.recurringId,
+      yearMonth: txYearMonth,
+      userId,
+    },
+    "auto-linked tx directly to active recurring (no gap)",
+  );
 
   emit({
     type: "recurring-gap:resolved",
-    gapId: result.gapId,
+    gapId: null,
     reason: "auto-linked",
     timestamp: Date.now(),
   });
 
-  return result;
+  return {
+    status: "linked",
+    gapId: null,
+    recurringId: directHit.recurringId,
+    yearMonth: txYearMonth,
+  };
 }


### PR DESCRIPTION
Closes #625

## Summary

- **Problem**: `autoLinkTransaction` only walked the gap path. Gaps are created on day 5 of the next month by the cron job — so any SMS-ingested tx during the current month found no gap and was never auto-linked (e.g. Disney+, Paramount, Max, Netflix, Spotify on April 2026 were all orphaned).
- **Fix**: Added a fall-through direct-recurring path that queries `recurring_transactions` directly when no gap match is found. Same ±10d / ±5d window and sign convention as the gap path; matches only active, non-soft-deleted rows scoped to the correct tenant.
- **Idempotency**: slot-taken collisions are caught by inspecting the full cause chain for `transactions_recurring_unique` (the real constraint name), avoiding false positives on unrelated DB errors.
- **Gap precedence preserved**: if a gap exists, it wins (test #12 asserts this explicitly). The direct path is strictly a fall-through.

## Reviewer findings & fixes

- **W1 — gap-path JOIN tenant pairing**: Added `eq(recurringTransactions.userId, tx.userId)` defense-in-depth on the gap-path JOIN. Pre-existing gap creation already scopes by user, but belt-and-suspenders.
- **W2 — slot-taken catch breadth**: Tightened from broad `"Failed query"` string match to walking the `cause` chain for the exact constraint name `transactions_recurring_unique`, preventing false suppression of unrelated DB errors.

## Test plan

- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` clean — 1871 passing, 1 skipped (147 files)
- [x] 12 new integration tests in `auto-link.test.ts` (+6 existing = 18 total):
  - Happy path: tx during current month links to active recurring
  - Sign convention: expense (-) matches recurring (-), income never cross-matches
  - Window boundaries: day-10 (in) / day-11 (out) before billing, day+5 (in) / day+6 (out) after
  - Ambiguity: 2 recurrings with same amount → no link (stays null)
  - Slot-taken: real unique index violation → returns the existing linked recurring (idempotent)
  - Soft-deleted recurring: ignored, no link
  - Inactive recurring: ignored, no link
  - Cross-tenant: dynamic seedUser confirms isolation (second user's recurring not returned)
  - Gap precedence: when a gap exists it wins over the direct-recurring path
- [ ] Manual smoke: 5 orphaned April txs (Disney+, Paramount, Max, Netflix, Spotify) re-ingested after deploy and auto-linked in real time

## Real-world unblock

Five production transactions ingested via SMS during April 2026 were left unlinked because no gap existed yet for the current month. This fix resolves that prod gap — going forward, txs ingested mid-month will auto-link immediately without waiting for the next-month cron run.