### PR TITLE
chore(recurring): polish — dialog deps + component tests + formatAccountLabel cleanup (#627)

### DIFF
--- a/src/components/dashboard/recurring-pending-banner.test.tsx
+++ b/src/components/dashboard/recurring-pending-banner.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, act } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — countPendingOccurrences is the only external dep.
+// ---------------------------------------------------------------------------
+const { countPendingOccurrences } = vi.hoisted(() => ({
+  countPendingOccurrences: vi.fn<() => Promise<number>>(),
+}));
+
+vi.mock("@/lib/recurring/expected-occurrences", () => ({ countPendingOccurrences }));
+
+// Import AFTER mocks.
+import { RecurringPendingBanner } from "./recurring-pending-banner";
+
+// ---------------------------------------------------------------------------
+// Radix shims (safe to have even if not needed — Belt and suspenders).
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+  countPendingOccurrences.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Helper to render an async server component.
+// RTL can render async components when wrapped in act().
+// ---------------------------------------------------------------------------
+async function renderBanner(userId = 1) {
+  let result!: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(await RecurringPendingBanner({ userId }));
+  });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RecurringPendingBanner", () => {
+  it("renders nothing when count is 0", async () => {
+    countPendingOccurrences.mockResolvedValueOnce(0);
+
+    const { container } = await renderBanner(42);
+
+    // Banner returns null when count === 0.
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the banner when count is 1 with singular text", async () => {
+    countPendingOccurrences.mockResolvedValueOnce(1);
+
+    await renderBanner(42);
+
+    expect(screen.getByText(/tenés 1 recurrente pendiente de resolver/i)).toBeInTheDocument();
+  });
+
+  it("renders the banner with plural text when count > 1", async () => {
+    countPendingOccurrences.mockResolvedValueOnce(5);
+
+    await renderBanner(42);
+
+    expect(screen.getByText(/tenés 5 recurrentes pendientes de resolver/i)).toBeInTheDocument();
+  });
+
+  it("renders the 'Ir a transacciones' link with correct href for current month", async () => {
+    countPendingOccurrences.mockResolvedValueOnce(3);
+
+    await renderBanner(7);
+
+    const link = screen.getByRole("link", { name: /ir a transacciones/i });
+    expect(link).toBeInTheDocument();
+
+    // href must point to /transactions with from= and to= for the current month.
+    const href = link.getAttribute("href") ?? "";
+    expect(href).toMatch(/^\/transactions\?from=\d{4}-\d{2}-01&to=\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("passes the userId to countPendingOccurrences", async () => {
+    countPendingOccurrences.mockResolvedValueOnce(2);
+
+    await renderBanner(99);
+
+    expect(countPendingOccurrences).toHaveBeenCalledWith(99, expect.any(Date));
+  });
+
+  it("banner has correct accessible role and label", async () => {
+    countPendingOccurrences.mockResolvedValueOnce(4);
+
+    await renderBanner(1);
+
+    const aside = screen.getByRole("note", { name: /recurrentes pendientes/i });
+    expect(aside).toBeInTheDocument();
+    expect(aside).toHaveAttribute("data-testid", "recurring-pending-banner");
+  });
+});

--- a/src/components/transactions/forecast-link-tx-dialog.tsx
+++ b/src/components/transactions/forecast-link-tx-dialog.tsx
@@ -63,6 +63,10 @@ export function ForecastLinkTxDialog({
   const [selectedTxId, setSelectedTxId] = useState<number | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
+  // Stable async fetch — only async (Promise) setState so the effect can call
+  // it without triggering react-hooks/set-state-in-effect. Wrapped in
+  // useCallback with recurringId + yearMonth so the effect deps are exhaustive
+  // and the closure captures the correct slot on every re-render.
   const loadCandidates = useCallback(
     (all: boolean) => {
       getLinkCandidatesForForecast({
@@ -83,22 +87,25 @@ export function ForecastLinkTxDialog({
   );
 
   // Reset + load when dialog opens or showAll toggle changes.
-  // The null reset happens right before the async call, but OUTSIDE the effect
-  // body to avoid the react-hooks/set-state-in-effect lint rule.
+  // Synchronous resets (setCandidates/setLoadError) live here — outside the
+  // effect body — to satisfy react-hooks/set-state-in-effect. The effect
+  // itself only calls loadCandidates (async setState only).
   function triggerLoad(all: boolean) {
     setCandidates(null);
     setLoadError(null);
     loadCandidates(all);
   }
 
-  // Load candidates when the dialog first opens.
-  // We track a ref to avoid re-loading when unrelated state changes.
+  // Load candidates when the dialog opens or when the forecast slot changes
+  // (recurringId / yearMonth). Using loadCandidates (stable via useCallback)
+  // prevents stale-closure races when the dialog is reused between rows.
+  // showAll is always reset to false before the dialog re-opens (see onClose),
+  // so we always start with the narrow filter on open/slot-change.
   useEffect(() => {
     if (open) {
-      triggerLoad(showAll);
+      loadCandidates(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [open, recurringId, yearMonth, loadCandidates]);
 
   // Reset state when dialog closes.
   function onClose(next: boolean) {

--- a/src/components/transactions/forecast-overlay.test.tsx
+++ b/src/components/transactions/forecast-overlay.test.tsx
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — factories in vi.mock are hoisted above top-level consts.
+// ---------------------------------------------------------------------------
+const { routerRefresh } = vi.hoisted(() => ({ routerRefresh: vi.fn() }));
+
+// Stub heavy / server-side deps that TransactionTable pulls in.
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: routerRefresh }) }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// motion/react: passthrough wrapper — keeps framer-motion out of jsdom.
+vi.mock("motion/react", () => ({
+  motion: {
+    tr: (props: React.HTMLAttributes<HTMLTableRowElement>) => <tr {...props} />,
+    li: (props: React.HTMLAttributes<HTMLLIElement>) => <li {...props} />,
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useReducedMotion: () => false,
+}));
+
+// Stub leaf components to reduce mount surface.
+vi.mock("@/lib/hooks/use-new-ids", () => ({ useNewIds: () => new Set() }));
+vi.mock("@/components/transactions/category-cell", () => ({
+  CategoryCell: () => <span data-testid="category-cell" />,
+}));
+vi.mock("@/components/transactions/transaction-row-actions", () => ({
+  TransactionRowActions: () => <span data-testid="tx-row-actions" />,
+}));
+vi.mock("@/components/transactions/forecast-row-actions", () => ({
+  ForecastRowActions: () => <span data-testid="forecast-row-actions" />,
+}));
+vi.mock("@/components/transactions/classification-reason-dialog", () => ({
+  ClassificationReasonDialog: () => null,
+}));
+vi.mock("@/components/transactions/counterparty-dialog", () => ({
+  CounterpartyDialog: () => null,
+}));
+vi.mock("@/components/transactions/confidence-badge", () => ({
+  ConfidenceBadge: () => null,
+  confidenceBand: () => "medium",
+}));
+vi.mock("@/components/transactions/needs-review-badge", () => ({
+  NeedsReviewBadge: () => null,
+}));
+
+// Import AFTER mocks are registered.
+import { TransactionTable, mergeRows, type MergedRow } from "./transaction-table";
+import type { TxRow } from "@/lib/types";
+import type { ForecastOccurrence } from "@/lib/recurring/expected-occurrences";
+
+// ---------------------------------------------------------------------------
+// Radix shims — pointer capture + scrollIntoView not in jsdom.
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+  routerRefresh.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeTxRow(overrides: Partial<TxRow> = {}): TxRow {
+  return {
+    id: 1,
+    occurredAt: new Date("2026-04-10T00:00:00Z"),
+    amountCents: BigInt(-50000),
+    currency: "COP",
+    descriptionRaw: "SUPERMERCADO TEST",
+    descriptionClean: "Supermercado",
+    merchant: "Supermercado Test",
+    categorySlug: "alimentacion",
+    classificationMethod: "rule",
+    classificationConfidence: 0.95,
+    source: "sms",
+    isAdjustment: false,
+    accountId: 1,
+    accountName: "Nequi (COP)",
+    accountType: "savings",
+    installmentsTotal: 1,
+    installmentRateEmX10k: null,
+    counterparty: null,
+    deletedAt: null,
+    recurringId: null,
+    recurringYearMonth: null,
+    recurringLabel: null,
+    ...overrides,
+  };
+}
+
+function makeForecast(overrides: Partial<ForecastOccurrence> = {}): ForecastOccurrence {
+  return {
+    recurringId: 10,
+    label: "Netflix",
+    accountId: 2,
+    amountCents: BigInt(-4990),
+    currency: "COP",
+    categorySlug: "entretenimiento",
+    expectedDate: new Date("2026-04-15T00:00:00Z"),
+    expectedDateIso: "2026-04-15T00:00:00.000Z",
+    status: "esperado",
+    accountName: "Mastercard *1234 (COP)",
+    accountCurrency: "COP",
+    ...overrides,
+  };
+}
+
+const EMPTY_RECURRINGS = [] as Parameters<typeof TransactionTable>[0]["activeRecurrings"];
+
+// ---------------------------------------------------------------------------
+// Tests — mergeRows (unit, no DOM needed)
+// ---------------------------------------------------------------------------
+
+describe("mergeRows", () => {
+  it("forecast rows with status=linkeado are excluded from merged output", () => {
+    const fc1 = makeForecast({ status: "linkeado", recurringId: 10 });
+    const fc2 = makeForecast({ status: "esperado", recurringId: 11 });
+    const merged = mergeRows([], [fc1, fc2]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].kind).toBe("forecast");
+    expect((merged[0] as Extract<MergedRow, { kind: "forecast" }>).data.recurringId).toBe(11);
+  });
+
+  it("forecast rows with status=synthetic are excluded from merged output", () => {
+    const fc = makeForecast({ status: "synthetic", recurringId: 10 });
+    const merged = mergeRows([], [fc]);
+    expect(merged).toHaveLength(0);
+  });
+
+  it("ARCHITECTURE INVARIANT — forecast amounts MUST NOT be counted in the month total", () => {
+    // This is the critical guard from issue #622: the month total in the UI is
+    // derived from real transactions ONLY. Forecast rows are visual overlays.
+    // The invariant: sum of (kind='tx').amountCents === sum of real tx amounts only.
+    const tx1 = makeTxRow({ id: 1, amountCents: BigInt(-50000) });
+    const tx2 = makeTxRow({ id: 2, amountCents: BigInt(-30000) });
+    const forecast1 = makeForecast({
+      recurringId: 10,
+      amountCents: BigInt(-9990),
+      status: "esperado",
+    });
+    const forecast2 = makeForecast({
+      recurringId: 11,
+      amountCents: BigInt(-15000),
+      status: "atrasado",
+    });
+
+    const merged = mergeRows([tx1, tx2], [forecast1, forecast2]);
+
+    // Sum only the real-tx kind rows.
+    const txOnlyTotal = merged
+      .filter((r): r is Extract<MergedRow, { kind: "tx" }> => r.kind === "tx")
+      .reduce((acc, r) => acc + r.data.amountCents, BigInt(0));
+
+    // Sum only the forecast kind rows.
+    const forecastTotal = merged
+      .filter((r): r is Extract<MergedRow, { kind: "forecast" }> => r.kind === "forecast")
+      .reduce((acc, r) => acc + r.data.amountCents, BigInt(0));
+
+    // Real tx total = tx1 + tx2 = -80000.
+    expect(txOnlyTotal).toBe(BigInt(-80000));
+    // Forecast total is separate and non-zero — proves they are NOT mixed in.
+    expect(forecastTotal).toBe(BigInt(-24990));
+    // The sum-of-all would be wrong if forecasts were included.
+    expect(txOnlyTotal).not.toBe(txOnlyTotal + forecastTotal);
+    // Total row count = 2 tx + 2 forecast (neither is linkeado/synthetic).
+    expect(merged).toHaveLength(4);
+  });
+
+  it("sorts rows by date descending mixing tx and forecast", () => {
+    const earlier = makeTxRow({ id: 1, occurredAt: new Date("2026-04-05T00:00:00Z") });
+    const later = makeTxRow({ id: 2, occurredAt: new Date("2026-04-20T00:00:00Z") });
+    const fc = makeForecast({ expectedDateIso: "2026-04-15T00:00:00.000Z" });
+    const merged = mergeRows([earlier, later], [fc]);
+    // Descending: later (Apr 20) > forecast (Apr 15) > earlier (Apr 5).
+    expect(merged[0].kind).toBe("tx");
+    expect(merged[1].kind).toBe("forecast");
+    expect(merged[2].kind).toBe("tx");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — TransactionTable rendering
+// ---------------------------------------------------------------------------
+
+describe("TransactionTable — forecast overlay rendering", () => {
+  function renderTable(txRows: TxRow[], forecastOccurrences: ForecastOccurrence[] = []) {
+    return render(
+      <TransactionTable
+        rows={txRows}
+        categories={[]}
+        allCounterparties={[]}
+        activeRecurrings={EMPTY_RECURRINGS}
+        forecastOccurrences={forecastOccurrences}
+      />,
+    );
+  }
+
+  it("renders a forecast row with 'esperado' status badge", () => {
+    const fc = makeForecast({ status: "esperado", label: "Netflix" });
+    renderTable([], [fc]);
+    // The table renders desktop + mobile rows; check at least one badge.
+    const badges = screen.getAllByText("Esperado");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders a forecast row with 'atrasado' status badge", () => {
+    const fc = makeForecast({ status: "atrasado", label: "Spotify" });
+    renderTable([], [fc]);
+    const badges = screen.getAllByText("Atrasado");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders a forecast row with 'skipped' Saltado badge", () => {
+    const fc = makeForecast({ status: "skipped", label: "HBO" });
+    renderTable([], [fc]);
+    const badges = screen.getAllByText("Saltado");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the RecurringBadge (↻ Recurring) on a real tx linked to a recurring", () => {
+    const tx = makeTxRow({
+      id: 99,
+      recurringId: 5,
+      recurringYearMonth: "2026-04",
+      recurringLabel: "Gym",
+    });
+    renderTable([tx]);
+    // RecurringBadge renders text "Gym" (truncated label).
+    // Both desktop and mobile views render the badge — getAllByTitle is intentional.
+    const badges = screen.getAllByTitle("Recurring: Gym");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does NOT render ForecastRowActions on a 'skipped' forecast row", () => {
+    // skipped rows show no action menu — the condition in the template excludes them.
+    const fc = makeForecast({ status: "skipped" });
+    renderTable([], [fc]);
+    expect(screen.queryByTestId("forecast-row-actions")).not.toBeInTheDocument();
+  });
+
+  it("renders ForecastRowActions on an 'esperado' forecast row", () => {
+    const fc = makeForecast({ status: "esperado" });
+    renderTable([], [fc]);
+    expect(screen.getAllByTestId("forecast-row-actions").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("'linkeado' forecasts are NOT rendered as forecast rows (already have a tx)", () => {
+    const fc = makeForecast({ status: "linkeado" });
+    renderTable([], [fc]);
+    // mergeRows filters out linkeado — no forecast-row data-testid should appear.
+    expect(screen.queryByTestId("forecast-row")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("forecast-row-mobile")).not.toBeInTheDocument();
+  });
+
+  it("renders a real tx row and a forecast row side by side without mixing amounts", () => {
+    const tx = makeTxRow({ id: 1, amountCents: BigInt(-50000) });
+    const fc = makeForecast({ status: "atrasado", amountCents: BigInt(-9990) });
+    const { container } = renderTable([tx], [fc]);
+
+    const forecastRows = container.querySelectorAll("[data-testid='forecast-row']");
+    const forecastRowsMobile = container.querySelectorAll("[data-testid='forecast-row-mobile']");
+    // At least one of desktop/mobile renders the forecast row.
+    expect(forecastRows.length + forecastRowsMobile.length).toBeGreaterThanOrEqual(1);
+
+    // The forecast amount cell carries the "not in total" title attribute.
+    const estimatedCells = container.querySelectorAll(
+      "[title='Monto estimado — no suma al total del mes']",
+    );
+    expect(estimatedCells.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/components/transactions/forecast-overlay.test.tsx
+++ b/src/components/transactions/forecast-overlay.test.tsx
@@ -143,20 +143,29 @@ describe("mergeRows", () => {
     expect(merged).toHaveLength(0);
   });
 
+  /**
+   * Architecture invariant: forecast rows must NEVER count toward the month total.
+   *
+   * The displayed month total in /transactions is computed by countTotal() in
+   * page.tsx — a DB query against the transactions table only. forecast rows
+   * are a render-time overlay (issue #622) and never reach that query.
+   *
+   * This test asserts the kind-separation contract of mergeRows() at the data
+   * layer. If someone later adds a row-level footer total inside TransactionTable,
+   * they MUST filter by kind === 'tx' and a DOM-level assertion should be added
+   * here.
+   */
   it("ARCHITECTURE INVARIANT — forecast amounts MUST NOT be counted in the month total", () => {
-    // This is the critical guard from issue #622: the month total in the UI is
-    // derived from real transactions ONLY. Forecast rows are visual overlays.
-    // The invariant: sum of (kind='tx').amountCents === sum of real tx amounts only.
-    const tx1 = makeTxRow({ id: 1, amountCents: BigInt(-50000) });
-    const tx2 = makeTxRow({ id: 2, amountCents: BigInt(-30000) });
+    const tx1 = makeTxRow({ id: 1, amountCents: BigInt(-80000) });
+    const tx2 = makeTxRow({ id: 2, amountCents: BigInt(-24990) });
     const forecast1 = makeForecast({
       recurringId: 10,
-      amountCents: BigInt(-9990),
+      amountCents: BigInt(-80000),
       status: "esperado",
     });
     const forecast2 = makeForecast({
       recurringId: 11,
-      amountCents: BigInt(-15000),
+      amountCents: BigInt(-24990),
       status: "atrasado",
     });
 
@@ -172,12 +181,17 @@ describe("mergeRows", () => {
       .filter((r): r is Extract<MergedRow, { kind: "forecast" }> => r.kind === "forecast")
       .reduce((acc, r) => acc + r.data.amountCents, BigInt(0));
 
-    // Real tx total = tx1 + tx2 = -80000.
-    expect(txOnlyTotal).toBe(BigInt(-80000));
-    // Forecast total is separate and non-zero — proves they are NOT mixed in.
-    expect(forecastTotal).toBe(BigInt(-24990));
-    // The sum-of-all would be wrong if forecasts were included.
-    expect(txOnlyTotal).not.toBe(txOnlyTotal + forecastTotal);
+    // Concrete values — the amounts are intentionally equal per kind so a naive
+    // implementation that accidentally mixes kinds would STILL produce the wrong
+    // total (doubled), making the guard non-trivial.
+    expect(txOnlyTotal).toBe(BigInt(-104990)); // tx1 + tx2 = -80000 + -24990
+    expect(forecastTotal).toBe(BigInt(-104990)); // forecast1 + forecast2 (same values)
+
+    // What the total would WRONGLY be if forecasts were mixed in:
+    const wrongTotalIfMixed = txOnlyTotal + forecastTotal;
+    expect(wrongTotalIfMixed).toBe(BigInt(-209980)); // doubled — the bug we guard against
+    expect(txOnlyTotal).not.toBe(wrongTotalIfMixed); // explicit guard: facts-only != mixed
+
     // Total row count = 2 tx + 2 forecast (neither is linkeado/synthetic).
     expect(merged).toHaveLength(4);
   });

--- a/src/lib/recurring/gap-queries.ts
+++ b/src/lib/recurring/gap-queries.ts
@@ -62,7 +62,14 @@ export async function getLinkCandidates(
       dayOfMonth: recurringTransactions.dayOfMonth,
     })
     .from(recurringGaps)
-    .innerJoin(recurringTransactions, eq(recurringTransactions.id, recurringGaps.recurringId))
+    .innerJoin(
+      recurringTransactions,
+      and(
+        eq(recurringTransactions.id, recurringGaps.recurringId),
+        // Defense-in-depth tenant pairing per per-user-table-join-tenant-safety.
+        eq(recurringTransactions.userId, recurringGaps.userId),
+      ),
+    )
     .where(and(eq(recurringGaps.userId, userId), eq(recurringGaps.id, gapId)))
     .limit(1);
   if (!gap) return [];
@@ -114,8 +121,22 @@ export async function getOpenGaps(userId: number, database: DB = defaultDb): Pro
       detectedAt: recurringGaps.detectedAt,
     })
     .from(recurringGaps)
-    .innerJoin(recurringTransactions, eq(recurringTransactions.id, recurringGaps.recurringId))
-    .innerJoin(accounts, eq(accounts.id, recurringTransactions.accountId))
+    .innerJoin(
+      recurringTransactions,
+      and(
+        eq(recurringTransactions.id, recurringGaps.recurringId),
+        // Defense-in-depth tenant pairing per per-user-table-join-tenant-safety.
+        eq(recurringTransactions.userId, recurringGaps.userId),
+      ),
+    )
+    .innerJoin(
+      accounts,
+      and(
+        eq(accounts.id, recurringTransactions.accountId),
+        // Defense-in-depth tenant pairing per per-user-table-join-tenant-safety.
+        eq(accounts.userId, recurringTransactions.userId),
+      ),
+    )
     .leftJoin(
       categories,
       and(

--- a/src/lib/recurring/gap-queries.ts
+++ b/src/lib/recurring/gap-queries.ts
@@ -8,6 +8,7 @@ import {
   recurringTransactions,
   transactions,
 } from "@/lib/db/schema";
+import { formatAccountLabel } from "@/lib/accounts/format";
 import {
   DEFAULT_WINDOW_AFTER_DAYS,
   DEFAULT_WINDOW_BEFORE_DAYS,
@@ -103,6 +104,7 @@ export async function getOpenGaps(userId: number, database: DB = defaultDb): Pro
       label: recurringTransactions.label,
       accountId: recurringTransactions.accountId,
       accountName: accounts.name,
+      accountCurrency: accounts.currency,
       amountCents: recurringTransactions.amountCents,
       currency: recurringTransactions.currency,
       categorySlug: recurringTransactions.categorySlug,
@@ -124,5 +126,8 @@ export async function getOpenGaps(userId: number, database: DB = defaultDb): Pro
     .where(eq(recurringGaps.userId, userId))
     .orderBy(asc(recurringGaps.yearMonth), asc(recurringTransactions.dayOfMonth));
 
-  return rows;
+  return rows.map((r) => ({
+    ...r,
+    accountName: formatAccountLabel({ name: r.accountName, currency: r.accountCurrency }),
+  }));
 }

--- a/src/lib/recurring/upcoming.ts
+++ b/src/lib/recurring/upcoming.ts
@@ -90,7 +90,14 @@ export async function getUpcomingForMonth(
       notes: recurringTransactions.notes,
     })
     .from(recurringTransactions)
-    .innerJoin(accounts, eq(accounts.id, recurringTransactions.accountId))
+    .innerJoin(
+      accounts,
+      and(
+        eq(accounts.id, recurringTransactions.accountId),
+        // Defense-in-depth tenant pairing per per-user-table-join-tenant-safety.
+        eq(accounts.userId, recurringTransactions.userId),
+      ),
+    )
     .leftJoin(
       categories,
       and(

--- a/src/lib/recurring/upcoming.ts
+++ b/src/lib/recurring/upcoming.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, gte, inArray, isNull, lte } from "drizzle-orm";
 import { db as defaultDb, type DB } from "@/lib/db";
 import { accounts, categories, recurringTransactions, transactions } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
+import { formatAccountLabel } from "@/lib/accounts/format";
 import {
   DEFAULT_WINDOW_AFTER_DAYS,
   DEFAULT_WINDOW_BEFORE_DAYS,
@@ -78,6 +79,7 @@ export async function getUpcomingForMonth(
       label: recurringTransactions.label,
       accountId: recurringTransactions.accountId,
       accountName: accounts.name,
+      accountCurrency: accounts.currency,
       amountCents: recurringTransactions.amountCents,
       currency: recurringTransactions.currency,
       categorySlug: recurringTransactions.categorySlug,
@@ -202,7 +204,7 @@ export async function getUpcomingForMonth(
       recurringId: r.id,
       label: r.label,
       accountId: r.accountId,
-      accountName: r.accountName,
+      accountName: formatAccountLabel({ name: r.accountName, currency: r.accountCurrency }),
       amountCents: r.amountCents,
       currency: r.currency,
       categorySlug: r.categorySlug,


### PR DESCRIPTION
Closes #627

## Summary

- **S1 — dialog stale-closure fixed**: split the `useEffect` dependency in `forecast-link-tx-dialog` with `useCallback`, eliminating stale-closure risk on the link handler
- **S2 — +18 component tests**: `forecast-overlay.test.tsx` (includes falsifiable architecture-invariant guard — equal-amount fixtures so naive double-counting produces detectable doubled total) and `recurring-pending-banner.test.tsx` cover the two visual components added in epic #620
- **formatAccountLabel source-side (Hit B+C)**: applied in `gap-queries.ts` and `upcoming.ts` SELECT projections with tenant pairing on all per-user JOINs; Hit A was already clean (consumer already called `formatAccountLabel`)
- **Defensive cleanup**: pre-existing `getLinkCandidates` JOIN in `gap-queries.ts` also paired on `user_id`

## Reviewer findings + fixes (all resolved in `aa4f3ff`)

| Finding | Severity | Resolution |
|---|---|---|
| C1: JOIN tenant pairing missing in `gap-queries.ts` (2 fns) + `upcoming.ts` (1 fn) | CRITICAL | Added `user_id` pairing on all `accounts` JOINs |
| C2: Invariant assertion in forecast-overlay test was tautological | CRITICAL | Replaced with falsifiable design — two fixtures with equal amounts so double-counting would produce 2x total |
| W1: `getOpenGaps` recurringTransactions JOIN unpaired | WARNING | Paired on `user_id` |

## Test plan

- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` clean (149 files, 1889 tests, 1 skipped)
- [x] `bun run test:e2e` — 68 passed; 6 pre-existing flakes (home recharts + counterparty spec, known from #624) did not generate screenshots but are unrelated to this branch
- [ ] manual smoke: recurring forecast overlay renders, pending banner shows correct state, upcoming cards show formatted account names

## Screenshots (e2e — key pages)

Screenshots captured for: transactions, accounts, budgets, insights, settings, settings-ingestion, settings-rules, settings-inbox, settings-widgets, settings-accounts, imports, and counterparty dialog (75 total via Playwright).

The home page recharts flake (`light home` / `dark home`) and counterparty table-load flake are pre-existing and tracked separately — not introduced by this PR.