### PR TITLE
feat(recurring): UpcomingCard redesign + window-based picker + cross-month auto-link (#632)

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -22,7 +22,7 @@ import { SmsHealthCard } from "@/components/dashboard/sms-health-card";
 import { CreditCardsCard } from "@/components/dashboard/credit-cards-card";
 import { PendingConsolidationBanner } from "@/components/dashboard/pending-consolidation-banner";
 import { PayPeriodNudge } from "@/components/dashboard/pay-period-nudge";
-import { getUpcomingForMonth } from "@/lib/recurring/upcoming";
+import { getUpcomingForWindow } from "@/lib/recurring/upcoming";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { getSmsHealthSnapshot } from "@/lib/ingestion/sms-health";
 import { getSessionUser } from "@/lib/auth/session";
@@ -46,8 +46,6 @@ export default async function DashboardPage({
   const refDate = refDateFromYearMonth(ym);
   const isFuture = isFutureYearMonth(ym, now);
   const monthLabel = formatYearMonth(ym);
-  const [refYear, refMonth] = ym.split("-").map(Number);
-
   const session = await getSessionUser();
   const fx = await getCurrentFxRate();
 
@@ -77,13 +75,8 @@ export default async function DashboardPage({
       getCategoryBreakdown(session.id, fx.rate, range),
       getTopExpenses(session.id, fx.rate, range, 5),
       getAccountStatuses(session.id),
-      getUpcomingForMonth({
-        userId: session.id,
-        year: refYear,
-        month: refMonth,
-        includeDismissed: true,
-        today: now,
-      }),
+      // #632: window-based query (today ±5d, cross-month, un-matched only).
+      getUpcomingForWindow({ userId: session.id, today: now }),
       getSmsHealthSnapshot(session.id, now),
       // Bank truth — TC summary stays on calendar regardless of cycle mode.
       getCreditCardsSummary(session.id, fx.rate, now),
@@ -152,7 +145,7 @@ export default async function DashboardPage({
             period={period}
             isFuture={isFuture}
           />
-          <UpcomingCard items={upcomingItems} monthLabel={monthLabel} />
+          <UpcomingCard items={upcomingItems} windowLabel="±5d desde hoy" />
         </section>
 
         <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">

--- a/src/app/(app)/transactions/forecast-actions.test.ts
+++ b/src/app/(app)/transactions/forecast-actions.test.ts
@@ -44,17 +44,11 @@ async function cleanup() {
 }
 
 async function seedUser(email: string): Promise<number> {
-  const [row] = await db
-    .insert(users)
-    .values({ email, name: email })
-    .returning({ id: users.id });
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
   return row.id;
 }
 
-async function seedAccount(
-  userId: number,
-  currency: "COP" | "USD" = "COP",
-): Promise<number> {
+async function seedAccount(userId: number, currency: "COP" | "USD" = "COP"): Promise<number> {
   const [row] = await db
     .insert(accounts)
     .values({

--- a/src/app/(app)/transactions/forecast-actions.test.ts
+++ b/src/app/(app)/transactions/forecast-actions.test.ts
@@ -1,0 +1,362 @@
+// #632: Integration tests for getLinkCandidatesForForecast (redesigned).
+// Tests window-based candidate fetching, sugeridas/todas split, and tenant safety.
+// Runs against findash_test (forced by vitest.setup.ts).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, recurringTransactions, transactions, users } from "@/lib/db/schema";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockResolvedValue({
+    id: 1,
+    email: "test@test.local",
+    name: "Test",
+    role: "user" as const,
+    active: true,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Lazy imports (after mocks)
+// ---------------------------------------------------------------------------
+
+const { getLinkCandidatesForForecast } = await import("./forecast-actions");
+const { getSessionUser } = await import("@/lib/auth/session");
+const mockGetSessionUser = vi.mocked(getSessionUser);
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
+
+const TAG = "__fcast632__";
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE ${TAG + "%"}`);
+  await db.execute(sql`DELETE FROM recurring_transactions WHERE label LIKE ${TAG + "%"}`);
+  await db.execute(sql`DELETE FROM accounts WHERE name LIKE ${TAG + "%"}`);
+  await db.execute(sql`DELETE FROM users WHERE email LIKE ${"%" + TAG + "%"}`);
+}
+
+async function seedUser(email: string): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({ email, name: email })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function seedAccount(
+  userId: number,
+  currency: "COP" | "USD" = "COP",
+): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG}acct`,
+      institution: TAG,
+      type: "savings",
+      currency,
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function seedRecurring(
+  userId: number,
+  accountId: number,
+  opts: {
+    label?: string;
+    amountCents?: bigint;
+    dayOfMonth?: number;
+    currency?: "COP" | "USD";
+  } = {},
+): Promise<number> {
+  const [row] = await db
+    .insert(recurringTransactions)
+    .values({
+      userId,
+      accountId,
+      label: opts.label ?? `${TAG}recurring`,
+      amountCents: opts.amountCents ?? BigInt(-100000),
+      currency: opts.currency ?? "COP",
+      dayOfMonth: opts.dayOfMonth ?? 15,
+      active: true,
+    })
+    .returning({ id: recurringTransactions.id });
+  return row.id;
+}
+
+async function seedTx(
+  userId: number,
+  accountId: number,
+  opts: {
+    occurredOn: string;
+    amountCents?: bigint;
+    currency?: "COP" | "USD";
+    description?: string;
+    recurringId?: number | null;
+  },
+): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: new Date(`${opts.occurredOn}T12:00:00Z`),
+      amountCents: opts.amountCents ?? BigInt(-100000),
+      currency: opts.currency ?? "COP",
+      descriptionRaw: opts.description ?? `${TAG}tx`,
+      source: "manual",
+      recurringId: opts.recurringId ?? null,
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+describe("getLinkCandidatesForForecast (#632 redesign)", () => {
+  const USER_ID = 1;
+
+  beforeEach(async () => {
+    await cleanup();
+    mockGetSessionUser.mockResolvedValue({
+      id: USER_ID,
+      email: "test@test.local",
+      name: "Test",
+      role: "user",
+      active: true,
+    });
+  });
+  afterEach(cleanup);
+
+  it("default window is [expectedDate-10d, expectedDate+5d], ALL accounts", async () => {
+    const accountId = await seedAccount(USER_ID);
+    const account2Id = await seedAccount(USER_ID);
+    const recurringId = await seedRecurring(USER_ID, accountId, {
+      dayOfMonth: 15,
+      amountCents: BigInt(-100000),
+    });
+
+    // tx on different account, within default window (day 15 ± 10d/+5d = Apr 5 – Apr 20).
+    await seedTx(USER_ID, account2Id, {
+      occurredOn: "2026-04-12",
+      amountCents: BigInt(-100000),
+    });
+
+    const result = await getLinkCandidatesForForecast({
+      recurringId,
+      yearMonth: "2026-04",
+      showAll: false,
+    });
+
+    // Should find the tx from account2 (all-accounts scope).
+    const allCandidates = [...result.sugeridas, ...result.todas];
+    expect(allCandidates.length).toBeGreaterThanOrEqual(1);
+    const found = allCandidates.some(() => true); // at least one candidate returned
+    expect(found).toBe(true);
+  });
+
+  it("excludes already-linked transactions (recurringId IS NOT NULL)", async () => {
+    const accountId = await seedAccount(USER_ID);
+    const recurringId = await seedRecurring(USER_ID, accountId, {
+      dayOfMonth: 15,
+      amountCents: BigInt(-100000),
+    });
+    const otherRecurring = await seedRecurring(USER_ID, accountId, {
+      label: `${TAG}other`,
+      dayOfMonth: 15,
+      amountCents: BigInt(-100000),
+    });
+
+    // tx already linked to another recurring.
+    const txId = await seedTx(USER_ID, accountId, {
+      occurredOn: "2026-04-15",
+      amountCents: BigInt(-100000),
+      recurringId: otherRecurring,
+    });
+
+    const result = await getLinkCandidatesForForecast({
+      recurringId,
+      yearMonth: "2026-04",
+    });
+
+    const allCandidates = [...result.sugeridas, ...result.todas];
+    expect(allCandidates.find((c) => c.txId === txId)).toBeUndefined();
+  });
+
+  it("window-based: tx outside window not returned even with showAll=false", async () => {
+    const accountId = await seedAccount(USER_ID);
+    const recurringId = await seedRecurring(USER_ID, accountId, {
+      dayOfMonth: 15, // Apr 15; window [Apr 5, Apr 20]
+      amountCents: BigInt(-100000),
+    });
+
+    // tx on Apr 1 — 14 days before expectedDate (Apr 15). Outside [-10d, +5d] window.
+    const txId = await seedTx(USER_ID, accountId, {
+      occurredOn: "2026-04-01",
+      amountCents: BigInt(-100000),
+    });
+
+    const result = await getLinkCandidatesForForecast({
+      recurringId,
+      yearMonth: "2026-04",
+      showAll: false,
+    });
+
+    const allCandidates = [...result.sugeridas, ...result.todas];
+    expect(allCandidates.find((c) => c.txId === txId)).toBeUndefined();
+  });
+
+  it("showAll=true expands window to [expectedDate-30d, expectedDate+10d]", async () => {
+    const accountId = await seedAccount(USER_ID);
+    const recurringId = await seedRecurring(USER_ID, accountId, {
+      dayOfMonth: 15, // Apr 15
+      amountCents: BigInt(-100000),
+    });
+
+    // tx on Mar 25 — 21 days before expectedDate. Outside default [-10d], inside expanded [-30d].
+    const txId = await seedTx(USER_ID, accountId, {
+      occurredOn: "2026-03-25",
+      amountCents: BigInt(-100000),
+    });
+
+    // Not returned in default window.
+    const defaultResult = await getLinkCandidatesForForecast({
+      recurringId,
+      yearMonth: "2026-04",
+      showAll: false,
+    });
+    const inDefault = [...defaultResult.sugeridas, ...defaultResult.todas];
+    expect(inDefault.find((c) => c.txId === txId)).toBeUndefined();
+
+    // Returned in expanded window.
+    const expandedResult = await getLinkCandidatesForForecast({
+      recurringId,
+      yearMonth: "2026-04",
+      showAll: true,
+    });
+    const inExpanded = [...expandedResult.sugeridas, ...expandedResult.todas];
+    expect(inExpanded.find((c) => c.txId === txId)).toBeDefined();
+  });
+
+  it("sugeridas: same-currency tx within ±20% of recurring amount", async () => {
+    const accountId = await seedAccount(USER_ID, "COP");
+    const recurringId = await seedRecurring(USER_ID, accountId, {
+      dayOfMonth: 15,
+      amountCents: BigInt(-100000),
+      currency: "COP",
+    });
+
+    // Tx within ±20% (-80000 to -120000): should go to sugeridas.
+    const txInRangeId = await seedTx(USER_ID, accountId, {
+      occurredOn: "2026-04-15",
+      amountCents: BigInt(-105000), // 5% away from -100000
+      currency: "COP",
+      description: `${TAG}in_range`,
+    });
+
+    // Tx out of range (-130000): should go to todas.
+    const txOutRangeId = await seedTx(USER_ID, accountId, {
+      occurredOn: "2026-04-15",
+      amountCents: BigInt(-130000), // 30% away
+      currency: "COP",
+      description: `${TAG}out_range`,
+    });
+
+    // USD tx (different currency): always goes to todas regardless of amount.
+    const account2Id = await seedAccount(USER_ID, "USD");
+    const txUsdId = await seedTx(USER_ID, account2Id, {
+      occurredOn: "2026-04-15",
+      amountCents: BigInt(-100),
+      currency: "USD",
+      description: `${TAG}usd`,
+    });
+
+    const result = await getLinkCandidatesForForecast({
+      recurringId,
+      yearMonth: "2026-04",
+    });
+
+    expect(result.sugeridas.find((c) => c.txId === txInRangeId)).toBeDefined();
+    expect(result.todas.find((c) => c.txId === txOutRangeId)).toBeDefined();
+    expect(result.todas.find((c) => c.txId === txUsdId)).toBeDefined();
+    // sugeridas should NOT contain the out-of-range or USD tx
+    expect(result.sugeridas.find((c) => c.txId === txOutRangeId)).toBeUndefined();
+    expect(result.sugeridas.find((c) => c.txId === txUsdId)).toBeUndefined();
+  });
+
+  it("tenant safety: user2 transactions not returned for user1", async () => {
+    const user2Id = await seedUser(`u2${TAG}@test.local`);
+    const user1AccountId = await seedAccount(USER_ID);
+    const user2AccountId = await seedAccount(user2Id);
+
+    const recurringId = await seedRecurring(USER_ID, user1AccountId, {
+      dayOfMonth: 15,
+      amountCents: BigInt(-100000),
+    });
+
+    // User2 has a tx at the same day+amount.
+    const user2TxId = await seedTx(user2Id, user2AccountId, {
+      occurredOn: "2026-04-15",
+      amountCents: BigInt(-100000),
+    });
+
+    // User1 is the session user.
+    mockGetSessionUser.mockResolvedValue({
+      id: USER_ID,
+      email: "test@test.local",
+      name: "Test",
+      role: "user",
+      active: true,
+    });
+
+    const result = await getLinkCandidatesForForecast({
+      recurringId,
+      yearMonth: "2026-04",
+    });
+
+    const allCandidates = [...result.sugeridas, ...result.todas];
+    expect(allCandidates.find((c) => c.txId === user2TxId)).toBeUndefined();
+  });
+
+  it("cross-month: tx on April 29 appears as candidate for May 1 recurring", async () => {
+    const accountId = await seedAccount(USER_ID);
+    const recurringId = await seedRecurring(USER_ID, accountId, {
+      dayOfMonth: 1, // May 1
+      amountCents: BigInt(-100000),
+    });
+
+    // tx on April 29 — within window for May 1: [Apr 21, May 6].
+    const txId = await seedTx(USER_ID, accountId, {
+      occurredOn: "2026-04-29",
+      amountCents: BigInt(-100000),
+    });
+
+    const result = await getLinkCandidatesForForecast({
+      recurringId,
+      yearMonth: "2026-05", // May slot
+    });
+
+    const allCandidates = [...result.sugeridas, ...result.todas];
+    expect(allCandidates.find((c) => c.txId === txId)).toBeDefined();
+  });
+
+  it("returns recurringAmountCents and recurringCurrency in result", async () => {
+    const accountId = await seedAccount(USER_ID);
+    const recurringId = await seedRecurring(USER_ID, accountId, {
+      amountCents: BigInt(-250000),
+      currency: "COP",
+      dayOfMonth: 10,
+    });
+
+    const result = await getLinkCandidatesForForecast({ recurringId, yearMonth: "2026-04" });
+    expect(result.recurringAmountCents).toBe(BigInt(-250000));
+    expect(result.recurringCurrency).toBe("COP");
+  });
+});

--- a/src/app/(app)/transactions/forecast-actions.ts
+++ b/src/app/(app)/transactions/forecast-actions.ts
@@ -106,8 +106,11 @@ export async function skipGap(input: SkipGapInput) {
 
 // ---------------------------------------------------------------------------
 // Fetch tx candidates for the "Asociar tx existente" picker.
-// Default scope: same account, ±10d/+5d window around expectedDate, unlinked.
-// Toggle: all tx for the user in the same yearMonth (no account/date filter).
+//
+// #632 redesign — window-based always, ALL accounts by default:
+//   Default: occurredAt ∈ [expectedDate-10d, expectedDate+5d], unlinked, ALL accounts.
+//   showAll toggle: expands window to [expectedDate-30d, expectedDate+10d]. NEVER
+//   falls back to month-calendar-based filtering.
 // NEVER filters by amount — variable recurrings (ARQ, EPM) depend on this.
 // ---------------------------------------------------------------------------
 
@@ -122,9 +125,21 @@ export type ForecastLinkCandidate = {
   accountName: string;
 };
 
+export type ForecastLinkCandidatesResult = {
+  /** Candidates matching same currency + within ±20% of recurringAmountCents. */
+  sugeridas: ForecastLinkCandidate[];
+  /** All remaining candidates (not in sugeridas), or all candidates if no sugeridas. */
+  todas: ForecastLinkCandidate[];
+  /** The expected amount of the recurring (for UI display). */
+  recurringAmountCents: bigint;
+  /** The currency of the recurring. */
+  recurringCurrency: string;
+};
+
 const linkCandidatesSchema = z.object({
   recurringId: z.coerce.number().int().positive(),
   yearMonth: z.string().regex(/^\d{4}-\d{2}$/),
+  /** When true, expands the window to [expectedDate-30d, expectedDate+10d]. */
   showAll: z.boolean().optional().default(false),
 });
 
@@ -133,22 +148,27 @@ export type GetLinkCandidatesInput = z.input<typeof linkCandidatesSchema>;
 /** Window constants matching gap-detector for consistency. */
 const WINDOW_BEFORE_DAYS = 10;
 const WINDOW_AFTER_DAYS = 5;
+/** Extended window when showAll=true. */
+const WINDOW_ALL_BEFORE_DAYS = 30;
+const WINDOW_ALL_AFTER_DAYS = 10;
 
 export async function getLinkCandidatesForForecast(
   input: GetLinkCandidatesInput,
-): Promise<ForecastLinkCandidate[]> {
+): Promise<ForecastLinkCandidatesResult> {
   const session = await getSessionUser();
   const parsed = linkCandidatesSchema.safeParse(input);
   if (!parsed.success) throw new Error(parsed.error.issues[0]?.message ?? "Input inválido");
 
   const { recurringId, yearMonth, showAll } = parsed.data;
 
-  // Fetch the recurring to get accountId + dayOfMonth — tenant-safe.
+  // Fetch the recurring to get dayOfMonth + amount + currency — tenant-safe.
   const [recurring] = await db
     .select({
       accountId: recurringTransactions.accountId,
       dayOfMonth: recurringTransactions.dayOfMonth,
       label: recurringTransactions.label,
+      amountCents: recurringTransactions.amountCents,
+      currency: recurringTransactions.currency,
     })
     .from(recurringTransactions)
     .where(
@@ -164,68 +184,46 @@ export async function getLinkCandidatesForForecast(
 
   const expectedDate = buildExpectedDate(recurring.dayOfMonth, yearMonth);
 
-  // Build the WHERE conditions.
-  let rows;
+  // Window-based always. showAll expands the window but NEVER switches to month-calendar.
+  const beforeDays = showAll ? WINDOW_ALL_BEFORE_DAYS : WINDOW_BEFORE_DAYS;
+  const afterDays = showAll ? WINDOW_ALL_AFTER_DAYS : WINDOW_AFTER_DAYS;
 
-  if (showAll) {
-    // "Mostrar todas las tx del mes" — all user tx in that yearMonth, unlinked.
-    const [ym_y, ym_m] = yearMonth.split("-").map(Number);
-    const monthStart = new Date(Date.UTC(ym_y, ym_m - 1, 1));
-    const monthEnd = new Date(Date.UTC(ym_y, ym_m, 0, 23, 59, 59, 999));
+  const windowStart = new Date(expectedDate.getTime() - beforeDays * 86400000);
+  const windowEnd = new Date(expectedDate.getTime() + afterDays * 86400000 + 86399999);
 
-    rows = await db
-      .select({
-        id: transactions.id,
-        occurredAt: transactions.occurredAt,
-        amountCents: transactions.amountCents,
-        currency: transactions.currency,
-        descriptionRaw: transactions.descriptionRaw,
-        merchant: transactions.merchant,
-        accountId: transactions.accountId,
-      })
-      .from(transactions)
-      .where(
-        and(
-          eq(transactions.userId, session.id),
-          isNull(transactions.recurringId),
-          gte(transactions.occurredAt, monthStart),
-          lte(transactions.occurredAt, monthEnd),
-          notDeleted(transactions.deletedAt),
-        ),
-      )
-      .orderBy(desc(transactions.occurredAt));
-  } else {
-    // Default: same account, ±10d/+5d window around expectedDate, unlinked.
-    const windowStart = new Date(expectedDate.getTime() - WINDOW_BEFORE_DAYS * 86400000);
-    const windowEnd = new Date(expectedDate.getTime() + WINDOW_AFTER_DAYS * 86400000 + 86399999);
+  // ALL accounts — no account filter. Currency-agnostic at query level.
+  const rows = await db
+    .select({
+      id: transactions.id,
+      occurredAt: transactions.occurredAt,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      descriptionRaw: transactions.descriptionRaw,
+      merchant: transactions.merchant,
+      accountId: transactions.accountId,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, session.id),
+        isNull(transactions.recurringId),
+        gte(transactions.occurredAt, windowStart),
+        lte(transactions.occurredAt, windowEnd),
+        notDeleted(transactions.deletedAt),
+      ),
+    )
+    .orderBy(desc(transactions.occurredAt));
 
-    rows = await db
-      .select({
-        id: transactions.id,
-        occurredAt: transactions.occurredAt,
-        amountCents: transactions.amountCents,
-        currency: transactions.currency,
-        descriptionRaw: transactions.descriptionRaw,
-        merchant: transactions.merchant,
-        accountId: transactions.accountId,
-      })
-      .from(transactions)
-      .where(
-        and(
-          eq(transactions.userId, session.id),
-          eq(transactions.accountId, recurring.accountId),
-          isNull(transactions.recurringId),
-          gte(transactions.occurredAt, windowStart),
-          lte(transactions.occurredAt, windowEnd),
-          notDeleted(transactions.deletedAt),
-        ),
-      )
-      .orderBy(desc(transactions.occurredAt));
+  if (rows.length === 0) {
+    return {
+      sugeridas: [],
+      todas: [],
+      recurringAmountCents: recurring.amountCents,
+      recurringCurrency: recurring.currency,
+    };
   }
 
-  if (rows.length === 0) return [];
-
-  // Fetch account names for display.
+  // Fetch account names for display (tenant-safe: filter by userId).
   const rowAccountIds = [...new Set(rows.map((r) => r.accountId))];
   const accountRows = await db
     .select({ id: accounts.id, name: accounts.name, currency: accounts.currency })
@@ -239,15 +237,16 @@ export async function getLinkCandidatesForForecast(
     );
   const accountMap = new Map(accountRows.map((a) => [a.id, a]));
 
-  // Sort by proximity to expectedDate (closest first).
   const expectedMs = expectedDate.getTime();
+
+  // Sort all rows by proximity to expectedDate (closest first).
   const sorted = rows.slice().sort((a, b) => {
     const da = Math.abs(a.occurredAt.getTime() - expectedMs);
     const db_ = Math.abs(b.occurredAt.getTime() - expectedMs);
     return da - db_;
   });
 
-  return sorted.map((r) => ({
+  const mapped: ForecastLinkCandidate[] = sorted.map((r) => ({
     txId: r.id,
     occurredAt: r.occurredAt,
     occurredAtIso: r.occurredAt.toISOString(),
@@ -257,4 +256,52 @@ export async function getLinkCandidatesForForecast(
     merchant: r.merchant,
     accountName: formatAccountLabel(accountMap.get(r.accountId) ?? { name: "?", currency: "" }),
   }));
+
+  // Build "Sugeridas": same currency + amount within ±20% of recurring.amountCents.
+  // Signed comparison (both amounts carry the sign).
+  const recAmt = recurring.amountCents;
+  const recCurrency = recurring.currency;
+
+  const sugeridasSet = new Set<number>();
+  const sugeridas: ForecastLinkCandidate[] = [];
+
+  for (const c of mapped) {
+    if (c.currency !== recCurrency) continue;
+    // ±20% window around the recurring amount (signed, absolute value for width).
+    const absMagnitude = recAmt < BigInt(0) ? -recAmt : recAmt;
+    const tolerance = (absMagnitude * BigInt(20)) / BigInt(100);
+    const lower = recAmt - tolerance;
+    const upper = recAmt + tolerance;
+    // For negative amounts: lower is more negative (e.g. -120k), upper is less negative (-80k).
+    // We check if c.amountCents is within [min(lower,upper), max(lower,upper)].
+    const lo = lower < upper ? lower : upper;
+    const hi = lower < upper ? upper : lower;
+    if (c.amountCents >= lo && c.amountCents <= hi) {
+      sugeridasSet.add(c.txId);
+      sugeridas.push(c);
+    }
+  }
+
+  // Sort sugeridas by amount-proximity to recurring.amountCents (closest first).
+  sugeridas.sort((a, b) => {
+    const da = a.amountCents - recAmt;
+    const db_ = b.amountCents - recAmt;
+    const absDa = da < BigInt(0) ? -da : da;
+    const absDb_ = db_ < BigInt(0) ? -db_ : db_;
+    return absDa < absDb_ ? -1 : absDa > absDb_ ? 1 : 0;
+  });
+
+  // Limit sugeridas to top 5.
+  const topSugeridas = sugeridas.slice(0, 5);
+  const topSugeridasSet = new Set(topSugeridas.map((c) => c.txId));
+
+  // "Todas": remaining candidates sorted by date-proximity (already sorted).
+  const todas = mapped.filter((c) => !topSugeridasSet.has(c.txId));
+
+  return {
+    sugeridas: topSugeridas,
+    todas,
+    recurringAmountCents: recAmt,
+    recurringCurrency: recCurrency,
+  };
 }

--- a/src/components/dashboard/upcoming-card.test.tsx
+++ b/src/components/dashboard/upcoming-card.test.tsx
@@ -12,7 +12,11 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: routerRefresh }),
 }));
 vi.mock("next/link", () => ({
-  default: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
     <a href={href} {...props}>
       {children}
     </a>
@@ -99,15 +103,18 @@ function makeItem(overrides: Partial<UpcomingCardItem> = {}): UpcomingCardItem {
 describe("UpcomingCard", () => {
   it("renders empty state when items list is empty", () => {
     render(<UpcomingCard items={[]} />);
-    expect(
-      screen.getByText(/Sin recurrentes pendientes/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Sin recurrentes pendientes/i)).toBeInTheDocument();
   });
 
   it("renders item labels and amounts", () => {
     const items = [
       makeItem({ label: "Arriendo", amountCents: "-150000000" }),
-      makeItem({ recurringId: 2, label: "Internet", amountCents: "-8000000", yearMonth: "2026-04" }),
+      makeItem({
+        recurringId: 2,
+        label: "Internet",
+        amountCents: "-8000000",
+        yearMonth: "2026-04",
+      }),
     ];
     render(<UpcomingCard items={items} />);
     expect(screen.getByText("Arriendo")).toBeInTheDocument();

--- a/src/components/dashboard/upcoming-card.test.tsx
+++ b/src/components/dashboard/upcoming-card.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — all heavy deps mocked before any import.
+// ---------------------------------------------------------------------------
+const { routerRefresh } = vi.hoisted(() => ({ routerRefresh: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: routerRefresh }),
+}));
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// Mock ForecastLinkTxDialog — we only want to verify it opens, not test the full dialog.
+const { mockDialogOpen } = vi.hoisted(() => ({ mockDialogOpen: vi.fn() }));
+vi.mock("@/components/transactions/forecast-link-tx-dialog", () => ({
+  ForecastLinkTxDialog: ({
+    open,
+    onOpenChange,
+    label,
+  }: {
+    open: boolean;
+    onOpenChange: (v: boolean) => void;
+    label: string;
+  }) => {
+    mockDialogOpen(open);
+    return open ? (
+      <div data-testid="forecast-link-dialog" data-label={label}>
+        <button onClick={() => onOpenChange(false)}>Close</button>
+      </div>
+    ) : null;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Radix shims (pointer-capture + scrollIntoView).
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+  mockDialogOpen.mockReset();
+  routerRefresh.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Import AFTER mocks.
+// ---------------------------------------------------------------------------
+import { UpcomingCard } from "./upcoming-card";
+import type { UpcomingCardItem } from "./upcoming-card";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeItem(overrides: Partial<UpcomingCardItem> = {}): UpcomingCardItem {
+  return {
+    recurringId: 1,
+    label: "Arriendo",
+    accountId: 10,
+    accountName: "Bancolombia Ahorros",
+    amountCents: "-150000000",
+    currency: "COP",
+    categorySlug: "housing",
+    categoryName: "Vivienda",
+    dayOfMonth: 5,
+    expectedOn: "2026-04-05",
+    status: "upcoming",
+    matchedTransactionId: null,
+    yearMonth: "2026-04",
+    notes: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("UpcomingCard", () => {
+  it("renders empty state when items list is empty", () => {
+    render(<UpcomingCard items={[]} />);
+    expect(
+      screen.getByText(/Sin recurrentes pendientes/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders item labels and amounts", () => {
+    const items = [
+      makeItem({ label: "Arriendo", amountCents: "-150000000" }),
+      makeItem({ recurringId: 2, label: "Internet", amountCents: "-8000000", yearMonth: "2026-04" }),
+    ];
+    render(<UpcomingCard items={items} />);
+    expect(screen.getByText("Arriendo")).toBeInTheDocument();
+    expect(screen.getByText("Internet")).toBeInTheDocument();
+  });
+
+  it("clicking the link button opens ForecastLinkTxDialog with correct label", () => {
+    const item = makeItem({ label: "Netflix", recurringId: 42, yearMonth: "2026-04" });
+    render(<UpcomingCard items={[item]} />);
+
+    const linkBtn = screen.getByRole("button", { name: /Asociar tx a Netflix/i });
+    fireEvent.click(linkBtn);
+
+    // Dialog should now be open with the correct label.
+    const dialog = screen.getByTestId("forecast-link-dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog.getAttribute("data-label")).toBe("Netflix");
+  });
+
+  it("renders overdue status badge", () => {
+    const item = makeItem({ status: "overdue", label: "Overdue Item" });
+    render(<UpcomingCard items={[item]} />);
+    expect(screen.getByText("atrasado")).toBeInTheDocument();
+  });
+
+  it("renders upcoming status badge", () => {
+    const item = makeItem({ status: "upcoming", label: "Upcoming Item" });
+    render(<UpcomingCard items={[item]} />);
+    expect(screen.getByText("pendiente")).toBeInTheDocument();
+  });
+
+  it("renders windowLabel in card description when provided", () => {
+    render(<UpcomingCard items={[]} windowLabel="±5d desde hoy" />);
+    expect(screen.getByText(/±5d desde hoy/)).toBeInTheDocument();
+  });
+
+  it("dialog closes when close button is clicked", () => {
+    const item = makeItem({ label: "Gym", recurringId: 7 });
+    render(<UpcomingCard items={[item]} />);
+
+    const linkBtn = screen.getByRole("button", { name: /Asociar tx a Gym/i });
+    fireEvent.click(linkBtn);
+
+    // Dialog open.
+    expect(screen.getByTestId("forecast-link-dialog")).toBeInTheDocument();
+
+    // Close it.
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.queryByTestId("forecast-link-dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders up to N items without overflow (max-h scroll container present)", () => {
+    const items = Array.from({ length: 8 }, (_, i) =>
+      makeItem({
+        recurringId: i + 1,
+        label: `Recurring ${i + 1}`,
+        yearMonth: "2026-04",
+      }),
+    );
+    render(<UpcomingCard items={items} />);
+    // All 8 items rendered
+    for (let i = 1; i <= 8; i++) {
+      expect(screen.getByText(`Recurring ${i}`)).toBeInTheDocument();
+    }
+    // Scroll container present (max-h-72)
+    const list = document.querySelector("ul");
+    expect(list?.className).toMatch(/max-h/);
+  });
+});

--- a/src/components/dashboard/upcoming-card.tsx
+++ b/src/components/dashboard/upcoming-card.tsx
@@ -1,20 +1,25 @@
 "use client";
 
-import { useTransition } from "react";
+// #632: UpcomingCard redesign.
+// Changes from original:
+//   - Data comes from getUpcomingForWindow (window-based, cross-month) instead of
+//     getUpcomingForMonth — only un-matched slots are shown.
+//   - Fixed-height with internal scroll to match TopExpensesCard sibling.
+//   - Single "Asociar" trigger per row opens ForecastLinkTxDialog (unified dialog).
+//   - dismissUpcoming / undismissUpcoming / promoteUpcoming buttons removed.
+//   - "No pagué" and "Pagué" are accessible via ForecastRowActions in /transactions.
+
+import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { CheckCircle2Icon, CircleXIcon, UndoIcon } from "lucide-react";
-import { toast } from "sonner";
+import { LinkIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Money } from "@/components/display/money";
 import { cn } from "@/lib/utils";
-import {
-  dismissUpcoming,
-  promoteUpcoming,
-  undismissUpcoming,
-} from "@/app/(app)/settings/recurring/actions";
+import { ForecastLinkTxDialog } from "@/components/transactions/forecast-link-tx-dialog";
 import type { UpcomingItem } from "@/lib/recurring/upcoming";
+import type { Currency } from "@/lib/types";
 
 export type UpcomingCardItem = Omit<UpcomingItem, "amountCents"> & {
   amountCents: string;
@@ -32,166 +37,139 @@ const statusStyles: Record<UpcomingItem["status"], string> = {
   dismissed: "bg-muted text-muted-foreground",
 };
 
+const statusLabels: Record<UpcomingItem["status"], string> = {
+  upcoming: "pendiente",
+  overdue: "atrasado",
+  matched: "pagado",
+  dismissed: "omitido",
+};
+
+type DialogSlot = {
+  recurringId: number;
+  yearMonth: string;
+  label: string;
+  amountCents: bigint;
+  currency: Currency;
+};
+
 export function UpcomingCard({
   items,
-  monthLabel,
+  windowLabel,
 }: {
   items: UpcomingCardItem[];
-  monthLabel: string;
+  /** e.g. "±5d desde hoy" */
+  windowLabel?: string;
 }) {
   const router = useRouter();
-  const [pending, startTransition] = useTransition();
+  const [dialogSlot, setDialogSlot] = useState<DialogSlot | null>(null);
 
-  function onPromote(item: UpcomingCardItem) {
-    startTransition(async () => {
-      try {
-        await promoteUpcoming({
-          recurringId: item.recurringId,
-          yearMonth: item.yearMonth,
-          occurredOn: item.expectedOn,
-        });
-        toast.success(`Imported "${item.label}"`);
-        router.refresh();
-      } catch (err) {
-        toast.error(err instanceof Error ? err.message : "Promote failed");
-      }
-    });
-  }
-
-  function onDismiss(item: UpcomingCardItem) {
-    startTransition(async () => {
-      try {
-        await dismissUpcoming({
-          recurringId: item.recurringId,
-          ym: item.yearMonth,
-        });
-        toast.success(`Skipped this month`);
-        router.refresh();
-      } catch (err) {
-        toast.error(err instanceof Error ? err.message : "Dismiss failed");
-      }
-    });
-  }
-
-  function onUndismiss(item: UpcomingCardItem) {
-    startTransition(async () => {
-      try {
-        await undismissUpcoming({
-          recurringId: item.recurringId,
-          ym: item.yearMonth,
-        });
-        toast.success("Restored");
-        router.refresh();
-      } catch (err) {
-        toast.error(err instanceof Error ? err.message : "Undismiss failed");
-      }
+  function openDialog(item: UpcomingCardItem) {
+    setDialogSlot({
+      recurringId: item.recurringId,
+      yearMonth: item.yearMonth,
+      label: item.label,
+      amountCents: BigInt(item.amountCents),
+      currency: item.currency,
     });
   }
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-start justify-between gap-2">
-        <div>
-          <CardDescription>Upcoming · {monthLabel}</CardDescription>
-          <CardTitle className="text-lg">Recurring forecast</CardTitle>
-        </div>
-        <Button asChild variant="outline" size="sm">
-          <Link href="/settings/recurring">Manage</Link>
-        </Button>
-      </CardHeader>
-      <CardContent>
-        {items.length === 0 ? (
-          <p className="text-muted-foreground py-4 text-center text-sm">
-            No recurring items.{" "}
-            <Link href="/settings/recurring" className="underline underline-offset-2">
-              Add one
-            </Link>{" "}
-            to start tracking.
-          </p>
-        ) : (
-          <ul className="flex flex-col divide-y">
-            {items.map((item) => {
-              const cents = BigInt(item.amountCents);
-              return (
-                <li
-                  key={`${item.recurringId}-${item.yearMonth}`}
-                  className="flex items-center gap-3 py-2 text-sm"
-                >
-                  <div className="text-muted-foreground flex w-12 flex-col items-center text-xs">
-                    <span className="font-medium">
-                      {dateFmt.format(new Date(`${item.expectedOn}T12:00:00Z`))}
-                    </span>
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="truncate font-medium">{item.label}</span>
-                      <span
-                        className={cn(
-                          "rounded px-1.5 py-0.5 text-[10px] tracking-wide uppercase",
-                          statusStyles[item.status],
-                        )}
-                      >
-                        {item.status}
+    <>
+      <Card className="flex flex-col">
+        <CardHeader className="flex flex-row items-start justify-between gap-2">
+          <div>
+            <CardDescription>
+              Próximos recurrentes{windowLabel ? ` · ${windowLabel}` : ""}
+            </CardDescription>
+            <CardTitle className="text-lg">Forecast</CardTitle>
+          </div>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/settings/recurring">Gestionar</Link>
+          </Button>
+        </CardHeader>
+        {/* Fixed height with internal scroll to match TopExpensesCard */}
+        <CardContent className="min-h-0 flex-1">
+          {items.length === 0 ? (
+            <p className="text-muted-foreground py-4 text-center text-sm">
+              Sin recurrentes pendientes en la ventana de ±5 días.{" "}
+              <Link href="/settings/recurring" className="underline underline-offset-2">
+                Agregar
+              </Link>
+            </p>
+          ) : (
+            <ul className="max-h-72 overflow-y-auto flex flex-col divide-y">
+              {items.map((item) => {
+                const cents = BigInt(item.amountCents);
+                return (
+                  <li
+                    key={`${item.recurringId}-${item.yearMonth}`}
+                    className="flex items-center gap-3 py-2 text-sm"
+                  >
+                    <div className="text-muted-foreground flex w-12 flex-col items-center text-xs">
+                      <span className="font-medium">
+                        {dateFmt.format(new Date(`${item.expectedOn}T12:00:00Z`))}
                       </span>
                     </div>
-                    <div className="text-muted-foreground truncate text-xs">
-                      {item.accountName}
-                      {item.categoryName ? ` · ${item.categoryName}` : ""}
-                      {item.matchedTransactionId ? ` · tx #${item.matchedTransactionId}` : ""}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="truncate font-medium">{item.label}</span>
+                        <span
+                          className={cn(
+                            "rounded px-1.5 py-0.5 text-[10px] tracking-wide uppercase",
+                            statusStyles[item.status],
+                          )}
+                        >
+                          {statusLabels[item.status]}
+                        </span>
+                      </div>
+                      <div className="text-muted-foreground truncate text-xs">
+                        {item.accountName}
+                        {item.categoryName ? ` · ${item.categoryName}` : ""}
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className={cn(
-                      "w-28 text-right font-medium tabular-nums",
-                      cents < BigInt(0) ? "text-rose-600" : "text-emerald-600",
-                    )}
-                  >
-                    <Money cents={cents} currency={item.currency} />
-                  </div>
-                  <div className="flex items-center gap-1">
-                    {item.status === "upcoming" || item.status === "overdue" ? (
-                      <>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          disabled={pending}
-                          onClick={() => onPromote(item)}
-                          aria-label="Promote to transaction"
-                          title="Import as real transaction"
-                        >
-                          <CheckCircle2Icon className="size-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          disabled={pending}
-                          onClick={() => onDismiss(item)}
-                          aria-label="Dismiss this month"
-                          title="Skip this month"
-                        >
-                          <CircleXIcon className="size-4" />
-                        </Button>
-                      </>
-                    ) : null}
-                    {item.status === "dismissed" ? (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        disabled={pending}
-                        onClick={() => onUndismiss(item)}
-                        aria-label="Undismiss"
-                        title="Restore this month"
-                      >
-                        <UndoIcon className="size-4" />
-                      </Button>
-                    ) : null}
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </CardContent>
-    </Card>
+                    <div
+                      className={cn(
+                        "w-28 text-right font-medium tabular-nums",
+                        cents < BigInt(0) ? "text-rose-600" : "text-emerald-600",
+                      )}
+                    >
+                      <Money cents={cents} currency={item.currency} />
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => openDialog(item)}
+                      aria-label={`Asociar tx a ${item.label}`}
+                      title="Asociar transacción existente"
+                      className="text-muted-foreground hover:text-foreground"
+                    >
+                      <LinkIcon className="size-4" />
+                    </Button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      {dialogSlot ? (
+        <ForecastLinkTxDialog
+          open={dialogSlot !== null}
+          onOpenChange={(next) => {
+            if (!next) setDialogSlot(null);
+          }}
+          recurringId={dialogSlot.recurringId}
+          yearMonth={dialogSlot.yearMonth}
+          label={dialogSlot.label}
+          expectedAmountCents={dialogSlot.amountCents}
+          currency={dialogSlot.currency}
+          onLinked={() => {
+            setDialogSlot(null);
+            router.refresh();
+          }}
+        />
+      ) : null}
+    </>
   );
 }

--- a/src/components/dashboard/upcoming-card.tsx
+++ b/src/components/dashboard/upcoming-card.tsx
@@ -97,7 +97,7 @@ export function UpcomingCard({
               </Link>
             </p>
           ) : (
-            <ul className="max-h-72 overflow-y-auto flex flex-col divide-y">
+            <ul className="flex max-h-72 flex-col divide-y overflow-y-auto">
               {items.map((item) => {
                 const cents = BigInt(item.amountCents);
                 return (

--- a/src/components/transactions/forecast-link-tx-dialog.tsx
+++ b/src/components/transactions/forecast-link-tx-dialog.tsx
@@ -70,10 +70,7 @@ function CandidateRow({
         <div className="text-muted-foreground truncate text-xs">{c.accountName}</div>
       </div>
       <div
-        className={cn(
-          "shrink-0 tabular-nums",
-          isExpense ? "text-rose-600" : "text-emerald-600",
-        )}
+        className={cn("shrink-0 tabular-nums", isExpense ? "text-rose-600" : "text-emerald-600")}
       >
         <Money cents={c.amountCents} currency={c.currency as Currency} />
       </div>
@@ -116,7 +113,12 @@ export function ForecastLinkTxDialog({
         })
         .catch((err) => {
           setLoadError(err instanceof Error ? err.message : "Error cargando candidatos");
-          setResult({ sugeridas: [], todas: [], recurringAmountCents: expectedAmountCents, recurringCurrency: currency });
+          setResult({
+            sugeridas: [],
+            todas: [],
+            recurringAmountCents: expectedAmountCents,
+            recurringCurrency: currency,
+          });
         });
     },
     [recurringId, yearMonth, expectedAmountCents, currency],
@@ -247,7 +249,7 @@ export function ForecastLinkTxDialog({
               {/* Sugeridas section */}
               {hasSugeridas ? (
                 <div className="flex flex-col gap-1">
-                  <p className="text-muted-foreground px-1 pt-1 text-xs font-medium uppercase tracking-wide">
+                  <p className="text-muted-foreground px-1 pt-1 text-xs font-medium tracking-wide uppercase">
                     Sugeridas
                   </p>
                   {filteredSugeridas.map((c) => (
@@ -265,7 +267,7 @@ export function ForecastLinkTxDialog({
               {filteredTodas.length > 0 ? (
                 <div className="flex flex-col gap-1">
                   {hasSugeridas ? (
-                    <p className="text-muted-foreground px-1 pt-2 text-xs font-medium uppercase tracking-wide">
+                    <p className="text-muted-foreground px-1 pt-2 text-xs font-medium tracking-wide uppercase">
                       Todas
                     </p>
                   ) : null}

--- a/src/components/transactions/forecast-link-tx-dialog.tsx
+++ b/src/components/transactions/forecast-link-tx-dialog.tsx
@@ -1,19 +1,17 @@
 "use client";
 
-// #622: Dialog for the "Asociar tx existente" action on a forecast row.
-// This is the INVERSE of LinkRecurringDialog — instead of picking a recurring
-// for a known tx, we pick a tx for a known recurring slot.
-//
-// Picker rules:
-//   - Default: account_id = forecast.accountId, occurredAt in [expected-10d, expected+5d],
-//     recurring_id IS NULL, not soft-deleted.
-//   - Toggle "Mostrar todas las tx del mes": all unlinked tx of the user's
-//     same yearMonth — no account/date filter.
-//   - Sort by proximity to expectedDate.
-//   - NEVER filter by amount.
+// #632: Redesigned picker dialog for "Asociar tx existente".
+// Changes from #622 original:
+//   - Default scope: ALL accounts (no account filter). Window-based always.
+//   - showAll toggle: expands window to [expectedDate-30d, expectedDate+10d],
+//     NEVER falls back to month-calendar.
+//   - Two sections: "Sugeridas" (same currency, ±20% amount) + "Todas" (rest).
+//   - Client-side search bar filtering both sections by description/merchant.
+//   - formatAccountLabel for multi-currency card disambiguation.
 
-import { useCallback, useEffect, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
+import { SearchIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -26,17 +24,62 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 import { Money } from "@/components/display/money";
 import { cn } from "@/lib/utils";
 import { getLinkCandidatesForForecast } from "@/app/(app)/transactions/forecast-actions";
 import { linkTxToRecurring } from "@/app/(app)/transactions/actions";
-import type { ForecastLinkCandidate } from "@/app/(app)/transactions/forecast-actions";
+import type {
+  ForecastLinkCandidate,
+  ForecastLinkCandidatesResult,
+} from "@/app/(app)/transactions/forecast-actions";
 import type { Currency } from "@/lib/types";
 
 const dateFmt = new Intl.DateTimeFormat("es-CO", {
   day: "2-digit",
   month: "short",
 });
+
+function CandidateRow({
+  c,
+  selected,
+  onClick,
+}: {
+  c: ForecastLinkCandidate;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const isExpense = c.amountCents < BigInt(0);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "hover:bg-accent flex items-center gap-3 rounded border px-3 py-2 text-left text-sm transition",
+        selected && "border-primary bg-primary/5",
+      )}
+    >
+      <div className="text-muted-foreground w-14 shrink-0 text-xs">
+        {dateFmt.format(c.occurredAt)}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium">{c.merchant ?? c.descriptionRaw}</div>
+        {c.merchant ? (
+          <div className="text-muted-foreground truncate text-xs">{c.descriptionRaw}</div>
+        ) : null}
+        <div className="text-muted-foreground truncate text-xs">{c.accountName}</div>
+      </div>
+      <div
+        className={cn(
+          "shrink-0 tabular-nums",
+          isExpense ? "text-rose-600" : "text-emerald-600",
+        )}
+      >
+        <Money cents={c.amountCents} currency={c.currency as Currency} />
+      </div>
+    </button>
+  );
+}
 
 export function ForecastLinkTxDialog({
   open,
@@ -59,62 +102,46 @@ export function ForecastLinkTxDialog({
 }) {
   const [pending, startTransition] = useTransition();
   const [showAll, setShowAll] = useState(false);
-  const [candidates, setCandidates] = useState<ForecastLinkCandidate[] | null>(null);
+  const [result, setResult] = useState<ForecastLinkCandidatesResult | null>(null);
   const [selectedTxId, setSelectedTxId] = useState<number | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
 
-  // Stable async fetch — only async (Promise) setState so the effect can call
-  // it without triggering react-hooks/set-state-in-effect. Wrapped in
-  // useCallback with recurringId + yearMonth so the effect deps are exhaustive
-  // and the closure captures the correct slot on every re-render.
   const loadCandidates = useCallback(
     (all: boolean) => {
-      getLinkCandidatesForForecast({
-        recurringId,
-        yearMonth,
-        showAll: all,
-      })
-        .then((rows) => {
-          setCandidates(rows);
+      getLinkCandidatesForForecast({ recurringId, yearMonth, showAll: all })
+        .then((res) => {
+          setResult(res);
           setLoadError(null);
         })
         .catch((err) => {
           setLoadError(err instanceof Error ? err.message : "Error cargando candidatos");
-          setCandidates([]);
+          setResult({ sugeridas: [], todas: [], recurringAmountCents: expectedAmountCents, recurringCurrency: currency });
         });
     },
-    [recurringId, yearMonth],
+    [recurringId, yearMonth, expectedAmountCents, currency],
   );
 
-  // Reset + load when dialog opens or showAll toggle changes.
-  // Synchronous resets (setCandidates/setLoadError) live here — outside the
-  // effect body — to satisfy react-hooks/set-state-in-effect. The effect
-  // itself only calls loadCandidates (async setState only).
   function triggerLoad(all: boolean) {
-    setCandidates(null);
+    setResult(null);
     setLoadError(null);
     loadCandidates(all);
   }
 
-  // Load candidates when the dialog opens or when the forecast slot changes
-  // (recurringId / yearMonth). Using loadCandidates (stable via useCallback)
-  // prevents stale-closure races when the dialog is reused between rows.
-  // showAll is always reset to false before the dialog re-opens (see onClose),
-  // so we always start with the narrow filter on open/slot-change.
   useEffect(() => {
     if (open) {
       loadCandidates(false);
     }
   }, [open, recurringId, yearMonth, loadCandidates]);
 
-  // Reset state when dialog closes.
   function onClose(next: boolean) {
     if (!pending) {
       if (!next) {
         setShowAll(false);
         setSelectedTxId(null);
-        setCandidates(null);
+        setResult(null);
         setLoadError(null);
+        setSearch("");
       }
       onOpenChange(next);
     }
@@ -123,21 +150,47 @@ export function ForecastLinkTxDialog({
   function onLink() {
     if (selectedTxId === null) return;
     startTransition(async () => {
-      const result = await linkTxToRecurring({
-        txId: selectedTxId,
-        recurringId,
-        yearMonth,
-      });
-      if (result.ok) {
+      const res = await linkTxToRecurring({ txId: selectedTxId, recurringId, yearMonth });
+      if (res.ok) {
         toast.success(`Asociado a ${label}`, { description: `Mes ${yearMonth}` });
         setSelectedTxId(null);
         onLinked();
         onOpenChange(false);
       } else {
-        toast.error("No se pudo asociar", { description: result.error });
+        toast.error("No se pudo asociar", { description: res.error });
       }
     });
   }
+
+  // Client-side search filter — no server roundtrip per keystroke.
+  const query = search.trim().toLowerCase();
+  const filteredSugeridas = useMemo(
+    () =>
+      query
+        ? (result?.sugeridas ?? []).filter(
+            (c) =>
+              c.descriptionRaw.toLowerCase().includes(query) ||
+              (c.merchant ?? "").toLowerCase().includes(query) ||
+              c.accountName.toLowerCase().includes(query),
+          )
+        : (result?.sugeridas ?? []),
+    [result, query],
+  );
+  const filteredTodas = useMemo(
+    () =>
+      query
+        ? (result?.todas ?? []).filter(
+            (c) =>
+              c.descriptionRaw.toLowerCase().includes(query) ||
+              (c.merchant ?? "").toLowerCase().includes(query) ||
+              c.accountName.toLowerCase().includes(query),
+          )
+        : (result?.todas ?? []),
+    [result, query],
+  );
+
+  const totalFiltered = filteredSugeridas.length + filteredTodas.length;
+  const hasSugeridas = filteredSugeridas.length > 0;
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
@@ -149,6 +202,19 @@ export function ForecastLinkTxDialog({
           </DialogDescription>
         </DialogHeader>
 
+        {/* Search bar */}
+        <div className="relative">
+          <SearchIcon className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+          <Input
+            placeholder="Buscar por descripción…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+            disabled={pending}
+          />
+        </div>
+
+        {/* showAll toggle — expands window, never month-calendar */}
         <div className="bg-muted/30 flex items-center gap-3 rounded-md border px-3 py-2">
           <Checkbox
             id="show-all"
@@ -157,17 +223,18 @@ export function ForecastLinkTxDialog({
               const next = checked === true;
               setShowAll(next);
               setSelectedTxId(null);
+              setSearch("");
               triggerLoad(next);
             }}
             disabled={pending}
           />
           <Label htmlFor="show-all" className="cursor-pointer text-sm font-normal">
-            Mostrar todas las tx del mes
+            Ampliar ventana (±30d/+10d)
           </Label>
         </div>
 
         <div className="flex max-h-[50vh] flex-col gap-1 overflow-y-auto">
-          {candidates === null ? (
+          {result === null ? (
             <>
               <Skeleton className="h-12 w-full" />
               <Skeleton className="h-12 w-full" />
@@ -175,48 +242,51 @@ export function ForecastLinkTxDialog({
             </>
           ) : loadError ? (
             <p className="text-destructive py-6 text-center text-sm">{loadError}</p>
-          ) : candidates.length > 0 ? (
-            candidates.map((c) => {
-              const selected = selectedTxId === c.txId;
-              const isExpense = c.amountCents < BigInt(0);
-              return (
-                <button
-                  key={c.txId}
-                  type="button"
-                  onClick={() => setSelectedTxId(c.txId)}
-                  className={cn(
-                    "hover:bg-accent flex items-center gap-3 rounded border px-3 py-2 text-left text-sm transition",
-                    selected && "border-primary bg-primary/5",
-                  )}
-                >
-                  <div className="text-muted-foreground w-14 shrink-0 text-xs">
-                    {dateFmt.format(c.occurredAt)}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate font-medium">{c.merchant ?? c.descriptionRaw}</div>
-                    {c.merchant ? (
-                      <div className="text-muted-foreground truncate text-xs">
-                        {c.descriptionRaw}
-                      </div>
-                    ) : null}
-                    <div className="text-muted-foreground truncate text-xs">{c.accountName}</div>
-                  </div>
-                  <div
-                    className={cn(
-                      "shrink-0 tabular-nums",
-                      isExpense ? "text-rose-600" : "text-emerald-600",
-                    )}
-                  >
-                    <Money cents={c.amountCents} currency={c.currency as Currency} />
-                  </div>
-                </button>
-              );
-            })
+          ) : totalFiltered > 0 ? (
+            <>
+              {/* Sugeridas section */}
+              {hasSugeridas ? (
+                <div className="flex flex-col gap-1">
+                  <p className="text-muted-foreground px-1 pt-1 text-xs font-medium uppercase tracking-wide">
+                    Sugeridas
+                  </p>
+                  {filteredSugeridas.map((c) => (
+                    <CandidateRow
+                      key={c.txId}
+                      c={c}
+                      selected={selectedTxId === c.txId}
+                      onClick={() => setSelectedTxId(c.txId)}
+                    />
+                  ))}
+                </div>
+              ) : null}
+
+              {/* Todas section */}
+              {filteredTodas.length > 0 ? (
+                <div className="flex flex-col gap-1">
+                  {hasSugeridas ? (
+                    <p className="text-muted-foreground px-1 pt-2 text-xs font-medium uppercase tracking-wide">
+                      Todas
+                    </p>
+                  ) : null}
+                  {filteredTodas.map((c) => (
+                    <CandidateRow
+                      key={c.txId}
+                      c={c}
+                      selected={selectedTxId === c.txId}
+                      onClick={() => setSelectedTxId(c.txId)}
+                    />
+                  ))}
+                </div>
+              ) : null}
+            </>
           ) : (
             <p className="text-muted-foreground py-6 text-center text-sm">
-              {showAll
-                ? "No hay transacciones sin asociar en este mes."
-                : 'No hay transacciones candidatas en la ventana ±10d/+5d. Activá "Mostrar todas" para ampliar.'}
+              {query
+                ? "Sin resultados para esa búsqueda."
+                : showAll
+                  ? "No hay transacciones sin asociar en la ventana ampliada."
+                  : "No hay candidatas en la ventana ±10d/+5d. Activá «Ampliar ventana» para ampliar."}
             </p>
           )}
         </div>

--- a/src/lib/recurring/auto-link.test.ts
+++ b/src/lib/recurring/auto-link.test.ts
@@ -560,3 +560,150 @@ describe("autoLinkTransaction direct-recurring path", () => {
     expect(gaps.length).toBe(0);
   });
 });
+
+// ── Cross-month auto-link (#632) ─────────────────────────────────────────────
+describe("autoLinkTransaction cross-month", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("tx on April 29 links to May 1 recurring (window [Apr 21, May 6])", async () => {
+    const accountId = await seedAccount();
+    // Recurring fires on day 1. Today is April 29 — within 5d before May 1.
+    const recurringId = await seedRecurring(accountId, {
+      label: "__autolink cross-month next",
+      amountCents: BigInt(-330010),
+      dayOfMonth: 1,
+    });
+    // tx on April 29 (expected window: May 1 - 10d = Apr 21 to May 1 + 5d = May 6)
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-29",
+      amountCents: BigInt(-330010),
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("linked");
+    if (result.status === "linked") {
+      // Must link to May's yearMonth (the cross-month evaluation)
+      expect(result.yearMonth).toBe("2026-05");
+      expect(result.recurringId).toBe(recurringId);
+      expect(result.gapId).toBeNull();
+    }
+
+    const [linked] = await db
+      .select({ recurringYearMonth: transactions.recurringYearMonth })
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+    expect(linked.recurringYearMonth).toBe("2026-05");
+  });
+
+  it("tx on Jan 2 links to December recurring (day 30 → window [Dec 20, Jan 4])", async () => {
+    const accountId = await seedAccount();
+    // Recurring fires on day 30. Jan 2 is within [Dec 20, Jan 4].
+    const recurringId = await seedRecurring(accountId, {
+      label: "__autolink cross-month prev",
+      amountCents: BigInt(-50000),
+      dayOfMonth: 30,
+    });
+    // tx on Jan 2, 2026. Expected date for Dec 2025: Dec 30. Window: [Dec 20, Jan 4].
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-01-02",
+      amountCents: BigInt(-50000),
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("linked");
+    if (result.status === "linked") {
+      expect(result.yearMonth).toBe("2025-12");
+      expect(result.recurringId).toBe(recurringId);
+    }
+
+    const [linked] = await db
+      .select({ recurringYearMonth: transactions.recurringYearMonth })
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+    expect(linked.recurringYearMonth).toBe("2025-12");
+  });
+
+  it("Feb 28 with day-30 recurring clamps to Feb 28 → match works (issue: clamp)", async () => {
+    const accountId = await seedAccount();
+    // Recurring fires on day 30. Feb 2026 has 28 days → clamped to Feb 28.
+    const recurringId = await seedRecurring(accountId, {
+      label: "__autolink cross-month feb-clamp",
+      amountCents: BigInt(-75000),
+      dayOfMonth: 30,
+    });
+    // tx on Feb 28, 2026. Expected: Feb 28 (clamped). Window: [Feb 18, Mar 5].
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-02-28",
+      amountCents: BigInt(-75000),
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("linked");
+    if (result.status === "linked") {
+      expect(result.yearMonth).toBe("2026-02");
+      expect(result.recurringId).toBe(recurringId);
+    }
+  });
+
+  it("Dec 30 tx links to Jan next-year recurring (day 1, window [Dec 22, Jan 6])", async () => {
+    const accountId = await seedAccount();
+    const recurringId = await seedRecurring(accountId, {
+      label: "__autolink cross-month dec30",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 1,
+    });
+    // tx on Dec 30, 2025. Expected: Jan 1, 2026. Window: [Dec 22, Jan 6].
+    const txId = await seedTx(accountId, {
+      occurredOn: "2025-12-30",
+      amountCents: BigInt(-100000),
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("linked");
+    if (result.status === "linked") {
+      expect(result.yearMonth).toBe("2026-01");
+      expect(result.recurringId).toBe(recurringId);
+    }
+
+    const [linked] = await db
+      .select({ recurringYearMonth: transactions.recurringYearMonth })
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+    expect(linked.recurringYearMonth).toBe("2026-01");
+  });
+
+  it("multiple matches across months → ambiguous (no link)", async () => {
+    const accountId = await seedAccount();
+    // Two recurrings: day 30 (evaluates Jan window) and day 1 (evaluates Jan and Feb windows).
+    // tx on Feb 1 2026 — day-30 recurring: Dec 30 window [Dec 20, Jan 4] NO. Jan 30 window [Jan 20, Feb 4] YES.
+    // day-1 recurring: Jan 1 window [Dec 22, Jan 6] NO. Feb 1 window [Jan 22, Feb 6] YES.
+    // → 2 matches across months → ambiguous.
+    await seedRecurring(accountId, {
+      label: "__autolink cross-month amb A",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 30,
+    });
+    await seedRecurring(accountId, {
+      label: "__autolink cross-month amb B",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 1,
+    });
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-02-01",
+      amountCents: BigInt(-100000),
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("ambiguous");
+    if (result.status === "ambiguous") {
+      expect(result.candidateCount).toBe(2);
+    }
+    // Verify tx not linked
+    const [row] = await db
+      .select({ recurringId: transactions.recurringId })
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+    expect(row.recurringId).toBeNull();
+  });
+});

--- a/src/lib/recurring/auto-link.ts
+++ b/src/lib/recurring/auto-link.ts
@@ -189,11 +189,7 @@ export async function autoLinkTransaction(
    * Evaluate expectedDate for a given yearMonth (year, month 1-based).
    * Returns whether the tx falls in the match window for that month.
    */
-  function txInWindowForYearMonth(
-    dayOfMonth: number,
-    year: number,
-    month: number,
-  ): boolean {
+  function txInWindowForYearMonth(dayOfMonth: number, year: number, month: number): boolean {
     const effectiveDay = Math.min(dayOfMonth, daysInMonth(year, month));
     const expected = new Date(Date.UTC(year, month - 1, effectiveDay));
     const windowStart = new Date(expected.getTime() - DEFAULT_WINDOW_BEFORE_DAYS * 86400000);

--- a/src/lib/recurring/auto-link.ts
+++ b/src/lib/recurring/auto-link.ts
@@ -163,6 +163,9 @@ export async function autoLinkTransaction(
   // ── Direct-recurring path (no gap exists yet — current month) ────────────
   // Fetch active, non-deleted recurrings for this user+account+amount.
   // Window filtering is done in JS (same constants as gap path).
+  // Cross-month extension (#632): for each candidate we evaluate expectedDate
+  // for [txYearMonth-1, txYearMonth, txYearMonth+1] so a tx paid early for
+  // next month (e.g. April 29 for May 1 recurring) is matched correctly.
   const directCandidates = await database
     .select({
       recurringId: recurringTransactions.id,
@@ -182,22 +185,66 @@ export async function autoLinkTransaction(
   const txYearMonth = toYearMonth(tx.occurredAt);
   const [txYear, txMonth] = txYearMonth.split("-").map(Number);
 
-  const matchingDirect = directCandidates.filter((c) => {
-    const effectiveDay = Math.min(c.dayOfMonth, daysInMonth(txYear, txMonth));
-    const expected = new Date(Date.UTC(txYear, txMonth - 1, effectiveDay));
+  /**
+   * Evaluate expectedDate for a given yearMonth (year, month 1-based).
+   * Returns whether the tx falls in the match window for that month.
+   */
+  function txInWindowForYearMonth(
+    dayOfMonth: number,
+    year: number,
+    month: number,
+  ): boolean {
+    const effectiveDay = Math.min(dayOfMonth, daysInMonth(year, month));
+    const expected = new Date(Date.UTC(year, month - 1, effectiveDay));
     const windowStart = new Date(expected.getTime() - DEFAULT_WINDOW_BEFORE_DAYS * 86400000);
     const windowEnd = new Date(
       expected.getTime() + DEFAULT_WINDOW_AFTER_DAYS * 86400000 + 86399999,
     );
     const t = tx.occurredAt.getTime();
     return t >= windowStart.getTime() && t <= windowEnd.getTime();
-  });
+  }
+
+  /** Derive year/month for prev month (handles Jan → Dec rollover). */
+  function prevYM(y: number, m: number): [number, number] {
+    return m === 1 ? [y - 1, 12] : [y, m - 1];
+  }
+
+  /** Derive year/month for next month (handles Dec → Jan rollover). */
+  function nextYM(y: number, m: number): [number, number] {
+    return m === 12 ? [y + 1, 1] : [y, m + 1];
+  }
+
+  type DirectMatch = { recurringId: number; matchedYearMonth: string };
+
+  const matchingDirect: DirectMatch[] = [];
+
+  for (const c of directCandidates) {
+    const [prevYear, prevMonth] = prevYM(txYear, txMonth);
+    const [nextYear, nextMonth] = nextYM(txYear, txMonth);
+
+    const evaluations: Array<{ year: number; month: number }> = [
+      { year: prevYear, month: prevMonth },
+      { year: txYear, month: txMonth },
+      { year: nextYear, month: nextMonth },
+    ];
+
+    for (const { year, month } of evaluations) {
+      if (txInWindowForYearMonth(c.dayOfMonth, year, month)) {
+        const ym = `${year}-${String(month).padStart(2, "0")}`;
+        matchingDirect.push({ recurringId: c.recurringId, matchedYearMonth: ym });
+        // Only count one yearMonth per recurring (first match wins, sorted prev→curr→next).
+        break;
+      }
+    }
+  }
 
   if (matchingDirect.length === 0) return { status: "no-open-gap" };
   if (matchingDirect.length > 1)
     return { status: "ambiguous", candidateCount: matchingDirect.length };
 
   const directHit = matchingDirect[0];
+  // Use the yearMonth derived from the window match (may be prev/next month).
+  const directYearMonth = directHit.matchedYearMonth;
 
   try {
     await database.transaction(async (trx) => {
@@ -205,7 +252,7 @@ export async function autoLinkTransaction(
         .update(transactions)
         .set({
           recurringId: directHit.recurringId,
-          recurringYearMonth: txYearMonth,
+          recurringYearMonth: directYearMonth,
           updatedAt: new Date(),
         })
         .where(
@@ -231,7 +278,7 @@ export async function autoLinkTransaction(
       causeMsg.includes("transactions_recurring_unique")
     ) {
       log.info(
-        { txId, recurringId: directHit.recurringId, yearMonth: txYearMonth, userId },
+        { txId, recurringId: directHit.recurringId, yearMonth: directYearMonth, userId },
         "direct auto-link: slot already taken — skipping",
       );
       return { status: "no-open-gap" };
@@ -244,7 +291,7 @@ export async function autoLinkTransaction(
       event: "auto_link_direct",
       txId,
       recurringId: directHit.recurringId,
-      yearMonth: txYearMonth,
+      yearMonth: directYearMonth,
       userId,
     },
     "auto-linked tx directly to active recurring (no gap)",
@@ -261,6 +308,6 @@ export async function autoLinkTransaction(
     status: "linked",
     gapId: null,
     recurringId: directHit.recurringId,
-    yearMonth: txYearMonth,
+    yearMonth: directYearMonth,
   };
 }

--- a/src/lib/recurring/upcoming-window.test.ts
+++ b/src/lib/recurring/upcoming-window.test.ts
@@ -1,27 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import {
-  accounts,
-  recurringTransactions,
-  transactions,
-  users,
-} from "@/lib/db/schema";
+import { accounts, recurringTransactions, transactions, users } from "@/lib/db/schema";
 import { getUpcomingForWindow } from "./upcoming";
 
 const TEST_USER_ID = 1;
 const TEST_USER2_EMAIL = "__upcoming_window_u2__@test.local";
 
 async function cleanup() {
-  await db.execute(
-    sql`DELETE FROM transactions WHERE description_raw LIKE '__upwin%'`,
-  );
-  await db.execute(
-    sql`DELETE FROM recurring_transactions WHERE label LIKE '__upwin%'`,
-  );
-  await db.execute(
-    sql`DELETE FROM accounts WHERE name LIKE '__upwin%'`,
-  );
+  await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE '__upwin%'`);
+  await db.execute(sql`DELETE FROM recurring_transactions WHERE label LIKE '__upwin%'`);
+  await db.execute(sql`DELETE FROM accounts WHERE name LIKE '__upwin%'`);
   await db.execute(sql`DELETE FROM users WHERE email = ${TEST_USER2_EMAIL}`);
 }
 

--- a/src/lib/recurring/upcoming-window.test.ts
+++ b/src/lib/recurring/upcoming-window.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  recurringTransactions,
+  transactions,
+  users,
+} from "@/lib/db/schema";
+import { getUpcomingForWindow } from "./upcoming";
+
+const TEST_USER_ID = 1;
+const TEST_USER2_EMAIL = "__upcoming_window_u2__@test.local";
+
+async function cleanup() {
+  await db.execute(
+    sql`DELETE FROM transactions WHERE description_raw LIKE '__upwin%'`,
+  );
+  await db.execute(
+    sql`DELETE FROM recurring_transactions WHERE label LIKE '__upwin%'`,
+  );
+  await db.execute(
+    sql`DELETE FROM accounts WHERE name LIKE '__upwin%'`,
+  );
+  await db.execute(sql`DELETE FROM users WHERE email = ${TEST_USER2_EMAIL}`);
+}
+
+async function seedAccount(userId = TEST_USER_ID, suffix = "") {
+  const [a] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `__upwin_acct${suffix}`,
+      institution: "TestBank",
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return a.id;
+}
+
+async function seedRecurring(
+  accountId: number,
+  opts: {
+    label: string;
+    amountCents: bigint;
+    dayOfMonth: number;
+    skippedMonths?: string[];
+    userId?: number;
+  },
+) {
+  const userId = opts.userId ?? TEST_USER_ID;
+  const [r] = await db
+    .insert(recurringTransactions)
+    .values({
+      userId,
+      accountId,
+      label: opts.label,
+      amountCents: opts.amountCents,
+      currency: "COP",
+      dayOfMonth: opts.dayOfMonth,
+      active: true,
+      skippedMonths: opts.skippedMonths ?? [],
+    })
+    .returning({ id: recurringTransactions.id });
+  return r.id;
+}
+
+async function seedTx(
+  accountId: number,
+  opts: {
+    occurredOn: string;
+    amountCents: bigint;
+    recurringId?: number;
+    recurringYearMonth?: string;
+    userId?: number;
+  },
+) {
+  const userId = opts.userId ?? TEST_USER_ID;
+  const [t] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: new Date(`${opts.occurredOn}T12:00:00Z`),
+      amountCents: opts.amountCents,
+      currency: "COP",
+      descriptionRaw: "__upwin_tx",
+      source: "manual",
+      recurringId: opts.recurringId ?? null,
+      recurringYearMonth: opts.recurringYearMonth ?? null,
+    })
+    .returning({ id: transactions.id });
+  return t.id;
+}
+
+async function seedUser2(): Promise<number> {
+  const [u] = await db
+    .insert(users)
+    .values({ email: TEST_USER2_EMAIL, name: "Window Test User 2" })
+    .returning({ id: users.id });
+  return u.id;
+}
+
+describe("getUpcomingForWindow", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("returns empty list when no recurrings exist", async () => {
+    const result = await getUpcomingForWindow({
+      userId: TEST_USER_ID,
+      today: new Date("2026-04-29T12:00:00Z"),
+    });
+    // No __upwin recurrings — may return other recurrings from seed data.
+    // Just verify it returns an array.
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it("cross-month: today=April 29, day-1 recurring → May slot appears in window", async () => {
+    const accountId = await seedAccount();
+    const recurringId = await seedRecurring(accountId, {
+      label: "__upwin cross-month next",
+      amountCents: BigInt(-100000),
+      dayOfMonth: 1,
+    });
+
+    // today = April 29. window: [Apr 24, May 4].
+    // May 1 falls in [Apr 24, May 4] → should appear.
+    const result = await getUpcomingForWindow({
+      userId: TEST_USER_ID,
+      today: new Date("2026-04-29T12:00:00Z"),
+    });
+
+    const found = result.find((i) => i.recurringId === recurringId);
+    expect(found).toBeDefined();
+    expect(found!.yearMonth).toBe("2026-05");
+    expect(found!.expectedOn).toBe("2026-05-01");
+    expect(found!.status).toBe("upcoming");
+  });
+
+  it("matched items are filtered out (explicit link)", async () => {
+    const accountId = await seedAccount();
+    const recurringId = await seedRecurring(accountId, {
+      label: "__upwin matched filter",
+      amountCents: BigInt(-50000),
+      dayOfMonth: 15,
+    });
+
+    // Link a tx to this recurring for April 2026.
+    await seedTx(accountId, {
+      occurredOn: "2026-04-15",
+      amountCents: BigInt(-50000),
+      recurringId,
+      recurringYearMonth: "2026-04",
+    });
+
+    // today = April 15 → day-15 is in window.
+    const result = await getUpcomingForWindow({
+      userId: TEST_USER_ID,
+      today: new Date("2026-04-15T12:00:00Z"),
+    });
+
+    const found = result.find((i) => i.recurringId === recurringId);
+    // Should NOT appear — it's already matched.
+    expect(found).toBeUndefined();
+  });
+
+  it("skipped items are filtered out", async () => {
+    const accountId = await seedAccount();
+    const recurringId = await seedRecurring(accountId, {
+      label: "__upwin skipped filter",
+      amountCents: BigInt(-50000),
+      dayOfMonth: 10,
+      skippedMonths: ["2026-04"],
+    });
+
+    // today = April 10 → day-10 is in window but it's skipped.
+    const result = await getUpcomingForWindow({
+      userId: TEST_USER_ID,
+      today: new Date("2026-04-10T12:00:00Z"),
+    });
+
+    const found = result.find((i) => i.recurringId === recurringId);
+    expect(found).toBeUndefined();
+  });
+
+  it("item outside window is excluded", async () => {
+    const accountId = await seedAccount();
+    const recurringId = await seedRecurring(accountId, {
+      label: "__upwin outside window",
+      amountCents: BigInt(-50000),
+      dayOfMonth: 20, // day 20
+    });
+
+    // today = April 1 → window [Mar 27, Apr 6]. Day 20 is outside.
+    const result = await getUpcomingForWindow({
+      userId: TEST_USER_ID,
+      today: new Date("2026-04-01T12:00:00Z"),
+    });
+
+    const found = result.find((i) => i.recurringId === recurringId);
+    expect(found).toBeUndefined();
+  });
+
+  it("result is sorted by expectedOn ascending", async () => {
+    const accountId = await seedAccount();
+    // Three recurrings with different days, all in the window.
+    // today=April 3 → window [Mar 29, Apr 8].
+    const r3 = await seedRecurring(accountId, {
+      label: "__upwin sort day3",
+      amountCents: BigInt(-10000),
+      dayOfMonth: 3,
+    });
+    const r5 = await seedRecurring(accountId, {
+      label: "__upwin sort day5",
+      amountCents: BigInt(-20000),
+      dayOfMonth: 5,
+    });
+    const r1 = await seedRecurring(accountId, {
+      label: "__upwin sort day1",
+      amountCents: BigInt(-30000),
+      dayOfMonth: 1,
+    });
+
+    const result = await getUpcomingForWindow({
+      userId: TEST_USER_ID,
+      today: new Date("2026-04-03T12:00:00Z"),
+    });
+
+    const ids = [r3, r5, r1];
+    const filtered = result.filter((i) => ids.includes(i.recurringId));
+    // Should be sorted by expectedOn — Apr 1, Apr 3, Apr 5
+    const expectedOns = filtered.map((i) => i.expectedOn);
+    const sorted = [...expectedOns].sort();
+    expect(expectedOns).toEqual(sorted);
+  });
+
+  it("tenant safety: user2 recurring does not appear in user1 results", async () => {
+    const user2Id = await seedUser2();
+    const user2AccountId = await seedAccount(user2Id, "_u2");
+    await seedRecurring(user2AccountId, {
+      label: "__upwin tenant safety recurring",
+      amountCents: BigInt(-999999),
+      dayOfMonth: 15,
+      userId: user2Id,
+    });
+
+    // today = April 15 → day-15 is in window.
+    const result = await getUpcomingForWindow({
+      userId: TEST_USER_ID,
+      today: new Date("2026-04-15T12:00:00Z"),
+    });
+
+    // User2's recurring must NOT appear in user1's results.
+    const leaked = result.find((i) => i.label === "__upwin tenant safety recurring");
+    expect(leaked).toBeUndefined();
+  });
+
+  it("custom beforeDays/afterDays: day outside default window appears with expanded window", async () => {
+    const accountId = await seedAccount();
+    const recurringId = await seedRecurring(accountId, {
+      label: "__upwin custom window",
+      amountCents: BigInt(-50000),
+      dayOfMonth: 20,
+    });
+
+    // today = April 5. Default window [Mar 31, Apr 10] → day 20 outside.
+    const defaultResult = await getUpcomingForWindow({
+      userId: TEST_USER_ID,
+      today: new Date("2026-04-05T12:00:00Z"),
+    });
+    const notInDefault = defaultResult.find((i) => i.recurringId === recurringId);
+    expect(notInDefault).toBeUndefined();
+
+    // Expanded window [Mar 6, May 5] → day 20 in BOTH March and April.
+    // March 20 is closer to today (Apr 5) in the past; the function returns all
+    // matching slots. The recurring appears at least once in the results.
+    const expandedResult = await getUpcomingForWindow({
+      userId: TEST_USER_ID,
+      today: new Date("2026-04-05T12:00:00Z"),
+      beforeDays: 30,
+      afterDays: 30,
+    });
+    const inExpanded = expandedResult.filter((i) => i.recurringId === recurringId);
+    // Both March 20 and April 20 fall in [Mar 6, May 5] — at least one slot returned.
+    expect(inExpanded.length).toBeGreaterThanOrEqual(1);
+    // All returned yearMonths should be valid (March or April).
+    for (const item of inExpanded) {
+      expect(["2026-03", "2026-04"]).toContain(item.yearMonth);
+    }
+  });
+});

--- a/src/lib/recurring/upcoming.ts
+++ b/src/lib/recurring/upcoming.ts
@@ -3,11 +3,14 @@ import { db as defaultDb, type DB } from "@/lib/db";
 import { accounts, categories, recurringTransactions, transactions } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { formatAccountLabel } from "@/lib/accounts/format";
+import { createLogger } from "@/lib/logger";
 import {
   DEFAULT_WINDOW_AFTER_DAYS,
   DEFAULT_WINDOW_BEFORE_DAYS,
 } from "@/lib/recurring/gap-detector";
 import type { Currency } from "@/lib/types";
+
+const log = createLogger({ module: "recurring/upcoming" });
 
 // Default window for getUpcomingForWindow (#632).
 export const UPCOMING_WINDOW_BEFORE_DAYS = 5;
@@ -254,6 +257,21 @@ export type UpcomingWindowOptions = {
 export async function getUpcomingForWindow(
   opts: UpcomingWindowOptions,
   database: DB = defaultDb,
+): Promise<UpcomingItem[]> {
+  try {
+    return await getUpcomingForWindowImpl(opts, database);
+  } catch (err) {
+    log.error(
+      { err, userId: opts.userId, event: "upcoming_window_failed" },
+      "upcoming window query failed",
+    );
+    throw err;
+  }
+}
+
+async function getUpcomingForWindowImpl(
+  opts: UpcomingWindowOptions,
+  database: DB,
 ): Promise<UpcomingItem[]> {
   const {
     userId,

--- a/src/lib/recurring/upcoming.ts
+++ b/src/lib/recurring/upcoming.ts
@@ -9,6 +9,10 @@ import {
 } from "@/lib/recurring/gap-detector";
 import type { Currency } from "@/lib/types";
 
+// Default window for getUpcomingForWindow (#632).
+export const UPCOMING_WINDOW_BEFORE_DAYS = 5;
+export const UPCOMING_WINDOW_AFTER_DAYS = 5;
+
 export type UpcomingStatus = "matched" | "upcoming" | "overdue" | "dismissed";
 
 export type UpcomingItem = {
@@ -224,6 +228,230 @@ export async function getUpcomingForMonth(
       notes: r.notes,
     });
   }
+
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// getUpcomingForWindow (#632)
+// ---------------------------------------------------------------------------
+// Returns un-matched recurring slots whose expectedDate falls in the window
+// [today - beforeDays, today + afterDays]. Unlike getUpcomingForMonth this:
+//   - Can span month boundaries (e.g., today=Apr 29, window includes May 1).
+//   - Only returns "esperado" / "atrasado" statuses (filters out matched/dismissed).
+//   - Sorted by expectedDate ascending.
+// ---------------------------------------------------------------------------
+
+export type UpcomingWindowOptions = {
+  userId: number;
+  today: Date;
+  beforeDays?: number;
+  afterDays?: number;
+  matchWindowBeforeDays?: number;
+  matchWindowAfterDays?: number;
+};
+
+export async function getUpcomingForWindow(
+  opts: UpcomingWindowOptions,
+  database: DB = defaultDb,
+): Promise<UpcomingItem[]> {
+  const {
+    userId,
+    today,
+    beforeDays = UPCOMING_WINDOW_BEFORE_DAYS,
+    afterDays = UPCOMING_WINDOW_AFTER_DAYS,
+    matchWindowBeforeDays = DEFAULT_WINDOW_BEFORE_DAYS,
+    matchWindowAfterDays = DEFAULT_WINDOW_AFTER_DAYS,
+  } = opts;
+
+  const todayDate = new Date(
+    Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
+  );
+  const windowStart = new Date(todayDate.getTime() - beforeDays * 86400000);
+  const windowEnd = new Date(todayDate.getTime() + afterDays * 86400000);
+
+  // Fetch all active, non-deleted recurrings for this user.
+  const rows = await database
+    .select({
+      id: recurringTransactions.id,
+      label: recurringTransactions.label,
+      accountId: recurringTransactions.accountId,
+      accountName: accounts.name,
+      accountCurrency: accounts.currency,
+      amountCents: recurringTransactions.amountCents,
+      currency: recurringTransactions.currency,
+      categorySlug: recurringTransactions.categorySlug,
+      categoryName: categories.name,
+      dayOfMonth: recurringTransactions.dayOfMonth,
+      skippedMonths: recurringTransactions.skippedMonths,
+      notes: recurringTransactions.notes,
+    })
+    .from(recurringTransactions)
+    .innerJoin(
+      accounts,
+      and(
+        eq(accounts.id, recurringTransactions.accountId),
+        // Tenant safety: pair user_id on both sides per per-user-table-join-tenant-safety.
+        eq(accounts.userId, recurringTransactions.userId),
+      ),
+    )
+    .leftJoin(
+      categories,
+      and(
+        eq(categories.slug, recurringTransactions.categorySlug),
+        eq(categories.userId, recurringTransactions.userId),
+      ),
+    )
+    .where(
+      and(
+        eq(recurringTransactions.userId, userId),
+        eq(recurringTransactions.active, true),
+        notDeleted(recurringTransactions.deletedAt),
+      ),
+    )
+    .orderBy(asc(recurringTransactions.dayOfMonth), asc(recurringTransactions.id));
+
+  if (rows.length === 0) return [];
+
+  // For each recurring we need to evaluate up to 3 year-months: the ones whose
+  // expectedDate might fall within the window. We consider prev-month, current-month
+  // (relative to windowStart), and next-month.
+  // Derive the set of year-months to evaluate.
+  const startYear = windowStart.getUTCFullYear();
+  const startMonth = windowStart.getUTCMonth() + 1; // 1-based
+  const endYear = windowEnd.getUTCFullYear();
+  const endMonth = windowEnd.getUTCMonth() + 1;
+
+  // Collect all unique (year, month) combos spanned by [windowStart, windowEnd].
+  const ymSet: Array<{ year: number; month: number; ym: string }> = [];
+  let y = startYear;
+  let m = startMonth;
+  while (y < endYear || (y === endYear && m <= endMonth)) {
+    ymSet.push({ year: y, month: m, ym: `${y}-${String(m).padStart(2, "0")}` });
+    if (m === 12) {
+      y += 1;
+      m = 1;
+    } else {
+      m += 1;
+    }
+  }
+
+  // Fetch explicit links for these year-months in one query.
+  const recurringIds = rows.map((r) => r.id);
+  const ymStrings = ymSet.map((e) => e.ym);
+
+  // We need explicit links for ALL year-months in the window.
+  // A single `inArray` on recurringYearMonth covers all relevant months.
+  const explicitLinks = await database
+    .select({
+      id: transactions.id,
+      recurringId: transactions.recurringId,
+      recurringYearMonth: transactions.recurringYearMonth,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        inArray(transactions.recurringId, recurringIds),
+        inArray(transactions.recurringYearMonth, ymStrings),
+        notDeleted(transactions.deletedAt),
+      ),
+    );
+
+  // Map: `${recurringId}:${yearMonth}` → txId
+  const explicitMap = new Map<string, number>();
+  for (const e of explicitLinks) {
+    if (e.recurringId !== null && e.recurringYearMonth !== null) {
+      explicitMap.set(`${e.recurringId}:${e.recurringYearMonth}`, e.id);
+    }
+  }
+
+  // Heuristic: unlinked txs in a broad range around the window for fallback matching.
+  const heuristicWindowStart = new Date(
+    windowStart.getTime() - matchWindowBeforeDays * 86400000,
+  );
+  const heuristicWindowEnd = new Date(
+    windowEnd.getTime() + matchWindowAfterDays * 86400000 + 86399999,
+  );
+  const nearbyTxs = await database
+    .select({
+      id: transactions.id,
+      accountId: transactions.accountId,
+      amountCents: transactions.amountCents,
+      occurredAt: transactions.occurredAt,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        gte(transactions.occurredAt, heuristicWindowStart),
+        lte(transactions.occurredAt, heuristicWindowEnd),
+        isNull(transactions.recurringId),
+        notDeleted(transactions.deletedAt),
+      ),
+    );
+
+  const items: UpcomingItem[] = [];
+
+  for (const r of rows) {
+    for (const { year, month, ym } of ymSet) {
+      const monthDays = daysInMonth(year, month);
+      const day = Math.min(r.dayOfMonth, monthDays);
+      const expectedOn = toIso(year, month, day);
+      const expectedDate = new Date(`${expectedOn}T00:00:00Z`);
+
+      // Only include if expectedDate falls within [windowStart, windowEnd].
+      if (expectedDate < windowStart || expectedDate > windowEnd) continue;
+
+      // Check skipped.
+      const isDismissed = (r.skippedMonths ?? []).includes(ym);
+      if (isDismissed) continue;
+
+      // Check explicit link.
+      const explicitTxId = explicitMap.get(`${r.id}:${ym}`);
+      if (explicitTxId !== undefined) continue; // already matched — skip
+
+      // Heuristic fallback: tx in same account + same amount in match window.
+      const matchHeurStart = new Date(
+        expectedDate.getTime() - matchWindowBeforeDays * 86400000,
+      );
+      const matchHeurEnd = new Date(
+        expectedDate.getTime() + matchWindowAfterDays * 86400000 + 86399999,
+      );
+      const heuristicMatch = nearbyTxs.find(
+        (tx) =>
+          tx.accountId === r.accountId &&
+          tx.amountCents === r.amountCents &&
+          tx.occurredAt >= matchHeurStart &&
+          tx.occurredAt <= matchHeurEnd,
+      );
+      if (heuristicMatch) continue; // already covered — skip
+
+      // Determine status.
+      const status: UpcomingStatus =
+        expectedDate <= todayDate ? "overdue" : "upcoming";
+
+      items.push({
+        recurringId: r.id,
+        label: r.label,
+        accountId: r.accountId,
+        accountName: formatAccountLabel({ name: r.accountName, currency: r.accountCurrency }),
+        amountCents: r.amountCents,
+        currency: r.currency,
+        categorySlug: r.categorySlug,
+        categoryName: r.categoryName,
+        dayOfMonth: r.dayOfMonth,
+        expectedOn,
+        status,
+        matchedTransactionId: null,
+        yearMonth: ym,
+        notes: r.notes,
+      });
+    }
+  }
+
+  // Sort by expectedDate ascending.
+  items.sort((a, b) => (a.expectedOn < b.expectedOn ? -1 : a.expectedOn > b.expectedOn ? 1 : 0));
 
   return items;
 }

--- a/src/lib/recurring/upcoming.ts
+++ b/src/lib/recurring/upcoming.ts
@@ -385,9 +385,7 @@ async function getUpcomingForWindowImpl(
   }
 
   // Heuristic: unlinked txs in a broad range around the window for fallback matching.
-  const heuristicWindowStart = new Date(
-    windowStart.getTime() - matchWindowBeforeDays * 86400000,
-  );
+  const heuristicWindowStart = new Date(windowStart.getTime() - matchWindowBeforeDays * 86400000);
   const heuristicWindowEnd = new Date(
     windowEnd.getTime() + matchWindowAfterDays * 86400000 + 86399999,
   );
@@ -430,9 +428,7 @@ async function getUpcomingForWindowImpl(
       if (explicitTxId !== undefined) continue; // already matched — skip
 
       // Heuristic fallback: tx in same account + same amount in match window.
-      const matchHeurStart = new Date(
-        expectedDate.getTime() - matchWindowBeforeDays * 86400000,
-      );
+      const matchHeurStart = new Date(expectedDate.getTime() - matchWindowBeforeDays * 86400000);
       const matchHeurEnd = new Date(
         expectedDate.getTime() + matchWindowAfterDays * 86400000 + 86399999,
       );
@@ -446,8 +442,7 @@ async function getUpcomingForWindowImpl(
       if (heuristicMatch) continue; // already covered — skip
 
       // Determine status.
-      const status: UpcomingStatus =
-        expectedDate <= todayDate ? "overdue" : "upcoming";
+      const status: UpcomingStatus = expectedDate <= todayDate ? "overdue" : "upcoming";
 
       items.push({
         recurringId: r.id,


### PR DESCRIPTION
Closes #632

## Summary

- **UpcomingCard** switched from month-calendar to `[today-5d, today+5d]` window view with un-matched filter; height matched to Top Expenses card with internal scroll; 2 icon buttons replaced with single trigger opening unified `ForecastLinkTxDialog`.
- **Picker rewritten** as window-based (NEVER month-calendar): two-section layout — Sugeridas (same-currency ±20% amount match) + Todas (all currencies) — with client-side search and lazy loading.
- **`autoLinkTransaction`** extended to evaluate prior + current + next year-month so a tx paid early for next month's recurring (or late for the prior month) auto-links correctly across month boundaries.
- **`getLinkCandidatesForForecast`** return type changed from `ForecastLinkCandidate[]` → `ForecastLinkCandidatesResult` (sole caller updated).
- **Path A** chosen for link action: uses `linkTxToRecurring` from Sub-A — handles both gap-exists and no-gap cases without branching at the call site.

## Architecture invariants preserved

- Forecast rows are NEVER persisted as transactions (display-only contract from #627 intact).
- Footer-total guard intact.
- Tenant safety: every per-user JOIN pairs `user_id` (verified by reviewer pass).

## Reviewer findings addressed

- **W1** (only actionable finding): added Pino logger + try/catch wrap in `getUpcomingForWindow` — committed as `fix(recurring): wrap getUpcomingForWindow with Pino logger + error trap (#632)`.
- **S2** (Dec→Jan year-rollover edge case test for `getUpcomingForWindow`) — deferred to follow-up, not blocking this PR.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean — 1931 passed, 1 pre-existing skip (153 files)
- [x] `bun run test:e2e` — 68 passed; 6 pre-existing flakes (home recharts ×4, counterparty ×2) — unrelated to this change
- [x] E2E screenshots captured (75 files) — key pages below
- [ ] Manual smoke: UpcomingCard window filter, picker dialog Sugeridas/Todas sections, search, cross-month auto-link

## Screenshots

> Captured via Playwright headless — 75 total. Key pages affected by this PR:

`chromium-light-transactions.png`, `chromium-dark-transactions.png`, `chromium-light-budgets.png`, `chromium-dark-budgets.png` (UpcomingCard appears on dashboard and budgets views). Full screenshot set available in `e2e/screenshots/` after running `bun run test:e2e` locally.