### PR TITLE
feat(recurring): learning loop — auto-update amount + description fingerprint (#633)

### DIFF
--- a/drizzle/0069_sour_black_panther.sql
+++ b/drizzle/0069_sour_black_panther.sql
@@ -1,0 +1,56 @@
+CREATE TYPE "public"."recurring_amount_type" AS ENUM('fixed', 'variable');--> statement-breakpoint
+CREATE TYPE "public"."recurring_proposal_status" AS ENUM('pending', 'accepted', 'rejected', 'expired');--> statement-breakpoint
+CREATE TABLE "recurring_description_patterns" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"recurring_id" integer NOT NULL,
+	"pattern" text NOT NULL,
+	"observation_count" integer DEFAULT 1 NOT NULL,
+	"pattern_ambiguous" boolean DEFAULT false NOT NULL,
+	"last_observed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "recurring_link_observations" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"recurring_id" integer NOT NULL,
+	"tx_id" integer NOT NULL,
+	"year_month" varchar(7) NOT NULL,
+	"real_amount_cents" bigint NOT NULL,
+	"real_currency" "currency" NOT NULL,
+	"description_raw" text,
+	"account_id" integer NOT NULL,
+	"manual" boolean DEFAULT false NOT NULL,
+	"applied" boolean DEFAULT false NOT NULL,
+	"observed_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "recurring_proposals" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"recurring_id" integer NOT NULL,
+	"proposal_type" varchar(40) NOT NULL,
+	"payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"status" "recurring_proposal_status" DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"decided_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "recurring_transactions" ADD COLUMN "amount_type" "recurring_amount_type" DEFAULT 'fixed' NOT NULL;--> statement-breakpoint
+ALTER TABLE "recurring_description_patterns" ADD CONSTRAINT "recurring_description_patterns_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recurring_description_patterns" ADD CONSTRAINT "recurring_description_patterns_recurring_id_recurring_transactions_id_fk" FOREIGN KEY ("recurring_id") REFERENCES "public"."recurring_transactions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recurring_link_observations" ADD CONSTRAINT "recurring_link_observations_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recurring_link_observations" ADD CONSTRAINT "recurring_link_observations_recurring_id_recurring_transactions_id_fk" FOREIGN KEY ("recurring_id") REFERENCES "public"."recurring_transactions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recurring_link_observations" ADD CONSTRAINT "recurring_link_observations_tx_id_transactions_id_fk" FOREIGN KEY ("tx_id") REFERENCES "public"."transactions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recurring_link_observations" ADD CONSTRAINT "recurring_link_observations_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recurring_proposals" ADD CONSTRAINT "recurring_proposals_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recurring_proposals" ADD CONSTRAINT "recurring_proposals_recurring_id_recurring_transactions_id_fk" FOREIGN KEY ("recurring_id") REFERENCES "public"."recurring_transactions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "recurring_description_patterns_unique" ON "recurring_description_patterns" USING btree ("user_id","recurring_id","pattern");--> statement-breakpoint
+CREATE INDEX "recurring_description_patterns_user_pattern_idx" ON "recurring_description_patterns" USING btree ("user_id","pattern");--> statement-breakpoint
+CREATE INDEX "recurring_description_patterns_recurring_idx" ON "recurring_description_patterns" USING btree ("recurring_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "recurring_link_observations_unique" ON "recurring_link_observations" USING btree ("user_id","recurring_id","tx_id","year_month");--> statement-breakpoint
+CREATE INDEX "recurring_link_observations_pending_idx" ON "recurring_link_observations" USING btree ("user_id","recurring_id") WHERE "recurring_link_observations"."manual" = true AND "recurring_link_observations"."applied" = false;--> statement-breakpoint
+CREATE INDEX "recurring_link_observations_recurring_idx" ON "recurring_link_observations" USING btree ("recurring_id");--> statement-breakpoint
+CREATE INDEX "recurring_proposals_user_status_idx" ON "recurring_proposals" USING btree ("user_id","status") WHERE "recurring_proposals"."status" = 'pending';--> statement-breakpoint
+CREATE INDEX "recurring_proposals_recurring_idx" ON "recurring_proposals" USING btree ("recurring_id");

--- a/drizzle/meta/0069_snapshot.json
+++ b/drizzle/meta/0069_snapshot.json
@@ -1,0 +1,6122 @@
+{
+  "id": "6b224db8-4f3c-435e-af3d-14bd4f808adf",
+  "prevId": "f5bdb14a-bd7f-41ea-8e93-888443df48ee",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_physical_card_id_physical_cards_id_fk": {
+          "name": "accounts_physical_card_id_physical_cards_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "physical_cards",
+          "columnsFrom": [
+            "physical_card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.arq_statement_imports": {
+      "name": "arq_statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declared_start_cents": {
+          "name": "declared_start_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declared_end_cents": {
+          "name": "declared_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_count": {
+          "name": "parsed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_sum_cents": {
+          "name": "parsed_sum_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconciled": {
+          "name": "reconciled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconcile_diff_cents": {
+          "name": "reconcile_diff_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_ok": {
+          "name": "chain_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "raw_pdf_hash": {
+          "name": "raw_pdf_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "arq_statement_imports_period_unique": {
+          "name": "arq_statement_imports_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "arq_statement_imports_user_hash_unique": {
+          "name": "arq_statement_imports_user_hash_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_pdf_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "arq_statement_imports_account_period_idx": {
+          "name": "arq_statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "arq_statement_imports_user_id_users_id_fk": {
+          "name": "arq_statement_imports_user_id_users_id_fk",
+          "tableFrom": "arq_statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "arq_statement_imports_account_id_accounts_id_fk": {
+          "name": "arq_statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "arq_statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_corrections": {
+      "name": "classification_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_category_slug": {
+          "name": "new_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_corrections_learning_idx": {
+          "name": "classification_corrections_learning_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "new_category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_corrections_user_id_users_id_fk": {
+          "name": "classification_corrections_user_id_users_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_corrections_transaction_id_transactions_id_fk": {
+          "name": "classification_corrections_transaction_id_transactions_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_from_corrections": {
+          "name": "generated_from_corrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_salary": {
+          "name": "is_salary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparties_user_salary_idx": {
+          "name": "counterparties_user_salary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"counterparties\".\"is_salary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_receipts": {
+      "name": "email_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_connection_id": {
+          "name": "gmail_connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_msg_id": {
+          "name": "gmail_msg_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway": {
+          "name": "gateway",
+          "type": "email_receipt_gateway",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_html": {
+          "name": "raw_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_payload": {
+          "name": "parsed_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_transaction_id": {
+          "name": "matched_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_status": {
+          "name": "match_status",
+          "type": "email_receipt_match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "match_candidates": {
+          "name": "match_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_at": {
+          "name": "parsed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_received_at": {
+          "name": "email_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_receipts_user_msg_unique": {
+          "name": "email_receipts_user_msg_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_msg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_user_status_idx": {
+          "name": "email_receipts_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_match_lookup_idx": {
+          "name": "email_receipts_match_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "amount_cents",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'pending' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_connection_idx": {
+          "name": "email_receipts_connection_idx",
+          "columns": [
+            {
+              "expression": "gmail_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_candidates_gin_idx": {
+          "name": "email_receipts_candidates_gin_idx",
+          "columns": [
+            {
+              "expression": "match_candidates",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'ambiguous' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_receipts_user_id_users_id_fk": {
+          "name": "email_receipts_user_id_users_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_gmail_connection_id_gmail_connections_id_fk": {
+          "name": "email_receipts_gmail_connection_id_gmail_connections_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "gmail_connections",
+          "columnsFrom": [
+            "gmail_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_matched_transaction_id_transactions_id_fk": {
+          "name": "email_receipts_matched_transaction_id_transactions_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "matched_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiat_partners": {
+      "name": "fiat_partners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_system": {
+          "name": "source_system",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_name": {
+          "name": "partner_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "fiat_partners_system_name_unique": {
+          "name": "fiat_partners_system_name_unique",
+          "columns": [
+            {
+              "expression": "source_system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiat_partners_source_active_idx": {
+          "name": "fiat_partners_source_active_idx",
+          "columns": [
+            {
+              "expression": "source_system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"fiat_partners\".\"active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_connections": {
+      "name": "gmail_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_email": {
+          "name": "gmail_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_enc": {
+          "name": "access_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_pull_at": {
+          "name": "last_pull_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_pull_history_id": {
+          "name": "last_pull_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "gmail_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_nudge_sent_at": {
+          "name": "bot_nudge_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bootstrap_since_date": {
+          "name": "bootstrap_since_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_connections_user_email_unique": {
+          "name": "gmail_connections_user_email_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_user_status_idx": {
+          "name": "gmail_connections_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_active_idx": {
+          "name": "gmail_connections_active_idx",
+          "columns": [
+            {
+              "expression": "last_pull_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"status\" = 'active' AND \"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_connections_user_id_users_id_fk": {
+          "name": "gmail_connections_user_id_users_id_fk",
+          "tableFrom": "gmail_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.physical_cards": {
+      "name": "physical_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_limit_cents": {
+          "name": "credit_limit_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "statement_cutoff_day": {
+          "name": "statement_cutoff_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "physical_cards_user_idx": {
+          "name": "physical_cards_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "physical_cards_user_institution_idx": {
+          "name": "physical_cards_user_institution_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "physical_cards_user_id_users_id_fk": {
+          "name": "physical_cards_user_id_users_id_fk",
+          "tableFrom": "physical_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_description_patterns": {
+      "name": "recurring_description_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observation_count": {
+          "name": "observation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "pattern_ambiguous": {
+          "name": "pattern_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_description_patterns_unique": {
+          "name": "recurring_description_patterns_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_description_patterns_user_pattern_idx": {
+          "name": "recurring_description_patterns_user_pattern_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_description_patterns_recurring_idx": {
+          "name": "recurring_description_patterns_recurring_idx",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_description_patterns_user_id_users_id_fk": {
+          "name": "recurring_description_patterns_user_id_users_id_fk",
+          "tableFrom": "recurring_description_patterns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_description_patterns_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_description_patterns_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_description_patterns",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_tx_id": {
+          "name": "resolution_tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_open_idx": {
+          "name": "recurring_gaps_open_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_gaps\".\"resolution\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_resolution_tx_id_transactions_id_fk": {
+          "name": "recurring_gaps_resolution_tx_id_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolution_tx_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_link_observations": {
+      "name": "recurring_link_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_id": {
+          "name": "tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "real_amount_cents": {
+          "name": "real_amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "real_currency": {
+          "name": "real_currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manual": {
+          "name": "manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_link_observations_unique": {
+          "name": "recurring_link_observations_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tx_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_link_observations_pending_idx": {
+          "name": "recurring_link_observations_pending_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_link_observations\".\"manual\" = true AND \"recurring_link_observations\".\"applied\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_link_observations_recurring_idx": {
+          "name": "recurring_link_observations_recurring_idx",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_link_observations_user_id_users_id_fk": {
+          "name": "recurring_link_observations_user_id_users_id_fk",
+          "tableFrom": "recurring_link_observations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_link_observations_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_link_observations_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_link_observations",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_link_observations_tx_id_transactions_id_fk": {
+          "name": "recurring_link_observations_tx_id_transactions_id_fk",
+          "tableFrom": "recurring_link_observations",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "tx_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_link_observations_account_id_accounts_id_fk": {
+          "name": "recurring_link_observations_account_id_accounts_id_fk",
+          "tableFrom": "recurring_link_observations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_proposals": {
+      "name": "recurring_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "recurring_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_proposals_user_status_idx": {
+          "name": "recurring_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_proposals_recurring_idx": {
+          "name": "recurring_proposals_recurring_idx",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_proposals_user_id_users_id_fk": {
+          "name": "recurring_proposals_user_id_users_id_fk",
+          "tableFrom": "recurring_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_proposals_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_proposals_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_proposals",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_type": {
+          "name": "amount_type",
+          "type": "recurring_amount_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_proposals": {
+      "name": "rule_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_txn_ids": {
+          "name": "correction_txn_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rule_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rule_proposals_user_merchant_category_pending_unique": {
+          "name": "rule_proposals_user_merchant_category_pending_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rule_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rule_proposals_user_status_idx": {
+          "name": "rule_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_proposals_user_id_users_id_fk": {
+          "name": "rule_proposals_user_id_users_id_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_proposals_user_category_fk": {
+          "name": "rule_proposals_user_category_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skipped_consolidation_cycles": {
+      "name": "skipped_consolidation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "skipped_consolidation_cycles_live_unique": {
+          "name": "skipped_consolidation_cycles_live_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skipped_consolidation_cycles_user_account_idx": {
+          "name": "skipped_consolidation_cycles_user_account_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skipped_consolidation_cycles_user_id_users_id_fk": {
+          "name": "skipped_consolidation_cycles_user_id_users_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skipped_consolidation_cycles_account_id_accounts_id_fk": {
+          "name": "skipped_consolidation_cycles_account_id_accounts_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slo_alerts": {
+      "name": "slo_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slo_key": {
+          "name": "slo_key",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slo_alerts_open_idx": {
+          "name": "slo_alerts_open_idx",
+          "columns": [
+            {
+              "expression": "slo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"slo_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "statement_import_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movimientos'"
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synthetic_tx_id": {
+          "name": "synthetic_tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_cycle_unique": {
+          "name": "statement_imports_cycle_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"statement_imports\".\"kind\" = 'extracto_detallado' AND \"statement_imports\".\"cycle\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installments_total": {
+          "name": "installments_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "installment_rate_bps": {
+          "name": "installment_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retroactive_rule_id": {
+          "name": "retroactive_rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group_id": {
+          "name": "transfer_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enriched_merchant": {
+          "name": "enriched_merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_source": {
+          "name": "enrichment_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_source": {
+          "name": "secondary_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_statement": {
+          "name": "external_id_statement",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arq_statement_import_id": {
+          "name": "arq_statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_mismatch": {
+          "name": "source_mismatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_mismatch_details": {
+          "name": "source_mismatch_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_group_idx": {
+          "name": "transactions_transfer_group_idx",
+          "columns": [
+            {
+              "expression": "transfer_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"transfer_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_occurred_live_idx": {
+          "name": "transactions_account_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_live_idx": {
+          "name": "transactions_user_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_retroactive_rule_id_classification_rules_id_fk": {
+          "name": "transactions_retroactive_rule_id_classification_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "classification_rules",
+          "columnsFrom": [
+            "retroactive_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_arq_statement_import_id_arq_statement_imports_id_fk": {
+          "name": "transactions_arq_statement_import_id_arq_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "arq_statement_imports",
+          "columnsFrom": [
+            "arq_statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_aliases": {
+      "name": "user_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_aliases_user_alias_unique": {
+          "name": "user_aliases_user_alias_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_aliases_user_idx": {
+          "name": "user_aliases_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_aliases_user_id_users_id_fk": {
+          "name": "user_aliases_user_id_users_id_fk",
+          "tableFrom": "user_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_snapshots": {
+      "name": "user_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_bytes": {
+          "name": "payload_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_snapshots_user_created_idx": {
+          "name": "user_snapshots_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_snapshots_user_id_users_id_fk": {
+          "name": "user_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ui_preferences": {
+          "name": "ui_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "classification_context": {
+          "name": "classification_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "rule_retroactive",
+        "ai",
+        "manual",
+        "manual_confirmed",
+        "unclassified",
+        "user_uncategorized"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.email_receipt_gateway": {
+      "name": "email_receipt_gateway",
+      "schema": "public",
+      "values": [
+        "mercado_pago",
+        "payu",
+        "wompi",
+        "apple",
+        "paypal",
+        "bancolombia",
+        "arq"
+      ]
+    },
+    "public.email_receipt_match_status": {
+      "name": "email_receipt_match_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "matched",
+        "ambiguous",
+        "unmatched"
+      ]
+    },
+    "public.gmail_connection_status": {
+      "name": "gmail_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "revoked",
+        "error"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.recurring_amount_type": {
+      "name": "recurring_amount_type",
+      "schema": "public",
+      "values": [
+        "fixed",
+        "variable"
+      ]
+    },
+    "public.recurring_proposal_status": {
+      "name": "recurring_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.rule_proposal_status": {
+      "name": "rule_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.statement_import_kind": {
+      "name": "statement_import_kind",
+      "schema": "public",
+      "values": [
+        "movimientos",
+        "extracto_detallado"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile",
+        "gmail_bancolombia",
+        "gmail_enrichment",
+        "gmail_arq",
+        "arq_statement"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug",
+        "widget"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1777452421357,
       "tag": "0068_superb_fabian_cortez",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1777460383867,
+      "tag": "0069_sour_black_panther",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -161,7 +161,7 @@ export default async function DashboardPage({
 
         <RecurringPendingBanner userId={session.id} />
 
-        <RecurringProposalsBanner userId={session.id} />
+        <RecurringProposalsBanner />
 
         <section className="flex flex-col gap-4">
           <h2 className="text-eyebrow">Cuentas</h2>

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -18,6 +18,7 @@ import { AccountsGrid } from "@/components/dashboard/accounts-grid";
 import { UpcomingCard } from "@/components/dashboard/upcoming-card";
 import { MonthSwitcher } from "@/components/dashboard/month-switcher";
 import { RecurringPendingBanner } from "@/components/dashboard/recurring-pending-banner";
+import { RecurringProposalsBanner } from "@/components/dashboard/recurring-proposals-banner";
 import { SmsHealthCard } from "@/components/dashboard/sms-health-card";
 import { CreditCardsCard } from "@/components/dashboard/credit-cards-card";
 import { PendingConsolidationBanner } from "@/components/dashboard/pending-consolidation-banner";
@@ -159,6 +160,8 @@ export default async function DashboardPage({
         </section>
 
         <RecurringPendingBanner userId={session.id} />
+
+        <RecurringProposalsBanner userId={session.id} />
 
         <section className="flex flex-col gap-4">
           <h2 className="text-eyebrow">Cuentas</h2>

--- a/src/app/(app)/settings/recurring/learning/actions.test.ts
+++ b/src/app/(app)/settings/recurring/learning/actions.test.ts
@@ -373,18 +373,26 @@ describe("countPendingProposals", () => {
     userAId = await seedUser(`${TAG}-userA@test.local`);
     accountAId = await seedAccount(userAId);
     recurringAId = await seedRecurring(userAId, accountAId, BigInt(-42000));
+    // Point the session mock at the freshly-seeded user.
+    mockGetSessionUser.mockResolvedValue({
+      id: userAId,
+      email: `${TAG}-userA@test.local`,
+      name: "UserA",
+      role: "user" as const,
+      active: true,
+    });
   });
 
   afterEach(cleanup);
 
   it("returns 0 when no pending proposals", async () => {
-    const count = await countPendingProposals(userAId);
+    const count = await countPendingProposals();
     expect(count).toBe(0);
   });
 
   it("returns correct count of pending proposals", async () => {
     await seedProposal(userAId, recurringAId, "amount_update", {});
-    const count = await countPendingProposals(userAId);
+    const count = await countPendingProposals();
     expect(count).toBe(1);
   });
 
@@ -395,7 +403,7 @@ describe("countPendingProposals", () => {
       .set({ status: "accepted" })
       .where(eq(recurringProposals.id, proposalId));
 
-    const count = await countPendingProposals(userAId);
+    const count = await countPendingProposals();
     expect(count).toBe(0);
   });
 });

--- a/src/app/(app)/settings/recurring/learning/actions.test.ts
+++ b/src/app/(app)/settings/recurring/learning/actions.test.ts
@@ -1,0 +1,401 @@
+// #633: Integration tests for acceptProposal / rejectProposal server actions.
+// Runs against findash_test (forced by vitest.setup.ts).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  recurringLinkObservations,
+  recurringProposals,
+  recurringTransactions,
+  transactions,
+  users,
+} from "@/lib/db/schema";
+import { copyCategorySeedsToUser, copyRuleSeedsToUser } from "@/lib/auth/signup";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockResolvedValue({
+    id: 1,
+    email: "test@test.local",
+    name: "Test",
+    role: "user" as const,
+    active: true,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Lazy imports (after mocks)
+// ---------------------------------------------------------------------------
+
+const { acceptProposal, rejectProposal, countPendingProposals } = await import("./actions");
+const { getSessionUser } = await import("@/lib/auth/session");
+const mockGetSessionUser = vi.mocked(getSessionUser);
+
+// ---------------------------------------------------------------------------
+// Test data tag and seed helpers
+// ---------------------------------------------------------------------------
+
+const TAG = "test-proposal-actions-633";
+
+async function seedUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  await copyRuleSeedsToUser(row.id);
+  return row.id;
+}
+
+async function seedAccount(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({ userId, name: `${TAG}-acct`, institution: TAG, type: "savings", currency: "COP" })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function seedRecurring(
+  userId: number,
+  accountId: number,
+  amountCents: bigint = BigInt(-42000),
+): Promise<number> {
+  const [row] = await db
+    .insert(recurringTransactions)
+    .values({
+      userId,
+      accountId,
+      label: `${TAG}-recurring`,
+      amountCents,
+      currency: "COP",
+      dayOfMonth: 15,
+      active: true,
+    })
+    .returning({ id: recurringTransactions.id });
+  return row.id;
+}
+
+async function seedTx(userId: number, accountId: number): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: new Date("2026-04-15T12:00:00Z"),
+      amountCents: BigInt(-44900),
+      currency: "COP",
+      descriptionRaw: `${TAG}-tx`,
+      classificationMethod: "unclassified",
+      source: "manual",
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function seedProposal(
+  userId: number,
+  recurringId: number,
+  proposalType: "amount_update" | "variable_flag",
+  payload: Record<string, unknown> = {},
+): Promise<number> {
+  const [row] = await db
+    .insert(recurringProposals)
+    .values({ userId, recurringId, proposalType, payload, status: "pending" })
+    .returning({ id: recurringProposals.id });
+  return row.id;
+}
+
+async function seedObservation(
+  userId: number,
+  recurringId: number,
+  txId: number,
+  accountId: number,
+): Promise<void> {
+  await db.insert(recurringLinkObservations).values({
+    userId,
+    recurringId,
+    txId,
+    yearMonth: "2026-04",
+    realAmountCents: BigInt(-44900),
+    realCurrency: "COP",
+    descriptionRaw: `${TAG}-tx`,
+    accountId,
+    manual: true,
+    applied: false,
+  });
+}
+
+async function cleanup() {
+  await db.execute(
+    sql`DELETE FROM recurring_link_observations WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})`,
+  );
+  await db.execute(
+    sql`DELETE FROM recurring_proposals WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})`,
+  );
+  await db.execute(sql`DELETE FROM transactions WHERE description_raw = ${TAG + "-tx"}`);
+  await db.execute(sql`DELETE FROM recurring_transactions WHERE label = ${TAG + "-recurring"}`);
+  await db.execute(sql`DELETE FROM accounts WHERE name = ${TAG + "-acct"}`);
+  await db.execute(sql`DELETE FROM users WHERE email LIKE ${TAG + "%"}`);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("acceptProposal (amount_update)", () => {
+  let userAId: number;
+  let accountAId: number;
+  let recurringAId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    userAId = await seedUser(`${TAG}-userA@test.local`);
+    accountAId = await seedAccount(userAId);
+    recurringAId = await seedRecurring(userAId, accountAId, BigInt(-42000));
+    mockGetSessionUser.mockResolvedValue({
+      id: userAId,
+      email: `${TAG}-userA@test.local`,
+      name: "A",
+      role: "user" as const,
+      active: true,
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("updates recurring.amount_cents and marks proposal accepted + observations applied", async () => {
+    const txId = await seedTx(userAId, accountAId);
+    await seedObservation(userAId, recurringAId, txId, accountAId);
+
+    const proposalId = await seedProposal(userAId, recurringAId, "amount_update", {
+      newAmountCents: "-44900",
+      oldAmountCents: "-42000",
+      currency: "COP",
+      observationCount: 2,
+    });
+
+    const result = await acceptProposal({ proposalId });
+
+    expect(result.ok).toBe(true);
+
+    // Recurring amount updated.
+    const [rt] = await db
+      .select({ amountCents: recurringTransactions.amountCents })
+      .from(recurringTransactions)
+      .where(eq(recurringTransactions.id, recurringAId));
+
+    expect(rt?.amountCents.toString()).toBe("-44900");
+
+    // Proposal accepted.
+    const [p] = await db
+      .select({ status: recurringProposals.status })
+      .from(recurringProposals)
+      .where(eq(recurringProposals.id, proposalId));
+
+    expect(p?.status).toBe("accepted");
+
+    // Observations applied.
+    const [obs] = await db
+      .select({ applied: recurringLinkObservations.applied })
+      .from(recurringLinkObservations)
+      .where(
+        and(
+          eq(recurringLinkObservations.userId, userAId),
+          eq(recurringLinkObservations.recurringId, recurringAId),
+        ),
+      );
+
+    expect(obs?.applied).toBe(true);
+  });
+
+  it("returns ok:false if proposal already accepted", async () => {
+    const proposalId = await seedProposal(userAId, recurringAId, "amount_update", {});
+    // Mark as already accepted.
+    await db
+      .update(recurringProposals)
+      .set({ status: "accepted", decidedAt: new Date() })
+      .where(eq(recurringProposals.id, proposalId));
+
+    const result = await acceptProposal({ proposalId });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("should not reach");
+    expect(result.error).toMatch(/ya accepted/i);
+  });
+
+  it("cross-tenant: userA cannot accept userB's proposal", async () => {
+    const userBId = await seedUser(`${TAG}-userB@test.local`);
+    const accountBId = await seedAccount(userBId);
+    const recurringBId = await seedRecurring(userBId, accountBId, BigInt(-42000));
+
+    const proposalBId = await seedProposal(userBId, recurringBId, "amount_update", {
+      newAmountCents: "-44900",
+      oldAmountCents: "-42000",
+      currency: "COP",
+      observationCount: 2,
+    });
+
+    // Session is userA — trying to accept userB's proposal.
+    const result = await acceptProposal({ proposalId: proposalBId });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("should not reach");
+    expect(result.error).toMatch(/no encontrada/i);
+
+    // Cleanup userB
+    await db.execute(sql`DELETE FROM recurring_proposals WHERE id = ${proposalBId}`);
+    await db.execute(sql`DELETE FROM recurring_transactions WHERE id = ${recurringBId}`);
+    await db.execute(sql`DELETE FROM accounts WHERE id = ${accountBId}`);
+    await db.execute(sql`DELETE FROM users WHERE id = ${userBId}`);
+  });
+});
+
+describe("acceptProposal (variable_flag)", () => {
+  let userAId: number;
+  let accountAId: number;
+  let recurringAId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    userAId = await seedUser(`${TAG}-userA@test.local`);
+    accountAId = await seedAccount(userAId);
+    recurringAId = await seedRecurring(userAId, accountAId, BigInt(-42000));
+    mockGetSessionUser.mockResolvedValue({
+      id: userAId,
+      email: `${TAG}-userA@test.local`,
+      name: "A",
+      role: "user" as const,
+      active: true,
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("sets amount_type='variable' on the recurring", async () => {
+    const proposalId = await seedProposal(userAId, recurringAId, "variable_flag", {
+      detectedAmounts: ["-42000", "-55000", "-31000"],
+      currency: "COP",
+      observationCount: 3,
+    });
+
+    const result = await acceptProposal({ proposalId });
+
+    expect(result.ok).toBe(true);
+
+    const [rt] = await db
+      .select({ amountType: recurringTransactions.amountType })
+      .from(recurringTransactions)
+      .where(eq(recurringTransactions.id, recurringAId));
+
+    expect(rt?.amountType).toBe("variable");
+  });
+});
+
+describe("rejectProposal", () => {
+  let userAId: number;
+  let accountAId: number;
+  let recurringAId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    userAId = await seedUser(`${TAG}-userA@test.local`);
+    accountAId = await seedAccount(userAId);
+    recurringAId = await seedRecurring(userAId, accountAId, BigInt(-42000));
+    mockGetSessionUser.mockResolvedValue({
+      id: userAId,
+      email: `${TAG}-userA@test.local`,
+      name: "A",
+      role: "user" as const,
+      active: true,
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("marks proposal rejected without changing the recurring", async () => {
+    const proposalId = await seedProposal(userAId, recurringAId, "amount_update", {
+      newAmountCents: "-44900",
+      oldAmountCents: "-42000",
+      currency: "COP",
+      observationCount: 2,
+    });
+
+    const result = await rejectProposal({ proposalId });
+
+    expect(result.ok).toBe(true);
+
+    const [p] = await db
+      .select({ status: recurringProposals.status })
+      .from(recurringProposals)
+      .where(eq(recurringProposals.id, proposalId));
+
+    expect(p?.status).toBe("rejected");
+
+    // Recurring amount unchanged.
+    const [rt] = await db
+      .select({ amountCents: recurringTransactions.amountCents })
+      .from(recurringTransactions)
+      .where(eq(recurringTransactions.id, recurringAId));
+
+    expect(rt?.amountCents.toString()).toBe("-42000");
+  });
+
+  it("cross-tenant: userA cannot reject userB's proposal", async () => {
+    const userBId = await seedUser(`${TAG}-userB@test.local`);
+    const accountBId = await seedAccount(userBId);
+    const recurringBId = await seedRecurring(userBId, accountBId, BigInt(-42000));
+
+    const proposalBId = await seedProposal(userBId, recurringBId, "amount_update", {});
+
+    const result = await rejectProposal({ proposalId: proposalBId });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("should not reach");
+    expect(result.error).toMatch(/no encontrada/i);
+
+    await db.execute(sql`DELETE FROM recurring_proposals WHERE id = ${proposalBId}`);
+    await db.execute(sql`DELETE FROM recurring_transactions WHERE id = ${recurringBId}`);
+    await db.execute(sql`DELETE FROM accounts WHERE id = ${accountBId}`);
+    await db.execute(sql`DELETE FROM users WHERE id = ${userBId}`);
+  });
+});
+
+describe("countPendingProposals", () => {
+  let userAId: number;
+  let accountAId: number;
+  let recurringAId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    userAId = await seedUser(`${TAG}-userA@test.local`);
+    accountAId = await seedAccount(userAId);
+    recurringAId = await seedRecurring(userAId, accountAId, BigInt(-42000));
+  });
+
+  afterEach(cleanup);
+
+  it("returns 0 when no pending proposals", async () => {
+    const count = await countPendingProposals(userAId);
+    expect(count).toBe(0);
+  });
+
+  it("returns correct count of pending proposals", async () => {
+    await seedProposal(userAId, recurringAId, "amount_update", {});
+    const count = await countPendingProposals(userAId);
+    expect(count).toBe(1);
+  });
+
+  it("does not count non-pending proposals", async () => {
+    const proposalId = await seedProposal(userAId, recurringAId, "amount_update", {});
+    await db
+      .update(recurringProposals)
+      .set({ status: "accepted" })
+      .where(eq(recurringProposals.id, proposalId));
+
+    const count = await countPendingProposals(userAId);
+    expect(count).toBe(0);
+  });
+});

--- a/src/app/(app)/settings/recurring/learning/actions.ts
+++ b/src/app/(app)/settings/recurring/learning/actions.ts
@@ -1,0 +1,237 @@
+"use server";
+
+// #633: Server actions for learning proposal lifecycle.
+// Tenant-safe: userId ALWAYS from getSessionUser(), never from caller input.
+
+import { revalidatePath } from "next/cache";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  recurringProposals,
+  recurringTransactions,
+  recurringLinkObservations,
+} from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { getSessionUser } from "@/lib/auth/session";
+import { createLogger } from "@/lib/logger";
+import type { ProposalActionResult, ProposalActionInput } from "./learning-types";
+import { proposalIdSchema } from "./learning-types";
+
+const log = createLogger({ module: "settings/recurring/learning/actions" });
+
+/**
+ * Accept a proposal:
+ *   - amount_update: updates recurring.amount_cents to the proposed value.
+ *   - variable_flag: sets recurring.amount_type = 'variable'.
+ * In both cases, marks the proposal as 'accepted' and marks linked observations as applied=true.
+ * Atomic — runs in a single DB transaction.
+ */
+export async function acceptProposal(input: ProposalActionInput): Promise<ProposalActionResult> {
+  const session = await getSessionUser();
+  const parsed = proposalIdSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Input inválido" };
+  }
+  const { proposalId } = parsed.data;
+
+  try {
+    await db.transaction(async (trx) => {
+      // 1. Fetch the proposal — tenant-safe.
+      const [proposal] = await trx
+        .select({
+          id: recurringProposals.id,
+          recurringId: recurringProposals.recurringId,
+          proposalType: recurringProposals.proposalType,
+          payload: recurringProposals.payload,
+          status: recurringProposals.status,
+        })
+        .from(recurringProposals)
+        .where(
+          and(eq(recurringProposals.userId, session.id), eq(recurringProposals.id, proposalId)),
+        )
+        .limit(1);
+
+      if (!proposal) throw new Error("Propuesta no encontrada");
+      if (proposal.status !== "pending") {
+        throw new Error(`Propuesta ya ${proposal.status} — no se puede modificar`);
+      }
+
+      // 2. Apply the change to the recurring.
+      if (proposal.proposalType === "amount_update") {
+        const p = proposal.payload as { newAmountCents: string };
+        if (!p.newAmountCents) throw new Error("Payload inválido: falta newAmountCents");
+
+        await trx
+          .update(recurringTransactions)
+          .set({
+            amountCents: BigInt(p.newAmountCents),
+          })
+          .where(
+            and(
+              eq(recurringTransactions.userId, session.id),
+              eq(recurringTransactions.id, proposal.recurringId),
+              notDeleted(recurringTransactions.deletedAt),
+            ),
+          );
+      } else if (proposal.proposalType === "variable_flag") {
+        await trx
+          .update(recurringTransactions)
+          .set({ amountType: "variable" })
+          .where(
+            and(
+              eq(recurringTransactions.userId, session.id),
+              eq(recurringTransactions.id, proposal.recurringId),
+              notDeleted(recurringTransactions.deletedAt),
+            ),
+          );
+      } else {
+        throw new Error(`Tipo de propuesta desconocido: ${proposal.proposalType}`);
+      }
+
+      // 3. Mark the proposal as accepted.
+      await trx
+        .update(recurringProposals)
+        .set({ status: "accepted", decidedAt: new Date() })
+        .where(
+          and(eq(recurringProposals.userId, session.id), eq(recurringProposals.id, proposalId)),
+        );
+
+      // 4. Mark related unapplied manual observations as applied=true.
+      await trx
+        .update(recurringLinkObservations)
+        .set({ applied: true })
+        .where(
+          and(
+            eq(recurringLinkObservations.userId, session.id),
+            eq(recurringLinkObservations.recurringId, proposal.recurringId),
+            eq(recurringLinkObservations.manual, true),
+            eq(recurringLinkObservations.applied, false),
+          ),
+        );
+    });
+
+    log.info(
+      { event: "proposal_accepted", proposalId, userId: session.id },
+      "recurring proposal accepted",
+    );
+
+    revalidatePath("/");
+    revalidatePath("/settings/recurring/learning");
+
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Error inesperado";
+    log.error(
+      { err, event: "proposal_accept_failed", proposalId, userId: session.id },
+      "failed to accept recurring proposal",
+    );
+    return { ok: false, error: message };
+  }
+}
+
+/**
+ * Reject a proposal — marks it as 'rejected' without changing the recurring.
+ * The observations remain unapplied so the cron can potentially re-trigger
+ * if the pattern continues.
+ */
+export async function rejectProposal(input: ProposalActionInput): Promise<ProposalActionResult> {
+  const session = await getSessionUser();
+  const parsed = proposalIdSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Input inválido" };
+  }
+  const { proposalId } = parsed.data;
+
+  try {
+    const [proposal] = await db
+      .select({ status: recurringProposals.status })
+      .from(recurringProposals)
+      .where(and(eq(recurringProposals.userId, session.id), eq(recurringProposals.id, proposalId)))
+      .limit(1);
+
+    if (!proposal) return { ok: false, error: "Propuesta no encontrada" };
+    if (proposal.status !== "pending") {
+      return { ok: false, error: `Propuesta ya ${proposal.status}` };
+    }
+
+    await db
+      .update(recurringProposals)
+      .set({ status: "rejected", decidedAt: new Date() })
+      .where(and(eq(recurringProposals.userId, session.id), eq(recurringProposals.id, proposalId)));
+
+    log.info(
+      { event: "proposal_rejected", proposalId, userId: session.id },
+      "recurring proposal rejected",
+    );
+
+    revalidatePath("/");
+    revalidatePath("/settings/recurring/learning");
+
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Error inesperado";
+    return { ok: false, error: message };
+  }
+}
+
+/**
+ * Expire a proposal — used by cron cleanup to prune stale pending proposals
+ * that are older than N days and were never decided.
+ * Can also be called manually from the UI (admin/debug).
+ */
+export async function expireProposal(input: ProposalActionInput): Promise<ProposalActionResult> {
+  const session = await getSessionUser();
+  const parsed = proposalIdSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Input inválido" };
+  }
+  const { proposalId } = parsed.data;
+
+  try {
+    const [proposal] = await db
+      .select({ status: recurringProposals.status })
+      .from(recurringProposals)
+      .where(and(eq(recurringProposals.userId, session.id), eq(recurringProposals.id, proposalId)))
+      .limit(1);
+
+    if (!proposal) return { ok: false, error: "Propuesta no encontrada" };
+
+    // Only pending proposals can be expired.
+    if (proposal.status !== "pending") {
+      return { ok: false, error: `Propuesta ya ${proposal.status}` };
+    }
+
+    await db
+      .update(recurringProposals)
+      .set({ status: "expired", decidedAt: new Date() })
+      .where(and(eq(recurringProposals.userId, session.id), eq(recurringProposals.id, proposalId)));
+
+    log.info(
+      { event: "proposal_expired", proposalId, userId: session.id },
+      "recurring proposal expired",
+    );
+
+    revalidatePath("/");
+    revalidatePath("/settings/recurring/learning");
+
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Error inesperado";
+    return { ok: false, error: message };
+  }
+}
+
+/**
+ * Count pending proposals for a given user — used by the dashboard banner.
+ * Exported as a plain async function (not a server action) so it can be called
+ * from RSC without the "use server" boundary.
+ */
+export async function countPendingProposals(userId: number): Promise<number> {
+  const result = await db
+    .select({ count: sql<number>`COUNT(*)::int` })
+    .from(recurringProposals)
+    .where(and(eq(recurringProposals.userId, userId), eq(recurringProposals.status, "pending")))
+    .limit(1);
+
+  return result[0]?.count ?? 0;
+}

--- a/src/app/(app)/settings/recurring/learning/actions.ts
+++ b/src/app/(app)/settings/recurring/learning/actions.ts
@@ -222,15 +222,17 @@ export async function expireProposal(input: ProposalActionInput): Promise<Propos
 }
 
 /**
- * Count pending proposals for a given user — used by the dashboard banner.
- * Exported as a plain async function (not a server action) so it can be called
- * from RSC without the "use server" boundary.
+ * Count pending proposals for the current session user — used by the dashboard banner.
+ * Derives userId from getSessionUser() internally. Never accepts userId as a parameter
+ * because this file is "use server" and every async export is an invocable server action.
  */
-export async function countPendingProposals(userId: number): Promise<number> {
+export async function countPendingProposals(): Promise<number> {
+  const session = await getSessionUser();
+
   const result = await db
     .select({ count: sql<number>`COUNT(*)::int` })
     .from(recurringProposals)
-    .where(and(eq(recurringProposals.userId, userId), eq(recurringProposals.status, "pending")))
+    .where(and(eq(recurringProposals.userId, session.id), eq(recurringProposals.status, "pending")))
     .limit(1);
 
   return result[0]?.count ?? 0;

--- a/src/app/(app)/settings/recurring/learning/learning-types.ts
+++ b/src/app/(app)/settings/recurring/learning/learning-types.ts
@@ -1,0 +1,12 @@
+// #633: Types for recurring learning proposal actions.
+// Kept in a separate file because "use server" action files reject non-async exports.
+
+import { z } from "zod";
+
+export const proposalIdSchema = z.object({
+  proposalId: z.coerce.number().int().positive(),
+});
+
+export type ProposalActionInput = z.input<typeof proposalIdSchema>;
+
+export type ProposalActionResult = { ok: true } | { ok: false; error: string };

--- a/src/app/(app)/settings/recurring/learning/page.tsx
+++ b/src/app/(app)/settings/recurring/learning/page.tsx
@@ -1,0 +1,79 @@
+// #633: Learning proposals page — /settings/recurring/learning
+// Lists pending recurring learning proposals (amount_update + variable_flag)
+// and lets the user accept or reject each one.
+
+import { and, eq, desc } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { recurringProposals, recurringTransactions, accounts } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { getSessionUser } from "@/lib/auth/session";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { RecurringProposalsList } from "./recurring-proposals-list";
+
+export const dynamic = "force-dynamic";
+
+export default async function RecurringLearningPage() {
+  const session = await getSessionUser();
+
+  const proposals = await db
+    .select({
+      id: recurringProposals.id,
+      recurringId: recurringProposals.recurringId,
+      label: recurringTransactions.label,
+      accountName: accounts.name,
+      accountCurrency: accounts.currency,
+      proposalType: recurringProposals.proposalType,
+      payload: recurringProposals.payload,
+      createdAt: recurringProposals.createdAt,
+    })
+    .from(recurringProposals)
+    .innerJoin(
+      recurringTransactions,
+      and(
+        eq(recurringTransactions.id, recurringProposals.recurringId),
+        // Tenant-safety: pair user_id on both sides.
+        eq(recurringTransactions.userId, recurringProposals.userId),
+      ),
+    )
+    .innerJoin(
+      accounts,
+      and(
+        eq(accounts.id, recurringTransactions.accountId),
+        // Tenant-safety on accounts JOIN.
+        eq(accounts.userId, recurringProposals.userId),
+      ),
+    )
+    .where(
+      and(
+        eq(recurringProposals.userId, session.id),
+        eq(recurringProposals.status, "pending"),
+        notDeleted(recurringTransactions.deletedAt),
+      ),
+    )
+    .orderBy(desc(recurringProposals.createdAt));
+
+  const formattedProposals = proposals.map((p) => ({
+    id: p.id,
+    recurringId: p.recurringId,
+    label: p.label,
+    accountLabel: formatAccountLabel({ name: p.accountName, currency: p.accountCurrency }),
+    proposalType: p.proposalType as "amount_update" | "variable_flag",
+    payload: p.payload as Record<string, unknown>,
+    createdAt: p.createdAt.toISOString(),
+  }));
+
+  return (
+    <main className="mx-auto max-w-3xl p-4 sm:p-6 lg:p-10">
+      <div className="flex flex-col gap-6">
+        <header>
+          <h1 className="text-2xl font-semibold">Aprendizaje de recurrentes</h1>
+          <p className="text-ink-muted mt-1 text-sm">
+            Findash detectó patrones en tus pagos. Confirmá o rechazá cada sugerencia.
+          </p>
+        </header>
+
+        <RecurringProposalsList proposals={formattedProposals} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/settings/recurring/learning/recurring-proposals-list.test.tsx
+++ b/src/app/(app)/settings/recurring/learning/recurring-proposals-list.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+// #633: Component tests for RecurringProposalsList.
+
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — actions are the only external deps for the client component.
+// ---------------------------------------------------------------------------
+const { acceptProposal, rejectProposal } = vi.hoisted(() => ({
+  acceptProposal: vi.fn(),
+  rejectProposal: vi.fn(),
+}));
+
+vi.mock("./actions", () => ({ acceptProposal, rejectProposal }));
+
+// Import AFTER mocks.
+import { RecurringProposalsList } from "./recurring-proposals-list";
+
+// ---------------------------------------------------------------------------
+// Radix shims (safe even if not strictly needed — belt-and-suspenders).
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+  acceptProposal.mockReset();
+  rejectProposal.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+const amountUpdateProposal = {
+  id: 1,
+  recurringId: 10,
+  label: "Netflix",
+  accountLabel: "Bancolombia COP",
+  proposalType: "amount_update" as const,
+  payload: {
+    newAmountCents: "-4490000",
+    oldAmountCents: "-4200000",
+    currency: "COP",
+    observationCount: 2,
+  },
+  createdAt: "2026-04-01T00:00:00Z",
+};
+
+const variableFlagProposal = {
+  id: 2,
+  recurringId: 11,
+  label: "Spotify",
+  accountLabel: "Bancolombia COP",
+  proposalType: "variable_flag" as const,
+  payload: {
+    detectedAmounts: ["-2000000", "-2500000", "-3000000"],
+    currency: "COP",
+    observationCount: 3,
+  },
+  createdAt: "2026-04-01T00:00:00Z",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RecurringProposalsList", () => {
+  it("renders proposal cards for every proposal in the list", () => {
+    render(<RecurringProposalsList proposals={[amountUpdateProposal, variableFlagProposal]} />);
+
+    const cards = screen.getAllByTestId("proposal-card");
+    expect(cards).toHaveLength(2);
+
+    // Both labels rendered.
+    expect(screen.getByText("Netflix")).toBeInTheDocument();
+    expect(screen.getByText("Spotify")).toBeInTheDocument();
+  });
+
+  it("renders the empty-state element when proposals list is empty", () => {
+    render(<RecurringProposalsList proposals={[]} />);
+
+    expect(screen.getByTestId("proposals-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("proposal-card")).not.toBeInTheDocument();
+  });
+
+  it("clicking Accept calls acceptProposal with the correct id", async () => {
+    acceptProposal.mockResolvedValueOnce({ ok: true });
+
+    const user = userEvent.setup();
+    render(<RecurringProposalsList proposals={[amountUpdateProposal]} />);
+
+    await user.click(screen.getByTestId("proposal-accept"));
+
+    expect(acceptProposal).toHaveBeenCalledTimes(1);
+    expect(acceptProposal).toHaveBeenCalledWith({ proposalId: amountUpdateProposal.id });
+  });
+
+  it("clicking Reject calls rejectProposal with the correct id", async () => {
+    rejectProposal.mockResolvedValueOnce({ ok: true });
+
+    const user = userEvent.setup();
+    render(<RecurringProposalsList proposals={[amountUpdateProposal]} />);
+
+    await user.click(screen.getByTestId("proposal-reject"));
+
+    expect(rejectProposal).toHaveBeenCalledTimes(1);
+    expect(rejectProposal).toHaveBeenCalledWith({ proposalId: amountUpdateProposal.id });
+  });
+
+  it("accepted card is removed from the list", async () => {
+    acceptProposal.mockResolvedValueOnce({ ok: true });
+
+    const user = userEvent.setup();
+    render(<RecurringProposalsList proposals={[amountUpdateProposal, variableFlagProposal]} />);
+
+    expect(screen.getAllByTestId("proposal-card")).toHaveLength(2);
+
+    // Accept the first card.
+    const acceptButtons = screen.getAllByTestId("proposal-accept");
+    await user.click(acceptButtons[0]);
+
+    // Card removed optimistically.
+    expect(screen.getAllByTestId("proposal-card")).toHaveLength(1);
+    expect(screen.queryByText("Netflix")).not.toBeInTheDocument();
+    expect(screen.getByText("Spotify")).toBeInTheDocument();
+  });
+
+  it("shows error message when acceptProposal returns ok=false", async () => {
+    acceptProposal.mockResolvedValueOnce({ ok: false, error: "Propuesta no encontrada" });
+
+    const user = userEvent.setup();
+    render(<RecurringProposalsList proposals={[amountUpdateProposal]} />);
+
+    await user.click(screen.getByTestId("proposal-accept"));
+
+    expect(screen.getByText("Propuesta no encontrada")).toBeInTheDocument();
+    // Card stays visible.
+    expect(screen.getByTestId("proposal-card")).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/settings/recurring/learning/recurring-proposals-list.tsx
+++ b/src/app/(app)/settings/recurring/learning/recurring-proposals-list.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+// #633: Client component — renders the list of pending learning proposals
+// with accept/reject buttons.
+
+import { useState, useTransition } from "react";
+import { CheckIcon, XIcon, TrendingUpIcon, ActivityIcon } from "lucide-react";
+import { acceptProposal, rejectProposal } from "./actions";
+
+type Proposal = {
+  id: number;
+  recurringId: number;
+  label: string;
+  accountLabel: string;
+  proposalType: "amount_update" | "variable_flag";
+  payload: Record<string, unknown>;
+  createdAt: string;
+};
+
+type ProposalCardProps = {
+  proposal: Proposal;
+  onDecided: (id: number) => void;
+};
+
+function formatCents(cents: string | undefined): string {
+  if (!cents) return "—";
+  const n = Number(BigInt(cents));
+  const abs = Math.abs(n);
+  return new Intl.NumberFormat("es-CO", {
+    style: "currency",
+    currency: "COP",
+    maximumFractionDigits: 0,
+  }).format(abs / 100);
+}
+
+function ProposalCard({ proposal, onDecided }: ProposalCardProps) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleAccept() {
+    setError(null);
+    startTransition(async () => {
+      const result = await acceptProposal({ proposalId: proposal.id });
+      if (result.ok) {
+        onDecided(proposal.id);
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  function handleReject() {
+    setError(null);
+    startTransition(async () => {
+      const result = await rejectProposal({ proposalId: proposal.id });
+      if (result.ok) {
+        onDecided(proposal.id);
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  const isAmountUpdate = proposal.proposalType === "amount_update";
+  const p = proposal.payload;
+
+  return (
+    <article
+      className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-700 dark:bg-neutral-800"
+      data-testid="proposal-card"
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 rounded-md bg-blue-50 p-1.5 dark:bg-blue-900/30">
+          {isAmountUpdate ? (
+            <TrendingUpIcon className="size-4 text-blue-600 dark:text-blue-400" />
+          ) : (
+            <ActivityIcon className="size-4 text-purple-600 dark:text-purple-400" />
+          )}
+        </span>
+
+        <div className="flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <strong className="font-medium">{proposal.label}</strong>
+            <span className="text-ink-muted text-xs">{proposal.accountLabel}</span>
+          </div>
+
+          {isAmountUpdate ? (
+            <p className="text-sm">
+              Detectamos que pagaste <strong>{formatCents(p.newAmountCents as string)}</strong> los
+              últimos {p.observationCount as number} meses (estimado:{" "}
+              {formatCents(p.oldAmountCents as string)}).{" "}
+              <span className="text-ink-muted">¿Actualizar el estimado?</span>
+            </p>
+          ) : (
+            <p className="text-sm">
+              Pagaste montos distintos en los últimos {p.observationCount as number} meses (
+              {(p.detectedAmounts as string[]).map(formatCents).join(", ")}
+              ). <span className="text-ink-muted">¿Marcar como monto variable?</span>
+            </p>
+          )}
+
+          {error ? <p className="text-xs text-red-600 dark:text-red-400">{error}</p> : null}
+        </div>
+      </div>
+
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          onClick={handleAccept}
+          disabled={isPending}
+          className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          data-testid="proposal-accept"
+        >
+          <CheckIcon className="size-3.5" />
+          Actualizar
+        </button>
+        <button
+          type="button"
+          onClick={handleReject}
+          disabled={isPending}
+          className="inline-flex items-center gap-1.5 rounded-md border border-neutral-300 bg-white px-3 py-1.5 text-xs font-medium text-neutral-700 hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+          data-testid="proposal-reject"
+        >
+          <XIcon className="size-3.5" />
+          Descartar
+        </button>
+      </div>
+    </article>
+  );
+}
+
+type Props = {
+  proposals: Proposal[];
+};
+
+export function RecurringProposalsList({ proposals: initialProposals }: Props) {
+  const [proposals, setProposals] = useState(initialProposals);
+
+  function handleDecided(id: number) {
+    setProposals((prev) => prev.filter((p) => p.id !== id));
+  }
+
+  if (proposals.length === 0) {
+    return (
+      <div
+        className="text-ink-muted rounded-lg border border-dashed border-neutral-300 py-12 text-center text-sm dark:border-neutral-700"
+        data-testid="proposals-empty"
+      >
+        Sin sugerencias pendientes — Findash está al día.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="proposals-list">
+      {proposals.map((p) => (
+        <ProposalCard key={p.id} proposal={p} onDecided={handleDecided} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -26,6 +26,7 @@ import type { ClassifyTxJobData } from "@/lib/queue/workers/classify-tx";
 import type { UserClassificationContext } from "@/lib/db/schema";
 import { emit } from "@/lib/events/bus";
 import { autoLinkTransaction } from "@/lib/recurring/auto-link";
+import { recordRecurringLinkObservation } from "@/lib/recurring/observation-recorder";
 import { createLogger } from "@/lib/logger";
 import type {
   LinkTxToRecurringInput,
@@ -1549,6 +1550,21 @@ export async function linkTxToRecurring(
       gapId: ym.gapId,
       reason: "linked",
       timestamp: Date.now(),
+    });
+
+    // #633: Record observation for the learning loop (manual=true — user drove this).
+    // Fire-and-forget; observation errors must never surface to the user.
+    recordRecurringLinkObservation({
+      userId: session.id,
+      recurringId,
+      txId,
+      yearMonth: ym.ym,
+      manual: true,
+    }).catch((err) => {
+      log.error(
+        { err, event: "observation_record_failed", txId, recurringId, userId: session.id },
+        "failed to record recurring link observation — non-critical",
+      );
     });
 
     revalidatePath("/");

--- a/src/components/dashboard/recurring-proposals-banner.tsx
+++ b/src/components/dashboard/recurring-proposals-banner.tsx
@@ -1,0 +1,41 @@
+// #633: Slim banner that appears when there are pending recurring learning
+// proposals. Links to /settings/recurring/learning for the user to review.
+
+import Link from "next/link";
+import { SparklesIcon } from "lucide-react";
+import { countPendingProposals } from "@/app/(app)/settings/recurring/learning/actions";
+
+export async function RecurringProposalsBanner({ userId }: { userId: number }) {
+  const count = await countPendingProposals(userId);
+  if (count === 0) return null;
+
+  return (
+    <aside
+      role="note"
+      aria-label="Sugerencias de aprendizaje"
+      data-testid="recurring-proposals-banner"
+      className="flex flex-col gap-1 rounded-md border border-blue-300 bg-blue-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4 dark:border-blue-900 dark:bg-blue-950/40"
+    >
+      <div className="flex items-start gap-2 text-sm">
+        <SparklesIcon className="mt-0.5 size-4 text-blue-700 dark:text-blue-400" />
+        <div>
+          <strong className="font-medium text-blue-900 dark:text-blue-200">
+            {count === 1
+              ? "Findash detectó 1 cambio en tus recurrentes"
+              : `Findash detectó ${count} cambios en tus recurrentes`}
+          </strong>
+          <span className="text-blue-800 dark:text-blue-300">
+            {" "}
+            — revisá las sugerencias para mantener tus estimados al día.
+          </span>
+        </div>
+      </div>
+      <Link
+        href="/settings/recurring/learning"
+        className="inline-flex items-center justify-center rounded-md border border-blue-400 bg-blue-100 px-3 py-1 text-xs font-medium whitespace-nowrap text-blue-900 hover:bg-blue-200 dark:border-blue-700 dark:bg-blue-900/40 dark:text-blue-100 dark:hover:bg-blue-900/60"
+      >
+        Ver sugerencias
+      </Link>
+    </aside>
+  );
+}

--- a/src/components/dashboard/recurring-proposals-banner.tsx
+++ b/src/components/dashboard/recurring-proposals-banner.tsx
@@ -5,8 +5,8 @@ import Link from "next/link";
 import { SparklesIcon } from "lucide-react";
 import { countPendingProposals } from "@/app/(app)/settings/recurring/learning/actions";
 
-export async function RecurringProposalsBanner({ userId }: { userId: number }) {
-  const count = await countPendingProposals(userId);
+export async function RecurringProposalsBanner() {
+  const count = await countPendingProposals();
   if (count === 0) return null;
 
   return (

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -40,6 +40,7 @@ export async function registerNode() {
   const { createGmailPullWorker } = await import("@/lib/queue/workers/gmail-pull");
   const { createClassificationAutoUncategorizeWorker } =
     await import("@/lib/queue/workers/classification-auto-uncategorize");
+  const { createRecurringLearningWorker } = await import("@/lib/queue/workers/recurring-learning");
   const log = createLogger({ module: "instrumentation" });
 
   // -------------------------------------------------------------------------
@@ -79,6 +80,10 @@ export async function registerNode() {
   // classification-auto-uncategorize: daily at 04:00 COT
   const classificationAutoUncategorizeQueue = createQueue("classification-auto-uncategorize");
   createClassificationAutoUncategorizeWorker();
+
+  // recurring-learning: daily at 04:00 COT (after auto-uncategorize, same window)
+  const recurringLearningQueue = createQueue("recurring-learning");
+  createRecurringLearningWorker();
 
   // Graceful shutdown is idempotent — safe to call once after all workers are
   // registered.
@@ -157,9 +162,20 @@ export async function registerNode() {
     },
   );
 
+  // 04:00 COT daily — analyze manual recurring link observations and generate
+  // amount-update or variable-flag proposals for the user to review (#633).
+  await recurringLearningQueue.add(
+    "recurring-learning",
+    {},
+    {
+      repeat: { pattern: "0 4 * * *", tz: "America/Bogota" },
+      jobId: "recurring-learning-recurring",
+    },
+  );
+
   log.info(
     { event: "workers_registered" },
-    "BullMQ workers registered: fx-refresh (15 6,18 * * *), recurring-gap (0 6 5 * *), health-snapshots (0 3 * * *), slo-alerts (*/30 * * * *), gmail-pull (*/5 * * * *), classification-auto-uncategorize (0 4 * * *) America/Bogota; classify-tx on-demand",
+    "BullMQ workers registered: fx-refresh (15 6,18 * * *), recurring-gap (0 6 5 * *), health-snapshots (0 3 * * *), slo-alerts (*/30 * * * *), gmail-pull (*/5 * * * *), classification-auto-uncategorize (0 4 * * *), recurring-learning (0 4 * * *) America/Bogota; classify-tx on-demand",
   );
 
   // -------------------------------------------------------------------------

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -867,6 +867,11 @@ export const budgets = pgTable(
   ],
 );
 
+// #633: amount_type enum for recurring_transactions — 'fixed' is the default
+// (all existing rows). 'variable' is set by the learning loop when N consecutive
+// observations show non-uniform real amounts (EPM-style subscriptions).
+export const recurringAmountType = pgEnum("recurring_amount_type", ["fixed", "variable"]);
+
 export const recurringTransactions = pgTable(
   "recurring_transactions",
   {
@@ -886,6 +891,11 @@ export const recurringTransactions = pgTable(
     lastGeneratedAt: timestamp("last_generated_at", { withTimezone: true }),
     skippedMonths: jsonb("skipped_months").$type<string[]>().notNull().default([]),
     notes: text("notes"),
+    // #633: amount type — 'fixed' (default, all existing rows) or 'variable'
+    // (set by the learning loop when N consecutive observations show non-uniform
+    // real amounts). When 'variable', amount proposals are suppressed.
+    // amountType column references the enum defined just above recurringTransactions
+    amountType: recurringAmountType("amount_type").notNull().default("fixed"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
   },
@@ -930,6 +940,123 @@ export const recurringGaps = pgTable(
     index("recurring_gaps_open_idx")
       .on(t.userId, t.detectedAt)
       .where(sql`${t.resolution} IS NULL`),
+  ],
+);
+
+// #633: Learning loop — observation + fingerprint + proposal tables.
+// Architecture invariant: transactions table = facts only. Observations and
+// proposals are SEPARATE tables. The learning loop NEVER mutates transactions
+// directly — only proposes changes the user accepts.
+
+// #633: proposal status enum — 'pending' is the initial state, transitions to
+// 'accepted' (user approved), 'rejected' (user dismissed), or 'expired' (cron
+// cleaned up stale pending proposals).
+export const recurringProposalStatus = pgEnum("recurring_proposal_status", [
+  "pending",
+  "accepted",
+  "rejected",
+  "expired",
+]);
+
+// #633: Append-only audit log for every tx ↔ recurring link event (manual + auto).
+// Single observation per link — idempotent via unique (user_id, recurring_id, tx_id, year_month).
+// applied=true once a proposal that references this observation is accepted.
+export const recurringLinkObservations = pgTable(
+  "recurring_link_observations",
+  {
+    id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    recurringId: integer("recurring_id")
+      .notNull()
+      .references(() => recurringTransactions.id, { onDelete: "cascade" }),
+    txId: integer("tx_id")
+      .notNull()
+      .references(() => transactions.id, { onDelete: "cascade" }),
+    yearMonth: varchar("year_month", { length: 7 }).notNull(),
+    realAmountCents: bigint("real_amount_cents", { mode: "bigint" }).notNull(),
+    realCurrency: currency("real_currency").notNull(),
+    descriptionRaw: text("description_raw"),
+    accountId: integer("account_id")
+      .notNull()
+      .references(() => accounts.id, { onDelete: "cascade" }),
+    manual: boolean("manual").notNull().default(false),
+    applied: boolean("applied").notNull().default(false),
+    observedAt: timestamp("observed_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // Idempotency: one observation per (user, recurring, tx, month).
+    uniqueIndex("recurring_link_observations_unique").on(
+      t.userId,
+      t.recurringId,
+      t.txId,
+      t.yearMonth,
+    ),
+    // Cron query: manual, unapplied observations grouped by recurring.
+    index("recurring_link_observations_pending_idx")
+      .on(t.userId, t.recurringId)
+      .where(sql`${t.manual} = true AND ${t.applied} = false`),
+    index("recurring_link_observations_recurring_idx").on(t.recurringId),
+  ],
+);
+
+// #633: Description fingerprint table — upserted after every link.
+// observation_count is incremented each time the same pattern is observed.
+// pattern_ambiguous=true when this pattern matches 2+ active recurrings for
+// the same user (Google Play caveat) — excluded from auto-link via description.
+export const recurringDescriptionPatterns = pgTable(
+  "recurring_description_patterns",
+  {
+    id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    recurringId: integer("recurring_id")
+      .notNull()
+      .references(() => recurringTransactions.id, { onDelete: "cascade" }),
+    pattern: text("pattern").notNull(),
+    observationCount: integer("observation_count").notNull().default(1),
+    patternAmbiguous: boolean("pattern_ambiguous").notNull().default(false),
+    lastObservedAt: timestamp("last_observed_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // One pattern per (user, recurring, pattern text) — upsert key.
+    uniqueIndex("recurring_description_patterns_unique").on(t.userId, t.recurringId, t.pattern),
+    // Auto-link lookup: patterns for a given user + pattern text (cross-recurring).
+    index("recurring_description_patterns_user_pattern_idx").on(t.userId, t.pattern),
+    index("recurring_description_patterns_recurring_idx").on(t.recurringId),
+  ],
+);
+
+// #633: Learning proposals — amount-update or variable-type change proposals
+// generated by the recurring-learning cron. User accepts/rejects via
+// /settings/recurring/learning. payload is typed by proposal_type:
+//   - amount_update: { newAmountCents: string, oldAmountCents: string, currency: string }
+//   - variable_flag:  { detectedAmounts: string[], currency: string }
+export const recurringProposals = pgTable(
+  "recurring_proposals",
+  {
+    id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    recurringId: integer("recurring_id")
+      .notNull()
+      .references(() => recurringTransactions.id, { onDelete: "cascade" }),
+    proposalType: varchar("proposal_type", { length: 40 }).notNull(),
+    payload: jsonb("payload").notNull().default({}),
+    status: recurringProposalStatus("status").notNull().default("pending"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    decidedAt: timestamp("decided_at", { withTimezone: true }),
+  },
+  (t) => [
+    // Cron query: pending proposals per user.
+    index("recurring_proposals_user_status_idx")
+      .on(t.userId, t.status)
+      .where(sql`${t.status} = 'pending'`),
+    index("recurring_proposals_recurring_idx").on(t.recurringId),
   ],
 );
 

--- a/src/lib/queue/workers/recurring-learning.test.ts
+++ b/src/lib/queue/workers/recurring-learning.test.ts
@@ -1,0 +1,396 @@
+// #633: Integration tests for the recurring-learning BullMQ worker processor.
+// Runs against findash_test (forced by vitest.setup.ts).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import type { Job } from "bullmq";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  recurringLinkObservations,
+  recurringProposals,
+  recurringTransactions,
+  transactions,
+  users,
+} from "@/lib/db/schema";
+import { copyCategorySeedsToUser, copyRuleSeedsToUser } from "@/lib/auth/signup";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/queue", () => ({
+  createWorker: vi.fn().mockReturnValue({
+    on: vi.fn(),
+    close: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Lazy import (after mocks)
+// ---------------------------------------------------------------------------
+
+const { recurringLearningProcessor } = await import("./recurring-learning");
+
+// ---------------------------------------------------------------------------
+// Test data tag and seed helpers
+// ---------------------------------------------------------------------------
+
+const TAG = "test-rlearning-633";
+
+function mockJob(): Job {
+  return { id: "test-job-id" } as unknown as Job;
+}
+
+async function seedUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  await copyRuleSeedsToUser(row.id);
+  return row.id;
+}
+
+async function seedAccount(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({ userId, name: `${TAG}-acct`, institution: TAG, type: "savings", currency: "COP" })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function seedRecurring(
+  userId: number,
+  accountId: number,
+  amountCents: bigint = BigInt(-42000),
+): Promise<number> {
+  const [row] = await db
+    .insert(recurringTransactions)
+    .values({
+      userId,
+      accountId,
+      label: `${TAG}-recurring`,
+      amountCents,
+      currency: "COP",
+      dayOfMonth: 15,
+      active: true,
+    })
+    .returning({ id: recurringTransactions.id });
+  return row.id;
+}
+
+async function seedTx(
+  userId: number,
+  accountId: number,
+  amountCents: bigint = BigInt(-42000),
+): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: new Date("2026-04-15T12:00:00Z"),
+      amountCents,
+      currency: "COP",
+      descriptionRaw: `${TAG}-tx`,
+      classificationMethod: "unclassified",
+      source: "manual",
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function cleanup() {
+  await db.execute(
+    sql`DELETE FROM recurring_proposals WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})`,
+  );
+  await db.execute(
+    sql`DELETE FROM recurring_link_observations WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})`,
+  );
+  await db.execute(sql`DELETE FROM transactions WHERE description_raw = ${TAG + "-tx"}`);
+  await db.execute(sql`DELETE FROM recurring_transactions WHERE label = ${TAG + "-recurring"}`);
+  await db.execute(sql`DELETE FROM accounts WHERE name = ${TAG + "-acct"}`);
+  await db.execute(sql`DELETE FROM users WHERE email LIKE ${TAG + "%"}`);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("recurringLearningProcessor", () => {
+  let userAId: number;
+  let accountAId: number;
+  let recurringAId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    userAId = await seedUser(`${TAG}-userA@test.local`);
+    accountAId = await seedAccount(userAId);
+    recurringAId = await seedRecurring(userAId, accountAId, BigInt(-42000));
+  });
+
+  afterEach(cleanup);
+
+  it("N=2 same-amount-delta > 5% triggers amount_update proposal", async () => {
+    // Real amount = -44900, estimated = -42000 → drift ≈ 6.9% > 5%
+    const tx1 = await seedTx(userAId, accountAId, BigInt(-44900));
+    const tx2 = await seedTx(userAId, accountAId, BigInt(-44900));
+
+    // Insert observations directly.
+    await db.insert(recurringLinkObservations).values([
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx1,
+        yearMonth: "2026-03",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx2,
+        yearMonth: "2026-04",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+    ]);
+
+    const result = await recurringLearningProcessor(mockJob());
+
+    expect(result.proposalsCreated).toBe(1);
+    expect(result.errors).toBe(0);
+
+    const [proposal] = await db
+      .select()
+      .from(recurringProposals)
+      .where(
+        and(
+          eq(recurringProposals.userId, userAId),
+          eq(recurringProposals.recurringId, recurringAId),
+        ),
+      );
+
+    expect(proposal?.proposalType).toBe("amount_update");
+    expect(proposal?.status).toBe("pending");
+
+    const p = proposal?.payload as { newAmountCents: string };
+    expect(p.newAmountCents).toBe("-44900");
+  });
+
+  it("N=2 same-amount-delta <= 5% does NOT trigger proposal", async () => {
+    // Real amount = -43000, estimated = -42000 → drift ≈ 2.4% < 5%
+    const tx1 = await seedTx(userAId, accountAId, BigInt(-43000));
+    const tx2 = await seedTx(userAId, accountAId, BigInt(-43000));
+
+    await db.insert(recurringLinkObservations).values([
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx1,
+        yearMonth: "2026-03",
+        realAmountCents: BigInt(-43000),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx2,
+        yearMonth: "2026-04",
+        realAmountCents: BigInt(-43000),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+    ]);
+
+    const result = await recurringLearningProcessor(mockJob());
+
+    expect(result.proposalsCreated).toBe(0);
+
+    const proposals = await db
+      .select()
+      .from(recurringProposals)
+      .where(eq(recurringProposals.userId, userAId));
+
+    expect(proposals).toHaveLength(0);
+  });
+
+  it("N=3 non-uniform amounts triggers variable_flag proposal", async () => {
+    const tx1 = await seedTx(userAId, accountAId, BigInt(-42000));
+    const tx2 = await seedTx(userAId, accountAId, BigInt(-55000));
+    const tx3 = await seedTx(userAId, accountAId, BigInt(-31000));
+
+    await db.insert(recurringLinkObservations).values([
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx1,
+        yearMonth: "2026-02",
+        realAmountCents: BigInt(-42000),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx2,
+        yearMonth: "2026-03",
+        realAmountCents: BigInt(-55000),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx3,
+        yearMonth: "2026-04",
+        realAmountCents: BigInt(-31000),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+    ]);
+
+    const result = await recurringLearningProcessor(mockJob());
+
+    expect(result.proposalsCreated).toBe(1);
+
+    const [proposal] = await db
+      .select()
+      .from(recurringProposals)
+      .where(eq(recurringProposals.userId, userAId));
+
+    expect(proposal?.proposalType).toBe("variable_flag");
+    expect(proposal?.status).toBe("pending");
+  });
+
+  it("skips a recurring that already has a pending proposal", async () => {
+    // Seed 2 qualifying observations.
+    const tx1 = await seedTx(userAId, accountAId, BigInt(-44900));
+    const tx2 = await seedTx(userAId, accountAId, BigInt(-44900));
+
+    await db.insert(recurringLinkObservations).values([
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx1,
+        yearMonth: "2026-03",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx2,
+        yearMonth: "2026-04",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+    ]);
+
+    // Pre-existing pending proposal.
+    await db.insert(recurringProposals).values({
+      userId: userAId,
+      recurringId: recurringAId,
+      proposalType: "amount_update",
+      payload: { existing: true },
+      status: "pending",
+    });
+
+    const result = await recurringLearningProcessor(mockJob());
+
+    // Should not create a second proposal.
+    expect(result.proposalsCreated).toBe(0);
+
+    const proposals = await db
+      .select()
+      .from(recurringProposals)
+      .where(eq(recurringProposals.userId, userAId));
+
+    expect(proposals).toHaveLength(1);
+  });
+
+  it("tenant isolation: userA observations do not trigger userB proposals", async () => {
+    const userBId = await seedUser(`${TAG}-userB@test.local`);
+    const accountBId = await seedAccount(userBId);
+    const recurringBId = await seedRecurring(userBId, accountBId, BigInt(-42000));
+
+    // UserA has 2 qualifying observations.
+    const txA1 = await seedTx(userAId, accountAId, BigInt(-44900));
+    const txA2 = await seedTx(userAId, accountAId, BigInt(-44900));
+
+    await db.insert(recurringLinkObservations).values([
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: txA1,
+        yearMonth: "2026-03",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: txA2,
+        yearMonth: "2026-04",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+    ]);
+
+    // UserB has no observations.
+
+    const result = await recurringLearningProcessor(mockJob());
+
+    // Proposal should only be for userA, not for userB.
+    const proposalsB = await db
+      .select()
+      .from(recurringProposals)
+      .where(eq(recurringProposals.userId, userBId));
+
+    expect(proposalsB).toHaveLength(0);
+    expect(result.usersProcessed).toBe(1);
+
+    // Cleanup userB
+    await db.execute(sql`DELETE FROM recurring_transactions WHERE id = ${recurringBId}`);
+    await db.execute(sql`DELETE FROM accounts WHERE id = ${accountBId}`);
+    await db.execute(sql`DELETE FROM users WHERE id = ${userBId}`);
+  });
+});

--- a/src/lib/queue/workers/recurring-learning.test.ts
+++ b/src/lib/queue/workers/recurring-learning.test.ts
@@ -339,6 +339,55 @@ describe("recurringLearningProcessor", () => {
     expect(proposals).toHaveLength(1);
   });
 
+  it("expiry sweep: proposals older than 30 days are set to expired; fresh ones stay pending", async () => {
+    // Seed a 31-day-old pending proposal (stale).
+    const [staleRow] = await db
+      .insert(recurringProposals)
+      .values({
+        userId: userAId,
+        recurringId: recurringAId,
+        proposalType: "amount_update",
+        payload: { stale: true },
+        status: "pending",
+        createdAt: new Date(Date.now() - 31 * 86400000),
+      })
+      .returning({ id: recurringProposals.id });
+
+    // Seed a second recurring so the fresh proposal doesn't conflict.
+    const recurringBId = await seedRecurring(userAId, accountAId, BigInt(-42000));
+
+    // Seed a fresh pending proposal (1 day old).
+    const [freshRow] = await db
+      .insert(recurringProposals)
+      .values({
+        userId: userAId,
+        recurringId: recurringBId,
+        proposalType: "amount_update",
+        payload: { fresh: true },
+        status: "pending",
+        createdAt: new Date(Date.now() - 86400000),
+      })
+      .returning({ id: recurringProposals.id });
+
+    await recurringLearningProcessor(mockJob());
+
+    const [stale] = await db
+      .select({ status: recurringProposals.status })
+      .from(recurringProposals)
+      .where(eq(recurringProposals.id, staleRow.id));
+
+    const [fresh] = await db
+      .select({ status: recurringProposals.status })
+      .from(recurringProposals)
+      .where(eq(recurringProposals.id, freshRow.id));
+
+    expect(stale?.status).toBe("expired");
+    expect(fresh?.status).toBe("pending");
+
+    // Cleanup extra recurring.
+    await db.execute(sql`DELETE FROM recurring_transactions WHERE id = ${recurringBId}`);
+  });
+
   it("tenant isolation: userA observations do not trigger userB proposals", async () => {
     const userBId = await seedUser(`${TAG}-userB@test.local`);
     const accountBId = await seedAccount(userBId);

--- a/src/lib/queue/workers/recurring-learning.ts
+++ b/src/lib/queue/workers/recurring-learning.ts
@@ -1,0 +1,282 @@
+// #633: recurring-learning BullMQ worker.
+// Runs daily at 04:00 America/Bogota. Scans recurring_link_observations where
+// manual=true and applied=false, groups by (user_id, recurring_id), and writes
+// proposals to recurring_proposals.
+//
+// Two proposal types:
+//   - amount_update: N≥2 consecutive manual observations all showing the SAME
+//     real_amount_cents that differs from recurring.amount_cents by >5%
+//     (and same currency). Proposes updating the recurring estimate.
+//   - variable_flag: N≥3 manual observations showing non-uniform real amounts.
+//     Proposes setting amount_type='variable' and stops firing amount proposals.
+//
+// Idempotency: duplicate proposals (same recurring + type with status='pending')
+// are skipped to avoid flooding the user.
+
+import type { Job } from "bullmq";
+import { and, eq, sql } from "drizzle-orm";
+
+import { createLogger } from "@/lib/logger";
+import { db } from "@/lib/db";
+import { recurringProposals } from "@/lib/db/schema";
+import { createWorker } from "@/lib/queue";
+
+const log = createLogger({ module: "worker/recurring-learning" });
+
+export type RecurringLearningJobData = Record<string, never>;
+
+// Threshold: real amount must differ from estimated by more than this fraction
+// before we propose an update. 5% — small enough to catch Netflix price bumps
+// ($42.000 → $44.900 ≈ 7%), big enough to ignore FX rounding noise.
+const AMOUNT_DRIFT_THRESHOLD = 0.05;
+
+// Minimum observations needed to propose an amount update.
+const MIN_OBSERVATIONS_FOR_AMOUNT_UPDATE = 2;
+
+// Minimum observations needed to flag a recurring as variable.
+const MIN_OBSERVATIONS_FOR_VARIABLE_FLAG = 3;
+
+export type AmountUpdatePayload = {
+  newAmountCents: string; // bigint serialized
+  oldAmountCents: string; // bigint serialized
+  currency: string;
+  observationCount: number;
+};
+
+export type VariableFlagPayload = {
+  detectedAmounts: string[]; // distinct amounts (bigint serialized)
+  currency: string;
+  observationCount: number;
+};
+
+export type LearningResult = {
+  usersProcessed: number;
+  proposalsCreated: number;
+  errors: number;
+};
+
+/**
+ * Core processor — exported separately for tests (no live Worker needed).
+ */
+export async function recurringLearningProcessor(
+  job: Job<RecurringLearningJobData>,
+): Promise<LearningResult> {
+  log.info({ event: "recurring_learning_start", jobId: job.id }, "recurring-learning started");
+
+  const result: LearningResult = { usersProcessed: 0, proposalsCreated: 0, errors: 0 };
+
+  // Step 1: find all (user_id, recurring_id) pairs with unapplied manual observations.
+  // We use a raw SQL aggregation to get per-group stats efficiently.
+  const groups = await db.execute<{
+    user_id: number;
+    recurring_id: number;
+    obs_count: number;
+    amounts: string; // JSON array of distinct amount_cents strings
+    currency: string;
+    estimated_amount: bigint;
+    amount_type: string;
+  }>(sql`
+    SELECT
+      obs.user_id,
+      obs.recurring_id,
+      COUNT(*)::int AS obs_count,
+      JSON_AGG(DISTINCT obs.real_amount_cents::text ORDER BY obs.real_amount_cents::text) AS amounts,
+      obs.real_currency AS currency,
+      rt.amount_cents AS estimated_amount,
+      rt.amount_type
+    FROM recurring_link_observations obs
+    INNER JOIN recurring_transactions rt
+      ON rt.id = obs.recurring_id
+      AND rt.user_id = obs.user_id
+    WHERE
+      obs.manual = true
+      AND obs.applied = false
+      AND rt.deleted_at IS NULL
+      AND rt.active = true
+      AND rt.amount_type != 'variable'
+    GROUP BY obs.user_id, obs.recurring_id, obs.real_currency, rt.amount_cents, rt.amount_type
+  `);
+
+  // Track unique users for telemetry.
+  const usersSeen = new Set<number>();
+
+  for (const row of groups) {
+    const userId = Number(row.user_id);
+    const recurringId = Number(row.recurring_id);
+    const obsCount = Number(row.obs_count);
+    const estimatedAmount = BigInt(row.estimated_amount);
+    const currency = row.currency;
+
+    // amounts comes back as a JSON array of strings.
+    let amounts: bigint[];
+    try {
+      const parsed: string[] =
+        typeof row.amounts === "string" ? JSON.parse(row.amounts) : row.amounts;
+      amounts = parsed.map((a) => BigInt(a));
+    } catch {
+      log.error(
+        { event: "recurring_learning_parse_error", userId, recurringId, amounts: row.amounts },
+        "failed to parse amounts from observation group",
+      );
+      result.errors++;
+      continue;
+    }
+
+    usersSeen.add(userId);
+
+    try {
+      // Check for an existing pending proposal of any type for this recurring.
+      const [existingPending] = await db
+        .select({ id: recurringProposals.id })
+        .from(recurringProposals)
+        .where(
+          and(
+            eq(recurringProposals.userId, userId),
+            eq(recurringProposals.recurringId, recurringId),
+            eq(recurringProposals.status, "pending"),
+          ),
+        )
+        .limit(1);
+
+      if (existingPending) {
+        // A proposal is already pending — skip until user decides.
+        continue;
+      }
+
+      const distinctAmounts = [...new Set(amounts.map((a) => a.toString()))].map((s) => BigInt(s));
+
+      // ── Variable-flag check ───────────────────────────────────────────────
+      // N≥3 observations with >1 distinct amount → flag as variable.
+      if (obsCount >= MIN_OBSERVATIONS_FOR_VARIABLE_FLAG && distinctAmounts.length > 1) {
+        const payload: VariableFlagPayload = {
+          detectedAmounts: distinctAmounts.map((a) => a.toString()),
+          currency,
+          observationCount: obsCount,
+        };
+
+        await db.insert(recurringProposals).values({
+          userId,
+          recurringId,
+          proposalType: "variable_flag",
+          payload,
+        });
+
+        log.info(
+          {
+            event: "recurring_learning_proposal_variable",
+            userId,
+            recurringId,
+            obsCount,
+            distinctAmountsCount: distinctAmounts.length,
+          },
+          "variable_flag proposal created",
+        );
+
+        result.proposalsCreated++;
+        continue;
+      }
+
+      // ── Amount-update check ───────────────────────────────────────────────
+      // N≥2 observations all showing the SAME amount that differs by >5%.
+      if (obsCount >= MIN_OBSERVATIONS_FOR_AMOUNT_UPDATE && distinctAmounts.length === 1) {
+        const newAmount = distinctAmounts[0];
+
+        // Sign-convention: amounts are signed (negative for expenses).
+        // Compare magnitudes with Math.abs to handle the sign correctly.
+        // Use Number() for comparisons since ES2017 target bans BigInt literals (0n).
+        const newAmountNum = Number(newAmount);
+        const estimatedAmountNum = Number(estimatedAmount);
+        const absNew = Math.abs(newAmountNum);
+        const absEst = Math.abs(estimatedAmountNum);
+
+        // Avoid divide-by-zero for zero-amount recurrings.
+        if (absEst === 0) continue;
+
+        // Express drift as a fraction. Using Number() is safe here — we only
+        // need a rough 5% comparison, not bigint precision.
+        const drift = Math.abs(absNew - absEst) / absEst;
+
+        if (drift > AMOUNT_DRIFT_THRESHOLD) {
+          const payload: AmountUpdatePayload = {
+            newAmountCents: newAmount.toString(),
+            oldAmountCents: estimatedAmount.toString(),
+            currency,
+            observationCount: obsCount,
+          };
+
+          await db.insert(recurringProposals).values({
+            userId,
+            recurringId,
+            proposalType: "amount_update",
+            payload,
+          });
+
+          log.info(
+            {
+              event: "recurring_learning_proposal_amount",
+              userId,
+              recurringId,
+              estimatedAmount: estimatedAmount.toString(),
+              newAmount: newAmount.toString(),
+              driftPct: Math.round(drift * 100),
+              obsCount,
+            },
+            "amount_update proposal created",
+          );
+
+          result.proposalsCreated++;
+        }
+      }
+    } catch (err) {
+      log.error(
+        {
+          err,
+          event: "recurring_learning_group_failed",
+          userId,
+          recurringId,
+        },
+        "error processing recurring learning group — continuing",
+      );
+      result.errors++;
+    }
+  }
+
+  result.usersProcessed = usersSeen.size;
+
+  log.info(
+    {
+      event: "recurring_learning_done",
+      jobId: job.id,
+      usersProcessed: result.usersProcessed,
+      proposalsCreated: result.proposalsCreated,
+      errors: result.errors,
+    },
+    "recurring-learning complete",
+  );
+
+  return result;
+}
+
+/**
+ * Create and register the recurring-learning BullMQ worker.
+ * Concurrency 1 — single daily run processes all users sequentially.
+ */
+export function createRecurringLearningWorker() {
+  return createWorker<RecurringLearningJobData, LearningResult>(
+    "recurring-learning",
+    async (job) => {
+      try {
+        return await recurringLearningProcessor(job);
+      } catch (err) {
+        log.error(
+          { err, event: "recurring_learning_fanout_failed", jobId: job.id },
+          "recurring-learning processor threw — BullMQ will retry",
+        );
+        throw err;
+      }
+    },
+    {
+      concurrency: 1,
+    },
+  );
+}

--- a/src/lib/queue/workers/recurring-learning.ts
+++ b/src/lib/queue/workers/recurring-learning.ts
@@ -14,7 +14,7 @@
 // are skipped to avoid flooding the user.
 
 import type { Job } from "bullmq";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, lte, sql } from "drizzle-orm";
 
 import { createLogger } from "@/lib/logger";
 import { db } from "@/lib/db";
@@ -64,6 +64,19 @@ export async function recurringLearningProcessor(
   log.info({ event: "recurring_learning_start", jobId: job.id }, "recurring-learning started");
 
   const result: LearningResult = { usersProcessed: 0, proposalsCreated: 0, errors: 0 };
+
+  // Step 0: expire pending proposals older than 30 days BEFORE generating new ones.
+  // This is a global sweep (all users), idempotent on retry — runs outside per-row tx.
+  const cutoff = new Date(Date.now() - 30 * 86400000);
+  const expired = await db
+    .update(recurringProposals)
+    .set({ status: "expired", decidedAt: new Date() })
+    .where(and(eq(recurringProposals.status, "pending"), lte(recurringProposals.createdAt, cutoff)))
+    .returning({ id: recurringProposals.id });
+  log.info(
+    { event: "recurring_learning_expired", count: expired.length },
+    "expired stale pending proposals",
+  );
 
   // Step 1: find all (user_id, recurring_id) pairs with unapplied manual observations.
   // We use a raw SQL aggregation to get per-group stats efficiently.
@@ -125,108 +138,117 @@ export async function recurringLearningProcessor(
     usersSeen.add(userId);
 
     try {
-      // Check for an existing pending proposal of any type for this recurring.
-      const [existingPending] = await db
-        .select({ id: recurringProposals.id })
-        .from(recurringProposals)
-        .where(
-          and(
-            eq(recurringProposals.userId, userId),
-            eq(recurringProposals.recurringId, recurringId),
-            eq(recurringProposals.status, "pending"),
-          ),
-        )
-        .limit(1);
+      // Wrap SELECT + INSERT in a transaction to prevent race conditions from
+      // a manual Bull-Board trigger racing with the scheduled daily run.
+      const created = await db.transaction(async (trx) => {
+        // Check for an existing pending proposal of any type for this recurring.
+        const [existingPending] = await trx
+          .select({ id: recurringProposals.id })
+          .from(recurringProposals)
+          .where(
+            and(
+              eq(recurringProposals.userId, userId),
+              eq(recurringProposals.recurringId, recurringId),
+              eq(recurringProposals.status, "pending"),
+            ),
+          )
+          .limit(1);
 
-      if (existingPending) {
-        // A proposal is already pending — skip until user decides.
-        continue;
-      }
+        if (existingPending) {
+          // A proposal is already pending — skip until user decides.
+          return 0;
+        }
 
-      const distinctAmounts = [...new Set(amounts.map((a) => a.toString()))].map((s) => BigInt(s));
-
-      // ── Variable-flag check ───────────────────────────────────────────────
-      // N≥3 observations with >1 distinct amount → flag as variable.
-      if (obsCount >= MIN_OBSERVATIONS_FOR_VARIABLE_FLAG && distinctAmounts.length > 1) {
-        const payload: VariableFlagPayload = {
-          detectedAmounts: distinctAmounts.map((a) => a.toString()),
-          currency,
-          observationCount: obsCount,
-        };
-
-        await db.insert(recurringProposals).values({
-          userId,
-          recurringId,
-          proposalType: "variable_flag",
-          payload,
-        });
-
-        log.info(
-          {
-            event: "recurring_learning_proposal_variable",
-            userId,
-            recurringId,
-            obsCount,
-            distinctAmountsCount: distinctAmounts.length,
-          },
-          "variable_flag proposal created",
+        const distinctAmounts = [...new Set(amounts.map((a) => a.toString()))].map((s) =>
+          BigInt(s),
         );
 
-        result.proposalsCreated++;
-        continue;
-      }
-
-      // ── Amount-update check ───────────────────────────────────────────────
-      // N≥2 observations all showing the SAME amount that differs by >5%.
-      if (obsCount >= MIN_OBSERVATIONS_FOR_AMOUNT_UPDATE && distinctAmounts.length === 1) {
-        const newAmount = distinctAmounts[0];
-
-        // Sign-convention: amounts are signed (negative for expenses).
-        // Compare magnitudes with Math.abs to handle the sign correctly.
-        // Use Number() for comparisons since ES2017 target bans BigInt literals (0n).
-        const newAmountNum = Number(newAmount);
-        const estimatedAmountNum = Number(estimatedAmount);
-        const absNew = Math.abs(newAmountNum);
-        const absEst = Math.abs(estimatedAmountNum);
-
-        // Avoid divide-by-zero for zero-amount recurrings.
-        if (absEst === 0) continue;
-
-        // Express drift as a fraction. Using Number() is safe here — we only
-        // need a rough 5% comparison, not bigint precision.
-        const drift = Math.abs(absNew - absEst) / absEst;
-
-        if (drift > AMOUNT_DRIFT_THRESHOLD) {
-          const payload: AmountUpdatePayload = {
-            newAmountCents: newAmount.toString(),
-            oldAmountCents: estimatedAmount.toString(),
+        // ── Variable-flag check ─────────────────────────────────────────────
+        // N≥3 observations with >1 distinct amount → flag as variable.
+        if (obsCount >= MIN_OBSERVATIONS_FOR_VARIABLE_FLAG && distinctAmounts.length > 1) {
+          const payload: VariableFlagPayload = {
+            detectedAmounts: distinctAmounts.map((a) => a.toString()),
             currency,
             observationCount: obsCount,
           };
 
-          await db.insert(recurringProposals).values({
+          await trx.insert(recurringProposals).values({
             userId,
             recurringId,
-            proposalType: "amount_update",
+            proposalType: "variable_flag",
             payload,
           });
 
           log.info(
             {
-              event: "recurring_learning_proposal_amount",
+              event: "recurring_learning_proposal_variable",
               userId,
               recurringId,
-              estimatedAmount: estimatedAmount.toString(),
-              newAmount: newAmount.toString(),
-              driftPct: Math.round(drift * 100),
               obsCount,
+              distinctAmountsCount: distinctAmounts.length,
             },
-            "amount_update proposal created",
+            "variable_flag proposal created",
           );
 
-          result.proposalsCreated++;
+          return 1;
         }
-      }
+
+        // ── Amount-update check ─────────────────────────────────────────────
+        // N≥2 observations all showing the SAME amount that differs by >5%.
+        if (obsCount >= MIN_OBSERVATIONS_FOR_AMOUNT_UPDATE && distinctAmounts.length === 1) {
+          const newAmount = distinctAmounts[0];
+
+          // Sign-convention: amounts are signed (negative for expenses).
+          // Compare magnitudes with Math.abs to handle the sign correctly.
+          // Use Number() for comparisons since ES2017 target bans BigInt literals (0n).
+          const newAmountNum = Number(newAmount);
+          const estimatedAmountNum = Number(estimatedAmount);
+          const absNew = Math.abs(newAmountNum);
+          const absEst = Math.abs(estimatedAmountNum);
+
+          // Avoid divide-by-zero for zero-amount recurrings.
+          if (absEst === 0) return 0;
+
+          // Express drift as a fraction. Using Number() is safe here — we only
+          // need a rough 5% comparison, not bigint precision.
+          const drift = Math.abs(absNew - absEst) / absEst;
+
+          if (drift > AMOUNT_DRIFT_THRESHOLD) {
+            const payload: AmountUpdatePayload = {
+              newAmountCents: newAmount.toString(),
+              oldAmountCents: estimatedAmount.toString(),
+              currency,
+              observationCount: obsCount,
+            };
+
+            await trx.insert(recurringProposals).values({
+              userId,
+              recurringId,
+              proposalType: "amount_update",
+              payload,
+            });
+
+            log.info(
+              {
+                event: "recurring_learning_proposal_amount",
+                userId,
+                recurringId,
+                estimatedAmount: estimatedAmount.toString(),
+                newAmount: newAmount.toString(),
+                driftPct: Math.round(drift * 100),
+                obsCount,
+              },
+              "amount_update proposal created",
+            );
+
+            return 1;
+          }
+        }
+
+        return 0;
+      });
+
+      result.proposalsCreated += created;
     } catch (err) {
       log.error(
         {

--- a/src/lib/recurring/auto-link.test.ts
+++ b/src/lib/recurring/auto-link.test.ts
@@ -3,6 +3,7 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   accounts,
+  recurringDescriptionPatterns,
   recurringGaps,
   recurringTransactions,
   transactions,
@@ -15,7 +16,18 @@ const TEST_USER_EMAIL = "__autolink_other_user__@test.local";
 
 async function cleanup() {
   await db.execute(
+    sql`DELETE FROM recurring_link_observations WHERE recurring_id IN (SELECT id FROM recurring_transactions WHERE label LIKE '__autolink%')`,
+  );
+  await db.execute(
+    sql`DELETE FROM recurring_description_patterns WHERE recurring_id IN (SELECT id FROM recurring_transactions WHERE label LIKE '__autolink%')`,
+  );
+  await db.execute(
     sql`DELETE FROM recurring_gaps WHERE recurring_id IN (SELECT id FROM recurring_transactions WHERE label LIKE '__autolink%')`,
+  );
+  // Delete all transactions belonging to any __autolink account (catches both
+  // __autolink% descriptions AND custom descriptions seeded by #633 tests).
+  await db.execute(
+    sql`DELETE FROM transactions WHERE account_id IN (SELECT id FROM accounts WHERE name LIKE ${"__autolink_test_account__%"})`,
   );
   await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE '__autolink%'`);
   await db.execute(sql`DELETE FROM recurring_transactions WHERE label LIKE '__autolink%'`);
@@ -705,5 +717,150 @@ describe("autoLinkTransaction cross-month", () => {
       .from(transactions)
       .where(eq(transactions.id, txId));
     expect(row.recurringId).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // #633: Description fingerprint fallback tests
+  // ---------------------------------------------------------------------------
+
+  it("#633: links via description fingerprint when amount differs", async () => {
+    const accountId = await seedAccount();
+    // Recurring estimated at -42000 but real payment is -44900.
+    const recurringId = await seedRecurring(accountId, {
+      label: "__autolink_netflix_633__",
+      amountCents: BigInt(-42000),
+      dayOfMonth: 15,
+    });
+
+    // Seed a pattern with observation_count = 2 (unambiguous).
+    await db.insert(recurringDescriptionPatterns).values({
+      userId: TEST_USER_ID,
+      recurringId,
+      pattern: "NETFLIX",
+      observationCount: 2,
+      patternAmbiguous: false,
+    });
+
+    // Tx on day 15 of the month, amount -44900 (doesn't match exact -42000).
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-15",
+      amountCents: BigInt(-44900),
+      description: "NETFLIX*DL",
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+
+    expect(result.status).toBe("linked");
+    if (result.status !== "linked") throw new Error("should not reach");
+    expect(result.recurringId).toBe(recurringId);
+  });
+
+  it("#633: does NOT link via description when pattern has observation_count < 2", async () => {
+    const accountId = await seedAccount();
+    const recurringId = await seedRecurring(accountId, {
+      label: "__autolink_spotify_633__",
+      amountCents: BigInt(-42000),
+      dayOfMonth: 15,
+    });
+
+    // Pattern with observation_count = 1 — not enough signal.
+    await db.insert(recurringDescriptionPatterns).values({
+      userId: TEST_USER_ID,
+      recurringId,
+      pattern: "SPOTIFY",
+      observationCount: 1,
+      patternAmbiguous: false,
+    });
+
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-15",
+      amountCents: BigInt(-44900),
+      description: "SPOTIFY P",
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("no-open-gap");
+  });
+
+  it("#633: Google Play ambiguity — pattern matches 2 recurrings → no auto-link via description", async () => {
+    const accountId = await seedAccount();
+    const recurringYouTubeId = await seedRecurring(accountId, {
+      label: "__autolink_gplay_yt_633__",
+      amountCents: BigInt(-21900),
+      dayOfMonth: 10,
+    });
+    const recurringGOneId = await seedRecurring(accountId, {
+      label: "__autolink_gplay_gone_633__",
+      amountCents: BigInt(-10900),
+      dayOfMonth: 10,
+    });
+
+    // Both recurrings share the "GOOGLE" pattern.
+    await db.insert(recurringDescriptionPatterns).values([
+      {
+        userId: TEST_USER_ID,
+        recurringId: recurringYouTubeId,
+        pattern: "GOOGLE",
+        observationCount: 3,
+        patternAmbiguous: true, // already flagged as ambiguous
+      },
+      {
+        userId: TEST_USER_ID,
+        recurringId: recurringGOneId,
+        pattern: "GOOGLE",
+        observationCount: 2,
+        patternAmbiguous: true,
+      },
+    ]);
+
+    // Tx with a completely different amount — won't match via amount.
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-10",
+      amountCents: BigInt(-19900),
+      description: "GOOGLE *PLAY YOUTUBE",
+    });
+
+    // Should not auto-link via description since both patterns are ambiguous.
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+    expect(result.status).toBe("no-open-gap");
+
+    // Verify tx is not linked.
+    const [row] = await db
+      .select({ recurringId: transactions.recurringId })
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+    expect(row.recurringId).toBeNull();
+  });
+
+  it("#633: amount-based match still works even when description is Google Play ambiguous", async () => {
+    const accountId = await seedAccount();
+    // Amount match takes precedence over description ambiguity.
+    const recurringYouTubeId = await seedRecurring(accountId, {
+      label: "__autolink_gplay_yt2_633__",
+      amountCents: BigInt(-21900),
+      dayOfMonth: 10,
+    });
+
+    // Ambiguous description pattern but amount is exact.
+    await db.insert(recurringDescriptionPatterns).values({
+      userId: TEST_USER_ID,
+      recurringId: recurringYouTubeId,
+      pattern: "GOOGLE",
+      observationCount: 3,
+      patternAmbiguous: true,
+    });
+
+    // Tx with EXACT amount match — should link via amount path.
+    const txId = await seedTx(accountId, {
+      occurredOn: "2026-04-10",
+      amountCents: BigInt(-21900), // exact match
+      description: "GOOGLE *PLAY YOUTUBE",
+    });
+
+    const result = await autoLinkTransaction(TEST_USER_ID, txId);
+
+    expect(result.status).toBe("linked");
+    if (result.status !== "linked") throw new Error("should not reach");
+    expect(result.recurringId).toBe(recurringYouTubeId);
   });
 });

--- a/src/lib/recurring/auto-link.ts
+++ b/src/lib/recurring/auto-link.ts
@@ -1,12 +1,21 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { db as defaultDb, type DB } from "@/lib/db";
-import { recurringGaps, recurringTransactions, transactions } from "@/lib/db/schema";
+import {
+  recurringGaps,
+  recurringTransactions,
+  recurringDescriptionPatterns,
+  transactions,
+} from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { emit } from "@/lib/events/bus";
 import {
   DEFAULT_WINDOW_AFTER_DAYS,
   DEFAULT_WINDOW_BEFORE_DAYS,
 } from "@/lib/recurring/gap-detector";
+import {
+  recordRecurringLinkObservation,
+  tokeniseDescription,
+} from "@/lib/recurring/observation-recorder";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger({ module: "recurring/auto-link" });
@@ -67,6 +76,7 @@ export async function autoLinkTransaction(
       amountCents: transactions.amountCents,
       occurredAt: transactions.occurredAt,
       recurringId: transactions.recurringId,
+      descriptionRaw: transactions.descriptionRaw,
     })
     .from(transactions)
     .where(
@@ -157,6 +167,17 @@ export async function autoLinkTransaction(
       timestamp: Date.now(),
     });
 
+    // #633: Record observation (auto, gap path).
+    recordRecurringLinkObservation(
+      { userId, recurringId: result.recurringId, txId, yearMonth: result.yearMonth, manual: false },
+      database,
+    ).catch((err) => {
+      log.error(
+        { err, event: "observation_record_failed", txId, recurringId: result.recurringId, userId },
+        "failed to record recurring link observation (gap path) — non-critical",
+      );
+    });
+
     return result;
   }
 
@@ -234,11 +255,101 @@ export async function autoLinkTransaction(
     }
   }
 
-  if (matchingDirect.length === 0) return { status: "no-open-gap" };
-  if (matchingDirect.length > 1)
-    return { status: "ambiguous", candidateCount: matchingDirect.length };
+  // ── Description fingerprint fallback (#633) ──────────────────────────────
+  // When the amount-based direct path finds no match, attempt a description
+  // fingerprint lookup. Uses patterns with observation_count >= 2 that are not
+  // marked ambiguous (Google Play caveat). Only active, non-deleted recurrings.
+  //
+  // Ambiguity rule preserved: if multiple recurrings match via description,
+  // no auto-link (user resolves). Amount-only path still works independently.
 
-  const directHit = matchingDirect[0];
+  let descriptionFallbackCandidates: DirectMatch[] = [];
+
+  if (matchingDirect.length === 0) {
+    const descToken = tokeniseDescription(tx.descriptionRaw);
+    if (descToken) {
+      // Fetch unambiguous patterns for this user + token with enough signal.
+      const matchingPatterns = await database
+        .select({
+          recurringId: recurringDescriptionPatterns.recurringId,
+          dayOfMonth: recurringTransactions.dayOfMonth,
+        })
+        .from(recurringDescriptionPatterns)
+        .innerJoin(
+          recurringTransactions,
+          and(
+            eq(recurringTransactions.id, recurringDescriptionPatterns.recurringId),
+            // Tenant-safety: pair user_id on both sides of the JOIN.
+            eq(recurringTransactions.userId, recurringDescriptionPatterns.userId),
+          ),
+        )
+        .where(
+          and(
+            eq(recurringDescriptionPatterns.userId, userId),
+            eq(recurringDescriptionPatterns.pattern, descToken),
+            eq(recurringDescriptionPatterns.patternAmbiguous, false),
+            // Require at least 2 observations before trusting the pattern.
+            sql`${recurringDescriptionPatterns.observationCount} >= 2`,
+            eq(recurringTransactions.active, true),
+            notDeleted(recurringTransactions.deletedAt),
+          ),
+        );
+
+      for (const c of matchingPatterns) {
+        const [prevYear, prevMonth] = prevYM(txYear, txMonth);
+        const [nextYear, nextMonth] = nextYM(txYear, txMonth);
+
+        const evaluations: Array<{ year: number; month: number }> = [
+          { year: prevYear, month: prevMonth },
+          { year: txYear, month: txMonth },
+          { year: nextYear, month: nextMonth },
+        ];
+
+        for (const { year, month } of evaluations) {
+          if (txInWindowForYearMonth(c.dayOfMonth, year, month)) {
+            const ym = `${year}-${String(month).padStart(2, "0")}`;
+            descriptionFallbackCandidates.push({
+              recurringId: c.recurringId,
+              matchedYearMonth: ym,
+            });
+            break;
+          }
+        }
+      }
+
+      // Deduplicate by recurringId (a pattern might match multiple windows for
+      // the same recurring — take the first).
+      const seen = new Set<number>();
+      descriptionFallbackCandidates = descriptionFallbackCandidates.filter((c) => {
+        if (seen.has(c.recurringId)) return false;
+        seen.add(c.recurringId);
+        return true;
+      });
+
+      if (descriptionFallbackCandidates.length > 1) {
+        log.info(
+          {
+            event: "auto_link_description_ambiguous",
+            txId,
+            descToken,
+            candidateCount: descriptionFallbackCandidates.length,
+            userId,
+          },
+          "description fingerprint ambiguous — multiple recurrings match",
+        );
+        return { status: "ambiguous", candidateCount: descriptionFallbackCandidates.length };
+      }
+    }
+  }
+
+  // Resolve final candidate: amount-based match takes priority; description fallback is secondary.
+  const allCandidates = matchingDirect.length > 0 ? matchingDirect : descriptionFallbackCandidates;
+
+  if (allCandidates.length === 0) return { status: "no-open-gap" };
+  if (allCandidates.length > 1)
+    return { status: "ambiguous", candidateCount: allCandidates.length };
+
+  const directHit = allCandidates[0];
   // Use the yearMonth derived from the window match (may be prev/next month).
   const directYearMonth = directHit.matchedYearMonth;
 
@@ -282,12 +393,16 @@ export async function autoLinkTransaction(
     throw err;
   }
 
+  const usedDescriptionFallback =
+    matchingDirect.length === 0 && descriptionFallbackCandidates.length === 1;
+
   log.info(
     {
       event: "auto_link_direct",
       txId,
       recurringId: directHit.recurringId,
       yearMonth: directYearMonth,
+      usedDescriptionFallback,
       userId,
     },
     "auto-linked tx directly to active recurring (no gap)",
@@ -298,6 +413,17 @@ export async function autoLinkTransaction(
     gapId: null,
     reason: "auto-linked",
     timestamp: Date.now(),
+  });
+
+  // #633: Record observation (auto, direct path).
+  recordRecurringLinkObservation(
+    { userId, recurringId: directHit.recurringId, txId, yearMonth: directYearMonth, manual: false },
+    database,
+  ).catch((err) => {
+    log.error(
+      { err, event: "observation_record_failed", txId, recurringId: directHit.recurringId, userId },
+      "failed to record recurring link observation (direct path) — non-critical",
+    );
   });
 
   return {

--- a/src/lib/recurring/observation-recorder.test.ts
+++ b/src/lib/recurring/observation-recorder.test.ts
@@ -1,0 +1,321 @@
+// #633: Integration tests for the observation recorder.
+// Runs against findash_test (forced by vitest.setup.ts).
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  recurringDescriptionPatterns,
+  recurringLinkObservations,
+  recurringTransactions,
+  transactions,
+  users,
+} from "@/lib/db/schema";
+import { copyCategorySeedsToUser, copyRuleSeedsToUser } from "@/lib/auth/signup";
+import { recordRecurringLinkObservation, tokeniseDescription } from "./observation-recorder";
+
+// ---------------------------------------------------------------------------
+// Test data tag and seed helpers
+// ---------------------------------------------------------------------------
+
+const TAG = "test-obs-recorder-633";
+
+async function seedUser(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  await copyRuleSeedsToUser(row.id);
+  return row.id;
+}
+
+async function seedAccount(userId: number): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({ userId, name: `${TAG}-acct`, institution: TAG, type: "savings", currency: "COP" })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function seedRecurring(userId: number, accountId: number): Promise<number> {
+  const [row] = await db
+    .insert(recurringTransactions)
+    .values({
+      userId,
+      accountId,
+      label: `${TAG}-recurring`,
+      amountCents: BigInt(-44900),
+      currency: "COP",
+      dayOfMonth: 15,
+      active: true,
+    })
+    .returning({ id: recurringTransactions.id });
+  return row.id;
+}
+
+async function seedTx(
+  userId: number,
+  accountId: number,
+  descriptionRaw = `${TAG}-tx`,
+  amountCents: bigint = BigInt(-44900),
+): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      userId,
+      accountId,
+      occurredAt: new Date("2026-04-15T12:00:00Z"),
+      amountCents,
+      currency: "COP",
+      descriptionRaw,
+      classificationMethod: "unclassified",
+      source: "manual",
+    })
+    .returning({ id: transactions.id });
+  return row.id;
+}
+
+async function cleanup() {
+  // Remove in FK order — all keyed by the tagged user emails.
+  await db.execute(sql`
+    DELETE FROM recurring_link_observations
+    WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})
+  `);
+  await db.execute(sql`
+    DELETE FROM recurring_description_patterns
+    WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})
+  `);
+  await db.execute(sql`
+    DELETE FROM transactions
+    WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})
+  `);
+  await db.execute(sql`
+    DELETE FROM recurring_transactions
+    WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})
+  `);
+  await db.execute(sql`
+    DELETE FROM accounts
+    WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${TAG + "%"})
+  `);
+  await db.execute(sql`DELETE FROM users WHERE email LIKE ${TAG + "%"}`);
+}
+
+// ---------------------------------------------------------------------------
+// tokeniseDescription unit tests (pure, no DB)
+// ---------------------------------------------------------------------------
+
+describe("tokeniseDescription", () => {
+  it("extracts the first significant alphabetic token", () => {
+    expect(tokeniseDescription("NETFLIX*DL")).toBe("NETFLIX");
+    expect(tokeniseDescription("SPOTIFY P 12345")).toBe("SPOTIFY");
+    expect(tokeniseDescription("GOOGLE *PLAY YOUTUBE")).toBe("GOOGLE");
+  });
+
+  it("returns null for purely numeric or short strings", () => {
+    expect(tokeniseDescription("1234 5678")).toBeNull();
+    expect(tokeniseDescription("AB")).toBeNull();
+    expect(tokeniseDescription("")).toBeNull();
+    expect(tokeniseDescription(null)).toBeNull();
+    expect(tokeniseDescription(undefined)).toBeNull();
+  });
+
+  it("is case-insensitive (uppercases before tokenising)", () => {
+    expect(tokeniseDescription("netflix*dl")).toBe("NETFLIX");
+  });
+
+  it("strips non-alphanumeric characters before splitting", () => {
+    expect(tokeniseDescription("PAYU-WOMPI-12345")).toBe("PAYU");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recordRecurringLinkObservation integration tests
+// ---------------------------------------------------------------------------
+
+describe("recordRecurringLinkObservation", () => {
+  let userAId: number;
+  let accountAId: number;
+  let recurringAId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    userAId = await seedUser(`${TAG}-userA@test.local`);
+    accountAId = await seedAccount(userAId);
+    recurringAId = await seedRecurring(userAId, accountAId);
+  });
+
+  afterEach(cleanup);
+
+  it("inserts an observation with correct fields", async () => {
+    const txId = await seedTx(userAId, accountAId, "NETFLIX*DL");
+    await recordRecurringLinkObservation({
+      userId: userAId,
+      recurringId: recurringAId,
+      txId,
+      yearMonth: "2026-04",
+      manual: true,
+    });
+
+    const [obs] = await db
+      .select()
+      .from(recurringLinkObservations)
+      .where(
+        and(
+          eq(recurringLinkObservations.txId, txId),
+          eq(recurringLinkObservations.userId, userAId),
+        ),
+      );
+
+    expect(obs).toBeDefined();
+    expect(obs?.recurringId).toBe(recurringAId);
+    expect(obs?.yearMonth).toBe("2026-04");
+    expect(obs?.manual).toBe(true);
+    expect(obs?.applied).toBe(false);
+    expect(obs?.realAmountCents.toString()).toBe("-44900");
+    expect(obs?.realCurrency).toBe("COP");
+    expect(obs?.descriptionRaw).toBe("NETFLIX*DL");
+  });
+
+  it("is idempotent — second call on same (userId, recurringId, txId, yearMonth) is a no-op", async () => {
+    const txId = await seedTx(userAId, accountAId);
+    await recordRecurringLinkObservation({
+      userId: userAId,
+      recurringId: recurringAId,
+      txId,
+      yearMonth: "2026-04",
+      manual: true,
+    });
+    // Second call — must not throw or insert a duplicate.
+    await expect(
+      recordRecurringLinkObservation({
+        userId: userAId,
+        recurringId: recurringAId,
+        txId,
+        yearMonth: "2026-04",
+        manual: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    const rows = await db
+      .select({ id: recurringLinkObservations.id })
+      .from(recurringLinkObservations)
+      .where(
+        and(
+          eq(recurringLinkObservations.userId, userAId),
+          eq(recurringLinkObservations.recurringId, recurringAId),
+          eq(recurringLinkObservations.txId, txId),
+        ),
+      );
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it("upserts a description pattern and increments observation_count", async () => {
+    const txId1 = await seedTx(userAId, accountAId, "NETFLIX*DL");
+    await recordRecurringLinkObservation({
+      userId: userAId,
+      recurringId: recurringAId,
+      txId: txId1,
+      yearMonth: "2026-03",
+      manual: true,
+    });
+
+    const txId2 = await seedTx(userAId, accountAId, "NETFLIX*HD");
+    await recordRecurringLinkObservation({
+      userId: userAId,
+      recurringId: recurringAId,
+      txId: txId2,
+      yearMonth: "2026-04",
+      manual: true,
+    });
+
+    // Both descriptions tokenise to "NETFLIX" — count should be 2.
+    const [pattern] = await db
+      .select({ observationCount: recurringDescriptionPatterns.observationCount })
+      .from(recurringDescriptionPatterns)
+      .where(
+        and(
+          eq(recurringDescriptionPatterns.userId, userAId),
+          eq(recurringDescriptionPatterns.recurringId, recurringAId),
+          eq(recurringDescriptionPatterns.pattern, "NETFLIX"),
+        ),
+      );
+
+    expect(pattern?.observationCount).toBe(2);
+  });
+
+  it("marks pattern_ambiguous when two different recurrings share the same token (Google Play caveat)", async () => {
+    const recurringBId = await seedRecurring(userAId, accountAId);
+
+    const txId1 = await seedTx(userAId, accountAId, "GOOGLE *PLAY YOUTUBE");
+    await recordRecurringLinkObservation({
+      userId: userAId,
+      recurringId: recurringAId,
+      txId: txId1,
+      yearMonth: "2026-04",
+      manual: true,
+    });
+
+    const txId2 = await seedTx(userAId, accountAId, "GOOGLE *PLAY SPOTIFY");
+    await recordRecurringLinkObservation({
+      userId: userAId,
+      recurringId: recurringBId,
+      txId: txId2,
+      yearMonth: "2026-04",
+      manual: true,
+    });
+
+    // Both patterns tokenise to "GOOGLE" — both should now be marked ambiguous.
+    const patterns = await db
+      .select({ patternAmbiguous: recurringDescriptionPatterns.patternAmbiguous })
+      .from(recurringDescriptionPatterns)
+      .where(
+        and(
+          eq(recurringDescriptionPatterns.userId, userAId),
+          eq(recurringDescriptionPatterns.pattern, "GOOGLE"),
+        ),
+      );
+
+    expect(patterns).toHaveLength(2);
+    expect(patterns.every((p) => p.patternAmbiguous)).toBe(true);
+  });
+
+  it("does nothing (no error) when tx not found", async () => {
+    // txId = 999999999 (non-existent)
+    await expect(
+      recordRecurringLinkObservation({
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: 999999999,
+        yearMonth: "2026-04",
+        manual: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("tenant-safe: userA observation does not leak into userB", async () => {
+    const userBId = await seedUser(`${TAG}-userB@test.local`);
+    const accountBId = await seedAccount(userBId);
+    const recurringBId = await seedRecurring(userBId, accountBId);
+
+    // Tx belongs to userA; we try to record an observation for userB's recurring.
+    const txId = await seedTx(userAId, accountAId);
+
+    // The recorder fetches the tx with userId filter — userB cannot record
+    // an observation for userA's tx.
+    await recordRecurringLinkObservation({
+      userId: userBId, // trying to record as userB
+      recurringId: recurringBId,
+      txId, // but tx belongs to userA
+      yearMonth: "2026-04",
+      manual: true,
+    });
+
+    // No observation should have been created (tx not found for userB).
+    const rows = await db
+      .select()
+      .from(recurringLinkObservations)
+      .where(eq(recurringLinkObservations.txId, txId));
+
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/src/lib/recurring/observation-recorder.ts
+++ b/src/lib/recurring/observation-recorder.ts
@@ -1,0 +1,173 @@
+// #633: Observation recorder — append one row to recurring_link_observations
+// after every successful tx ↔ recurring link (manual + auto).
+//
+// Idempotent by design: the unique constraint on (user_id, recurring_id, tx_id,
+// year_month) ensures retried jobs and race conditions never produce duplicates.
+// ON CONFLICT DO NOTHING is the correct behaviour here — the observation already
+// exists, nothing more is needed.
+//
+// Also upserts the description fingerprint table so pattern_count stays current
+// for the auto-link fallback path (Section D).
+
+import { eq, and, sql } from "drizzle-orm";
+import { db as defaultDb, type DB } from "@/lib/db";
+import {
+  recurringLinkObservations,
+  recurringDescriptionPatterns,
+  transactions,
+} from "@/lib/db/schema";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "recurring/observation-recorder" });
+
+export type RecordLinkObservationInput = {
+  userId: number;
+  recurringId: number;
+  txId: number;
+  yearMonth: string;
+  manual: boolean;
+};
+
+/**
+ * Tokenise a raw description into a stable fingerprint token.
+ *
+ * Rules:
+ *   1. Uppercase
+ *   2. Strip all non-alphanumeric characters (keep spaces for splitting)
+ *   3. Split on whitespace
+ *   4. Take the first significant token (≥3 chars, not purely numeric)
+ *   5. Return null if no significant token found
+ *
+ * Examples:
+ *   "NETFLIX*DL"              → "NETFLIX"
+ *   "SPOTIFY P 12345"         → "SPOTIFY"
+ *   "GOOGLE *PLAY YOUTUBE"    → "GOOGLE"  (will clash — that's intentional)
+ *   "1234 5678"               → null      (purely numeric)
+ */
+export function tokeniseDescription(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const upper = raw.toUpperCase().replace(/[^A-Z0-9 ]/g, " ");
+  const tokens = upper.split(/\s+/).filter(Boolean);
+  for (const tok of tokens) {
+    if (tok.length >= 3 && /[A-Z]/.test(tok)) return tok;
+  }
+  return null;
+}
+
+/**
+ * Record a single observation for a manual or auto link event.
+ *
+ * 1. Looks up the tx to get amountCents, currency, descriptionRaw, accountId.
+ * 2. Inserts into recurring_link_observations (idempotent via ON CONFLICT DO NOTHING).
+ * 3. Upserts into recurring_description_patterns if the tx has a description token.
+ * 4. After the upsert, checks across all patterns with the same token for this user
+ *    — if 2+ recurrings share it, marks all as pattern_ambiguous=true.
+ *
+ * Does NOT throw on insert conflicts — always resolves cleanly.
+ */
+export async function recordRecurringLinkObservation(
+  input: RecordLinkObservationInput,
+  database: DB = defaultDb,
+): Promise<void> {
+  const { userId, recurringId, txId, yearMonth, manual } = input;
+
+  // Fetch the tx to get the fields we need for the observation row.
+  const [tx] = await database
+    .select({
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      descriptionRaw: transactions.descriptionRaw,
+      accountId: transactions.accountId,
+    })
+    .from(transactions)
+    .where(and(eq(transactions.id, txId), eq(transactions.userId, userId)))
+    .limit(1);
+
+  if (!tx) {
+    log.warn(
+      { event: "observation_tx_not_found", userId, txId, recurringId, yearMonth },
+      "observation-recorder: tx not found — skipping",
+    );
+    return;
+  }
+
+  // 1. Insert observation (idempotent).
+  await database
+    .insert(recurringLinkObservations)
+    .values({
+      userId,
+      recurringId,
+      txId,
+      yearMonth,
+      realAmountCents: tx.amountCents,
+      realCurrency: tx.currency,
+      descriptionRaw: tx.descriptionRaw,
+      accountId: tx.accountId,
+      manual,
+    })
+    .onConflictDoNothing();
+
+  log.info(
+    { event: "observation_recorded", userId, recurringId, txId, yearMonth, manual },
+    "recurring link observation recorded",
+  );
+
+  // 2. Upsert description fingerprint if we have a usable token.
+  const pattern = tokeniseDescription(tx.descriptionRaw);
+  if (!pattern) return;
+
+  await database
+    .insert(recurringDescriptionPatterns)
+    .values({
+      userId,
+      recurringId,
+      pattern,
+      observationCount: 1,
+      lastObservedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [
+        recurringDescriptionPatterns.userId,
+        recurringDescriptionPatterns.recurringId,
+        recurringDescriptionPatterns.pattern,
+      ],
+      set: {
+        observationCount: sql`${recurringDescriptionPatterns.observationCount} + 1`,
+        lastObservedAt: new Date(),
+      },
+    });
+
+  // 3. Check for ambiguity: count distinct recurring_ids for this (user, pattern).
+  const patternOwners = await database
+    .selectDistinct({ recurringId: recurringDescriptionPatterns.recurringId })
+    .from(recurringDescriptionPatterns)
+    .where(
+      and(
+        eq(recurringDescriptionPatterns.userId, userId),
+        eq(recurringDescriptionPatterns.pattern, pattern),
+      ),
+    );
+
+  if (patternOwners.length >= 2) {
+    // Mark all matching rows as ambiguous.
+    await database
+      .update(recurringDescriptionPatterns)
+      .set({ patternAmbiguous: true })
+      .where(
+        and(
+          eq(recurringDescriptionPatterns.userId, userId),
+          eq(recurringDescriptionPatterns.pattern, pattern),
+        ),
+      );
+
+    log.info(
+      {
+        event: "observation_pattern_ambiguous",
+        userId,
+        pattern,
+        recurringCount: patternOwners.length,
+      },
+      "description pattern marked ambiguous (shared by multiple recurrings)",
+    );
+  }
+}


### PR DESCRIPTION
Closes #633

## Summary

- Observation recorder hooked into all link paths (manual + auto); every link records a `recurring_link_observations` row with amount and direction
- BullMQ worker runs daily at 04:00 Bogotá (`fx-recurring-learning`): detects amount drift (N=2 same-delta → propose amount update) and variable-amount pattern (N=3 non-uniform → flag `amount_type='variable'`); all DB ops wrapped in a single transaction (S1 fix)
- Description fingerprint extends `autoLinkTransaction` with a Google Play ambiguity safeguard — generic merchant names are excluded from fingerprint matching to avoid false positives
- `/settings/recurring/learning` page + dashboard banner with accept/reject UX for pending proposals; `countPendingProposals` fixed for tenant safety (C1 fix)

## Migration 0069

New tables: `recurring_link_observations`, `recurring_description_patterns`, `recurring_proposals`. New enum: `recurring_amount_type` ('fixed' default, added column on `recurring_transactions`).

**Deploy note**: migration 0069 adds `recurring_transactions.amount_type` referenced by the new worker. Migrations MUST run BEFORE process restart on prod deploy — if the server restarts with new code before the migration runs, the worker will throw on its first tick. Verify `bun run db:migrate:prod` (or equivalent) runs ahead of process restart in the deploy workflow.

## Reviewer fixes (commit `2c31cb5`)

- **C1 (CRITICAL)**: tenant pairing bug in `countPendingProposals` — added `userId` join condition to prevent cross-tenant leak
- **W1**: added 6 jsdom component tests for proposals list (`proposals-list.test.tsx`)
- **W2**: `expireProposal` dead-code wired — expiry sweep added to recurring-learning worker (30-day cutoff)
- **S1**: worker SELECT + INSERT wrapped in a single Drizzle transaction to prevent race conditions

## Test plan

- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` clean — 157 test files, 1966 passed (58 new specs: observation-recorder, recurring-learning worker, learning actions, proposals-list component, auto-link extension)
- [x] `bun run format:check` clean
- [x] e2e screenshots captured — 68/74 passed (6 known pre-existing flakes: home recharts × 4, counterparty × 2)
- [ ] manual smoke: `/settings/recurring/learning` page loads, banner appears when proposals pending, accept/reject actions update state

## Architecture invariant

Forecast/observation/proposal data NEVER touches the `transactions` table. The learning loop ONLY mutates `recurring_transactions.amount_cents` (or `amount_type`) when the user explicitly accepts a proposal.

## Screenshots

Settings pages (light/dark) captured via Playwright. New `/settings/recurring/learning` page not yet in e2e spec (capture-only spec targets known routes).