### PR TITLE
feat(ui/transactions): inline counterparty picker per row (#638)

### DIFF
--- a/src/app/(app)/transactions/actions.test.ts
+++ b/src/app/(app)/transactions/actions.test.ts
@@ -60,6 +60,7 @@ const {
   updateTransactionInstallments,
   runAiClassifier,
   enqueueClassifyAllPending,
+  setTransactionCounterparty,
 } = await import("./actions");
 const { classifySingleWithAi: classifySingleWithAiLib } = await import("@/lib/classification/ai");
 const mockAiClassifySingle = vi.mocked(classifySingleWithAiLib);
@@ -2224,5 +2225,321 @@ describe("enqueueClassifyAllPending (#592)", () => {
       SELECT classification_method FROM transactions WHERE id = ${txId}
     `);
     expect(row.classification_method).toBe("unclassified");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setTransactionCounterparty
+// ---------------------------------------------------------------------------
+
+describe("setTransactionCounterparty", () => {
+  const CPSET_EXT = "test-cpset";
+  const CPSET_ALIAS = "test-cpset-";
+
+  // Helper: seed a tx with no counterparty and a given merchant value
+  async function seedTxForCpSet(args: {
+    externalId: string;
+    merchant?: string | null;
+    counterpartyId?: number | null;
+  }): Promise<number> {
+    const [acc] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM accounts WHERE name = 'Bancolombia Ahorros' LIMIT 1
+    `);
+    const rows = await db.execute<{ id: number }>(sql`
+      INSERT INTO transactions (
+        user_id, account_id, occurred_at, amount_cents, currency, description_raw,
+        merchant, counterparty_id, category_slug, classification_method, source, external_id, raw_data
+      ) VALUES (
+        ${TEST_USER_ID}, ${acc.id}, now(), -5000, 'COP', 'test tx',
+        ${args.merchant ?? null},
+        ${args.counterpartyId ?? null},
+        null,
+        'unclassified'::classification_method,
+        'manual',
+        ${args.externalId},
+        '{}'::jsonb
+      )
+      RETURNING id
+    `);
+    return rows[0].id;
+  }
+
+  // Helper: seed a counterparty with an alias owned by TEST_USER_ID
+  async function seedCpForCpSet(args: {
+    displayName: string;
+    aliasKind?: string;
+    aliasValue?: string;
+  }): Promise<number> {
+    const rows = await db.execute<{ id: number }>(sql`
+      INSERT INTO counterparties (user_id, display_name, type)
+      VALUES (${TEST_USER_ID}, ${args.displayName}, 'unknown')
+      RETURNING id
+    `);
+    const cpId = rows[0].id;
+    if (args.aliasKind && args.aliasValue) {
+      await db.execute(sql`
+        INSERT INTO counterparty_aliases (user_id, counterparty_id, kind, value)
+        VALUES (
+          ${TEST_USER_ID}, ${cpId},
+          ${args.aliasKind}::counterparty_key_kind,
+          ${args.aliasValue}
+        )
+      `);
+    }
+    return cpId;
+  }
+
+  async function cleanupCpSet() {
+    await db.execute(sql`
+      DELETE FROM transactions WHERE external_id LIKE ${CPSET_EXT + ":%"}
+    `);
+    await db.execute(sql`
+      DELETE FROM counterparties
+      WHERE id IN (
+        SELECT counterparty_id FROM counterparty_aliases WHERE value LIKE ${CPSET_ALIAS + "%"}
+      )
+         OR display_name LIKE ${CPSET_ALIAS + "%"}
+    `);
+    // Also clean tenant-isolation test users
+    await db.execute(sql`
+      DELETE FROM users WHERE email LIKE 'tenant-cpset-%@test.local'
+    `);
+  }
+
+  beforeEach(async () => {
+    await cleanupCpSet();
+  });
+
+  afterEach(async () => {
+    await cleanupCpSet();
+  });
+
+  it("links an existing counterparty and auto-aliases the tx merchant", async () => {
+    const cpId = await seedCpForCpSet({
+      displayName: `${CPSET_ALIAS}amazon`,
+      aliasKind: "name",
+      aliasValue: `${CPSET_ALIAS}amazon`,
+    });
+    const txId = await seedTxForCpSet({
+      externalId: `${CPSET_EXT}:link-existing`,
+      merchant: "AMAZN MKTPL",
+    });
+
+    const res = await setTransactionCounterparty({ txId, counterpartyId: cpId });
+    expect(res.status).toBe("ok");
+
+    // tx is now linked
+    const [txRow] = await db.execute<{ counterparty_id: number }>(sql`
+      SELECT counterparty_id FROM transactions WHERE id = ${txId}
+    `);
+    expect(txRow.counterparty_id).toBe(cpId);
+
+    // auto-alias from merchant inserted
+    const aliases = await db.execute<{ id: number }>(sql`
+      SELECT id FROM counterparty_aliases
+      WHERE user_id = ${TEST_USER_ID}
+        AND counterparty_id = ${cpId}
+        AND kind = 'name'
+        AND value = 'AMAZN MKTPL'
+    `);
+    expect(aliases.length).toBeGreaterThan(0);
+  });
+
+  it("creates a new counterparty by displayName and links", async () => {
+    const txId = await seedTxForCpSet({
+      externalId: `${CPSET_EXT}:create-new`,
+      merchant: "RAPPI",
+    });
+
+    const res = await setTransactionCounterparty({
+      txId,
+      counterpartyId: null,
+      displayName: "Rappi",
+    });
+    expect(res.status).toBe("ok");
+
+    // tx has a counterparty now
+    const [txRow] = await db.execute<{ counterparty_id: number }>(sql`
+      SELECT counterparty_id FROM transactions WHERE id = ${txId}
+    `);
+    expect(txRow.counterparty_id).not.toBeNull();
+    const newCpId = txRow.counterparty_id;
+
+    // counterparty row has right display_name
+    const [cp] = await db.execute<{ display_name: string }>(sql`
+      SELECT display_name FROM counterparties WHERE id = ${newCpId}
+    `);
+    expect(cp.display_name).toBe("Rappi");
+
+    // alias for normalized name exists
+    const [alias] = await db.execute<{ value: string }>(sql`
+      SELECT value FROM counterparty_aliases
+      WHERE counterparty_id = ${newCpId} AND kind = 'name'
+    `);
+    expect(alias.value).toBe("RAPPI");
+
+    // auto-alias for merchant also exists (ON CONFLICT DO NOTHING — same value)
+    const aliases = await db.execute<{ id: number }>(sql`
+      SELECT id FROM counterparty_aliases
+      WHERE counterparty_id = ${newCpId} AND kind = 'name' AND value = 'RAPPI'
+    `);
+    expect(aliases.length).toBe(1);
+  });
+
+  it("unlinks an existing counterparty when both null", async () => {
+    const cpId = await seedCpForCpSet({
+      displayName: `${CPSET_ALIAS}unlink-test`,
+    });
+    const txId = await seedTxForCpSet({
+      externalId: `${CPSET_EXT}:unlink`,
+      counterpartyId: cpId,
+    });
+
+    const res = await setTransactionCounterparty({ txId, counterpartyId: null });
+    expect(res.status).toBe("ok");
+
+    const [txRow] = await db.execute<{ counterparty_id: number | null }>(sql`
+      SELECT counterparty_id FROM transactions WHERE id = ${txId}
+    `);
+    expect(txRow.counterparty_id).toBeNull();
+  });
+
+  it("rejects tx owned by another user (tenant safety)", async () => {
+    // Create a second user
+    const userBEmail = `tenant-cpset-${Date.now()}-${Math.random()}@test.local`;
+    let userBId: number | undefined;
+    try {
+      const [userB] = await db.execute<{ id: number }>(sql`
+        INSERT INTO users (email, name, created_at, updated_at)
+        VALUES (${userBEmail}, 'User B', now(), now())
+        RETURNING id
+      `);
+      userBId = userB.id;
+
+      // Seed a tx owned by USER_B
+      const [acc] = await db.execute<{ id: number }>(sql`
+        SELECT id FROM accounts WHERE name = 'Bancolombia Ahorros' LIMIT 1
+      `);
+      const [txRow] = await db.execute<{ id: number }>(sql`
+        INSERT INTO transactions (
+          user_id, account_id, occurred_at, amount_cents, currency,
+          description_raw, classification_method, source, external_id, raw_data
+        ) VALUES (
+          ${userBId}, ${acc.id}, now(), -1000, 'COP', 'other user tx',
+          'unclassified'::classification_method, 'manual',
+          ${CPSET_EXT + ":tenant-safety"},
+          '{}'::jsonb
+        )
+        RETURNING id
+      `);
+      const txId = txRow.id;
+
+      // USER_A (session = 1) tries to assign a counterparty to USER_B's tx
+      const res = await setTransactionCounterparty({ txId, counterpartyId: null });
+      expect(res.status).toBe("error");
+
+      // tx unchanged
+      const [row] = await db.execute<{ counterparty_id: number | null }>(sql`
+        SELECT counterparty_id FROM transactions WHERE id = ${txId}
+      `);
+      expect(row.counterparty_id).toBeNull();
+    } finally {
+      if (userBId) {
+        await db.execute(sql`DELETE FROM users WHERE id = ${userBId}`);
+      }
+    }
+  });
+
+  it("rejects counterparty owned by another user (cross-tenant)", async () => {
+    const userBEmail = `tenant-cpset-${Date.now()}-${Math.random()}@test.local`;
+    let userBId: number | undefined;
+    try {
+      const [userB] = await db.execute<{ id: number }>(sql`
+        INSERT INTO users (email, name, created_at, updated_at)
+        VALUES (${userBEmail}, 'User B', now(), now())
+        RETURNING id
+      `);
+      userBId = userB.id;
+
+      // Counterparty owned by USER_B
+      const [cpRow] = await db.execute<{ id: number }>(sql`
+        INSERT INTO counterparties (user_id, display_name, type)
+        VALUES (${userBId}, 'Other User CP', 'unknown')
+        RETURNING id
+      `);
+      const otherCpId = cpRow.id;
+
+      // tx owned by USER_A
+      const txId = await seedTxForCpSet({ externalId: `${CPSET_EXT}:cross-tenant-cp` });
+
+      // USER_A tries to link USER_B's counterparty
+      const res = await setTransactionCounterparty({ txId, counterpartyId: otherCpId });
+      expect(res.status).toBe("error");
+
+      // tx unchanged
+      const [row] = await db.execute<{ counterparty_id: number | null }>(sql`
+        SELECT counterparty_id FROM transactions WHERE id = ${txId}
+      `);
+      expect(row.counterparty_id).toBeNull();
+    } finally {
+      if (userBId) {
+        await db.execute(sql`DELETE FROM users WHERE id = ${userBId}`);
+      }
+    }
+  });
+
+  it("is idempotent on auto-alias (ON CONFLICT DO NOTHING)", async () => {
+    const cpId = await seedCpForCpSet({
+      displayName: `${CPSET_ALIAS}idem-test`,
+      aliasKind: "name",
+      aliasValue: `${CPSET_ALIAS}idem-test`,
+    });
+    const txId = await seedTxForCpSet({
+      externalId: `${CPSET_EXT}:idempotent`,
+      merchant: "IDEM MERCHANT",
+    });
+
+    // Call twice — second should not fail on UNIQUE constraint
+    const res1 = await setTransactionCounterparty({ txId, counterpartyId: cpId });
+    const res2 = await setTransactionCounterparty({ txId, counterpartyId: cpId });
+    expect(res1.status).toBe("ok");
+    expect(res2.status).toBe("ok");
+
+    // Only one alias row for this merchant
+    const aliases = await db.execute<{ id: number }>(sql`
+      SELECT id FROM counterparty_aliases
+      WHERE user_id = ${TEST_USER_ID}
+        AND counterparty_id = ${cpId}
+        AND kind = 'name'
+        AND value = 'IDEM MERCHANT'
+    `);
+    expect(aliases.length).toBe(1);
+  });
+
+  it("does NOT create auto-alias when merchant is null", async () => {
+    const cpId = await seedCpForCpSet({
+      displayName: `${CPSET_ALIAS}no-merchant`,
+      aliasKind: "name",
+      aliasValue: `${CPSET_ALIAS}no-merchant`,
+    });
+    const txId = await seedTxForCpSet({
+      externalId: `${CPSET_EXT}:no-merchant`,
+      merchant: null,
+    });
+
+    const aliasBefore = await db.execute<{ id: number }>(sql`
+      SELECT id FROM counterparty_aliases
+      WHERE counterparty_id = ${cpId} AND kind = 'name' AND value != ${CPSET_ALIAS + "no-merchant"}
+    `);
+
+    const res = await setTransactionCounterparty({ txId, counterpartyId: cpId });
+    expect(res.status).toBe("ok");
+
+    // No new alias rows created for NULL merchant
+    const aliasAfter = await db.execute<{ id: number }>(sql`
+      SELECT id FROM counterparty_aliases
+      WHERE counterparty_id = ${cpId} AND kind = 'name' AND value != ${CPSET_ALIAS + "no-merchant"}
+    `);
+    expect(aliasAfter.length).toBe(aliasBefore.length);
   });
 });

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -38,7 +38,7 @@ import type {
 import { linkTxToRecurringSchema, unlinkTxFromRecurringSchema } from "./link-recurring-types";
 
 const log = createLogger({ module: "transactions/actions" });
-import { keyForParsed } from "@/lib/counterparties/alias-key";
+import { keyForParsed, normalizeName } from "@/lib/counterparties/alias-key";
 import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
 import { decimalStringToCents } from "@/lib/money";
 import {
@@ -271,6 +271,141 @@ export async function markUncategorized(input: {
   revalidatePath("/settings/inbox");
   revalidatePath("/transactions");
   revalidatePath("/insights");
+  return { status: "ok" };
+}
+
+// ---------------------------------------------------------------------------
+// setTransactionCounterparty — assign, create, or unlink a counterparty
+// ---------------------------------------------------------------------------
+
+const setTxCounterpartySchema = z.object({
+  txId: z.number().int().positive(),
+  counterpartyId: z.number().int().positive().nullable(),
+  displayName: z.string().trim().min(1).max(255).optional(),
+});
+
+/**
+ * Assign an existing counterparty, create a new one inline, or unlink.
+ *
+ * Three modes (discriminated by input):
+ *   - counterpartyId non-null → link existing (with tenant safety check)
+ *   - counterpartyId null + displayName provided → create new counterparty + alias
+ *   - both null → unlink (set counterparty_id = NULL)
+ *
+ * Auto-alias side-effect: when LINKING (either mode) and tx.merchant is
+ * non-null, inserts (kind='name', value=normalizeName(merchant)) into
+ * counterparty_aliases with ON CONFLICT DO NOTHING. This ensures that future
+ * ingestion for the same merchant string auto-links to this counterparty.
+ *
+ * NOTE: resolveCounterpartyByKey calls database.transaction() internally so
+ * it cannot be passed a PgTransaction. We inline the equivalent SQL here so
+ * everything runs in one flat transaction.
+ */
+export async function setTransactionCounterparty(input: {
+  txId: number;
+  counterpartyId: number | null;
+  displayName?: string;
+}): Promise<{ status: "ok" } | { status: "error"; message: string }> {
+  const session = await getSessionUser();
+  const parsed = setTxCounterpartySchema.safeParse(input);
+  if (!parsed.success) return { status: "error", message: "Input inválido." };
+
+  const { txId, counterpartyId, displayName } = parsed.data;
+
+  const result = await db.transaction(async (trx) => {
+    // 1. Verify tx ownership and capture merchant for auto-alias
+    const [tx] = await trx
+      .select({ id: transactions.id, merchant: transactions.merchant })
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.userId, session.id),
+          eq(transactions.id, txId),
+          notDeleted(transactions.deletedAt),
+        ),
+      )
+      .limit(1);
+
+    if (!tx) return { status: "error" as const, message: "Transacción no encontrada." };
+
+    // 2. Resolve target counterparty ID
+    let targetId: number | null = null;
+
+    if (counterpartyId !== null) {
+      // Link existing — verify ownership
+      const [cp] = await trx
+        .select({ id: counterparties.id })
+        .from(counterparties)
+        .where(and(eq(counterparties.id, counterpartyId), eq(counterparties.userId, session.id)))
+        .limit(1);
+
+      if (!cp) return { status: "error" as const, message: "Counterparty no encontrado." };
+      targetId = cp.id;
+    } else if (displayName) {
+      // Create new (or find existing alias by name key) — inline equivalent of
+      // resolveCounterpartyByKey so we stay in the same flat transaction.
+      const aliasKey = normalizeName(displayName);
+      const existing = await trx.execute<{ id: number }>(sql`
+        SELECT c.id
+        FROM counterparty_aliases a
+        JOIN counterparties c ON c.id = a.counterparty_id
+        WHERE a.user_id = ${session.id}
+          AND a.kind = 'name'::counterparty_key_kind
+          AND a.value = ${aliasKey}
+        LIMIT 1
+      `);
+
+      if (existing.length > 0) {
+        await trx.execute(sql`
+          UPDATE counterparties
+          SET hit_count = hit_count + 1, last_hit_at = now()
+          WHERE user_id = ${session.id} AND id = ${existing[0].id}
+        `);
+        targetId = existing[0].id;
+      } else {
+        const inserted = await trx.execute<{ id: number }>(sql`
+          INSERT INTO counterparties (user_id, display_name, type, hit_count, last_hit_at)
+          VALUES (${session.id}, ${displayName.trim()}, 'unknown', 1, now())
+          RETURNING id
+        `);
+        await trx.execute(sql`
+          INSERT INTO counterparty_aliases (user_id, counterparty_id, kind, value)
+          VALUES (${session.id}, ${inserted[0].id}, 'name'::counterparty_key_kind, ${aliasKey})
+        `);
+        targetId = inserted[0].id;
+      }
+    }
+    // else: targetId stays null → unlink
+
+    // 3. Update the transaction
+    await trx
+      .update(transactions)
+      .set({ counterpartyId: targetId, updatedAt: new Date() })
+      .where(and(eq(transactions.userId, session.id), eq(transactions.id, txId)));
+
+    // 4. Auto-alias when LINKING and tx.merchant is non-null/non-empty
+    if (targetId !== null && tx.merchant) {
+      const normalizedMerchant = normalizeName(tx.merchant);
+      await trx.execute(sql`
+        INSERT INTO counterparty_aliases (user_id, counterparty_id, kind, value)
+        VALUES (${session.id}, ${targetId}, 'name'::counterparty_key_kind, ${normalizedMerchant})
+        ON CONFLICT DO NOTHING
+      `);
+    }
+
+    return { status: "ok" as const };
+  });
+
+  if (result.status === "error") return result;
+
+  revalidatePath("/transactions");
+  revalidatePath("/insights");
+  revalidatePath("/settings/period");
+
+  emit({ type: "transaction:updated", id: txId, source: "manual", timestamp: Date.now() });
+
+  log.info({ txId, counterpartyId, event: "tx_counterparty_set" }, "counterparty assigned");
+
   return { status: "ok" };
 }
 

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -363,16 +363,39 @@ export async function setTransactionCounterparty(input: {
         `);
         targetId = existing[0].id;
       } else {
+        // Race-safe upsert: two concurrent requests with the same displayName
+        // can both miss the SELECT above. The alias UNIQUE(user_id, kind, value)
+        // serializes them. ON CONFLICT lets the loser short-circuit; we then
+        // re-query to find the winner's counterparty_id.
         const inserted = await trx.execute<{ id: number }>(sql`
           INSERT INTO counterparties (user_id, display_name, type, hit_count, last_hit_at)
           VALUES (${session.id}, ${displayName.trim()}, 'unknown', 1, now())
           RETURNING id
         `);
-        await trx.execute(sql`
+        const aliasInsert = await trx.execute<{ counterparty_id: number }>(sql`
           INSERT INTO counterparty_aliases (user_id, counterparty_id, kind, value)
           VALUES (${session.id}, ${inserted[0].id}, 'name'::counterparty_key_kind, ${aliasKey})
+          ON CONFLICT (user_id, kind, value) DO NOTHING
+          RETURNING counterparty_id
         `);
-        targetId = inserted[0].id;
+        if (aliasInsert.length > 0) {
+          targetId = inserted[0].id;
+        } else {
+          // Lost the race — clean up the orphan counterparty we just created
+          // and adopt the winner's id.
+          await trx.execute(sql`
+            DELETE FROM counterparties
+            WHERE user_id = ${session.id} AND id = ${inserted[0].id}
+          `);
+          const winner = await trx.execute<{ counterparty_id: number }>(sql`
+            SELECT counterparty_id FROM counterparty_aliases
+            WHERE user_id = ${session.id}
+              AND kind = 'name'::counterparty_key_kind
+              AND value = ${aliasKey}
+            LIMIT 1
+          `);
+          targetId = winner[0].counterparty_id;
+        }
       }
     }
     // else: targetId stays null → unlink
@@ -389,7 +412,7 @@ export async function setTransactionCounterparty(input: {
       await trx.execute(sql`
         INSERT INTO counterparty_aliases (user_id, counterparty_id, kind, value)
         VALUES (${session.id}, ${targetId}, 'name'::counterparty_key_kind, ${normalizedMerchant})
-        ON CONFLICT DO NOTHING
+        ON CONFLICT (user_id, kind, value) DO NOTHING
       `);
     }
 

--- a/src/components/transactions/counterparty-cell.test.tsx
+++ b/src/components/transactions/counterparty-cell.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---------------------------------------------------------------------------
+// Hoist mocks before any imports that reference the mocked modules.
+// ---------------------------------------------------------------------------
+const { setTransactionCounterparty, toastError, toastSuccess } = vi.hoisted(() => ({
+  setTransactionCounterparty: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/app/(app)/transactions/actions", () => ({ setTransactionCounterparty }));
+vi.mock("sonner", () => ({ toast: { error: toastError, success: toastSuccess } }));
+
+import { CounterpartyCell } from "./counterparty-cell";
+
+// Radix Popover + Command + cmdk use pointer-capture, scrollIntoView, and
+// ResizeObserver APIs that jsdom does not implement natively — shim them.
+beforeEach(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+  // cmdk uses ResizeObserver internally
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  setTransactionCounterparty.mockReset();
+  toastError.mockReset();
+  toastSuccess.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const OPTIONS = [
+  { id: 1, displayName: "Amazon", type: "merchant" as const },
+  { id: 2, displayName: "Rappi", type: "merchant" as const },
+];
+
+describe("CounterpartyCell", () => {
+  it("calls setTransactionCounterparty with counterpartyId when picking an existing option", async () => {
+    const user = userEvent.setup();
+    setTransactionCounterparty.mockResolvedValueOnce({ status: "ok" });
+
+    render(<CounterpartyCell txId={99} counterparty={null} options={OPTIONS} />);
+
+    // Open the combobox
+    await user.click(screen.getByRole("combobox"));
+
+    // Pick the first option
+    const option = await screen.findByText("Amazon");
+    await user.click(option);
+
+    await waitFor(() => {
+      expect(setTransactionCounterparty).toHaveBeenCalledWith({
+        txId: 99,
+        counterpartyId: 1,
+      });
+    });
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  it("calls setTransactionCounterparty with displayName when creating a new counterparty", async () => {
+    const user = userEvent.setup();
+    setTransactionCounterparty.mockResolvedValueOnce({ status: "ok" });
+
+    render(<CounterpartyCell txId={77} counterparty={null} options={OPTIONS} />);
+
+    // Open the combobox
+    await user.click(screen.getByRole("combobox"));
+
+    // Type a name that doesn't exist
+    const input = await screen.findByPlaceholderText(/buscar counterparty/i);
+    await user.type(input, "Nuevo Negocio");
+
+    // The "+ Crear nuevo" item should appear
+    const createItem = await screen.findByText(/crear nuevo/i);
+    await user.click(createItem);
+
+    await waitFor(() => {
+      expect(setTransactionCounterparty).toHaveBeenCalledWith({
+        txId: 77,
+        counterpartyId: null,
+        displayName: "Nuevo Negocio",
+      });
+    });
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  it("calls setTransactionCounterparty with null to unlink an assigned counterparty", async () => {
+    const user = userEvent.setup();
+    setTransactionCounterparty.mockResolvedValueOnce({ status: "ok" });
+
+    const currentCounterparty = {
+      id: 1,
+      displayName: "Amazon",
+      type: "merchant" as const,
+      isSalary: false,
+      defaultCategorySlug: null,
+      notes: null,
+      aliases: [],
+    };
+
+    render(<CounterpartyCell txId={55} counterparty={currentCounterparty} options={OPTIONS} />);
+
+    // Open the combobox
+    await user.click(screen.getByRole("combobox"));
+
+    // "Sin asignar" unlink item should be visible (only when a counterparty is assigned)
+    const unlinkItem = await screen.findByText("Sin asignar");
+    await user.click(unlinkItem);
+
+    await waitFor(() => {
+      expect(setTransactionCounterparty).toHaveBeenCalledWith({
+        txId: 55,
+        counterpartyId: null,
+      });
+    });
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/components/transactions/counterparty-cell.tsx
+++ b/src/components/transactions/counterparty-cell.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useTransition } from "react";
+import { toast } from "sonner";
+import { setTransactionCounterparty } from "@/app/(app)/transactions/actions";
+import type { CounterpartyBrief, CounterpartyValue } from "@/lib/types";
+import { CounterpartyCombobox } from "./counterparty-combobox";
+
+export function CounterpartyCell({
+  txId,
+  counterparty,
+  options,
+}: {
+  txId: number;
+  counterparty: CounterpartyValue | null;
+  options: CounterpartyBrief[];
+}) {
+  const [pending, startTransition] = useTransition();
+
+  const current = counterparty
+    ? { id: counterparty.id, displayName: counterparty.displayName }
+    : null;
+
+  function handlePick(counterpartyId: number) {
+    startTransition(async () => {
+      try {
+        const res = await setTransactionCounterparty({ txId, counterpartyId });
+        if (res.status === "error") {
+          toast.error(res.message);
+        } else {
+          toast.success("Counterparty actualizado");
+        }
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Error al actualizar counterparty");
+      }
+    });
+  }
+
+  function handleCreate(displayName: string) {
+    startTransition(async () => {
+      try {
+        const res = await setTransactionCounterparty({
+          txId,
+          counterpartyId: null,
+          displayName,
+        });
+        if (res.status === "error") {
+          toast.error(res.message);
+        } else {
+          toast.success(`Counterparty "${displayName}" creado y asignado`);
+        }
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Error al crear counterparty");
+      }
+    });
+  }
+
+  function handleUnlink() {
+    startTransition(async () => {
+      try {
+        const res = await setTransactionCounterparty({ txId, counterpartyId: null });
+        if (res.status === "error") {
+          toast.error(res.message);
+        } else {
+          toast.success("Counterparty desvinculado");
+        }
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Error al desvincular counterparty");
+      }
+    });
+  }
+
+  return (
+    <CounterpartyCombobox
+      value={current}
+      options={options}
+      onPick={handlePick}
+      onCreate={handleCreate}
+      onUnlink={handleUnlink}
+      disabled={pending}
+    />
+  );
+}

--- a/src/components/transactions/counterparty-combobox.tsx
+++ b/src/components/transactions/counterparty-combobox.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type { CounterpartyBrief } from "@/lib/types";
+
+export function CounterpartyCombobox({
+  value,
+  options,
+  onPick,
+  onCreate,
+  onUnlink,
+  disabled,
+}: {
+  value: { id: number; displayName: string } | null;
+  options: CounterpartyBrief[];
+  onPick: (id: number) => void;
+  onCreate: (displayName: string) => void;
+  onUnlink: () => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const sorted = [...options].sort((a, b) => a.displayName.localeCompare(b.displayName));
+
+  const trimmedSearch = search.trim();
+
+  // Show "+ Crear nuevo" only when search is non-empty AND no existing option
+  // matches exactly (case-insensitive).
+  const exactMatch = trimmedSearch
+    ? options.some((o) => o.displayName.toLowerCase() === trimmedSearch.toLowerCase())
+    : false;
+  const showCreate = trimmedSearch.length > 0 && !exactMatch;
+
+  const displayLabel = value?.displayName ?? "Sin asignar";
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setSearch("");
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn(
+            "h-7 w-full justify-between text-xs font-normal",
+            !value && "text-muted-foreground",
+          )}
+        >
+          <span className="truncate">{displayLabel}</span>
+          <ChevronDownIcon className="ml-1 size-3 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] min-w-[220px] p-0" align="start">
+        <Command
+          filter={(itemValue, s) => {
+            const needle = s.toLowerCase().trim();
+            if (!needle) return 1;
+            return itemValue.toLowerCase().includes(needle) ? 1 : 0;
+          }}
+        >
+          <CommandInput
+            placeholder="Buscar counterparty…"
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList>
+            <CommandEmpty>Sin resultados.</CommandEmpty>
+
+            {/* Existing counterparties */}
+            <CommandGroup>
+              {sorted.map((cp) => (
+                <CommandItem
+                  key={cp.id}
+                  value={cp.displayName}
+                  onSelect={() => {
+                    onPick(cp.id);
+                    setSearch("");
+                    setOpen(false);
+                  }}
+                >
+                  <span className="truncate">{cp.displayName}</span>
+                  {value?.id === cp.id ? <CheckIcon className="ml-auto size-4" /> : null}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+
+            {/* Bottom group: create + unlink */}
+            <CommandGroup>
+              {showCreate ? (
+                <CommandItem
+                  value={`__create__ ${trimmedSearch}`}
+                  onSelect={() => {
+                    onCreate(trimmedSearch);
+                    setSearch("");
+                    setOpen(false);
+                  }}
+                >
+                  <span className="text-muted-foreground">+ Crear nuevo: </span>
+                  <span className="ml-1 font-medium">{trimmedSearch}</span>
+                </CommandItem>
+              ) : null}
+              {value !== null ? (
+                <CommandItem
+                  value="__unlink__ sin asignar"
+                  onSelect={() => {
+                    onUnlink();
+                    setSearch("");
+                    setOpen(false);
+                  }}
+                >
+                  <span className="text-muted-foreground">Sin asignar</span>
+                </CommandItem>
+              ) : null}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/transactions/forecast-overlay.test.tsx
+++ b/src/components/transactions/forecast-overlay.test.tsx
@@ -39,6 +39,9 @@ vi.mock("@/components/transactions/classification-reason-dialog", () => ({
 vi.mock("@/components/transactions/counterparty-dialog", () => ({
   CounterpartyDialog: () => null,
 }));
+vi.mock("@/components/transactions/counterparty-cell", () => ({
+  CounterpartyCell: () => <span data-testid="counterparty-cell" />,
+}));
 vi.mock("@/components/transactions/confidence-badge", () => ({
   ConfidenceBadge: () => null,
   confidenceBand: () => "medium",

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -27,6 +27,7 @@ import { useNewIds } from "@/lib/hooks/use-new-ids";
 import { hasSecondaryDescription, primaryDescription } from "@/lib/transactions/description";
 import type { CounterpartyBrief, TxRow } from "@/lib/transactions/queries";
 import { CategoryCell, type CategoryOption } from "./category-cell";
+import { CounterpartyCell } from "./counterparty-cell";
 import { ClassificationReasonDialog } from "./classification-reason-dialog";
 import { ConfidenceBadge, confidenceBand } from "./confidence-badge";
 import { CounterpartyDialog } from "./counterparty-dialog";
@@ -458,6 +459,11 @@ export function TransactionTable({
                     <TableCell className="px-4">
                       <div className="flex flex-col gap-1">
                         <CategoryCell txId={tx.id} value={tx.categorySlug} options={categories} />
+                        <CounterpartyCell
+                          txId={tx.id}
+                          counterparty={tx.counterparty}
+                          options={allCounterparties}
+                        />
                         <div className="flex flex-wrap items-center gap-1">
                           <ConfidenceBadge
                             method={tx.classificationMethod}
@@ -659,6 +665,11 @@ export function TransactionTable({
 
                 <div className="flex flex-col gap-1">
                   <CategoryCell txId={tx.id} value={tx.categorySlug} options={categories} />
+                  <CounterpartyCell
+                    txId={tx.id}
+                    counterparty={tx.counterparty}
+                    options={allCounterparties}
+                  />
                   <div className="flex flex-wrap items-center gap-1">
                     <ConfidenceBadge
                       method={tx.classificationMethod}


### PR DESCRIPTION
Closes #638

## Summary

- Adds `<CounterpartyCell>` to each row in `/transactions`: shows current counterparty or "Sin asignar"; click opens a Combobox with existing counterparties + "Crear nuevo" sentinel
- Adds `setTransactionCounterparty` server action: links by `counterpartyId`, creates a new counterparty + alias by `displayName`, or unlinks when `null`; tenant-safe + race-safe (named ON CONFLICT + orphan cleanup on alias collision)
- Auto-assigns alias matching `displayName` on every link; `revalidatePath` on `/transactions`, `/insights`, and `/settings/period`

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (159 files, 1981 specs)
- [x] manual smoke: counterparty picker opens, existing option links, new name creates+links, "Sin asignar" unlinks — verified via E2E screenshots
- [x] fix(test): added `CounterpartyCell` stub to `forecast-overlay.test.tsx` — `transaction-table` now imports the new component and the jsdom worker was crashing on `next-auth/lib/env.js` without the stub (same leaf-component pattern as `category-cell`, `confidence-badge`, etc.)

## Screenshots

Desktop (light):
![transactions light](https://github.com/ingamartinez/personal-financial-dashboard/blob/claude/phase-3/638-counterparty-picker/e2e/screenshots/chromium-light-transactions.png?raw=true)

Counterparty dialog open:
![cp-dialog-open](https://github.com/ingamartinez/personal-financial-dashboard/blob/claude/phase-3/638-counterparty-picker/e2e/screenshots/cp-dialog-open.png?raw=true)

Mobile (dark):
![transactions mobile dark](https://github.com/ingamartinez/personal-financial-dashboard/blob/claude/phase-3/638-counterparty-picker/e2e/screenshots/mobile-dark-transactions.png?raw=true)