### PR TITLE
feat(ui/transactions): expose transfer_group_id and badge paired transfers (#642)

### DIFF
--- a/src/components/transactions/forecast-overlay.test.tsx
+++ b/src/components/transactions/forecast-overlay.test.tsx
@@ -103,6 +103,9 @@ function makeTxRow(overrides: Partial<TxRow> = {}): TxRow {
     recurringId: null,
     recurringYearMonth: null,
     recurringLabel: null,
+    // #642: transfer pairing defaults
+    channel: "bank",
+    transferGroupId: null,
     ...overrides,
   };
 }

--- a/src/components/transactions/transaction-table.test.tsx
+++ b/src/components/transactions/transaction-table.test.tsx
@@ -190,4 +190,29 @@ describe("TransactionTable — paired transfer suppresses 'Sin clasificar'", () 
     const porqueBtns = screen.getAllByLabelText("¿Por qué esta categoría?");
     expect(porqueBtns.length).toBeGreaterThanOrEqual(1);
   });
+
+  it("does NOT apply destructive styling on paired transfer even when method is 'unclassified'", () => {
+    // Theoretical edge case: a transfer that arrives before classification.
+    // The `isUnclassified && !isPairedTransfer` guard at desktop line 467 must
+    // suppress the red text. This test locks in that behavior.
+    const tx = makeTxRow({
+      id: 202,
+      channel: "transfer",
+      transferGroupId: TRANSFER_GROUP_ID,
+      categorySlug: null,
+      classificationMethod: "unclassified",
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    // Desktop renders the method label as a span; assert no destructive class.
+    const methodLabels = screen.getAllByText("unclassified");
+    for (const label of methodLabels) {
+      expect(label).not.toHaveClass("text-destructive");
+    }
+
+    // ¿Por qué? must still be suppressed.
+    const porqueBtns = screen.queryAllByLabelText("¿Por qué esta categoría?");
+    expect(porqueBtns).toHaveLength(0);
+  });
 });

--- a/src/components/transactions/transaction-table.test.tsx
+++ b/src/components/transactions/transaction-table.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const { routerRefresh } = vi.hoisted(() => ({ routerRefresh: vi.fn() }));
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: routerRefresh }) }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// motion/react: passthrough — keeps framer-motion out of jsdom.
+vi.mock("motion/react", () => ({
+  motion: {
+    tr: (props: React.HTMLAttributes<HTMLTableRowElement>) => <tr {...props} />,
+    li: (props: React.HTMLAttributes<HTMLLIElement>) => <li {...props} />,
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useReducedMotion: () => false,
+}));
+
+vi.mock("@/lib/hooks/use-new-ids", () => ({ useNewIds: () => new Set() }));
+vi.mock("@/components/transactions/category-cell", () => ({
+  CategoryCell: () => <span data-testid="category-cell" />,
+}));
+vi.mock("@/components/transactions/transaction-row-actions", () => ({
+  TransactionRowActions: () => <span data-testid="tx-row-actions" />,
+}));
+vi.mock("@/components/transactions/forecast-row-actions", () => ({
+  ForecastRowActions: () => <span data-testid="forecast-row-actions" />,
+}));
+vi.mock("@/components/transactions/counterparty-dialog", () => ({
+  CounterpartyDialog: () => null,
+}));
+vi.mock("@/components/transactions/counterparty-cell", () => ({
+  CounterpartyCell: () => <span data-testid="counterparty-cell" />,
+}));
+vi.mock("@/components/transactions/confidence-badge", () => ({
+  ConfidenceBadge: () => null,
+  confidenceBand: () => null,
+}));
+vi.mock("@/components/transactions/needs-review-badge", () => ({
+  NeedsReviewBadge: () => null,
+}));
+
+// Import AFTER mocks are registered.
+import { TransactionTable } from "./transaction-table";
+import type { TxRow } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Radix shims — pointer capture + scrollIntoView not in jsdom.
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+  routerRefresh.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TRANSFER_GROUP_ID = "39ef646a-eb58-4259-9bfc-e1c62e75fc26";
+
+function makeTxRow(overrides: Partial<TxRow> = {}): TxRow {
+  return {
+    id: 1,
+    occurredAt: new Date("2026-04-16T00:00:00Z"),
+    amountCents: BigInt(-50000),
+    currency: "COP",
+    descriptionRaw: "PAGO TC *2575",
+    descriptionClean: "Pago TC",
+    merchant: null,
+    categorySlug: "alimentacion",
+    classificationMethod: "rule",
+    classificationConfidence: 0.95,
+    source: "sms",
+    isAdjustment: false,
+    accountId: 1,
+    accountName: "Nequi (COP)",
+    accountType: "savings",
+    installmentsTotal: 1,
+    installmentRateEmX10k: null,
+    counterparty: null,
+    deletedAt: null,
+    recurringId: null,
+    recurringYearMonth: null,
+    recurringLabel: null,
+    channel: "bank",
+    transferGroupId: null,
+    ...overrides,
+  };
+}
+
+const TABLE_PROPS = {
+  categories: [] as Parameters<typeof TransactionTable>[0]["categories"],
+  allCounterparties: [] as Parameters<typeof TransactionTable>[0]["allCounterparties"],
+  activeRecurrings: [] as Parameters<typeof TransactionTable>[0]["activeRecurrings"],
+};
+
+// ---------------------------------------------------------------------------
+// Tests — #642: transfer badge and "Sin clasificar" suppression
+// ---------------------------------------------------------------------------
+
+// The table renders both a desktop (<table>) and a mobile (<ul>) view.
+// Elements appear twice in the DOM — use getAllBy* or queryAllBy* accordingly.
+
+describe("TransactionTable — paired transfer badge", () => {
+  it("renders the transfer badge (desktop+mobile) when transferGroupId is set", () => {
+    const tx = makeTxRow({
+      id: 100,
+      channel: "transfer",
+      transferGroupId: TRANSFER_GROUP_ID,
+      categorySlug: null,
+      classificationMethod: "manual",
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    // Both desktop table row and mobile list item render the badge.
+    const badges = screen.getAllByTestId("transfer-badge");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does NOT render the transfer badge when transferGroupId is null", () => {
+    const tx = makeTxRow({ id: 101, channel: "bank", transferGroupId: null });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    expect(screen.queryByTestId("transfer-badge")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render the transfer badge when channel is not transfer even if transferGroupId is set", () => {
+    // Defensive: transferGroupId without channel='transfer' should not badge.
+    const tx = makeTxRow({
+      id: 102,
+      channel: "bank",
+      transferGroupId: TRANSFER_GROUP_ID,
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    expect(screen.queryByTestId("transfer-badge")).not.toBeInTheDocument();
+  });
+});
+
+describe("TransactionTable — paired transfer suppresses 'Sin clasificar'", () => {
+  it("does NOT show '¿Por qué?' button for a paired transfer row", () => {
+    const tx = makeTxRow({
+      id: 200,
+      channel: "transfer",
+      transferGroupId: TRANSFER_GROUP_ID,
+      categorySlug: null,
+      classificationMethod: "manual",
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    // ClassificationReasonDialog is suppressed for paired transfers.
+    const porqueBtns = screen.queryAllByLabelText("¿Por qué esta categoría?");
+    expect(porqueBtns).toHaveLength(0);
+  });
+
+  it("shows '¿Por qué?' button for a non-transfer classified row", () => {
+    const tx = makeTxRow({
+      id: 201,
+      channel: "bank",
+      transferGroupId: null,
+      categorySlug: "alimentacion",
+      classificationMethod: "rule",
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    // ClassificationReasonDialog renders the button for non-unclassified rows.
+    // Both desktop and mobile render it, so at least 1 is present.
+    const porqueBtns = screen.getAllByLabelText("¿Por qué esta categoría?");
+    expect(porqueBtns.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
   ArchiveIcon,
+  ArrowLeftRightIcon,
   CalendarClockIcon,
   ReceiptTextIcon,
   RefreshCwIcon,
@@ -124,6 +125,21 @@ function RecurringBadge({ label }: { label: string | null }) {
     >
       <RefreshCwIcon className="size-2.5" />
       {label ? <span className="max-w-[80px] truncate">{label}</span> : "Recurring"}
+    </Badge>
+  );
+}
+
+// #642: badge shown when a tx is part of a paired transfer (transfer_group_id set).
+function TransferBadge() {
+  return (
+    <Badge
+      variant="outline"
+      className="shrink-0 gap-1 border-teal-300 text-[10px] font-medium tracking-wide text-teal-700 uppercase dark:border-teal-700 dark:text-teal-300"
+      title="Transferencia interna — pareada con otra cuenta"
+      data-testid="transfer-badge"
+    >
+      <ArrowLeftRightIcon className="size-2.5" />
+      Transferencia
     </Badge>
   );
 }
@@ -379,6 +395,10 @@ export function TransactionTable({
                 const isHighlighted = tx.id === highlightId;
                 const isUnclassified = tx.classificationMethod === "unclassified";
                 const isArchived = tx.deletedAt !== null;
+                // #642: paired transfers have category_slug=NULL by design — suppress
+                // "Sin clasificar" styling and the "¿Por qué?" button for these rows.
+                const isPairedTransfer =
+                  tx.channel === "transfer" && tx.transferGroupId !== null;
                 const isLowConfidence =
                   confidenceBand(tx.classificationMethod, tx.classificationConfidence) === "low";
                 return (
@@ -434,6 +454,7 @@ export function TransactionTable({
                         {tx.recurringId !== null ? (
                           <RecurringBadge label={tx.recurringLabel} />
                         ) : null}
+                        {isPairedTransfer ? <TransferBadge /> : null}
                       </div>
                       <div className="text-muted-foreground mt-0.5 flex min-w-0 items-center gap-1.5 text-xs">
                         <span className="truncate">{tx.accountName}</span>
@@ -443,7 +464,7 @@ export function TransactionTable({
                         <span
                           className={cn(
                             "shrink-0",
-                            isUnclassified && "text-destructive font-medium",
+                            isUnclassified && !isPairedTransfer && "text-destructive font-medium",
                           )}
                         >
                           {tx.classificationMethod}
@@ -469,10 +490,12 @@ export function TransactionTable({
                             method={tx.classificationMethod}
                             confidence={tx.classificationConfidence}
                           />
-                          <ClassificationReasonDialog
-                            txId={tx.id}
-                            method={tx.classificationMethod}
-                          />
+                          {!isPairedTransfer ? (
+                            <ClassificationReasonDialog
+                              txId={tx.id}
+                              method={tx.classificationMethod}
+                            />
+                          ) : null}
                         </div>
                       </div>
                     </TableCell>
@@ -574,6 +597,9 @@ export function TransactionTable({
             const isNew = newIds.has(tx.id);
             const isHighlighted = tx.id === highlightId;
             const isArchived = tx.deletedAt !== null;
+            // #642: paired transfers — same guard as desktop row.
+            const isPairedTransferMobile =
+              tx.channel === "transfer" && tx.transferGroupId !== null;
             return (
               <motion.li
                 key={tx.id}
@@ -617,6 +643,7 @@ export function TransactionTable({
                       {tx.recurringId !== null ? (
                         <RecurringBadge label={tx.recurringLabel} />
                       ) : null}
+                      {isPairedTransferMobile ? <TransferBadge /> : null}
                     </div>
                     {hasSecondaryDescription(tx) ? (
                       <p className="text-muted-foreground line-clamp-1 text-xs">
@@ -658,7 +685,14 @@ export function TransactionTable({
                   <Badge variant="outline" className="font-normal">
                     {sourceLabel[tx.source]}
                   </Badge>
-                  <Badge variant={methodVariant[tx.classificationMethod]} className="font-normal">
+                  <Badge
+                    variant={
+                      isPairedTransferMobile
+                        ? "outline"
+                        : methodVariant[tx.classificationMethod]
+                    }
+                    className="font-normal"
+                  >
                     {tx.classificationMethod}
                   </Badge>
                 </div>
@@ -675,7 +709,9 @@ export function TransactionTable({
                       method={tx.classificationMethod}
                       confidence={tx.classificationConfidence}
                     />
-                    <ClassificationReasonDialog txId={tx.id} method={tx.classificationMethod} />
+                    {!isPairedTransferMobile ? (
+                      <ClassificationReasonDialog txId={tx.id} method={tx.classificationMethod} />
+                    ) : null}
                   </div>
                 </div>
               </motion.li>

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -598,6 +598,12 @@ export function TransactionTable({
             const isHighlighted = tx.id === highlightId;
             const isArchived = tx.deletedAt !== null;
             // #642: paired transfers — same guard as desktop row.
+            // NOTE: the method-label `<Badge>` below relies on
+            // `methodVariant["unclassified"] = "destructive"` AND on
+            // `isPairedTransferMobile` overriding it to "outline". If a future
+            // change adds a `text-destructive` span here mirroring desktop's
+            // line 467, include the explicit guard:
+            //   tx.classificationMethod === "unclassified" && !isPairedTransferMobile
             const isPairedTransferMobile =
               tx.channel === "transfer" && tx.transferGroupId !== null;
             return (

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -397,8 +397,7 @@ export function TransactionTable({
                 const isArchived = tx.deletedAt !== null;
                 // #642: paired transfers have category_slug=NULL by design — suppress
                 // "Sin clasificar" styling and the "¿Por qué?" button for these rows.
-                const isPairedTransfer =
-                  tx.channel === "transfer" && tx.transferGroupId !== null;
+                const isPairedTransfer = tx.channel === "transfer" && tx.transferGroupId !== null;
                 const isLowConfidence =
                   confidenceBand(tx.classificationMethod, tx.classificationConfidence) === "low";
                 return (
@@ -604,8 +603,7 @@ export function TransactionTable({
             // change adds a `text-destructive` span here mirroring desktop's
             // line 467, include the explicit guard:
             //   tx.classificationMethod === "unclassified" && !isPairedTransferMobile
-            const isPairedTransferMobile =
-              tx.channel === "transfer" && tx.transferGroupId !== null;
+            const isPairedTransferMobile = tx.channel === "transfer" && tx.transferGroupId !== null;
             return (
               <motion.li
                 key={tx.id}
@@ -693,9 +691,7 @@ export function TransactionTable({
                   </Badge>
                   <Badge
                     variant={
-                      isPairedTransferMobile
-                        ? "outline"
-                        : methodVariant[tx.classificationMethod]
+                      isPairedTransferMobile ? "outline" : methodVariant[tx.classificationMethod]
                     }
                     className="font-normal"
                   >

--- a/src/lib/transactions/queries.test.ts
+++ b/src/lib/transactions/queries.test.ts
@@ -148,3 +148,77 @@ describe("countTotal hideAdjustments", () => {
     expect(n).toBe(2);
   });
 });
+
+// #642: transferGroupId must be present in TxRow shape and populated for
+// paired transfer rows.
+describe("listTransactions transferGroupId", () => {
+  const PAIR_GROUP = "39ef646a-eb58-4259-9bfc-e1c62e75fc26";
+
+  afterEach(async () => {
+    await db.execute(
+      sql`DELETE FROM transactions WHERE description_raw LIKE ${"__test_tx_transfer%"}`,
+    );
+  });
+
+  it("returns transferGroupId=null for regular transactions", async () => {
+    await db.insert(transactions).values({
+      userId: USER_ID,
+      accountId: ACCOUNT_ID,
+      occurredAt: new Date("2026-04-15T12:00:00Z"),
+      amountCents: BigInt(-3000),
+      currency: "COP",
+      descriptionRaw: "__test_tx_transfer-regular",
+      categorySlug: "food",
+      classificationMethod: "manual",
+      source: "manual",
+    });
+
+    const { rows } = await listTransactions(USER_ID, {});
+    const row = rows.find((r) => r.descriptionRaw === "__test_tx_transfer-regular");
+    expect(row).toBeDefined();
+    expect(row!.transferGroupId).toBeNull();
+    expect(Object.prototype.hasOwnProperty.call(row, "transferGroupId")).toBe(true);
+  });
+
+  it("returns matching transferGroupId for both legs of a paired transfer", async () => {
+    await db.insert(transactions).values([
+      {
+        userId: USER_ID,
+        accountId: ACCOUNT_ID,
+        occurredAt: new Date("2026-04-16T10:00:00Z"),
+        amountCents: BigInt(-500000),
+        currency: "COP",
+        descriptionRaw: "__test_tx_transfer-leg-a",
+        categorySlug: null,
+        classificationMethod: "manual",
+        source: "sms",
+        channel: "transfer",
+        transferGroupId: PAIR_GROUP,
+      },
+      {
+        userId: USER_ID,
+        accountId: ACCOUNT_ID,
+        occurredAt: new Date("2026-04-16T10:00:00Z"),
+        amountCents: BigInt(500000),
+        currency: "COP",
+        descriptionRaw: "__test_tx_transfer-leg-b",
+        categorySlug: null,
+        classificationMethod: "manual",
+        source: "sms",
+        channel: "transfer",
+        transferGroupId: PAIR_GROUP,
+      },
+    ]);
+
+    const { rows } = await listTransactions(USER_ID, {});
+    const legA = rows.find((r) => r.descriptionRaw === "__test_tx_transfer-leg-a");
+    const legB = rows.find((r) => r.descriptionRaw === "__test_tx_transfer-leg-b");
+
+    expect(legA).toBeDefined();
+    expect(legB).toBeDefined();
+    expect(legA!.transferGroupId).toBe(PAIR_GROUP);
+    expect(legB!.transferGroupId).toBe(PAIR_GROUP);
+    expect(legA!.channel).toBe("transfer");
+    expect(legB!.channel).toBe("transfer");
+  });
+});

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -130,6 +130,9 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
       recurringId: transactions.recurringId,
       recurringYearMonth: transactions.recurringYearMonth,
       recurringLabel: recurringTransactions.label,
+      // #642: transfer pairing
+      channel: transactions.channel,
+      transferGroupId: transactions.transferGroupId,
     })
     .from(transactions)
     .innerJoin(accounts, eq(accounts.id, transactions.accountId))
@@ -187,6 +190,8 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
     recurringId: r.recurringId,
     recurringYearMonth: r.recurringYearMonth,
     recurringLabel: r.recurringLabel ?? null,
+    channel: r.channel,
+    transferGroupId: r.transferGroupId ?? null,
   }));
 
   return { rows: shaped, nextCursor };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,7 @@ import {
   counterpartyType,
   currency,
   emailReceiptGateway,
+  txChannel,
   txSource,
 } from "@/lib/db/schema";
 
@@ -15,6 +16,7 @@ export type AccountType = (typeof accountType.enumValues)[number];
 export type Currency = (typeof currency.enumValues)[number];
 export type TransactionSource = (typeof txSource.enumValues)[number];
 export type ClassificationMethod = (typeof classificationMethod.enumValues)[number];
+export type TxChannel = (typeof txChannel.enumValues)[number];
 export type CounterpartyType = (typeof counterpartyType.enumValues)[number];
 export type CounterpartyKind = (typeof counterpartyKeyKind.enumValues)[number];
 export type EmailReceiptGateway = (typeof emailReceiptGateway.enumValues)[number];
@@ -86,4 +88,8 @@ export type TxRow = {
   recurringId: number | null;
   recurringYearMonth: string | null;
   recurringLabel: string | null;
+  // #642: transfer pairing. channel='transfer' means the tx is an internal
+  // move (pago TC, intra-account). transferGroupId links the two legs.
+  channel: TxChannel;
+  transferGroupId: string | null;
 };


### PR DESCRIPTION
Closes #642

## Summary

- `listTransactions` now selects `channel` and `transfer_group_id` from the DB and surfaces them on `TxRow`
- `TransferBadge` component renders an "Transferencia" pill for any row whose `transferGroupId` is set
- Rows that are both unclassified AND paired with a transfer group no longer show the red "Sin clasificar" emphasis or the "¿Por qué?" classification button — the pair status is self-explanatory

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (160 files, 1989 tests)
- [x] e2e screenshots captured (`bun run test:e2e`) — transactions page passes on all viewports/themes
- [ ] manual smoke: verify transfer rows show badge and suppress red emphasis in the UI

## E2E screenshots

> Note: e2e runs unauthenticated — screenshots land on the login page. The `/transactions` Playwright tests (non-screenshot spec) all pass. The `light home` / `dark home` failures and `counterparty` spec failures are pre-existing on `main` (recharts timeout + missing test data) — unrelated to this branch.

`chromium` — light transactions:
![chromium-light-transactions](e2e/screenshots/chromium-light-transactions.png)

`chromium` — dark transactions:
![chromium-dark-transactions](e2e/screenshots/chromium-dark-transactions.png)

`mobile` — light transactions:
![mobile-light-transactions](e2e/screenshots/mobile-light-transactions.png)