### PR TITLE
feat(ingestion/email-arq): resolve+link counterparty on insert + backfill orphans (#637)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:migrate:pago-tc": "bun run scripts/migrate-pago-tc-to-transfer.ts",
     "intereses:run": "bun run scripts/run-intereses-causados.ts",
     "backfill:arq-snapshots": "bun run scripts/backfill-arq-snapshots.ts",
+    "backfill:email-arq-counterparties": "bun run scripts/backfill-email-arq-counterparties.ts",
     "statement:parse": "bun run scripts/parse-bancolombia-statement.ts",
     "statement:apply": "bun run scripts/consolidate-statement.ts",
     "db:bootstrap:invites": "bun run scripts/bootstrap-invites.ts",

--- a/scripts/backfill-email-arq-counterparties.ts
+++ b/scripts/backfill-email-arq-counterparties.ts
@@ -1,0 +1,229 @@
+// #637: Backfill counterparty_id on existing email_arq transactions.
+//
+// For each tx with source='gmail_arq' and counterparty_id IS NULL, resolves
+// (or creates) a counterparty via the same resolveCounterpartyByKey used at
+// ingest time and writes it back via UPDATE. Idempotent — re-running does not
+// duplicate counterparties (alias uniqueIndex guards that).
+//
+// Invocation:
+//   bun run backfill:email-arq-counterparties
+//   bun run backfill:email-arq-counterparties --dry-run
+//   bun run backfill:email-arq-counterparties --user-id=1
+//   bun run backfill:email-arq-counterparties --user-id=1 --dry-run
+//
+// Flags:
+//   --dry-run      Log what WOULD be done without writing anything.
+//                  In dry-run mode the resolveCounterpartyByKey call is
+//                  skipped entirely — the lookup is read-only but would still
+//                  increment hit_count; we avoid that side-effect.
+//   --user-id=N    Restrict to a single user (optional; defaults to all users).
+
+import { sql } from "drizzle-orm";
+
+import { db } from "../src/lib/db";
+import { resolveCounterpartyByKey } from "../src/lib/ingestion/sms-pipeline";
+import { normalizeName } from "../src/lib/counterparties/alias-key";
+import { createLogger } from "../src/lib/logger";
+
+const log = createLogger({ module: "backfill-email-arq-counterparties" });
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: string[]): { dryRun: boolean; userId: number | null } {
+  let dryRun = false;
+  let userId: number | null = null;
+  for (const arg of argv.slice(2)) {
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    const m = arg.match(/^--user-id=(\d+)$/);
+    if (m) {
+      userId = Number(m[1]);
+      continue;
+    }
+    log.warn({ arg, event: "backfill_arq_cp_unknown_arg" }, "unknown flag — ignored");
+  }
+  return { dryRun, userId };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { dryRun, userId } = parseArgs(process.argv);
+
+  log.info(
+    { dryRun, userId, event: "backfill_arq_cp_start" },
+    dryRun ? "DRY RUN — no writes will be performed" : "starting backfill",
+  );
+
+  // Walk transactions with source='gmail_arq' and counterparty_id IS NULL.
+  // Soft-delete guard: deleted_at IS NULL.
+  // Optionally restrict to a single user for targeted runs.
+  const rows = await db.execute<{
+    id: number;
+    user_id: number;
+    merchant: string | null;
+  }>(sql`
+    SELECT id, user_id, merchant
+    FROM transactions
+    WHERE source = 'gmail_arq'
+      AND counterparty_id IS NULL
+      AND deleted_at IS NULL
+      ${userId !== null ? sql`AND user_id = ${userId}` : sql``}
+    ORDER BY user_id, id
+  `);
+
+  if (rows.length === 0) {
+    log.info({ event: "backfill_arq_cp_noop" }, "no orphan email_arq transactions found");
+    await db.$client.end({ timeout: 1 });
+    return;
+  }
+
+  log.info(
+    { count: rows.length, dryRun, event: "backfill_arq_cp_found" },
+    "orphan transactions to process",
+  );
+
+  // Per-user counters for summary logging.
+  const byUser: Record<number, { processed: number; skipped: number; errors: number }> = {};
+  let totalProcessed = 0;
+  let totalSkipped = 0;
+  let totalErrors = 0;
+
+  for (const row of rows) {
+    if (!byUser[row.user_id]) {
+      byUser[row.user_id] = { processed: 0, skipped: 0, errors: 0 };
+    }
+    const counters = byUser[row.user_id];
+
+    // Skip rows where merchant is null or empty — we have nothing to key on.
+    if (!row.merchant || row.merchant.trim() === "") {
+      log.warn(
+        { txId: row.id, userId: row.user_id, event: "backfill_arq_cp_no_merchant" },
+        "tx has no merchant — skipping",
+      );
+      counters.skipped += 1;
+      totalSkipped += 1;
+      continue;
+    }
+
+    const normalizedName = normalizeName(row.merchant);
+
+    if (dryRun) {
+      log.info(
+        {
+          txId: row.id,
+          userId: row.user_id,
+          merchant: row.merchant,
+          normalizedName,
+          event: "backfill_arq_cp_dry_run",
+        },
+        "[dry-run] would resolve counterparty",
+      );
+      counters.processed += 1;
+      totalProcessed += 1;
+      continue;
+    }
+
+    try {
+      const cp = await resolveCounterpartyByKey(
+        row.user_id,
+        {
+          kind: "name",
+          value: normalizedName,
+          initialDisplayName: row.merchant,
+        },
+        db,
+      );
+
+      if (cp.counterpartyId === null) {
+        // Should not happen for kind="name" — resolveCounterpartyByKey always
+        // inserts if not found. Log as a warning and skip to avoid null writes.
+        log.warn(
+          { txId: row.id, userId: row.user_id, event: "backfill_arq_cp_null_result" },
+          "resolveCounterpartyByKey returned null — skipping",
+        );
+        counters.skipped += 1;
+        totalSkipped += 1;
+        continue;
+      }
+
+      // Tenant-safe UPDATE: always include user_id in the WHERE clause.
+      await db.execute(sql`
+        UPDATE transactions
+        SET counterparty_id = ${cp.counterpartyId},
+            updated_at = now()
+        WHERE id = ${row.id}
+          AND user_id = ${row.user_id}
+      `);
+
+      log.info(
+        {
+          txId: row.id,
+          userId: row.user_id,
+          counterpartyId: cp.counterpartyId,
+          merchant: row.merchant,
+          event: "backfill_arq_cp_updated",
+        },
+        "linked counterparty to tx",
+      );
+      counters.processed += 1;
+      totalProcessed += 1;
+    } catch (err) {
+      log.error(
+        {
+          txId: row.id,
+          userId: row.user_id,
+          merchant: row.merchant,
+          err,
+          event: "backfill_arq_cp_error",
+        },
+        "failed to resolve/update counterparty — continuing",
+      );
+      counters.errors += 1;
+      totalErrors += 1;
+    }
+  }
+
+  // Per-user summary.
+  for (const [uid, c] of Object.entries(byUser)) {
+    log.info(
+      {
+        userId: Number(uid),
+        processed: c.processed,
+        skipped: c.skipped,
+        errors: c.errors,
+        event: "backfill_arq_cp_user_summary",
+      },
+      dryRun ? "[dry-run] user summary" : "user summary",
+    );
+  }
+
+  log.info(
+    {
+      dryRun,
+      total: rows.length,
+      totalProcessed,
+      totalSkipped,
+      totalErrors,
+      event: "backfill_arq_cp_done",
+    },
+    dryRun ? "DRY RUN complete" : "backfill complete",
+  );
+
+  await db.$client.end({ timeout: 1 });
+
+  if (totalErrors > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  log.error({ err, event: "backfill_arq_cp_fatal" }, "backfill-email-arq-counterparties failed");
+  process.exit(1);
+});

--- a/src/lib/ingestion/email-arq.test.ts
+++ b/src/lib/ingestion/email-arq.test.ts
@@ -166,8 +166,11 @@ const NOW = new Date("2026-04-01T10:00:00Z");
 // ---------------------------------------------------------------------------
 
 describe("ingestArqEmail — counterparty linking", () => {
-  it("happy path — new ingest links counterparty", async () => {
-    const html = buildReceivedHtml("CODEBRANCH LLC", "2,180");
+  it("happy path — new ingest links counterparty (and normalizes the alias)", async () => {
+    // Mixed case input: proves normalizeName uppercases the alias value
+    // even though the parser preserves casing in counterpartyName.
+    // (The parser already collapses internal whitespace via /\s+/g, " ").
+    const html = buildReceivedHtml("Codebranch Llc", "2,180");
     const receiptId = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-1`, html);
 
     const result = await ingestArqEmail(USER_A, receiptId, html, NOW);
@@ -181,14 +184,14 @@ describe("ingestArqEmail — counterparty linking", () => {
       .where(eq(transactions.userId, USER_A));
     expect(tx.counterpartyId).not.toBeNull();
 
-    // One counterparty row created with the correct display name.
+    // Display name preserves the original (post-parse) casing.
     const [cp] = await db
       .select({ displayName: counterparties.displayName })
       .from(counterparties)
       .where(eq(counterparties.userId, USER_A));
-    expect(cp.displayName).toBe("CODEBRANCH LLC");
+    expect(cp.displayName).toBe("Codebranch Llc");
 
-    // One alias row with normalized name value.
+    // Alias VALUE is the uppercased normalized form — proves normalizeName ran.
     const [alias] = await db
       .select({ kind: counterpartyAliases.kind, value: counterpartyAliases.value })
       .from(counterpartyAliases)
@@ -197,11 +200,22 @@ describe("ingestArqEmail — counterparty linking", () => {
     expect(alias.value).toBe("CODEBRANCH LLC");
   });
 
-  it("idempotency — same receipt twice returns duplicated, no new counterparty rows", async () => {
+  it("idempotency — same receipt twice returns duplicated, first call still linked counterparty", async () => {
     const html = buildReceivedHtml("CODEBRANCH LLC", "2,180");
     const receiptId = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-2`, html);
 
-    await ingestArqEmail(USER_A, receiptId, html, NOW);
+    const result1 = await ingestArqEmail(USER_A, receiptId, html, NOW);
+    expect(result1.status).toBe("inserted");
+
+    // Confirm the FIRST call actually linked the counterparty — without this,
+    // the test would still pass even if resolveCounterpartyByKey silently
+    // returned null on the first call.
+    const [tx] = await db
+      .select({ counterpartyId: transactions.counterpartyId })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_A));
+    expect(tx.counterpartyId).not.toBeNull();
+
     const result2 = await ingestArqEmail(USER_A, receiptId, html, NOW);
 
     expect(result2.status).toBe("duplicated");

--- a/src/lib/ingestion/email-arq.test.ts
+++ b/src/lib/ingestion/email-arq.test.ts
@@ -1,0 +1,329 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  counterparties,
+  counterpartyAliases,
+  emailReceipts,
+  gmailConnections,
+  transactions,
+  users,
+} from "@/lib/db/schema";
+import { ingestArqEmail } from "./email-arq";
+
+const MARKER = "__email_arq_test";
+
+let USER_A = 0;
+let USER_B = 0;
+let CONN_A = 0;
+let CONN_B = 0;
+let ARQ_ACCOUNT_A = 0;
+let ARQ_ACCOUNT_B = 0;
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM counterparty_aliases WHERE user_id IN (${USER_A}, ${USER_B})`);
+  await db.execute(sql`DELETE FROM counterparties WHERE user_id IN (${USER_A}, ${USER_B})`);
+  await db.execute(sql`DELETE FROM email_receipts WHERE user_id IN (${USER_A}, ${USER_B})`);
+  await db.execute(sql`DELETE FROM transactions WHERE user_id IN (${USER_A}, ${USER_B})`);
+}
+
+beforeAll(async () => {
+  const [a] = await db
+    .insert(users)
+    .values({ email: `${MARKER}-a@test.local`, name: "A" })
+    .returning({ id: users.id });
+  const [b] = await db
+    .insert(users)
+    .values({ email: `${MARKER}-b@test.local`, name: "B" })
+    .returning({ id: users.id });
+  USER_A = a.id;
+  USER_B = b.id;
+
+  // Gmail connections are required by the emailReceipts FK.
+  const [connA] = await db
+    .insert(gmailConnections)
+    .values({
+      userId: USER_A,
+      gmailEmail: `${MARKER}-a@test.local`,
+      accessTokenEnc: "dummy",
+      refreshTokenEnc: "dummy",
+      accessTokenExpiresAt: new Date(Date.now() + 3600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  const [connB] = await db
+    .insert(gmailConnections)
+    .values({
+      userId: USER_B,
+      gmailEmail: `${MARKER}-b@test.local`,
+      accessTokenEnc: "dummy",
+      refreshTokenEnc: "dummy",
+      accessTokenExpiresAt: new Date(Date.now() + 3600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  CONN_A = connA.id;
+  CONN_B = connB.id;
+
+  // ARQ Ahorros account for each user (institution_slug='other', USD, last4s=['7073']).
+  const [acctA] = await db
+    .insert(accounts)
+    .values({
+      userId: USER_A,
+      name: `${MARKER} ARQ Ahorros A`,
+      institution: "ARQ",
+      institutionSlug: "other",
+      type: "savings",
+      currency: "USD",
+      metadata: { last4s: ["7073"] },
+    })
+    .returning({ id: accounts.id });
+  const [acctB] = await db
+    .insert(accounts)
+    .values({
+      userId: USER_B,
+      name: `${MARKER} ARQ Ahorros B`,
+      institution: "ARQ",
+      institutionSlug: "other",
+      type: "savings",
+      currency: "USD",
+      metadata: { last4s: ["7073"] },
+    })
+    .returning({ id: accounts.id });
+  ARQ_ACCOUNT_A = acctA.id;
+  ARQ_ACCOUNT_B = acctB.id;
+});
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM accounts WHERE id IN (${ARQ_ACCOUNT_A}, ${ARQ_ACCOUNT_B})`);
+  await db.execute(sql`DELETE FROM gmail_connections WHERE id IN (${CONN_A}, ${CONN_B})`);
+  await db.execute(sql`DELETE FROM users WHERE id IN (${USER_A}, ${USER_B})`);
+});
+
+// ---------------------------------------------------------------------------
+// HTML fixture builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal ARQ transfer_received HTML (titled template).
+ * Produces: txKind='transfer_received', counterpartyName=name, amountUsdcCents=cents
+ */
+function buildReceivedHtml(name: string, amountUsd: string): string {
+  return `<html>
+    <head><title>You received ${amountUsd} USD from ${name}</title></head>
+    <body>
+      <p>We&apos;ve credited ${amountUsd} USDc to your balance.</p>
+    </body>
+  </html>`;
+}
+
+/**
+ * Minimal ARQ transfer_sent HTML (titled template).
+ * Produces: txKind='transfer_sent', counterpartyName=name, amountUsdcCents=cents
+ */
+function buildSentHtml(name: string, amountUsd: string): string {
+  return `<html>
+    <head><title>You sent ${amountUsd} USD to ${name}</title></head>
+    <body>
+      <p>We&apos;ve debited ${amountUsd} USDc from your balance.</p>
+    </body>
+  </html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Receipt seed helper
+// ---------------------------------------------------------------------------
+
+async function seedReceipt(
+  userId: number,
+  connId: number,
+  msgId: string,
+  rawHtml: string,
+): Promise<number> {
+  const [row] = await db
+    .insert(emailReceipts)
+    .values({
+      userId,
+      gmailConnectionId: connId,
+      gmailMsgId: msgId,
+      gateway: "arq",
+      rawHtml,
+    })
+    .returning({ id: emailReceipts.id });
+  return row.id;
+}
+
+const NOW = new Date("2026-04-01T10:00:00Z");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ingestArqEmail — counterparty linking", () => {
+  it("happy path — new ingest links counterparty", async () => {
+    const html = buildReceivedHtml("CODEBRANCH LLC", "2,180");
+    const receiptId = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-1`, html);
+
+    const result = await ingestArqEmail(USER_A, receiptId, html, NOW);
+
+    expect(result.status).toBe("inserted");
+
+    // Transaction must have counterparty_id set.
+    const [tx] = await db
+      .select({ counterpartyId: transactions.counterpartyId })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_A));
+    expect(tx.counterpartyId).not.toBeNull();
+
+    // One counterparty row created with the correct display name.
+    const [cp] = await db
+      .select({ displayName: counterparties.displayName })
+      .from(counterparties)
+      .where(eq(counterparties.userId, USER_A));
+    expect(cp.displayName).toBe("CODEBRANCH LLC");
+
+    // One alias row with normalized name value.
+    const [alias] = await db
+      .select({ kind: counterpartyAliases.kind, value: counterpartyAliases.value })
+      .from(counterpartyAliases)
+      .where(eq(counterpartyAliases.userId, USER_A));
+    expect(alias.kind).toBe("name");
+    expect(alias.value).toBe("CODEBRANCH LLC");
+  });
+
+  it("idempotency — same receipt twice returns duplicated, no new counterparty rows", async () => {
+    const html = buildReceivedHtml("CODEBRANCH LLC", "2,180");
+    const receiptId = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-2`, html);
+
+    await ingestArqEmail(USER_A, receiptId, html, NOW);
+    const result2 = await ingestArqEmail(USER_A, receiptId, html, NOW);
+
+    expect(result2.status).toBe("duplicated");
+
+    // Still exactly one counterparty and one alias.
+    const cpRows = await db
+      .select({ id: counterparties.id })
+      .from(counterparties)
+      .where(eq(counterparties.userId, USER_A));
+    expect(cpRows).toHaveLength(1);
+
+    const aliasRows = await db
+      .select({ id: counterpartyAliases.id })
+      .from(counterpartyAliases)
+      .where(eq(counterpartyAliases.userId, USER_A));
+    expect(aliasRows).toHaveLength(1);
+  });
+
+  it("alias matching — different casing maps to the same counterparty", async () => {
+    const html1 = buildReceivedHtml("CODEBRANCH LLC", "2,180");
+    const html2 = buildReceivedHtml("Codebranch Llc", "500");
+
+    const receipt1 = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-3a`, html1);
+    const receipt2 = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-3b`, html2);
+
+    const r1 = await ingestArqEmail(USER_A, receipt1, html1, NOW);
+    const r2 = await ingestArqEmail(USER_A, receipt2, html2, NOW);
+
+    expect(r1.status).toBe("inserted");
+    expect(r2.status).toBe("inserted");
+
+    // Both transactions share the same counterparty_id.
+    const txRows = await db
+      .select({ counterpartyId: transactions.counterpartyId })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_A));
+    expect(txRows).toHaveLength(2);
+    expect(txRows[0].counterpartyId).not.toBeNull();
+    expect(txRows[0].counterpartyId).toBe(txRows[1].counterpartyId);
+
+    // Only one counterparty row and one alias row.
+    const cpRows = await db
+      .select({ id: counterparties.id })
+      .from(counterparties)
+      .where(eq(counterparties.userId, USER_A));
+    expect(cpRows).toHaveLength(1);
+
+    const aliasRows = await db
+      .select({ id: counterpartyAliases.id })
+      .from(counterpartyAliases)
+      .where(eq(counterpartyAliases.userId, USER_A));
+    expect(aliasRows).toHaveLength(1);
+  });
+
+  it("both directions — transfer_received and transfer_sent create distinct counterparties", async () => {
+    const htmlReceived = buildReceivedHtml("CODEBRANCH LLC", "2,180");
+    const htmlSent = buildSentHtml("GUSTAVO PEREZ", "100");
+
+    const receipt1 = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-4a`, htmlReceived);
+    const receipt2 = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-4b`, htmlSent);
+
+    const r1 = await ingestArqEmail(USER_A, receipt1, htmlReceived, NOW);
+    const r2 = await ingestArqEmail(USER_A, receipt2, htmlSent, new Date(NOW.getTime() + 1000));
+
+    expect(r1.status).toBe("inserted");
+    expect(r2.status).toBe("inserted");
+
+    // Two distinct counterparties.
+    const cpRows = await db
+      .select({ displayName: counterparties.displayName })
+      .from(counterparties)
+      .where(eq(counterparties.userId, USER_A));
+    expect(cpRows).toHaveLength(2);
+    const names = cpRows.map((c) => c.displayName).sort();
+    expect(names).toEqual(["CODEBRANCH LLC", "GUSTAVO PEREZ"]);
+
+    // Both transactions have counterparty_id set and they differ.
+    const txRows = await db
+      .select({ counterpartyId: transactions.counterpartyId })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_A));
+    expect(txRows).toHaveLength(2);
+    const ids = txRows.map((t) => t.counterpartyId);
+    expect(ids[0]).not.toBeNull();
+    expect(ids[1]).not.toBeNull();
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  it("tenant safety — counterparties are scoped per user", async () => {
+    const htmlA = buildReceivedHtml("CODEBRANCH LLC", "2,180");
+    const htmlB = buildReceivedHtml("CODEBRANCH LLC", "500");
+
+    const receiptA = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-5a`, htmlA);
+    const receiptB = await seedReceipt(USER_B, CONN_B, `msg-${MARKER}-5b`, htmlB);
+
+    const rA = await ingestArqEmail(USER_A, receiptA, htmlA, NOW);
+    const rB = await ingestArqEmail(USER_B, receiptB, htmlB, NOW);
+
+    expect(rA.status).toBe("inserted");
+    expect(rB.status).toBe("inserted");
+
+    // Two distinct counterparty rows — one per user.
+    const allCp = await db.execute<{ id: number; user_id: number }>(sql`
+        SELECT id, user_id FROM counterparties
+        WHERE user_id IN (${USER_A}, ${USER_B})
+      `);
+    expect(allCp).toHaveLength(2);
+    const userIds = allCp.map((c) => c.user_id).sort();
+    expect(userIds).toEqual([USER_A, USER_B].sort());
+
+    // Each user's tx points only to their own counterparty.
+    const [txA] = await db
+      .select({ counterpartyId: transactions.counterpartyId, userId: transactions.userId })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_A));
+    const [txB] = await db
+      .select({ counterpartyId: transactions.counterpartyId, userId: transactions.userId })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_B));
+
+    expect(txA.counterpartyId).not.toBeNull();
+    expect(txB.counterpartyId).not.toBeNull();
+    expect(txA.counterpartyId).not.toBe(txB.counterpartyId);
+  });
+});

--- a/src/lib/ingestion/email-arq.ts
+++ b/src/lib/ingestion/email-arq.ts
@@ -7,6 +7,8 @@ import { emit } from "@/lib/events/bus";
 import { autoLinkTransaction } from "@/lib/recurring/auto-link";
 import { parseArqEmail, type ArqParseResult, type ParsedArqTx } from "@/lib/gmail/parsers/arq";
 import { pairIntraUserTransfer } from "@/lib/transfers/intra-user-pair";
+import { resolveCounterpartyByKey } from "@/lib/ingestion/sms-pipeline";
+import { normalizeName } from "@/lib/counterparties/alias-key";
 import type { FxMetadata } from "@/lib/types/fx-metadata";
 
 const log = createLogger({ module: "ingestion/email-arq" });
@@ -233,6 +235,21 @@ export async function ingestArqEmail(
     fx: fxMetadata,
   };
 
+  // --- Counterparty resolution (#637) ---
+  // Both transfer_received and transfer_sent populate counterpartyName.
+  // We always use kind="name" for ARQ — there is no account number or QR key
+  // available in ARQ emails, so the normalized display name is the only stable key.
+  // Do NOT use inheritedCategory here — email-arq has its own category logic.
+  const cpResolution = await resolveCounterpartyByKey(
+    userId,
+    {
+      kind: "name",
+      value: normalizeName(parsed.counterpartyName),
+      initialDisplayName: parsed.counterpartyName,
+    },
+    db,
+  );
+
   // --- Insert ---
   try {
     const result = await db
@@ -249,6 +266,7 @@ export async function ingestArqEmail(
         channel: "transfer",
         externalId,
         rawData,
+        counterpartyId: cpResolution.counterpartyId,
       })
       .onConflictDoNothing({
         target: [transactions.accountId, transactions.externalId],
@@ -297,6 +315,7 @@ export async function ingestArqEmail(
         txKind: parsed.txKind,
         amountUsdcCents: parsed.amountUsdcCents.toString(),
         counterparty: parsed.counterpartyName,
+        counterpartyId: cpResolution.counterpartyId,
         event: "arq_email_inserted",
       },
       "ARQ email ingested as transaction",

--- a/src/lib/ingestion/email-arq.ts
+++ b/src/lib/ingestion/email-arq.ts
@@ -235,23 +235,25 @@ export async function ingestArqEmail(
     fx: fxMetadata,
   };
 
-  // --- Counterparty resolution (#637) ---
-  // Both transfer_received and transfer_sent populate counterpartyName.
-  // We always use kind="name" for ARQ — there is no account number or QR key
-  // available in ARQ emails, so the normalized display name is the only stable key.
-  // Do NOT use inheritedCategory here — email-arq has its own category logic.
-  const cpResolution = await resolveCounterpartyByKey(
-    userId,
-    {
-      kind: "name",
-      value: normalizeName(parsed.counterpartyName),
-      initialDisplayName: parsed.counterpartyName,
-    },
-    db,
-  );
-
   // --- Insert ---
   try {
+    // --- Counterparty resolution (#637) ---
+    // Both transfer_received and transfer_sent populate counterpartyName.
+    // Always kind="name" for ARQ — there is no account number or QR key
+    // available, so the normalized display name is the only stable key.
+    // Do NOT use inheritedCategory — email-arq has its own category logic.
+    // Inside the try so resolver errors return { status: "error" } instead of
+    // throwing through the outcome contract.
+    const cpResolution = await resolveCounterpartyByKey(
+      userId,
+      {
+        kind: "name",
+        value: normalizeName(parsed.counterpartyName),
+        initialDisplayName: parsed.counterpartyName,
+      },
+      db,
+    );
+
     const result = await db
       .insert(transactions)
       .values({

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -21,7 +21,7 @@ import {
   recordParserEvent,
   type AiFallbackOutcome,
 } from "@/lib/ingestion/sms-ai-fallback";
-import { keyForParsed } from "@/lib/counterparties/alias-key";
+import { keyForParsed, type KeyForKind } from "@/lib/counterparties/alias-key";
 import { enqueueClassification } from "@/lib/classification/enqueue";
 import type { ClassificationMethod, TransactionSource } from "@/lib/types";
 
@@ -321,14 +321,20 @@ type CounterpartyResolution = {
   inheritedCategory: string | null;
 };
 
-export async function resolveCounterparty(
+/**
+ * Resolve (or create) a counterparty by its canonical key.
+ *
+ * This is the low-level building block. It performs the alias lookup + insert
+ * inside a transaction and returns the counterparty id and any inherited
+ * category slug. Extracted from resolveCounterparty so that non-SMS pipelines
+ * (e.g. email-arq) can call it directly with their own key — without needing
+ * a ParsedSms shape. (#637)
+ */
+export async function resolveCounterpartyByKey(
   userId: number,
-  parsed: ParsedSms,
+  key: KeyForKind,
   database: DB,
 ): Promise<CounterpartyResolution> {
-  const key = keyForParsed(parsed);
-  if (!key) return { counterpartyId: null, inheritedCategory: null };
-
   return database.transaction(async (trx) => {
     const existing = await trx.execute<{
       id: number;
@@ -366,6 +372,16 @@ export async function resolveCounterparty(
     `);
     return { counterpartyId: inserted[0].id, inheritedCategory: null };
   });
+}
+
+export async function resolveCounterparty(
+  userId: number,
+  parsed: ParsedSms,
+  database: DB,
+): Promise<CounterpartyResolution> {
+  const key = keyForParsed(parsed);
+  if (!key) return { counterpartyId: null, inheritedCategory: null };
+  return resolveCounterpartyByKey(userId, key, database);
 }
 
 function resolveAccountForParsed(


### PR DESCRIPTION
Closes #637

## Summary

- Extracts `resolveCounterpartyByKey` as a standalone reusable helper (now importable by other pipelines beyond email-arq)
- Wires counterparty resolution into the email-arq insert flow: every new email-arq transaction is linked to a counterparty row on insert, with upsert semantics
- Adds a `scripts/backfill-email-arq-counterparties.ts` script to retroactively link existing orphan rows; supports `--dry-run` and `--user-id` flags

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (158 files, 1971 specs)
- [x] 5/5 email-arq-specific specs pass (resolver, insert wire-up, idempotency, mixed-case normalization)
- [ ] manual smoke: run backfill with `--dry-run` on prod after deploy (see post-merge action below)

## Post-merge action

After merge + deploy, run the backfill on prod to link existing orphan rows:

```bash
# On prod (147.182.138.79, deployed dir):
sudo -u findash bun run backfill:email-arq-counterparties --user-id=1 --dry-run
# Verify dry-run output, then:
sudo -u findash bun run backfill:email-arq-counterparties --user-id=1
```