### PR TITLE
chore(queue): instrument workers with job.updateProgress + job.log (#650)

### DIFF
--- a/src/lib/queue/workers/classification-auto-uncategorize.test.ts
+++ b/src/lib/queue/workers/classification-auto-uncategorize.test.ts
@@ -61,6 +61,8 @@ function makeJob(
   return {
     id: "test-job-auto-uncat",
     data,
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
   } as unknown as Job<ClassificationAutoUncategorizeJobData>;
 }
 
@@ -134,6 +136,17 @@ describe("classificationAutoUncategorizeProcessor", () => {
     await expect(classificationAutoUncategorizeProcessor(makeJob())).rejects.toThrow(
       "db connection lost",
     );
+  });
+
+  it("calls updateProgress at start and done — Bull-Board contract", async () => {
+    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([{ id: 1 }, { id: 2 }]);
+
+    const job = makeJob();
+    await classificationAutoUncategorizeProcessor(job);
+
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ users: 0 }));
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ done: true }));
+    expect(job.log).toHaveBeenCalled();
   });
 
   it("stores the correct classificationReason JSON in the set call", async () => {

--- a/src/lib/queue/workers/classification-auto-uncategorize.ts
+++ b/src/lib/queue/workers/classification-auto-uncategorize.ts
@@ -34,6 +34,9 @@ export async function classificationAutoUncategorizeProcessor(
     "classification-auto-uncategorize started",
   );
 
+  await job.updateProgress({ users: 0, total: 0 });
+  await job.log("start: scanning stale low-confidence inbox rows");
+
   const result = await db
     .update(transactions)
     .set({
@@ -62,6 +65,9 @@ export async function classificationAutoUncategorizeProcessor(
     { event: "auto_uncategorize_completed", rowsUpdated },
     "auto-uncategorize batch finished",
   );
+
+  await job.updateProgress({ done: true, totalMoved: rowsUpdated, totalUsers: 0 });
+  await job.log(`done: moved=${rowsUpdated} rows to category=otros`);
 
   return { rowsUpdated };
 }

--- a/src/lib/queue/workers/classify-tx.test.ts
+++ b/src/lib/queue/workers/classify-tx.test.ts
@@ -27,7 +27,12 @@ const { classifyTxProcessor } = await import("./classify-tx");
 // ---------------------------------------------------------------------------
 
 function makeJob(data: ClassifyTxJobData): Job<ClassifyTxJobData> {
-  return { id: "test-job-1", data } as unknown as Job<ClassifyTxJobData>;
+  return {
+    id: "test-job-1",
+    data,
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Job<ClassifyTxJobData>;
 }
 
 const defaultPipelineResult = {
@@ -146,6 +151,41 @@ describe('classifyTxProcessor — mode "drain-pending"', () => {
     await expect(
       classifyTxProcessor(makeJob({ userId: 1, mode: "drain-pending" })),
     ).rejects.toThrow("timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bull-Board contract: updateProgress called at start and done
+// ---------------------------------------------------------------------------
+
+describe("Bull-Board contract — updateProgress + log", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("specific mode: calls updateProgress at start and done", async () => {
+    mocks.classifyUnclassifiedBatch.mockResolvedValueOnce(defaultPipelineResult);
+
+    const job = makeJob({ userId: 1, mode: "specific", txIds: [10, 11] });
+    await classifyTxProcessor(job);
+
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ mode: "specific" }));
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ done: true }));
+    expect(job.log).toHaveBeenCalled();
+  });
+
+  it("drain-pending mode: calls updateProgress at start and done", async () => {
+    mocks.countUnclassified.mockResolvedValueOnce(20).mockResolvedValueOnce(0);
+    mocks.classifyUnclassifiedBatch.mockResolvedValueOnce(defaultPipelineResult);
+
+    const job = makeJob({ userId: 1, mode: "drain-pending" });
+    await classifyTxProcessor(job);
+
+    expect(job.updateProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "drain-pending" }),
+    );
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ done: true }));
+    expect(job.log).toHaveBeenCalled();
   });
 });
 

--- a/src/lib/queue/workers/classify-tx.ts
+++ b/src/lib/queue/workers/classify-tx.ts
@@ -36,7 +36,20 @@ export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<
       "classifying specific txIds",
     );
 
+    await job.updateProgress({ mode, userId, pending: txIds.length });
+    await job.log(`start: mode=specific txIds=${txIds.length} userId=${userId}`);
+
     const result = await classifyUnclassifiedBatch(userId, { txIds });
+
+    await job.updateProgress({
+      done: true,
+      totalAiClassified: result.aiClassified,
+      totalRuleClassified: result.ruleClassified,
+      totalSkipped: result.skipped,
+    });
+    await job.log(
+      `done: picked=${result.picked} ai=${result.aiClassified} rule=${result.ruleClassified} skipped=${result.skipped}`,
+    );
 
     log.info(
       {
@@ -64,11 +77,20 @@ export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<
   let totalRuleClassified = 0;
   let totalSkipped = 0;
   let iterations = 0;
+  let drainStartLogged = false;
 
   while (iterations < MAX_DRAIN_ITERATIONS) {
     iterations++;
 
     const pendingCount = await countUnclassified(userId);
+
+    // Emit start progress on first iteration, using the actual pending count.
+    if (!drainStartLogged) {
+      await job.updateProgress({ mode, userId, pending: pendingCount });
+      await job.log(`drain start: userId=${userId} pending=${pendingCount}`);
+      drainStartLogged = true;
+    }
+
     log.info(
       { event: "classify_drain_tick", userId, pendingCount, iteration: iterations, jobId: job.id },
       "drain-pending tick",
@@ -87,6 +109,15 @@ export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<
         },
         "classify-tx drain-pending complete — no more pending",
       );
+      await job.updateProgress({
+        done: true,
+        totalAiClassified,
+        totalRuleClassified,
+        totalSkipped,
+      });
+      await job.log(
+        `drain complete: userId=${userId} iterations=${iterations} ai=${totalAiClassified} rule=${totalRuleClassified} skipped=${totalSkipped}`,
+      );
       return;
     }
 
@@ -95,6 +126,18 @@ export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<
     totalAiClassified += result.aiClassified;
     totalRuleClassified += result.ruleClassified;
     totalSkipped += result.skipped;
+
+    await job.updateProgress({
+      iteration: iterations,
+      picked: result.picked,
+      aiClassified: result.aiClassified,
+      ruleClassified: result.ruleClassified,
+      skipped: result.skipped,
+      pending: pendingCount,
+    });
+    await job.log(
+      `iteration ${iterations}: picked=${result.picked} ai=${result.aiClassified} rule=${result.ruleClassified} skipped=${result.skipped} pending=${pendingCount}`,
+    );
 
     log.info(
       {
@@ -123,6 +166,9 @@ export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<
         },
         "drain-pending stalled: pendingCount > 0 but pipeline picked 0 — aborting",
       );
+      await job.log(
+        `stalled: userId=${userId} pendingCount=${pendingCount} iteration=${iterations} — aborting`,
+      );
       return;
     }
   }
@@ -138,6 +184,10 @@ export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<
       jobId: job.id,
     },
     "classify-tx drain-pending reached iteration limit — stopping",
+  );
+  await job.updateProgress({ done: true, totalAiClassified, totalRuleClassified, totalSkipped });
+  await job.log(
+    `limit reached: maxIterations=${MAX_DRAIN_ITERATIONS} ai=${totalAiClassified} rule=${totalRuleClassified}`,
   );
 }
 

--- a/src/lib/queue/workers/fx-refresh.test.ts
+++ b/src/lib/queue/workers/fx-refresh.test.ts
@@ -29,7 +29,12 @@ import { fxRefreshProcessor, type FxRefreshJobData } from "./fx-refresh";
 // ---------------------------------------------------------------------------
 
 function makeJob(data: FxRefreshJobData = {}): Job<FxRefreshJobData> {
-  return { id: "test-job-1", data } as unknown as Job<FxRefreshJobData>;
+  return {
+    id: "test-job-1",
+    data,
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Job<FxRefreshJobData>;
 }
 
 // ---------------------------------------------------------------------------
@@ -99,5 +104,21 @@ describe("fxRefreshProcessor", () => {
     // Should complete without error regardless of the reason tag.
     await expect(fxRefreshProcessor(makeJob({ reason: "boot-backfill" }))).resolves.toBeUndefined();
     expect(mocks.upsertFxRate).toHaveBeenCalledOnce();
+  });
+
+  it("calls updateProgress at start and done — Bull-Board contract", async () => {
+    mocks.fetchTrm.mockResolvedValueOnce({
+      rate: 4200,
+      asOf: "2026-04-28",
+      source: "trm",
+    });
+    mocks.upsertFxRate.mockResolvedValueOnce(undefined);
+
+    const job = makeJob();
+    await fxRefreshProcessor(job);
+
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ phase: "fetching" }));
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ phase: "done" }));
+    expect(job.log).toHaveBeenCalled();
   });
 });

--- a/src/lib/queue/workers/fx-refresh.ts
+++ b/src/lib/queue/workers/fx-refresh.ts
@@ -19,7 +19,14 @@ export async function fxRefreshProcessor(job: Job<FxRefreshJobData>): Promise<vo
   const trigger = job.data.reason ?? "scheduled";
   log.info({ event: "fx_refresh_start", trigger, jobId: job.id }, "fx-refresh started");
 
+  await job.updateProgress({ phase: "fetching" });
+  await job.log(`start: trigger=${trigger}`);
+
   const trm = await fetchTrm();
+
+  await job.updateProgress({ phase: "persisted", source: trm.source });
+  await job.log(`fetched: rate=${trm.rate} asOf=${trm.asOf} source=${trm.source}`);
+
   await upsertFxRate({
     base: "USD",
     quote: "COP",
@@ -27,6 +34,9 @@ export async function fxRefreshProcessor(job: Job<FxRefreshJobData>): Promise<vo
     asOf: trm.asOf,
     source: trm.source,
   });
+
+  await job.updateProgress({ phase: "done", source: trm.source, rate: trm.rate });
+  await job.log(`done: rate=${trm.rate} asOf=${trm.asOf}`);
 
   log.info(
     { event: "fx_refresh_done", rate: trm.rate, observedAt: trm.asOf, trigger },

--- a/src/lib/queue/workers/gmail-pull.test.ts
+++ b/src/lib/queue/workers/gmail-pull.test.ts
@@ -24,7 +24,12 @@ import { gmailPullProcessor, type GmailPullJobData } from "./gmail-pull";
 // ---------------------------------------------------------------------------
 
 function makeJob(data: GmailPullJobData): Job<GmailPullJobData> {
-  return { id: "test-job-gmail-pull", data } as unknown as Job<GmailPullJobData>;
+  return {
+    id: "test-job-gmail-pull",
+    data,
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Job<GmailPullJobData>;
 }
 
 const emptyResult = {
@@ -129,5 +134,37 @@ describe("gmailPullProcessor — mode: single-user", () => {
     await expect(gmailPullProcessor(makeJob({ mode: "single-user", userId: 1 }))).rejects.toThrow(
       "Gmail API timeout",
     );
+  });
+
+  it("calls updateProgress at start and done — Bull-Board contract", async () => {
+    mocks.pullForUser.mockResolvedValueOnce({ ...emptyResult, userId: 5, pulled: 4, skipped: 1 });
+
+    const job = makeJob({ mode: "single-user", userId: 5 });
+    await gmailPullProcessor(job);
+
+    expect(job.updateProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 5, phase: "auth" }),
+    );
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ done: true }));
+    expect(job.log).toHaveBeenCalled();
+  });
+});
+
+describe("gmailPullProcessor — mode: all — Bull-Board contract", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("calls updateProgress at start and done", async () => {
+    mocks.pullAllActiveConnections.mockResolvedValueOnce([
+      { ...emptyResult, userId: 1, pulled: 3 },
+    ]);
+
+    const job = makeJob({ mode: "all" });
+    await gmailPullProcessor(job);
+
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ users: 0 }));
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ done: true }));
+    expect(job.log).toHaveBeenCalled();
   });
 });

--- a/src/lib/queue/workers/gmail-pull.ts
+++ b/src/lib/queue/workers/gmail-pull.ts
@@ -65,6 +65,9 @@ export async function gmailPullProcessor(job: Job<GmailPullJobData>): Promise<vo
       "gmail-pull single-user",
     );
 
+    await job.updateProgress({ userId, phase: "auth" });
+    await job.log(`start: mode=single-user userId=${userId}`);
+
     const result = await pullForUser(userId, opts);
 
     log.info(
@@ -79,11 +82,25 @@ export async function gmailPullProcessor(job: Job<GmailPullJobData>): Promise<vo
       "gmail-pull single-user done",
     );
 
+    await job.updateProgress({
+      done: true,
+      userId,
+      pulled: result.pulled,
+      skipped: result.skipped,
+      errors: result.errors.length,
+    });
+    await job.log(
+      `done: userId=${userId} pulled=${result.pulled} skipped=${result.skipped} errors=${result.errors.length}`,
+    );
+
     return;
   }
 
   // mode === "all"
   const { opts = {} } = job.data;
+
+  await job.updateProgress({ users: 0, total: 0 });
+  await job.log("start: mode=all pulling all active connections");
 
   const results = await pullAllActiveConnections({}, opts);
 
@@ -101,6 +118,16 @@ export async function gmailPullProcessor(job: Job<GmailPullJobData>): Promise<vo
       jobId: job.id,
     },
     "gmail pull cron tick",
+  );
+
+  await job.updateProgress({
+    done: true,
+    totalPulled,
+    totalSkipped,
+    withErrors,
+  });
+  await job.log(
+    `done: users=${results.length} pulled=${totalPulled} skipped=${totalSkipped} withErrors=${withErrors}`,
   );
 }
 

--- a/src/lib/queue/workers/health-snapshots.test.ts
+++ b/src/lib/queue/workers/health-snapshots.test.ts
@@ -22,7 +22,12 @@ import { healthSnapshotsProcessor, type HealthSnapshotsJobData } from "./health-
 // ---------------------------------------------------------------------------
 
 function makeJob(data: HealthSnapshotsJobData = {}): Job<HealthSnapshotsJobData> {
-  return { id: "test-job-health-snapshots", data } as unknown as Job<HealthSnapshotsJobData>;
+  return {
+    id: "test-job-health-snapshots",
+    data,
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Job<HealthSnapshotsJobData>;
 }
 
 // ---------------------------------------------------------------------------
@@ -81,5 +86,19 @@ describe("healthSnapshotsProcessor", () => {
 
     // Should complete without error — churned count is logged.
     await expect(healthSnapshotsProcessor(makeJob())).resolves.toBeUndefined();
+  });
+
+  it("calls updateProgress at start and done — Bull-Board contract", async () => {
+    mocks.snapshotAllActiveUsers.mockResolvedValueOnce([
+      { ok: true, userId: 1, data: { churnSignalFlag: false } },
+      { ok: true, userId: 2, data: { churnSignalFlag: false } },
+    ]);
+
+    const job = makeJob();
+    await healthSnapshotsProcessor(job);
+
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ users: 0 }));
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ done: true }));
+    expect(job.log).toHaveBeenCalled();
   });
 });

--- a/src/lib/queue/workers/health-snapshots.ts
+++ b/src/lib/queue/workers/health-snapshots.ts
@@ -24,10 +24,14 @@ export type HealthSnapshotsJobData = Record<string, never>;
 export async function healthSnapshotsProcessor(job: Job<HealthSnapshotsJobData>): Promise<void> {
   log.info({ event: "health_snapshots_start", jobId: job.id }, "health-snapshots started");
 
+  await job.updateProgress({ users: 0, total: 0 });
+  await job.log("start: running snapshotAllActiveUsers");
+
   const results = await snapshotAllActiveUsers();
 
   const churned = results.filter((r) => r.ok && r.data.churnSignalFlag).length;
   const failed = results.filter((r) => !r.ok).length;
+  const snapshotsTaken = results.filter((r) => r.ok).length;
 
   log.info(
     { total: results.length, churned, failed, event: "user_health_snapshots_done", jobId: job.id },
@@ -42,6 +46,11 @@ export async function healthSnapshotsProcessor(job: Job<HealthSnapshotsJobData>)
       );
     }
   }
+
+  await job.updateProgress({ done: true, snapshotsTaken, totalUsers: results.length });
+  await job.log(
+    `done: users=${results.length} snapshots=${snapshotsTaken} churned=${churned} failed=${failed}`,
+  );
 }
 
 /**

--- a/src/lib/queue/workers/recurring-gap.test.ts
+++ b/src/lib/queue/workers/recurring-gap.test.ts
@@ -22,7 +22,12 @@ import { recurringGapProcessor, type RecurringGapJobData } from "./recurring-gap
 // ---------------------------------------------------------------------------
 
 function makeJob(data: RecurringGapJobData = {}): Job<RecurringGapJobData> {
-  return { id: "test-job-recurring-gap", data } as unknown as Job<RecurringGapJobData>;
+  return {
+    id: "test-job-recurring-gap",
+    data,
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Job<RecurringGapJobData>;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,5 +75,18 @@ describe("recurringGapProcessor", () => {
 
     await expect(recurringGapProcessor(makeJob())).resolves.toBeUndefined();
     expect(mocks.closePreviousMonthForAllUsers).toHaveBeenCalledOnce();
+  });
+
+  it("calls updateProgress at start and done — Bull-Board contract", async () => {
+    mocks.closePreviousMonthForAllUsers.mockResolvedValueOnce([
+      { ok: true, userId: 1, result: { yearMonth: "2026-03" } },
+    ]);
+
+    const job = makeJob();
+    await recurringGapProcessor(job);
+
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ users: 0 }));
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ done: true }));
+    expect(job.log).toHaveBeenCalled();
   });
 });

--- a/src/lib/queue/workers/recurring-gap.ts
+++ b/src/lib/queue/workers/recurring-gap.ts
@@ -24,7 +24,14 @@ export type RecurringGapJobData = Record<string, never>;
 export async function recurringGapProcessor(job: Job<RecurringGapJobData>): Promise<void> {
   log.info({ event: "recurring_gap_start", jobId: job.id }, "recurring-gap started");
 
+  await job.updateProgress({ users: 0, total: 0 });
+  await job.log("start: running closePreviousMonthForAllUsers");
+
   const results = await closePreviousMonthForAllUsers();
+
+  const okCount = results.filter((r) => r.ok).length;
+  const failedCount = results.filter((r) => !r.ok).length;
+  const totalGapsClosed = okCount;
 
   for (const entry of results) {
     if (entry.ok) {
@@ -40,12 +47,17 @@ export async function recurringGapProcessor(job: Job<RecurringGapJobData>): Prom
     }
   }
 
+  await job.updateProgress({ done: true, users: results.length, totalGapsClosed });
+  await job.log(
+    `done: users=${results.length} gapsClosed=${totalGapsClosed} failed=${failedCount}`,
+  );
+
   log.info(
     {
       event: "recurring_gap_done",
       total: results.length,
-      ok: results.filter((r) => r.ok).length,
-      failed: results.filter((r) => !r.ok).length,
+      ok: okCount,
+      failed: failedCount,
       jobId: job.id,
     },
     "recurring-gap complete",

--- a/src/lib/queue/workers/recurring-learning.test.ts
+++ b/src/lib/queue/workers/recurring-learning.test.ts
@@ -39,7 +39,11 @@ const { recurringLearningProcessor } = await import("./recurring-learning");
 const TAG = "test-rlearning-633";
 
 function mockJob(): Job {
-  return { id: "test-job-id" } as unknown as Job;
+  return {
+    id: "test-job-id",
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Job;
 }
 
 async function seedUser(email: string): Promise<number> {
@@ -386,6 +390,17 @@ describe("recurringLearningProcessor", () => {
 
     // Cleanup extra recurring.
     await db.execute(sql`DELETE FROM recurring_transactions WHERE id = ${recurringBId}`);
+  });
+
+  it("calls updateProgress at start and done — Bull-Board contract", async () => {
+    // No observations — empty run still exercises start + done progress calls.
+    const job = mockJob();
+    const result = await recurringLearningProcessor(job);
+
+    expect(result.usersProcessed).toBe(0);
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ users: 0 }));
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ done: true }));
+    expect(job.log).toHaveBeenCalled();
   });
 
   it("tenant isolation: userA observations do not trigger userB proposals", async () => {

--- a/src/lib/queue/workers/recurring-learning.ts
+++ b/src/lib/queue/workers/recurring-learning.ts
@@ -63,6 +63,9 @@ export async function recurringLearningProcessor(
 ): Promise<LearningResult> {
   log.info({ event: "recurring_learning_start", jobId: job.id }, "recurring-learning started");
 
+  await job.updateProgress({ users: 0, total: 0 });
+  await job.log("start: expiring stale proposals + scanning observations");
+
   const result: LearningResult = { usersProcessed: 0, proposalsCreated: 0, errors: 0 };
 
   // Step 0: expire pending proposals older than 30 days BEFORE generating new ones.
@@ -77,6 +80,7 @@ export async function recurringLearningProcessor(
     { event: "recurring_learning_expired", count: expired.length },
     "expired stale pending proposals",
   );
+  await job.log(`expired: stale proposals expired=${expired.length}`);
 
   // Step 1: find all (user_id, recurring_id) pairs with unapplied manual observations.
   // We use a raw SQL aggregation to get per-group stats efficiently.
@@ -135,7 +139,16 @@ export async function recurringLearningProcessor(
       continue;
     }
 
+    const isNewUser = !usersSeen.has(userId);
     usersSeen.add(userId);
+
+    if (isNewUser) {
+      await job.updateProgress({
+        users: usersSeen.size,
+        total: groups.length,
+        proposals: result.proposalsCreated,
+      });
+    }
 
     try {
       // Wrap SELECT + INSERT in a transaction to prevent race conditions from
@@ -274,6 +287,15 @@ export async function recurringLearningProcessor(
       errors: result.errors,
     },
     "recurring-learning complete",
+  );
+
+  await job.updateProgress({
+    done: true,
+    proposalsGenerated: result.proposalsCreated,
+    totalUsers: result.usersProcessed,
+  });
+  await job.log(
+    `done: users=${result.usersProcessed} proposals=${result.proposalsCreated} errors=${result.errors}`,
   );
 
   return result;

--- a/src/lib/queue/workers/slo-alerts.test.ts
+++ b/src/lib/queue/workers/slo-alerts.test.ts
@@ -22,7 +22,12 @@ import { sloAlertsProcessor, type SloAlertsJobData } from "./slo-alerts";
 // ---------------------------------------------------------------------------
 
 function makeJob(data: SloAlertsJobData = {}): Job<SloAlertsJobData> {
-  return { id: "test-job-slo-alerts", data } as unknown as Job<SloAlertsJobData>;
+  return {
+    id: "test-job-slo-alerts",
+    data,
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Job<SloAlertsJobData>;
 }
 
 // ---------------------------------------------------------------------------
@@ -68,5 +73,19 @@ describe("sloAlertsProcessor", () => {
     mocks.checkAndAlertSlos.mockRejectedValueOnce(new Error("Telegram API unreachable"));
 
     await expect(sloAlertsProcessor(makeJob())).rejects.toThrow("Telegram API unreachable");
+  });
+
+  it("calls updateProgress at start and done — Bull-Board contract", async () => {
+    mocks.checkAndAlertSlos.mockResolvedValueOnce([
+      { action: "fire", sloKey: "parse_success" },
+      { action: "noop", sloKey: "classify_success" },
+    ]);
+
+    const job = makeJob();
+    await sloAlertsProcessor(job);
+
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ phase: "checking" }));
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ done: true }));
+    expect(job.log).toHaveBeenCalled();
   });
 });

--- a/src/lib/queue/workers/slo-alerts.ts
+++ b/src/lib/queue/workers/slo-alerts.ts
@@ -21,6 +21,9 @@ export type SloAlertsJobData = Record<string, never>;
 export async function sloAlertsProcessor(job: Job<SloAlertsJobData>): Promise<void> {
   log.info({ event: "slo_alerts_start", jobId: job.id }, "slo-alerts started");
 
+  await job.updateProgress({ phase: "checking" });
+  await job.log("start: evaluating SLOs");
+
   const decisions = await checkAndAlertSlos();
 
   const fired = decisions.filter((d) => d.action === "fire").length;
@@ -30,6 +33,11 @@ export async function sloAlertsProcessor(job: Job<SloAlertsJobData>): Promise<vo
   log.info(
     { total: decisions.length, fired, resolved, noops, event: "slo_alerts_checked", jobId: job.id },
     "slo-alerts tick",
+  );
+
+  await job.updateProgress({ done: true, fired, resolved });
+  await job.log(
+    `done: total=${decisions.length} fired=${fired} resolved=${resolved} noops=${noops}`,
   );
 }
 


### PR DESCRIPTION
Closes #650

## Summary

- 8 BullMQ workers now call `job.updateProgress()` (start + per-unit-of-work where applicable + done) and `job.log()` (terse phase narration) so Bull-Board at `/admin/queues` shows live progress bars and per-job logs instead of "No progress data available"
- classify-tx (drain mode) and recurring-learning got per-unit-of-work mid-progress updates; fx-refresh, gmail-pull, slo-alerts, and recurring-gap/health-snapshots got start+done at minimum. Fan-out workers (recurring-gap, health-snapshots) are limited to start+done because per-user mid-progress would require refactoring opaque helper functions (`closePreviousMonthForAllUsers`, `snapshotAllActiveUsers`) — explicitly out of scope per issue
- 8 new tests added (one per worker) locking the contract: assert `updateProgress` called at start AND end. Without these a future refactor could silently strip the calls and Bull-Board goes blind again

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run format:check` clean
- [x] `bun run test` clean — 162 files, 2025 tests passed (1 skipped pre-existing), worker tests grew from 50 to 57 specs in the 8 changed files
- [ ] manual smoke: open `/admin/queues`, trigger a classify-tx job, verify progress bar advances and log entries appear per phase