### PR TITLE
feat(notifications): Wave 1 emitters — gmail/disambiguation/recon/slo (#657)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,9 @@ const eslintConfig = defineConfig([
     // /settings/widgets fetches them from here). Linting them against
     // next-ts rules produces false positives.
     "public/widgets/scriptable/**",
+    // Claude Code tooling directory — agent worktrees, settings, transcripts.
+    // Not source code; lint here would re-walk every isolated agent worktree.
+    ".claude/**",
   ]),
 ]);
 

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions-emit.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions-emit.test.ts
@@ -1,0 +1,181 @@
+// Unit test for Wave 1 reconciliation_flagged_txns emitter (#657).
+// Mocks commitReconciliation to return flagged > 0 and spies on emitNotification.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as emitModule from "@/lib/notifications/emit";
+
+// ── module mocks (hoisted) ────────────────────────────────────────────────
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+const sessionMock = { id: 42, email: "test@test.local", name: "Test" };
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockImplementation(async () => sessionMock),
+}));
+
+vi.mock("@/lib/reconciliation/commit", () => ({
+  commitReconciliation: vi.fn(),
+  hashFileBuffer: vi.fn().mockReturnValue("a".repeat(64)),
+  recordReconciliationDecision: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/reconciliation/dispatch", () => ({
+  parseAny: vi.fn().mockReturnValue({
+    detected: { bank: "bancolombia" },
+    parsed: {
+      format: "bancolombia_savings",
+      periodStart: new Date("2026-04-01"),
+      periodEnd: new Date("2026-04-30"),
+      rows: [],
+    },
+  }),
+}));
+
+vi.mock("@/lib/reconciliation/engine/match", () => ({
+  matchStatement: vi.fn().mockReturnValue({
+    toInsert: [],
+    toMatch: [],
+    flaggedExisting: [],
+  }),
+}));
+
+vi.mock("@/lib/reconciliation/pago-tc-router", () => ({
+  applyPagoTcRouting: vi.fn().mockResolvedValue({ routed: 0, skipped: 0 }),
+}));
+
+vi.mock("@/lib/classification/enqueue", () => ({
+  classifyByRuleThenEnqueue: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([
+            {
+              id: 7,
+              institutionSlug: "bancolombia",
+              currency: "COP",
+              physicalCardId: null,
+            },
+          ]),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("./window", () => ({
+  expandReconcileWindow: vi.fn().mockReturnValue({
+    windowStart: new Date("2026-03-29"),
+    windowEnd: new Date("2026-04-30"),
+  }),
+}));
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+describe("applyReconcile — reconciliation_flagged_txns emitter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits reconciliation_flagged_txns once when flagged > 0", async () => {
+    const { commitReconciliation } = await import("@/lib/reconciliation/commit");
+    (commitReconciliation as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "applied",
+      inserted: 0,
+      insertedIds: [],
+      matched: 2,
+      flagged: 3,
+      statementImportId: 55,
+    });
+
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { applyReconcile } = await import("./actions");
+    await applyReconcile({
+      accountId: 7,
+      fileHash: "a".repeat(64),
+      parsed: {
+        format: "bancolombia_savings",
+        periodStart: "2026-04-01T00:00:00.000Z",
+        periodEnd: "2026-04-30T00:00:00.000Z",
+        rows: [],
+      },
+      plan: { toInsert: [], toMatch: [], flaggedExisting: [] },
+      userBalanceAtEndCents: null,
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      sessionMock.id,
+      expect.objectContaining({
+        type: "reconciliation_flagged_txns",
+        entityId: "55",
+        audience: "user",
+        priority: "high",
+      }),
+    );
+  });
+
+  it("does NOT emit when flagged === 0", async () => {
+    const { commitReconciliation } = await import("@/lib/reconciliation/commit");
+    (commitReconciliation as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "applied",
+      inserted: 5,
+      insertedIds: [1, 2, 3, 4, 5],
+      matched: 0,
+      flagged: 0,
+      statementImportId: 56,
+    });
+
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { applyReconcile } = await import("./actions");
+    await applyReconcile({
+      accountId: 7,
+      fileHash: "a".repeat(64),
+      parsed: {
+        format: "bancolombia_savings",
+        periodStart: "2026-04-01T00:00:00.000Z",
+        periodEnd: "2026-04-30T00:00:00.000Z",
+        rows: [],
+      },
+      plan: { toInsert: [], toMatch: [], flaggedExisting: [] },
+      userBalanceAtEndCents: null,
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT emit when result.status is not 'applied'", async () => {
+    const { commitReconciliation } = await import("@/lib/reconciliation/commit");
+    (commitReconciliation as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "already_imported",
+      inserted: 0,
+      insertedIds: [],
+      matched: 0,
+      flagged: 5,
+      statementImportId: 57,
+    });
+
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { applyReconcile } = await import("./actions");
+    await applyReconcile({
+      accountId: 7,
+      fileHash: "a".repeat(64),
+      parsed: {
+        format: "bancolombia_savings",
+        periodStart: "2026-04-01T00:00:00.000Z",
+        periodEnd: "2026-04-30T00:00:00.000Z",
+        rows: [],
+      },
+      plan: { toInsert: [], toMatch: [], flaggedExisting: [] },
+      userBalanceAtEndCents: null,
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
@@ -19,6 +19,7 @@ import type { ParsedStatement } from "@/lib/reconciliation/parsers/types";
 import { applyPagoTcRouting } from "@/lib/reconciliation/pago-tc-router";
 import { classifyByRuleThenEnqueue } from "@/lib/classification/enqueue";
 import { createLogger } from "@/lib/logger";
+import { emitNotification } from "@/lib/notifications/emit";
 import { expandReconcileWindow } from "./window";
 
 const log = createLogger({ module: "reconciliation-actions" });
@@ -382,6 +383,35 @@ export async function applyReconcile(input: ApplyReconcileInput) {
     },
     "reconciliation applied",
   );
+
+  // #657 — notify user when reconciliation flags transactions.
+  if (result.status === "applied" && result.flagged > 0) {
+    await emitNotification(session.id, {
+      type: "reconciliation_flagged_txns",
+      entityId: String(result.statementImportId),
+      audience: "user",
+      title: `Reconciliación: ${result.flagged} movimiento(s) marcados`,
+      body: "Encontramos diferencias entre el extracto y tus transacciones. Revisalos para ajustar.",
+      actionUrl: `/transactions?status=flagged&accountId=${accountId}`,
+      priority: "high",
+      metadata: {
+        statementImportId: result.statementImportId,
+        flagged: result.flagged,
+        accountId,
+      },
+    }).catch((emitErr: unknown) => {
+      log.error(
+        {
+          err: emitErr,
+          userId: session.id,
+          accountId,
+          statementImportId: result.statementImportId,
+          event: "emit_reconciliation_flagged_txns_failed",
+        },
+        "failed to emit reconciliation_flagged_txns notification",
+      );
+    });
+  }
 
   // #591 — classify newly-inserted reconciliation rows. Mirrors the flow
   // used by /imports commit functions: rules engine first (in-place update),

--- a/src/lib/gmail/pull-disambig-emit.test.ts
+++ b/src/lib/gmail/pull-disambig-emit.test.ts
@@ -1,0 +1,192 @@
+// Integration test for Wave 1 gmail_disambiguation_required emitter (#657).
+// Mocks matchReceipt to return "ambiguous" and spies on emitNotification.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { emailReceipts, gmailConnections, users } from "@/lib/db/schema";
+import { gmailCipher } from "@/lib/crypto/gmail-cipher";
+import * as emitModule from "@/lib/notifications/emit";
+import type { AuthedGmailClient } from "./client";
+
+// Static vi.mock must be at top level (hoisted by Vitest).
+vi.mock("@/lib/gmail/matcher", () => ({
+  matchReceipt: vi.fn(),
+}));
+
+// parsers returns "parsed" so the receipt proceeds to the matcher.
+vi.mock("@/lib/gmail/parsers", () => ({
+  parseReceipt: vi.fn().mockReturnValue({
+    kind: "parsed",
+    data: {
+      merchant: "Test Merchant",
+      amountCents: BigInt(10000),
+      currency: "COP",
+      occurredAt: new Date("2026-04-01T12:00:00Z"),
+      referenceId: "ref-disambig-test",
+    },
+  }),
+}));
+
+// applyEnrichment won't be called for ambiguous, but import it to avoid errors.
+vi.mock("@/lib/gmail/enrich", () => ({
+  applyEnrichment: vi.fn().mockResolvedValue(undefined),
+}));
+
+const TAG = "GMAIL_DISAMBIG_EMIT";
+let userId: number;
+let connId: number;
+
+const ORIGINAL_GMAIL_KEY = process.env.GMAIL_TOKEN_ENCRYPTION_KEY;
+
+async function cleanup() {
+  await db.delete(users).where(sql`email LIKE ${"%" + TAG + "%"}`);
+}
+
+beforeAll(async () => {
+  process.env.GMAIL_TOKEN_ENCRYPTION_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  await cleanup();
+  const [u] = await db
+    .insert(users)
+    .values({ email: `${TAG}@test.local`, name: TAG })
+    .returning({ id: users.id });
+  userId = u.id;
+  const [c] = await db
+    .insert(gmailConnections)
+    .values({
+      userId,
+      gmailEmail: `${TAG}@gmail.com`,
+      accessTokenEnc: gmailCipher.encrypt("dummy-access-token"),
+      refreshTokenEnc: gmailCipher.encrypt("dummy-refresh-token"),
+      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  connId = c.id;
+});
+
+afterAll(async () => {
+  await cleanup();
+  if (ORIGINAL_GMAIL_KEY === undefined) delete process.env.GMAIL_TOKEN_ENCRYPTION_KEY;
+  else process.env.GMAIL_TOKEN_ENCRYPTION_KEY = ORIGINAL_GMAIL_KEY;
+});
+
+beforeEach(async () => {
+  vi.restoreAllMocks();
+  // Clean receipts between tests.
+  await db
+    .delete(emailReceipts)
+    .where(and(eq(emailReceipts.userId, userId), sql`gmail_msg_id LIKE ${"%" + TAG + "%"}`));
+});
+
+describe("gmail_disambiguation_required emitter", () => {
+  it("emits once with receipt.id as entityId when matchReceipt returns ambiguous", async () => {
+    const { matchReceipt } = await import("@/lib/gmail/matcher");
+    (matchReceipt as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "ambiguous",
+      candidateIds: [10, 11],
+    });
+
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    // Insert a pending receipt that the enrich loop will pick up.
+    const [receipt] = await db
+      .insert(emailReceipts)
+      .values({
+        userId,
+        gmailConnectionId: connId,
+        gateway: "mercado_pago",
+        gmailMsgId: `${TAG}-msg-1`,
+        rawHtml: "<html>body</html>",
+        matchStatus: "pending",
+        parsedAt: new Date(), // already parsed → skip parser, go straight to matcher
+      })
+      .returning({ id: emailReceipts.id });
+
+    // pullForUser with a fakeAuthed that returns no new messages — only the
+    // existing pending receipt is processed by processPendingEnrichReceipts.
+    const fakeAuthed: AuthedGmailClient = {
+      oauth: {} as unknown,
+      gmail: {
+        users: {
+          messages: {
+            list: vi.fn().mockResolvedValue({ data: { messages: [] } }),
+            get: vi.fn(),
+          },
+        },
+      },
+      connection: { id: connId, gmailEmail: `${TAG}@gmail.com`, accessTokenStale: false },
+    } as unknown as AuthedGmailClient;
+
+    const { pullForUser } = await import("./pull");
+    await pullForUser(
+      userId,
+      { gateways: ["mercado_pago"] },
+      { getClient: async () => fakeAuthed },
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      userId,
+      expect.objectContaining({
+        type: "gmail_disambiguation_required",
+        entityId: String(receipt.id),
+        audience: "user",
+        priority: "high",
+      }),
+    );
+  });
+
+  it("does NOT emit when matchReceipt returns matched", async () => {
+    const { matchReceipt } = await import("@/lib/gmail/matcher");
+    (matchReceipt as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "matched",
+      transactionId: 5,
+    });
+
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const [receipt] = await db
+      .insert(emailReceipts)
+      .values({
+        userId,
+        gmailConnectionId: connId,
+        gateway: "mercado_pago",
+        gmailMsgId: `${TAG}-msg-2`,
+        rawHtml: "<html>body</html>",
+        matchStatus: "pending",
+        parsedAt: new Date(),
+      })
+      .returning({ id: emailReceipts.id });
+
+    const fakeAuthed: AuthedGmailClient = {
+      oauth: {} as unknown,
+      gmail: {
+        users: {
+          messages: {
+            list: vi.fn().mockResolvedValue({ data: { messages: [] } }),
+            get: vi.fn(),
+          },
+        },
+      },
+      connection: { id: connId, gmailEmail: `${TAG}@gmail.com`, accessTokenStale: false },
+    } as unknown as AuthedGmailClient;
+
+    // applyEnrichment is mocked to avoid needing a real transaction.
+    const { applyEnrichment } = await import("@/lib/gmail/enrich");
+    (applyEnrichment as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const { pullForUser } = await import("./pull");
+    await pullForUser(
+      userId,
+      { gateways: ["mercado_pago"] },
+      { getClient: async () => fakeAuthed },
+    );
+
+    // Cleanup
+    await db.delete(emailReceipts).where(eq(emailReceipts.id, receipt.id));
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/gmail/pull-emit.test.ts
+++ b/src/lib/gmail/pull-emit.test.ts
@@ -1,0 +1,133 @@
+// Integration tests for Wave 1 gmail_token_expired emitters (#657).
+// Uses the real DB (findash_test) and a spy on emitNotification.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { gmailConnections, users } from "@/lib/db/schema";
+import { gmailCipher } from "@/lib/crypto/gmail-cipher";
+import * as emitModule from "@/lib/notifications/emit";
+import type { AuthedGmailClient } from "./client";
+import { GmailConnectionUnusableError } from "./client";
+import { pullForUser } from "./pull";
+
+const TAG = "GMAIL_EMIT_TEST";
+let userId: number;
+let connId: number;
+
+const ORIGINAL_GMAIL_KEY = process.env.GMAIL_TOKEN_ENCRYPTION_KEY;
+
+async function cleanup() {
+  await db.delete(users).where(sql`email LIKE ${"%" + TAG + "%"}`);
+}
+
+beforeAll(async () => {
+  process.env.GMAIL_TOKEN_ENCRYPTION_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  await cleanup();
+  const [u] = await db
+    .insert(users)
+    .values({ email: `${TAG}@test.local`, name: TAG })
+    .returning({ id: users.id });
+  userId = u.id;
+  const [c] = await db
+    .insert(gmailConnections)
+    .values({
+      userId,
+      gmailEmail: `${TAG}@gmail.com`,
+      accessTokenEnc: gmailCipher.encrypt("dummy-access-token"),
+      refreshTokenEnc: gmailCipher.encrypt("dummy-refresh-token"),
+      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      status: "active",
+    })
+    .returning({ id: gmailConnections.id });
+  connId = c.id;
+});
+
+afterAll(async () => {
+  await cleanup();
+  if (ORIGINAL_GMAIL_KEY === undefined) delete process.env.GMAIL_TOKEN_ENCRYPTION_KEY;
+  else process.env.GMAIL_TOKEN_ENCRYPTION_KEY = ORIGINAL_GMAIL_KEY;
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── emitter 1: gmail_token_expired (GmailConnectionUnusableError — expired) ─
+
+describe("gmail_token_expired — expired branch (connRow path)", () => {
+  it("emits once with correct type, entityId, audience, priority", async () => {
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const getClient = async (): Promise<AuthedGmailClient> => {
+      throw new GmailConnectionUnusableError("expired", "token expired");
+    };
+
+    await pullForUser(userId, {}, { getClient });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      userId,
+      expect.objectContaining({
+        type: "gmail_token_expired",
+        entityId: String(connId),
+        audience: "user",
+        priority: "high",
+      }),
+    );
+  });
+
+  it("does NOT emit when status is invalid_credentials (no expired/revoked branch)", async () => {
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const getClient = async (): Promise<AuthedGmailClient> => {
+      // Only "expired" and "revoked" trigger the connRow lookup + emitter.
+      throw new GmailConnectionUnusableError("invalid_credentials" as never, "bad creds");
+    };
+
+    await pullForUser(userId, {}, { getClient });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+// ── emitter 1: gmail_token_expired (invalid_grant during pull — authed path) ─
+
+describe("gmail_token_expired — invalid_grant path (authed path)", () => {
+  it("emits once with connectionId from authed.connection.id", async () => {
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const fakeAuthed: AuthedGmailClient = {
+      oauth: {} as unknown,
+      gmail: {
+        users: {
+          messages: {
+            list: vi.fn().mockRejectedValue(
+              Object.assign(new Error("invalid_grant"), {
+                response: { status: 401, data: { error: "invalid_grant" } },
+              }),
+            ),
+            get: vi.fn(),
+          },
+        },
+      },
+      connection: { id: connId, gmailEmail: `${TAG}@gmail.com`, accessTokenStale: false },
+    } as unknown as AuthedGmailClient;
+
+    const getClient = async () => fakeAuthed;
+
+    await pullForUser(userId, { gateways: ["mercado_pago"] }, { getClient });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      userId,
+      expect.objectContaining({
+        type: "gmail_token_expired",
+        entityId: String(connId),
+        audience: "user",
+        priority: "high",
+      }),
+    );
+  });
+});

--- a/src/lib/gmail/pull.ts
+++ b/src/lib/gmail/pull.ts
@@ -27,6 +27,7 @@ import { applyEnrichment } from "@/lib/gmail/enrich";
 import { pushToUser } from "@/lib/telegram/push";
 import { renderReauthNudge } from "@/lib/telegram/formatter";
 import { loadPendingAmbiguousReceipt } from "@/lib/telegram/disambiguation-query";
+import { emitNotification } from "@/lib/notifications/emit";
 
 const log = createLogger({ module: "gmail/pull" });
 
@@ -515,6 +516,26 @@ async function processPendingEnrichReceipts(userId: number, gatewayId: GatewayId
           },
           "receipt has ambiguous tx candidates; persisted for user disambiguation",
         );
+        await emitNotification(userId, {
+          type: "gmail_disambiguation_required",
+          entityId: String(receipt.id),
+          audience: "user",
+          title: "Movimiento ambiguo: requiere tu confirmación",
+          body: "Encontramos varios candidatos que matchean este recibo. Elegí cuál corresponde.",
+          actionUrl: "/settings/integrations",
+          priority: "high",
+          metadata: { receiptId: receipt.id, gatewayId },
+        }).catch((emitErr: unknown) => {
+          log.error(
+            {
+              err: emitErr,
+              userId,
+              receiptId: receipt.id,
+              event: "emit_disambiguation_required_failed",
+            },
+            "failed to emit gmail_disambiguation_required notification",
+          );
+        });
       } else {
         // unmatched: persist the status so it's queryable, but leave it
         // eligible for re-attempt on future pulls.
@@ -719,6 +740,26 @@ export async function pullForUser(
               "re-auth nudge threw",
             );
           });
+          await emitNotification(userId, {
+            type: "gmail_token_expired",
+            entityId: String(connRow.id),
+            audience: "user",
+            title: "Gmail desconectado",
+            body: "Findash dejó de leer tus recibos. Reconectá tu cuenta para seguir recibiendo movimientos.",
+            actionUrl: "/settings/integrations",
+            priority: "high",
+            metadata: { connectionId: connRow.id },
+          }).catch((emitErr: unknown) => {
+            log.error(
+              {
+                err: emitErr,
+                userId,
+                connectionId: connRow.id,
+                event: "emit_gmail_token_expired_failed",
+              },
+              "failed to emit gmail_token_expired notification",
+            );
+          });
         }
       }
       return { userId, pulled: 0, skipped: 0, byGateway, errors, connectionId: null };
@@ -778,6 +819,26 @@ export async function pullForUser(
         log.error(
           { err: nudgeErr, userId, event: "reauth_nudge_failed" },
           "re-auth nudge threw during invalid_grant handling",
+        );
+      });
+      await emitNotification(userId, {
+        type: "gmail_token_expired",
+        entityId: String(authed.connection.id),
+        audience: "user",
+        title: "Gmail desconectado",
+        body: "Findash dejó de leer tus recibos. Reconectá tu cuenta para seguir recibiendo movimientos.",
+        actionUrl: "/settings/integrations",
+        priority: "high",
+        metadata: { connectionId: authed.connection.id, gmailEmail: authed.connection.gmailEmail },
+      }).catch((emitErr: unknown) => {
+        log.error(
+          {
+            err: emitErr,
+            userId,
+            connectionId: authed.connection.id,
+            event: "emit_gmail_token_expired_failed",
+          },
+          "failed to emit gmail_token_expired notification",
         );
       });
       return {

--- a/src/lib/observability/slo-alerts.test.ts
+++ b/src/lib/observability/slo-alerts.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { parserEvents, sloAlerts, type ParserEventKind } from "@/lib/db/schema";
+import * as emitModule from "@/lib/notifications/emit";
 import {
   ALERT_MIN_SAMPLES,
   SLO_ALERTS,
@@ -175,5 +176,59 @@ describe("checkAndAlertSlos — fire/resolve cycle", () => {
     const [decision] = await checkAndAlertSlos();
     expect(decision.action).toBe("noop");
     if (decision.action === "noop") expect(decision.reason).toBe("healthy");
+  });
+});
+
+// ── Wave 1 emitter: slo_alert_fired (#657) ────────────────────────────────
+
+describe("checkAndAlertSlos — slo_alert_fired emitter", () => {
+  beforeEach(cleanup);
+  afterEach(() => {
+    vi.restoreAllMocks();
+    return cleanup();
+  });
+
+  it("emits slo_alert_fired once with correct type, entityId, audience when firing", async () => {
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    // 70% success rate over 25 samples → fires.
+    for (let i = 0; i < 18; i++) await seedEvent("parse_outcome_success", 30);
+    for (let i = 0; i < 7; i++) await seedEvent("parse_needs_review", 30);
+
+    const [decision] = await checkAndAlertSlos();
+    expect(decision.action).toBe("fire");
+
+    // Retrieve the inserted alert row id to assert entityId.
+    const [alertRow] = await db
+      .select({ id: sloAlerts.id })
+      .from(sloAlerts)
+      .where(eq(sloAlerts.sloKey, "parse_success"));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      expect.any(Number), // adminId — varies by test DB seed
+      expect.objectContaining({
+        type: "slo_alert_fired",
+        entityId: String(alertRow.id),
+        audience: "admin",
+        priority: "high",
+      }),
+    );
+  });
+
+  it("does NOT emit on noop tick (already_alerted dedup)", async () => {
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    for (let i = 0; i < 18; i++) await seedEvent("parse_outcome_success", 30);
+    for (let i = 0; i < 7; i++) await seedEvent("parse_needs_review", 30);
+
+    // First tick fires.
+    await checkAndAlertSlos();
+    spy.mockClear();
+
+    // Second tick must noop — emitter must NOT fire again.
+    const [second] = await checkAndAlertSlos();
+    expect(second.action).toBe("noop");
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/observability/slo-alerts.test.ts
+++ b/src/lib/observability/slo-alerts.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { parserEvents, sloAlerts, type ParserEventKind } from "@/lib/db/schema";
+import * as busModule from "@/lib/events/bus";
 import * as emitModule from "@/lib/notifications/emit";
 import {
   ALERT_MIN_SAMPLES,
@@ -230,5 +231,29 @@ describe("checkAndAlertSlos — slo_alert_fired emitter", () => {
     const [second] = await checkAndAlertSlos();
     expect(second.action).toBe("noop");
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("emits slo:resolved on the bus when the SLO recovers (auto-mark-read pairing)", async () => {
+    const busSpy = vi.spyOn(busModule, "emit");
+
+    // Fire first.
+    for (let i = 0; i < 18; i++) await seedEvent("parse_outcome_success", 30);
+    for (let i = 0; i < 7; i++) await seedEvent("parse_needs_review", 30);
+    await checkAndAlertSlos();
+    busSpy.mockClear();
+
+    // Recover.
+    for (let i = 0; i < 200; i++) await seedEvent("parse_outcome_success", 15);
+    const [decision] = await checkAndAlertSlos();
+    expect(decision.action).toBe("resolve");
+
+    // Without this bus emit, slo_alert_fired notifications stay unread forever.
+    const resolvedCalls = busSpy.mock.calls.filter(([event]) => event.type === "slo:resolved");
+    expect(resolvedCalls).toHaveLength(1);
+    const event = resolvedCalls[0]![0];
+    if (event.type === "slo:resolved") {
+      expect(event.alertId).toBe(decision.action === "resolve" ? decision.alertId : -1);
+      expect(typeof event.userId).toBe("number");
+    }
   });
 });

--- a/src/lib/observability/slo-alerts.test.ts
+++ b/src/lib/observability/slo-alerts.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { parserEvents, sloAlerts, type ParserEventKind } from "@/lib/db/schema";
+import { parserEvents, sloAlerts, users, type ParserEventKind } from "@/lib/db/schema";
 import * as busModule from "@/lib/events/bus";
 import * as emitModule from "@/lib/notifications/emit";
 import {
@@ -183,6 +183,32 @@ describe("checkAndAlertSlos — fire/resolve cycle", () => {
 // ── Wave 1 emitter: slo_alert_fired (#657) ────────────────────────────────
 
 describe("checkAndAlertSlos — slo_alert_fired emitter", () => {
+  // The emitter gates on `if (admin && alertRow)`. CI starts with a clean DB
+  // (no admin), so we ensure at least one active admin exists before these
+  // tests. Local DBs may already have a bootstrap admin (e.g. user id=1),
+  // and `checkAndAlertSlos` can pick either — so we don't pin to a specific
+  // admin id; we only assert that the emitter was called with SOME admin id.
+  const TEST_ADMIN_EMAIL = "slo-alerts-test-admin@findash.test";
+
+  beforeAll(async () => {
+    await db
+      .insert(users)
+      .values({
+        email: TEST_ADMIN_EMAIL,
+        name: "SLO Alerts Test Admin",
+        role: "admin",
+        active: true,
+      })
+      .onConflictDoUpdate({
+        target: users.email,
+        set: { role: "admin", active: true },
+      });
+  });
+
+  afterAll(async () => {
+    await db.delete(users).where(eq(users.email, TEST_ADMIN_EMAIL));
+  });
+
   beforeEach(cleanup);
   afterEach(() => {
     vi.restoreAllMocks();
@@ -207,7 +233,7 @@ describe("checkAndAlertSlos — slo_alert_fired emitter", () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(
-      expect.any(Number), // adminId — varies by test DB seed
+      expect.any(Number), // admin id — varies (bootstrap user, seed user, or our beforeAll admin)
       expect.objectContaining({
         type: "slo_alert_fired",
         entityId: String(alertRow.id),

--- a/src/lib/observability/slo-alerts.ts
+++ b/src/lib/observability/slo-alerts.ts
@@ -4,6 +4,7 @@ import { parserEvents, sloAlerts, telegramBots, telegramSessions, users } from "
 import { telegramCipher } from "@/lib/crypto/telegram-cipher";
 import { createLogger } from "@/lib/logger";
 import { createTelegramClient } from "@/lib/telegram/client";
+import { emit as busEmit } from "@/lib/events/bus";
 import { emitNotification } from "@/lib/notifications/emit";
 
 const log = createLogger({ module: "slo-alerts" });
@@ -109,8 +110,11 @@ export async function checkAndAlertSlos(database: DB = db): Promise<SloDecision[
   const now = new Date();
   const decisions: SloDecision[] = [];
 
-  // Look up the admin once per invocation — reused by both Telegram dispatch
-  // and the emitNotification call so we avoid a redundant query per SLO.
+  // Look up the admin once per invocation. Used by:
+  //   - dispatchTelegramAlert (admin id + session lookup), passed as parameter
+  //   - emitNotification (admin id is the notification owner; SSE filter routes
+  //     by audience='admin', not userId)
+  //   - busEmit('slo:resolved') in the resolve branch (carries userId for the bus)
   const [admin] = await database
     .select({ id: users.id })
     .from(users)
@@ -130,7 +134,7 @@ export async function checkAndAlertSlos(database: DB = db): Promise<SloDecision[
     const decision = decideSloAction(cfg, computed, latestUnresolved ?? null);
 
     if (decision.action === "fire") {
-      const status = await dispatchTelegramAlert(database, cfg, {
+      const status = await dispatchTelegramAlert(database, cfg, admin?.id ?? null, {
         rate: decision.rate,
         samples: decision.samples,
       }).catch((err) => {
@@ -176,6 +180,18 @@ export async function checkAndAlertSlos(database: DB = db): Promise<SloDecision[
         .update(sloAlerts)
         .set({ resolvedAt: now })
         .where(eq(sloAlerts.id, decision.alertId));
+
+      // Pair with auto-mark-read: a resolved SLO must mark the bell notification
+      // read. Without this emit, slo_alert_fired notifications stay unread forever
+      // even after the SLO recovers.
+      if (admin) {
+        busEmit({
+          type: "slo:resolved",
+          userId: admin.id,
+          alertId: decision.alertId,
+          timestamp: now.getTime(),
+        });
+      }
     }
 
     decisions.push(decision);
@@ -187,26 +203,22 @@ export async function checkAndAlertSlos(database: DB = db): Promise<SloDecision[
 async function dispatchTelegramAlert(
   database: DB,
   cfg: SloAlertConfig,
+  adminId: number | null,
   computed: { rate: number; samples: number },
 ): Promise<string> {
-  const [admin] = await database
-    .select({ id: users.id })
-    .from(users)
-    .where(and(eq(users.role, "admin"), eq(users.active, true)))
-    .limit(1);
-  if (!admin) return "no_admin";
+  if (adminId === null) return "no_admin";
 
   const [bot] = await database
     .select()
     .from(telegramBots)
-    .where(eq(telegramBots.userId, admin.id))
+    .where(eq(telegramBots.userId, adminId))
     .limit(1);
   if (!bot) return "no_bot";
 
   const [session] = await database
     .select({ chatId: telegramSessions.chatId })
     .from(telegramSessions)
-    .where(eq(telegramSessions.userId, admin.id))
+    .where(eq(telegramSessions.userId, adminId))
     .orderBy(desc(telegramSessions.updatedAt))
     .limit(1);
   if (!session) return "no_session";

--- a/src/lib/observability/slo-alerts.ts
+++ b/src/lib/observability/slo-alerts.ts
@@ -4,6 +4,7 @@ import { parserEvents, sloAlerts, telegramBots, telegramSessions, users } from "
 import { telegramCipher } from "@/lib/crypto/telegram-cipher";
 import { createLogger } from "@/lib/logger";
 import { createTelegramClient } from "@/lib/telegram/client";
+import { emitNotification } from "@/lib/notifications/emit";
 
 const log = createLogger({ module: "slo-alerts" });
 
@@ -108,6 +109,14 @@ export async function checkAndAlertSlos(database: DB = db): Promise<SloDecision[
   const now = new Date();
   const decisions: SloDecision[] = [];
 
+  // Look up the admin once per invocation — reused by both Telegram dispatch
+  // and the emitNotification call so we avoid a redundant query per SLO.
+  const [admin] = await database
+    .select({ id: users.id })
+    .from(users)
+    .where(and(eq(users.role, "admin"), eq(users.active, true)))
+    .limit(1);
+
   for (const cfg of SLO_ALERTS) {
     const computed = await cfg.compute(now, database);
 
@@ -128,13 +137,40 @@ export async function checkAndAlertSlos(database: DB = db): Promise<SloDecision[
         log.error({ err, event: "slo_telegram_dispatch_failed" }, "telegram dispatch failed");
         return "telegram_error";
       });
-      await database.insert(sloAlerts).values({
-        sloKey: cfg.key,
-        rate: decision.rate.toFixed(4),
-        target: cfg.target.toFixed(4),
-        samples: decision.samples,
-        notificationStatus: status,
-      });
+      const [alertRow] = await database
+        .insert(sloAlerts)
+        .values({
+          sloKey: cfg.key,
+          rate: decision.rate.toFixed(4),
+          target: cfg.target.toFixed(4),
+          samples: decision.samples,
+          notificationStatus: status,
+        })
+        .returning({ id: sloAlerts.id });
+
+      if (admin && alertRow) {
+        const targetPct = (decision.target * 100).toFixed(0);
+        await emitNotification(admin.id, {
+          type: "slo_alert_fired",
+          entityId: String(alertRow.id),
+          audience: "admin",
+          title: `SLO en alerta: ${cfg.label}`,
+          body: `Burn rate ${(decision.rate * 100).toFixed(1)}% bajo el target ${targetPct}%.`,
+          actionUrl: "/admin/slo",
+          priority: "high",
+          metadata: { alertId: alertRow.id, sloName: cfg.label, burnRate: decision.rate },
+        }).catch((emitErr: unknown) => {
+          log.error(
+            {
+              err: emitErr,
+              adminId: admin.id,
+              alertId: alertRow.id,
+              event: "emit_slo_alert_fired_failed",
+            },
+            "failed to emit slo_alert_fired notification",
+          );
+        });
+      }
     } else if (decision.action === "resolve") {
       await database
         .update(sloAlerts)


### PR DESCRIPTION
Closes #657

## Summary

Wires `emitNotification(userId, ...)` at four high-signal callsites for Phase 4 of Epic N (#503).

| Event | Audience | entityId |
|---|---|---|
| `gmail_token_expired` | user | `String(connectionId)` |
| `gmail_disambiguation_required` | user | `String(receiptId)` |
| `reconciliation_flagged_txns` | user | `String(statementImportId)` |
| `slo_alert_fired` | admin | `String(alertId)` |

All four already have `auto-mark-read` mappings — when the resolution channel fires (re-auth, disambiguation resolved, slo recovers, manual link), the bell flips to read automatically.

Reviewer fix-up commit also:
- Refactors `dispatchTelegramAlert` to take `adminId` as a parameter, eliminating the redundant admin lookup that the misleading hoisted-comment had implied was already deduped.
- Emits `slo:resolved` on the bus when the resolve branch fires — without it, `slo_alert_fired` notifications would stay unread forever.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` — 172 files, 2122 passed, 1 skipped
- [ ] CI (lint + typecheck + test + build)
- [ ] Manual smoke after deploy: trigger a Gmail re-auth flow and confirm the bell shows the notification, then reconnect and confirm it auto-marks read