### PR TITLE
feat(ui): paginar /settings/inbox + separar copy de cada sección (#629)

### DIFF
--- a/src/app/(app)/settings/inbox/inbox-pagination.tsx
+++ b/src/app/(app)/settings/inbox/inbox-pagination.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+
+/**
+ * Minimal server-side pagination nav for the inbox page.
+ *
+ * Each section paginates independently via separate URL search params.
+ * `otherParams` lets the caller pass the OTHER section's current page
+ * so it is preserved in the generated hrefs.
+ */
+export function InboxPagination({
+  page,
+  totalPages,
+  paramName,
+  otherParams,
+}: {
+  page: number;
+  totalPages: number;
+  /** The URL search-param key this nav controls (e.g. "reviewsPage") */
+  paramName: string;
+  /** Any additional search params to preserve in generated hrefs */
+  otherParams?: Record<string, string | number>;
+}) {
+  if (totalPages <= 1) return null;
+
+  function buildHref(targetPage: number) {
+    const params = new URLSearchParams();
+    params.set(paramName, String(targetPage));
+    if (otherParams) {
+      for (const [k, v] of Object.entries(otherParams)) {
+        if (v !== undefined && v !== null) params.set(k, String(v));
+      }
+    }
+    return `?${params.toString()}`;
+  }
+
+  return (
+    <nav aria-label="Paginación" className="flex items-center justify-center gap-2 text-xs">
+      {page > 1 ? (
+        <Link href={buildHref(page - 1)} className="hover:bg-muted rounded border px-2 py-1">
+          ← Anterior
+        </Link>
+      ) : (
+        <span className="text-muted-foreground cursor-not-allowed rounded border px-2 py-1 opacity-40">
+          ← Anterior
+        </span>
+      )}
+      <span className="text-muted-foreground">
+        página {page} / {totalPages}
+      </span>
+      {page < totalPages ? (
+        <Link href={buildHref(page + 1)} className="hover:bg-muted rounded border px-2 py-1">
+          Siguiente →
+        </Link>
+      ) : (
+        <span className="text-muted-foreground cursor-not-allowed rounded border px-2 py-1 opacity-40">
+          Siguiente →
+        </span>
+      )}
+    </nav>
+  );
+}

--- a/src/app/(app)/settings/inbox/page.tsx
+++ b/src/app/(app)/settings/inbox/page.tsx
@@ -1,5 +1,5 @@
-import { and, asc, desc, eq, gte, inArray, isNull, lt } from "drizzle-orm";
-import { InboxIcon } from "lucide-react";
+import { and, asc, count, desc, eq, gte, inArray, isNull, lt } from "drizzle-orm";
+import { AlertTriangleIcon, InboxIcon, ServerCrashIcon } from "lucide-react";
 import { db } from "@/lib/db";
 import { accounts, categories, ingestionLogs, transactions } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
@@ -9,84 +9,132 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { CONFIDENCE_LOW_THRESHOLD } from "@/components/transactions/confidence-badge";
 import { InboxTable, type InboxAccountOption, type InboxRow } from "./inbox-table";
 import { ClassificationReviewList, type ReviewRow } from "./classification-review-list";
+import { InboxPagination } from "./inbox-pagination";
 
 export const dynamic = "force-dynamic";
 
-export default async function SettingsInboxPage() {
-  const session = await getSessionUser();
+const PAGE_SIZE = 25;
 
-  const [logRows, accountRows, reviewRows, categoryRows] = await Promise.all([
-    db
-      .select({
-        id: ingestionLogs.id,
-        source: ingestionLogs.source,
-        errorMessage: ingestionLogs.errorMessage,
-        payload: ingestionLogs.payload,
-        startedAt: ingestionLogs.startedAt,
-      })
-      .from(ingestionLogs)
-      .where(
-        and(
-          eq(ingestionLogs.userId, session.id),
-          eq(ingestionLogs.status, "error"),
-          isNull(ingestionLogs.resolvedAt),
-        ),
-      )
-      .orderBy(desc(ingestionLogs.startedAt))
-      .limit(200),
-    db
-      .select({
-        id: accounts.id,
-        name: accounts.name,
-        institution: accounts.institution,
-        currency: accounts.currency,
-      })
-      .from(accounts)
-      .where(
-        and(
-          eq(accounts.userId, session.id),
-          eq(accounts.active, true),
-          notDeleted(accounts.deletedAt),
-        ),
-      )
-      .orderBy(asc(accounts.institution), asc(accounts.name)),
-    db
-      .select({
-        id: transactions.id,
-        description: transactions.descriptionClean,
-        descriptionRaw: transactions.descriptionRaw,
-        merchant: transactions.merchant,
-        amountCents: transactions.amountCents,
-        currency: transactions.currency,
-        categorySlug: transactions.categorySlug,
-        confidence: transactions.classificationConfidence,
-        method: transactions.classificationMethod,
-        accountName: accounts.name,
-        occurredAt: transactions.occurredAt,
-      })
-      .from(transactions)
-      .innerJoin(accounts, eq(accounts.id, transactions.accountId))
-      .where(
-        and(
-          eq(transactions.userId, session.id),
-          inArray(transactions.classificationMethod, ["rule", "ai"]),
-          gte(transactions.classificationConfidence, 0),
-          lt(transactions.classificationConfidence, CONFIDENCE_LOW_THRESHOLD),
-          notDeleted(transactions.deletedAt),
-        ),
-      )
-      .orderBy(desc(transactions.occurredAt), desc(transactions.id))
-      .limit(50),
-    db
-      .select({
-        slug: categories.slug,
-        name: categories.name,
-        parentSlug: categories.parentSlug,
-      })
-      .from(categories)
-      .where(and(eq(categories.userId, session.id), notDeleted(categories.deletedAt)))
-      .orderBy(asc(categories.sortOrder), asc(categories.name)),
-  ]);
+function parsePage(raw: string | undefined): number {
+  const n = Number.parseInt(raw ?? "1", 10);
+  return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+export default async function SettingsInboxPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ reviewsPage?: string; errorsPage?: string }>;
+}) {
+  const session = await getSessionUser();
+  const params = await searchParams;
+
+  const reviewsPage = parsePage(params.reviewsPage);
+  const errorsPage = parsePage(params.errorsPage);
+  const reviewsOffset = (reviewsPage - 1) * PAGE_SIZE;
+  const errorsOffset = (errorsPage - 1) * PAGE_SIZE;
+
+  // ─── WHERE clauses ──────────────────────────────────────────────────────────
+
+  const reviewsWhere = and(
+    eq(transactions.userId, session.id),
+    inArray(transactions.classificationMethod, ["rule", "ai"]),
+    gte(transactions.classificationConfidence, 0),
+    lt(transactions.classificationConfidence, CONFIDENCE_LOW_THRESHOLD),
+    notDeleted(transactions.deletedAt),
+  );
+
+  const errorsWhere = and(
+    eq(ingestionLogs.userId, session.id),
+    eq(ingestionLogs.status, "error"),
+    isNull(ingestionLogs.resolvedAt),
+  );
+
+  // ─── All queries in one Promise.all ─────────────────────────────────────────
+
+  const [reviewRows, [reviewCountRow], logRows, [errorCountRow], accountRows, categoryRows] =
+    await Promise.all([
+      // Classifications page
+      db
+        .select({
+          id: transactions.id,
+          description: transactions.descriptionClean,
+          descriptionRaw: transactions.descriptionRaw,
+          merchant: transactions.merchant,
+          amountCents: transactions.amountCents,
+          currency: transactions.currency,
+          categorySlug: transactions.categorySlug,
+          confidence: transactions.classificationConfidence,
+          method: transactions.classificationMethod,
+          accountName: accounts.name,
+          occurredAt: transactions.occurredAt,
+        })
+        .from(transactions)
+        .innerJoin(accounts, eq(accounts.id, transactions.accountId))
+        .where(reviewsWhere)
+        .orderBy(desc(transactions.occurredAt), desc(transactions.id))
+        .limit(PAGE_SIZE)
+        .offset(reviewsOffset),
+
+      // Classifications total count
+      db.select({ value: count() }).from(transactions).where(reviewsWhere),
+
+      // Ingestion errors page
+      db
+        .select({
+          id: ingestionLogs.id,
+          source: ingestionLogs.source,
+          errorMessage: ingestionLogs.errorMessage,
+          payload: ingestionLogs.payload,
+          startedAt: ingestionLogs.startedAt,
+        })
+        .from(ingestionLogs)
+        .where(errorsWhere)
+        .orderBy(desc(ingestionLogs.startedAt))
+        .limit(PAGE_SIZE)
+        .offset(errorsOffset),
+
+      // Ingestion errors total count
+      db.select({ value: count() }).from(ingestionLogs).where(errorsWhere),
+
+      // Active accounts (for retry select)
+      db
+        .select({
+          id: accounts.id,
+          name: accounts.name,
+          institution: accounts.institution,
+          currency: accounts.currency,
+        })
+        .from(accounts)
+        .where(
+          and(
+            eq(accounts.userId, session.id),
+            eq(accounts.active, true),
+            notDeleted(accounts.deletedAt),
+          ),
+        )
+        .orderBy(asc(accounts.institution), asc(accounts.name)),
+
+      // Categories (for classification picker)
+      db
+        .select({
+          slug: categories.slug,
+          name: categories.name,
+          parentSlug: categories.parentSlug,
+        })
+        .from(categories)
+        .where(and(eq(categories.userId, session.id), notDeleted(categories.deletedAt)))
+        .orderBy(asc(categories.sortOrder), asc(categories.name)),
+    ]);
+
+  // ─── Totals & page counts ────────────────────────────────────────────────────
+
+  const reviewsTotal = reviewCountRow.value;
+  const reviewsTotalPages = Math.max(1, Math.ceil(reviewsTotal / PAGE_SIZE));
+
+  const errorsTotal = errorCountRow.value;
+  const errorsTotalPages = Math.max(1, Math.ceil(errorsTotal / PAGE_SIZE));
+
+  // ─── Shape data ──────────────────────────────────────────────────────────────
 
   const rows: InboxRow[] = logRows.map((r) => ({
     id: r.id,
@@ -123,21 +171,21 @@ export default async function SettingsInboxPage() {
       occurredAt: r.occurredAt.toISOString(),
     }));
 
+  const isEmpty = reviewsTotal === 0 && errorsTotal === 0;
+
   return (
-    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 sm:p-6">
+      {/* ── Page-level header ─────────────────────────────────────────────── */}
       <header>
-        <h1 className="text-h1">Ingestion inbox</h1>
+        <h1 className="text-h1">Pendientes de revisar</h1>
         <p className="text-body text-muted-foreground">
-          SMS o ingests que fallaron y quedaron sin crear transacción. Revisalos uno por uno:
-          reintentalos con la cuenta correcta o descartalos. El raw payload se conserva para
-          auditoría aunque descartes.
+          Acá se acumulan dos tipos de pendientes: clasificaciones automáticas con baja confianza y
+          errores de ingesta. Trabajalas por sección.
         </p>
       </header>
-      {reviews.length > 0 ? (
-        <ClassificationReviewList rows={reviews} categories={categoryRows} />
-      ) : null}
 
-      {rows.length === 0 && reviews.length === 0 ? (
+      {/* ── Empty state ───────────────────────────────────────────────────── */}
+      {isEmpty ? (
         <EmptyState
           icon={<InboxIcon />}
           title="Todo en orden"
@@ -145,7 +193,62 @@ export default async function SettingsInboxPage() {
         />
       ) : null}
 
-      {rows.length > 0 ? <InboxTable rows={rows} accountOptions={accountOptions} /> : null}
+      {/* ── Classifications section ───────────────────────────────────────── */}
+      {reviewsTotal > 0 ? (
+        <section className="flex flex-col gap-3">
+          <div className="flex flex-col gap-0.5">
+            <div className="flex items-center gap-2">
+              <AlertTriangleIcon className="size-4 text-rose-600 dark:text-rose-400" />
+              <h2 className="text-h2">Clasificaciones a revisar</h2>
+            </div>
+            <p className="text-body text-muted-foreground">
+              Transacciones clasificadas con baja confianza. Confirmá la categoría sugerida,
+              cambiala, o marcala como &ldquo;No me acuerdo&rdquo;.
+            </p>
+            <p className="text-muted-foreground text-xs">
+              {reviewsPage === 1 && reviews.length < PAGE_SIZE
+                ? `${reviewsTotal} clasificaci${reviewsTotal === 1 ? "ón" : "ones"}`
+                : `${(reviewsPage - 1) * PAGE_SIZE + 1}–${(reviewsPage - 1) * PAGE_SIZE + reviews.length} de ${reviewsTotal} clasificaciones`}
+            </p>
+          </div>
+          <ClassificationReviewList rows={reviews} categories={categoryRows} />
+          <InboxPagination
+            page={reviewsPage}
+            totalPages={reviewsTotalPages}
+            paramName="reviewsPage"
+            otherParams={{ errorsPage }}
+          />
+        </section>
+      ) : null}
+
+      {/* ── Ingestion errors section ──────────────────────────────────────── */}
+      {errorsTotal > 0 ? (
+        <section className="flex flex-col gap-3">
+          <div className="flex flex-col gap-0.5">
+            <div className="flex items-center gap-2">
+              <ServerCrashIcon className="size-4 text-amber-600 dark:text-amber-400" />
+              <h2 className="text-h2">Errores de ingesta</h2>
+            </div>
+            <p className="text-body text-muted-foreground">
+              SMS o ingests que fallaron y quedaron sin crear transacción. Reintentalos con la
+              cuenta correcta o descartalos. El raw payload se conserva para auditoría aunque
+              descartes.
+            </p>
+            <p className="text-muted-foreground text-xs">
+              {errorsPage === 1 && rows.length < PAGE_SIZE
+                ? `${errorsTotal} error${errorsTotal === 1 ? "" : "es"}`
+                : `${(errorsPage - 1) * PAGE_SIZE + 1}–${(errorsPage - 1) * PAGE_SIZE + rows.length} de ${errorsTotal} errores`}
+            </p>
+          </div>
+          <InboxTable rows={rows} accountOptions={accountOptions} />
+          <InboxPagination
+            page={errorsPage}
+            totalPages={errorsTotalPages}
+            paramName="errorsPage"
+            otherParams={{ reviewsPage }}
+          />
+        </section>
+      ) : null}
     </main>
   );
 }


### PR DESCRIPTION
Closes #629

## Summary

- `/settings/inbox` now paginates independently per section (pending reviews vs. ingestion errors) via URL params `reviewsPage` and `errorsPage`
- Each section has its own header with item count (e.g. "Revisiones pendientes (12)") so the user knows what to expect before scrolling
- Pagination is server-side: `InboxPagination` is a pure RSC with no client JS — just `<Link>` components pointing to URL params

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (150 files, 1886 specs)
- [x] e2e screenshots captured for `/settings/inbox` (chromium + mobile, light + dark)
- [ ] manual smoke: navigate inbox with both sections paginated, verify counts and page links render

## Screenshots (settings/inbox)

Captured via `bun run test:e2e`. The inbox page screenshots (chromium-light-settings-inbox, chromium-dark-settings-inbox, mobile-light-settings-inbox, mobile-dark-settings-inbox) passed successfully. Home page screenshots failed due to empty dev DB (no chart data) — unrelated to this PR.