### PR TITLE
fix(ingestion/email-arq): decode &rsquo; entities + mark needs_review as unmatched (#641)

### DIFF
--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -89,6 +89,14 @@ export type ParsedReceiptPayload = {
   extra?: Record<string, unknown>;
 };
 
+// #641: written when a parser returns `needs_review` so the receipt has an
+// audit trail (reason + kind) and can be distinguished from intentional skips
+// (which leave parsedPayload null). Callers reading parsedPayload must
+// type-narrow on the presence of `error` before accessing payload fields.
+export type ParsedReceiptError = {
+  error: { reason: string; kind: "needs_review" };
+};
+
 export const users = pgTable(
   "users",
   {
@@ -1483,7 +1491,9 @@ export const emailReceipts = pgTable(
     occurredAt: timestamp("occurred_at", { withTimezone: true }),
     referenceId: varchar("reference_id", { length: 120 }),
     rawHtml: text("raw_html").notNull(),
-    parsedPayload: jsonb("parsed_payload").$type<ParsedReceiptPayload | Record<string, never>>(),
+    parsedPayload: jsonb("parsed_payload").$type<
+      ParsedReceiptPayload | ParsedReceiptError | Record<string, never>
+    >(),
     matchedTransactionId: integer("matched_transaction_id").references(
       (): AnyPgColumn => transactions.id,
       { onDelete: "set null" },

--- a/src/lib/gmail/parsers/_text.test.ts
+++ b/src/lib/gmail/parsers/_text.test.ts
@@ -16,9 +16,7 @@ import { extractVisibleText } from "./_text";
 describe("extractVisibleText — smart quotes and ellipsis (issue #641)", () => {
   it("decodes &rsquo; to right single quotation mark", () => {
     // ARQ emails use "We&rsquo;ve debited" — this was the root cause of #641.
-    expect(extractVisibleText("We&rsquo;ve debited 334.64 USDc")).toBe(
-      "We’ve debited 334.64 USDc",
-    );
+    expect(extractVisibleText("We&rsquo;ve debited 334.64 USDc")).toBe("We’ve debited 334.64 USDc");
   });
 
   it("decodes &lsquo; to left single quotation mark", () => {
@@ -26,9 +24,7 @@ describe("extractVisibleText — smart quotes and ellipsis (issue #641)", () => 
   });
 
   it("decodes &rdquo; to right double quotation mark", () => {
-    expect(extractVisibleText("She said &rdquo;done&rdquo;")).toBe(
-      "She said ”done”",
-    );
+    expect(extractVisibleText("She said &rdquo;done&rdquo;")).toBe("She said ”done”");
   });
 
   it("decodes &ldquo; to left double quotation mark", () => {

--- a/src/lib/gmail/parsers/_text.test.ts
+++ b/src/lib/gmail/parsers/_text.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { extractVisibleText } from "./_text";
+
+// ---------------------------------------------------------------------------
+// extractVisibleText — entity decoding tests
+//
+// The main risk area documented in _text.ts is CodeQL js/double-escaping:
+//   - NAMED_ENTITIES uses a single-pass atomic replacer, so no entity
+//     replacement can cascade through another.
+//   - "amp" lives only in the lookup table, never as a standalone .replace() call.
+//
+// These tests cover entities that were missing before issue #641 and verify
+// the no-cascade guarantee for the amp+rsquo combination.
+// ---------------------------------------------------------------------------
+
+describe("extractVisibleText — smart quotes and ellipsis (issue #641)", () => {
+  it("decodes &rsquo; to right single quotation mark", () => {
+    // ARQ emails use "We&rsquo;ve debited" — this was the root cause of #641.
+    expect(extractVisibleText("We&rsquo;ve debited 334.64 USDc")).toBe(
+      "We’ve debited 334.64 USDc",
+    );
+  });
+
+  it("decodes &lsquo; to left single quotation mark", () => {
+    expect(extractVisibleText("&lsquo;Hello&rsquo;")).toBe("‘Hello’");
+  });
+
+  it("decodes &rdquo; to right double quotation mark", () => {
+    expect(extractVisibleText("She said &rdquo;done&rdquo;")).toBe(
+      "She said ”done”",
+    );
+  });
+
+  it("decodes &ldquo; to left double quotation mark", () => {
+    expect(extractVisibleText("&ldquo;Quoted&rdquo;")).toBe("“Quoted”");
+  });
+
+  it("decodes &hellip; to horizontal ellipsis", () => {
+    expect(extractVisibleText("Loading&hellip;")).toBe("Loading…");
+  });
+});
+
+describe("extractVisibleText — no double-decoding (CodeQL js/double-escaping regression)", () => {
+  it("does not double-decode &amp;rsquo; (escaped smart quote)", () => {
+    // "&amp;rsquo;" should become "&rsquo;" (just amp decoded), NOT "'" (double-decode).
+    // The single-pass atomic replacer ensures amp is replaced in one pass and the
+    // resulting "&rsquo;" is never re-scanned.
+    expect(extractVisibleText("&amp;rsquo;")).toBe("&rsquo;");
+  });
+
+  it("does not double-decode &amp;amp; (escaped ampersand)", () => {
+    // "&amp;amp;" → "&amp;" (one pass), NOT "&" (double-decode).
+    expect(extractVisibleText("&amp;amp;")).toBe("&amp;");
+  });
+
+  it("mixes &amp; and &rsquo; in the same string without cascade", () => {
+    // Combines both entities in one string to confirm neither cascades through the other.
+    // "Johnson &amp; Johnson&rsquo;s product" → "Johnson & Johnson’s product"
+    expect(extractVisibleText("Johnson &amp; Johnson&rsquo;s product")).toBe(
+      "Johnson & Johnson’s product",
+    );
+  });
+});
+
+describe("extractVisibleText — pre-existing entities (regression guard)", () => {
+  it("decodes &nbsp; to space", () => {
+    expect(extractVisibleText("hello&nbsp;world")).toBe("hello world");
+  });
+
+  it("decodes &amp; to ampersand", () => {
+    expect(extractVisibleText("a &amp; b")).toBe("a & b");
+  });
+
+  it("decodes Spanish accents", () => {
+    expect(extractVisibleText("&ntilde;&uacute;mero")).toBe("ñúmero");
+  });
+
+  it("strips HTML tags and collapses whitespace", () => {
+    expect(extractVisibleText("<p>Hello   <strong>world</strong></p>")).toBe("Hello world");
+  });
+
+  it("strips style blocks before decoding entities", () => {
+    const html = `<style>.x::before { content: "We&rsquo;ve loaded"; }</style><p>Done</p>`;
+    // The entity inside <style> must NOT appear in output.
+    expect(extractVisibleText(html)).toBe("Done");
+  });
+});

--- a/src/lib/gmail/parsers/_text.ts
+++ b/src/lib/gmail/parsers/_text.ts
@@ -57,6 +57,13 @@ const NAMED_ENTITIES: Record<string, string> = {
   // Punctuation used in Spanish text
   iexcl: "¡",
   iquest: "¿",
+  // Smart quotes and ellipsis — ARQ emails use &rsquo; in "We&rsquo;ve debited"
+  // which breaks DEBITED_RE when left undecoded. See issue #641.
+  rsquo: "’", // ' right single quotation mark
+  lsquo: "‘", // ' left single quotation mark
+  rdquo: "”", // " right double quotation mark
+  ldquo: "“", // " left double quotation mark
+  hellip: "…", // … horizontal ellipsis
 };
 
 /**

--- a/src/lib/gmail/parsers/arq.test.ts
+++ b/src/lib/gmail/parsers/arq.test.ts
@@ -295,6 +295,75 @@ describe("parseArqEmail — amount edge cases", () => {
   });
 });
 
+describe("parseArqEmail — titled COP transfer_sent with &rsquo; in body (issue #641)", () => {
+  /**
+   * This fixture reproduces the exact template that caused receipt id 1364 to
+   * loop indefinitely in prod (2026-04-29). The distinguishing features are:
+   *
+   *   1. <title>You sent {COP} COP to {name}</title>  — template 2 route
+   *   2. Body uses &rsquo; in "We&rsquo;ve debited" — was undecoded before #641
+   *   3. A display:none preheader contains the "Hi USER, You&rsquo;ve set up..."
+   *      sentence — mimics the real ARQ HTML structure
+   *
+   * PII redacted: name → "Test Recipient", amounts → synthetic but structurally
+   * equivalent. DO NOT commit the real prod HTML at /tmp/arq-1364.html.
+   */
+  function makeCopTitledSentWithRsquo(
+    copAmount: string,
+    name: string,
+    usdcDebited: string,
+  ): string {
+    return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>You sent ${copAmount} COP to ${name}</title>
+  <style>body{margin:0;font-family:sans-serif;}</style>
+</head>
+<body>
+  <!-- Preheader: display:none — visible text extractor must strip tags but keep text -->
+  <div style="display:none;max-height:0;overflow:hidden;">
+    Hi User, You&rsquo;ve set up a transfer to ${name}. We&rsquo;ve debited ${usdcDebited} USDc from your balance.
+  </div>
+  <table>
+    <tr><td><h1>COP transfer sent</h1></td></tr>
+    <tr><td><p>Amount sent: ${copAmount} COP</p></td></tr>
+    <tr><td><p>We&rsquo;ve debited ${usdcDebited} USDc from your balance.</p></td></tr>
+    <tr><td><p>To: ${name}</p></td></tr>
+  </table>
+</body>
+</html>`;
+  }
+
+  it("parses titled COP transfer_sent where body uses &rsquo; apostrophe", () => {
+    // Before #641 fix: &rsquo; was left literal → DEBITED_RE didn't match →
+    // needs_review('no_usdc_amount_titled_sent') → receipt stuck in pending forever.
+    const html = makeCopTitledSentWithRsquo("1,234,567", "Test Recipient", "337.05");
+    const r = parseArqEmail(html, { occurredAt: RECEIVED_AT });
+    if (r.kind !== "parsed")
+      throw new Error(`expected parsed, got ${r.kind}: ${JSON.stringify(r)}`);
+    expect(r.txKind).toBe("transfer_sent");
+    // USDc debited: 337.05 × 100 = 33705 cents
+    expect(r.amountUsdcCents).toBe(BigInt(33705));
+    expect(r.counterpartyName).toBe("Test Recipient");
+    // COP amount: 1,234,567 × 100 = 123456700 cents
+    expect(r.copAmountCents).toBe(BigInt(123456700));
+    // implied TRM: 123_456_700 / 33_705 ≈ 3663 COP/USDc (realistic)
+    expect(r.impliedTrmCopPerUsdc).toBeCloseTo(123456700 / 33705, 0);
+  });
+
+  it("preheader &rsquo; lines do not confuse amount extraction (two debited lines)", () => {
+    // Same template but confirms that when the preheader and main body both say
+    // "We've debited X USDc", the parser finds the correct amount (they agree).
+    const html = makeCopTitledSentWithRsquo("500,000", "Test Recipient", "136.58");
+    const r = parseArqEmail(html, { occurredAt: RECEIVED_AT });
+    if (r.kind !== "parsed") throw new Error(`expected parsed, got ${r.kind}`);
+    // 136.58 × 100 = 13658 cents
+    expect(r.amountUsdcCents).toBe(BigInt(13658));
+    expect(r.copAmountCents).toBe(BigInt(50000000));
+  });
+});
+
 describe("parseArqEmail — FROM display name tolerance", () => {
   it("parses emails regardless of display name format in From header (parser ignores From)", () => {
     // The FROM header 'ARQ (formerly DolarApp) <no-reply@arqfinance.com>' is

--- a/src/lib/ingestion/email-arq.test.ts
+++ b/src/lib/ingestion/email-arq.test.ts
@@ -165,6 +165,73 @@ const NOW = new Date("2026-04-01T10:00:00Z");
 // Tests
 // ---------------------------------------------------------------------------
 
+describe("ingestArqEmail — needs_review breaks the retry loop (issue #641)", () => {
+  it("marks receipt unmatched with error payload when parser returns needs_review", async () => {
+    // Garbage HTML: no title, no recognisable body markers → unknown_arq_template.
+    const html = `<html><head></head><body><p>Some unrecognised ARQ email content.</p></body></html>`;
+    const receiptId = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-nr-1`, html);
+
+    const result = await ingestArqEmail(USER_A, receiptId, html, NOW);
+
+    // Outcome is still "error" (no transaction) but the receipt is now persisted
+    // as unmatched so the cron loop won't pick it up again.
+    expect(result.status).toBe("error");
+
+    // Receipt must be updated — match_status='unmatched', parsed_at not null.
+    const [row] = await db
+      .select({
+        matchStatus: emailReceipts.matchStatus,
+        parsedAt: emailReceipts.parsedAt,
+        parsedPayload: emailReceipts.parsedPayload,
+      })
+      .from(emailReceipts)
+      .where(eq(emailReceipts.id, receiptId));
+
+    expect(row.matchStatus).toBe("unmatched");
+    expect(row.parsedAt).not.toBeNull();
+
+    // Audit trail: parsed_payload.error.reason populated and kind='needs_review'.
+    const payload = row.parsedPayload as { error: { reason: string; kind: string } } | null;
+    expect(payload).not.toBeNull();
+    expect(payload?.error?.kind).toBe("needs_review");
+    expect(payload?.error?.reason).toBe("unknown_arq_template");
+  });
+
+  it("no transaction is inserted when parser returns needs_review", async () => {
+    const html = `<html><head></head><body><p>Unrecognised content.</p></body></html>`;
+    const receiptId = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-nr-2`, html);
+
+    await ingestArqEmail(USER_A, receiptId, html, NOW);
+
+    const txRows = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_A));
+    expect(txRows).toHaveLength(0);
+  });
+
+  it("idempotency — calling ingestArqEmail twice on needs_review receipt is safe", async () => {
+    // After the first call the receipt is unmatched. A second call on the same
+    // receipt (simulating manual retry with same HTML) should still just error
+    // and update the receipt fields again — no crash, no transaction inserted.
+    const html = `<html><head></head><body><p>Unrecognised again.</p></body></html>`;
+    const receiptId = await seedReceipt(USER_A, CONN_A, `msg-${MARKER}-nr-3`, html);
+
+    const r1 = await ingestArqEmail(USER_A, receiptId, html, NOW);
+    const r2 = await ingestArqEmail(USER_A, receiptId, html, NOW);
+
+    expect(r1.status).toBe("error");
+    expect(r2.status).toBe("error");
+
+    // Still no transaction.
+    const txRows = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.userId, USER_A));
+    expect(txRows).toHaveLength(0);
+  });
+});
+
 describe("ingestArqEmail — counterparty linking", () => {
   it("happy path — new ingest links counterparty (and normalizes the alias)", async () => {
     // Mixed case input: proves normalizeName uppercases the alias value

--- a/src/lib/ingestion/email-arq.ts
+++ b/src/lib/ingestion/email-arq.ts
@@ -1,6 +1,6 @@
 import { and, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, emailReceipts, transactions, type ParsedReceiptPayload } from "@/lib/db/schema";
+import { accounts, emailReceipts, transactions } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { createLogger } from "@/lib/logger";
 import { emit } from "@/lib/events/bus";
@@ -167,10 +167,7 @@ async function markReceiptNeedsReview(
     .set({
       matchStatus: "unmatched",
       parsedAt: new Date(),
-      // Cast required: schema type is ParsedReceiptPayload but we intentionally
-      // store an error-shaped object for audit trail. The underlying column is
-      // JSONB so the DB accepts arbitrary JSON. No migration needed.
-      parsedPayload: { error: { reason, kind: "needs_review" } } as unknown as ParsedReceiptPayload,
+      parsedPayload: { error: { reason, kind: "needs_review" } },
       updatedAt: new Date(),
     })
     .where(and(eq(emailReceipts.id, receiptId), eq(emailReceipts.userId, userId)));

--- a/src/lib/ingestion/email-arq.ts
+++ b/src/lib/ingestion/email-arq.ts
@@ -1,6 +1,6 @@
 import { and, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, emailReceipts, transactions } from "@/lib/db/schema";
+import { accounts, emailReceipts, transactions, type ParsedReceiptPayload } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { createLogger } from "@/lib/logger";
 import { emit } from "@/lib/events/bus";
@@ -144,6 +144,38 @@ async function markReceiptSkipped(receiptId: number, userId: number): Promise<vo
     .where(and(eq(emailReceipts.id, receiptId), eq(emailReceipts.userId, userId)));
 }
 
+/**
+ * Mark a receipt as needing manual review — persists the failure so the cron
+ * loop stops re-processing it. Sets match_status='unmatched' (breaks the
+ * pending loop) and records the reason in parsed_payload for audit trail.
+ *
+ * To retry after extending the parser, run:
+ *   UPDATE email_receipts
+ *   SET match_status='pending', parsed_at=NULL, parsed_payload=NULL
+ *   WHERE id = <receiptId>;
+ *
+ * Mirrors markReceiptSkipped — deliberately kept separate so callers and
+ * metrics can distinguish "intentional skip" from "parse failure".
+ */
+async function markReceiptNeedsReview(
+  receiptId: number,
+  userId: number,
+  reason: string,
+): Promise<void> {
+  await db
+    .update(emailReceipts)
+    .set({
+      matchStatus: "unmatched",
+      parsedAt: new Date(),
+      // Cast required: schema type is ParsedReceiptPayload but we intentionally
+      // store an error-shaped object for audit trail. The underlying column is
+      // JSONB so the DB accepts arbitrary JSON. No migration needed.
+      parsedPayload: { error: { reason, kind: "needs_review" } } as unknown as ParsedReceiptPayload,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(emailReceipts.id, receiptId), eq(emailReceipts.userId, userId)));
+}
+
 // ---------------------------------------------------------------------------
 // Main ingestion entry point
 // ---------------------------------------------------------------------------
@@ -152,7 +184,8 @@ async function markReceiptSkipped(receiptId: number, userId: number): Promise<vo
  * Parse and ingest a single ARQ email receipt.
  *
  * Flow:
- *   1. Parser skip / needs_review → log and exit.
+ *   1. Parser skip → mark unmatched, log, exit.
+ *      Parser needs_review → mark unmatched with error payload (breaks retry loop), log, exit.
  *   2. Resolve ARQ Ahorros account for this user.
  *   3. Insert transaction with source='gmail_arq'. Idempotency by
  *      external_id=(accountId, 'arq-email-<receiptId>') — if the same receipt
@@ -182,8 +215,9 @@ export async function ingestArqEmail(
   if (parsed.kind === "needs_review") {
     log.warn(
       { userId, receiptId, reason: parsed.reason, event: "arq_email_needs_review" },
-      "ARQ email could not be parsed; leaving pending for retry",
+      "ARQ email could not be parsed; marking unmatched to break retry loop",
     );
+    await markReceiptNeedsReview(receiptId, userId, parsed.reason);
     return { status: "error", reason: `parser: ${parsed.reason}` };
   }
 


### PR DESCRIPTION
Closes #641

## Summary
- Decodes 5 HTML entities (`&rsquo;`, `&lsquo;`, `&rdquo;`, `&ldquo;`, `&hellip;`) in the ARQ text normalizer so COP-titled emails (e.g. "Aida's Bakery") are correctly parsed instead of falling through
- Adds `markReceiptNeedsReview` helper that persists stuck receipts as `unmatched` with an audit trail (error, raw HTML, timestamp), breaking the infinite `needs_review` re-processing loop
- Widens `parsedPayload` column type union in schema to include the new `ParsedReceiptError` shape, fixing the TypeScript type gap

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean (`bunx tsc --noEmit`)
- [x] `bun run test` clean — 160 files, 1999 passed, 1 skipped
- [x] 13 new unit tests in `_text.test.ts` covering entity decoding
- [x] 2 new tests in `arq.test.ts` covering rsquo + combined entity inputs
- [x] 3 new integration tests in `email-arq.test.ts` covering `needs_review` → `unmatched` path
- [ ] manual smoke: prod receipt #1364 (still `pending`) will self-heal on next cron tick after merge