### PR TITLE
feat(notifications): sms_drift_detected nightly cron + emitter (#660)

### DIFF
--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -42,6 +42,7 @@ export async function registerNode() {
     await import("@/lib/queue/workers/classification-auto-uncategorize");
   const { createRecurringLearningWorker } = await import("@/lib/queue/workers/recurring-learning");
   const { createBudgetCheckWorker } = await import("@/lib/queue/workers/budget-check");
+  const { createSmsDriftCheckWorker } = await import("@/lib/queue/workers/sms-drift-check");
   const log = createLogger({ module: "instrumentation" });
 
   // -------------------------------------------------------------------------
@@ -90,6 +91,10 @@ export async function registerNode() {
   // auto-uncategorize (04:00); budget alarms notify once per calendar month.
   const budgetCheckQueue = createQueue("budget-check");
   createBudgetCheckWorker();
+
+  // sms-drift-check: nightly 22:30 COT — detect users with SMS baseline but 0 SMS today
+  const smsDriftCheckQueue = createQueue("sms-drift-check");
+  createSmsDriftCheckWorker();
 
   // Graceful shutdown is idempotent — safe to call once after all workers are
   // registered.
@@ -195,9 +200,21 @@ export async function registerNode() {
     },
   );
 
+  // 22:30 COT daily — detect users with a 7-day SMS baseline but 0 SMS today.
+  // Fires at 22:30 (well within the day) so the alert lands before the user
+  // sleeps (#660).
+  await smsDriftCheckQueue.add(
+    "sms-drift-check",
+    {},
+    {
+      repeat: { pattern: "30 22 * * *", tz: "America/Bogota" },
+      jobId: "sms-drift-check-recurring",
+    },
+  );
+
   log.info(
     { event: "workers_registered" },
-    "BullMQ workers registered: fx-refresh (15 6,18 * * *), recurring-gap (0 6 5 * *), health-snapshots (0 3 * * *), slo-alerts (*/30 * * * *), gmail-pull (*/5 * * * *), classification-auto-uncategorize (0 4 * * *), recurring-learning (0 4 * * *), budget-check (0 4 * * *) America/Bogota; classify-tx on-demand",
+    "BullMQ workers registered: fx-refresh (15 6,18 * * *), recurring-gap (0 6 5 * *), health-snapshots (0 3 * * *), slo-alerts (*/30 * * * *), gmail-pull (*/5 * * * *), classification-auto-uncategorize (0 4 * * *), recurring-learning (0 4 * * *), budget-check (0 4 * * *), sms-drift-check (30 22 * * *) America/Bogota; classify-tx on-demand",
   );
 
   // -------------------------------------------------------------------------

--- a/src/lib/queue/workers/sms-drift-check.test.ts
+++ b/src/lib/queue/workers/sms-drift-check.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Job } from "bullmq";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { ingestionLogs, users } from "@/lib/db/schema";
+import { smsDriftCheckProcessor } from "./sms-drift-check";
+
+// ---------------------------------------------------------------------------
+// emitNotification mock — hoisted so factories run before module-level code
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => ({
+  emitNotification: vi.fn().mockResolvedValue({ id: 999 }),
+}));
+
+vi.mock("@/lib/notifications/emit", () => ({
+  emitNotification: mocks.emitNotification,
+}));
+
+// ---------------------------------------------------------------------------
+// Minimal Job stub — only the methods the processor calls
+// ---------------------------------------------------------------------------
+function makeJob(): Job<Record<string, never>> {
+  return {
+    id: "test-job-id",
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Job<Record<string, never>>;
+}
+
+// ---------------------------------------------------------------------------
+// User setup — only user 1 is seeded in findash_test by default.
+// For multi-user tests we create an ephemeral user and clean it up after.
+// ---------------------------------------------------------------------------
+
+const USER_A = 1; // permanent seeded user
+
+let ephemeralUserBId: number | null = null;
+
+async function createEphemeralUserB(): Promise<number> {
+  const [row] = await db
+    .insert(users)
+    .values({ email: "sms-drift-test-b@example.com", name: "SMS Drift Test B" })
+    .returning({ id: users.id });
+  ephemeralUserBId = row.id;
+  return row.id;
+}
+
+async function deleteEphemeralUserB() {
+  if (ephemeralUserBId !== null) {
+    await db.execute(sql`DELETE FROM users WHERE id = ${ephemeralUserBId}`);
+    ephemeralUserBId = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a Date that falls within the given Bogota day offset.
+ * daysOffset=0 → today in COT, daysOffset=-1 → yesterday, etc.
+ */
+function bogotaDay(daysOffset: number, hour = 12): Date {
+  const nowUtc = new Date();
+  const todayBogotaStr = nowUtc.toLocaleDateString("en-CA", { timeZone: "America/Bogota" });
+  const d = new Date(`${todayBogotaStr}T${String(hour).padStart(2, "0")}:00:00-05:00`);
+  d.setDate(d.getDate() + daysOffset);
+  return d;
+}
+
+async function insertLog(userId: number, daysOffset: number, itemsReceived: number) {
+  await db.insert(ingestionLogs).values({
+    userId,
+    source: "sms",
+    status: "success",
+    itemsReceived,
+    itemsInserted: itemsReceived,
+    itemsDuplicated: 0,
+    startedAt: bogotaDay(daysOffset),
+  });
+}
+
+async function cleanup(extraUserId?: number | null) {
+  const userIds = [USER_A, ...(extraUserId != null ? [extraUserId] : [])];
+  for (const uid of userIds) {
+    await db.execute(sql`DELETE FROM ingestion_logs WHERE source = 'sms' AND user_id = ${uid}`);
+  }
+  mocks.emitNotification.mockClear();
+  mocks.emitNotification.mockResolvedValue({ id: 999 });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("smsDriftCheckProcessor", () => {
+  beforeEach(() => cleanup());
+  afterEach(() => cleanup(ephemeralUserBId));
+
+  it("emits when avg_7d >= 5 and count_today = 0", async () => {
+    // 7 days × 8 SMS/day in past week (no SMS today)
+    for (let d = -7; d <= -1; d++) {
+      await insertLog(USER_A, d, 8);
+    }
+
+    await smsDriftCheckProcessor(makeJob());
+
+    expect(mocks.emitNotification).toHaveBeenCalledOnce();
+    const [calledUserId, calledInput] = mocks.emitNotification.mock.calls[0]! as [
+      number,
+      { type: string; priority: string; actionUrl: string; metadata: { avg7d: number } },
+    ];
+    expect(calledUserId).toBe(USER_A);
+    expect(calledInput.type).toBe("sms_drift_detected");
+    expect(calledInput.priority).toBe("medium");
+    expect(calledInput.actionUrl).toBe("/settings/integrations");
+    // avg7d = 56 / 7 = 8.0
+    expect(calledInput.metadata.avg7d).toBeCloseTo(8.0);
+  });
+
+  it("does NOT emit when avg_7d < 5 (below threshold)", async () => {
+    // 7 days × 3 SMS/day → avg_7d = 3, below threshold of 5
+    for (let d = -7; d <= -1; d++) {
+      await insertLog(USER_A, d, 3);
+    }
+
+    await smsDriftCheckProcessor(makeJob());
+
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("does NOT emit when count_today > 0", async () => {
+    // Past week: avg = 8/day
+    for (let d = -7; d <= -1; d++) {
+      await insertLog(USER_A, d, 8);
+    }
+    // Today: 2 SMS received
+    await insertLog(USER_A, 0, 2);
+
+    await smsDriftCheckProcessor(makeJob());
+
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("does NOT emit when user has 0 SMS in last 7 days (no baseline)", async () => {
+    // No rows at all → no baseline, no emit
+    await smsDriftCheckProcessor(makeJob());
+
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("tenant safety: emits only for user A when A qualifies but B does not", async () => {
+    const userBId = await createEphemeralUserB();
+
+    // User A: avg 8/day last 7, nothing today → qualifies
+    for (let d = -7; d <= -1; d++) {
+      await insertLog(USER_A, d, 8);
+    }
+    // User B: avg 3/day last 7, nothing today → below threshold
+    for (let d = -7; d <= -1; d++) {
+      await insertLog(userBId, d, 3);
+    }
+
+    await smsDriftCheckProcessor(makeJob());
+
+    expect(mocks.emitNotification).toHaveBeenCalledOnce();
+    expect(mocks.emitNotification.mock.calls[0]![0]).toBe(USER_A);
+
+    await deleteEphemeralUserB();
+  });
+
+  it("dedup: second run on the same day does NOT fire a second insert", async () => {
+    // Arrange: user qualifies
+    for (let d = -7; d <= -1; d++) {
+      await insertLog(USER_A, d, 8);
+    }
+
+    // First run → emitNotification returns { id: 999 } (inserted)
+    mocks.emitNotification.mockResolvedValueOnce({ id: 999 });
+    await smsDriftCheckProcessor(makeJob());
+    expect(mocks.emitNotification).toHaveBeenCalledOnce();
+
+    // Second run → emitNotification returns null (deduped by the emit layer)
+    mocks.emitNotification.mockResolvedValueOnce(null);
+    await smsDriftCheckProcessor(makeJob());
+
+    // emitNotification was called twice total (the processor attempted both times,
+    // but the emit layer deduped the second)
+    expect(mocks.emitNotification).toHaveBeenCalledTimes(2);
+
+    // Both calls used the same entityId (same Bogota date)
+    const entityId0 = (mocks.emitNotification.mock.calls[0]![1] as { entityId: string }).entityId;
+    const entityId1 = (mocks.emitNotification.mock.calls[1]![1] as { entityId: string }).entityId;
+    expect(entityId0).toBe(entityId1);
+  });
+});

--- a/src/lib/queue/workers/sms-drift-check.ts
+++ b/src/lib/queue/workers/sms-drift-check.ts
@@ -1,0 +1,228 @@
+import type { Job } from "bullmq";
+
+import { db } from "@/lib/db";
+import { ingestionLogs } from "@/lib/db/schema";
+import { createLogger } from "@/lib/logger";
+import { emitNotification } from "@/lib/notifications/emit";
+import { createWorker } from "@/lib/queue";
+import { and, eq, gte, lt, sql } from "drizzle-orm";
+
+const log = createLogger({ module: "worker/sms-drift-check" });
+
+export type SmsDriftCheckJobData = Record<string, never>;
+
+/**
+ * Returns the start and end of "today" in America/Bogota as UTC timestamps.
+ * The cron runs at 22:30 COT — well within the day — so "today" is reliable.
+ */
+function getBogotaDayBoundaries(): { todayStart: Date; todayEnd: Date; todayISODate: string } {
+  const nowUtc = new Date();
+  // Obtain YYYY-MM-DD in Bogota time
+  const bogotaDateStr = nowUtc.toLocaleDateString("en-CA", { timeZone: "America/Bogota" });
+  // todayISODate is the Bogota calendar date, e.g. "2026-04-30"
+  const todayISODate = bogotaDateStr;
+
+  // Reconstruct midnight COT boundaries in UTC.
+  // COT = UTC-5. "2026-04-30T00:00:00-05:00" → add 5h to get UTC.
+  const todayStart = new Date(`${todayISODate}T00:00:00-05:00`);
+  const todayEnd = new Date(`${todayISODate}T23:59:59.999-05:00`);
+
+  return { todayStart, todayEnd, todayISODate };
+}
+
+interface UserDriftRow {
+  userId: number;
+  countToday: number;
+  sumLast7ExcludingToday: number;
+}
+
+/**
+ * Queries ingestion_logs to find users where SMS activity shows a drift today.
+ *
+ * For each user who has had at least one SMS log in the last 7 days:
+ *   - count_today = SUM(items_received) WHERE source='sms', startedAt in Bogota-today
+ *   - avg_7d = SUM(items_received) for last 7 calendar days EXCLUDING today, divided by 7
+ *   - emit if count_today === 0 AND avg_7d >= 5
+ *
+ * Uses AT TIME ZONE for correct Bogota day boundaries in Postgres.
+ */
+async function detectSmsDrift(): Promise<UserDriftRow[]> {
+  const { todayStart, todayEnd, todayISODate } = getBogotaDayBoundaries();
+
+  // 7-day window start = todayStart minus 7 days
+  const sevenDaysAgo = new Date(todayStart.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  // postgres.js requires ISO strings (not Date objects) when embedded in raw
+  // sql`` template expressions. Column-operator helpers (gte/lt) handle Date
+  // serialization internally, but values inside CASE WHEN must be explicit strings.
+  const todayStartIso = todayStart.toISOString();
+  const todayEndIso = todayEnd.toISOString();
+  const sevenDaysAgoIso = sevenDaysAgo.toISOString();
+
+  const rows = await db
+    .select({
+      userId: ingestionLogs.userId,
+      countToday:
+        sql<number>`COALESCE(SUM(CASE WHEN ${ingestionLogs.startedAt} >= ${todayStartIso}::timestamptz AND ${ingestionLogs.startedAt} < ${todayEndIso}::timestamptz THEN ${ingestionLogs.itemsReceived} ELSE 0 END), 0)`.as(
+          "count_today",
+        ),
+      sumLast7ExcludingToday:
+        sql<number>`COALESCE(SUM(CASE WHEN ${ingestionLogs.startedAt} >= ${sevenDaysAgoIso}::timestamptz AND ${ingestionLogs.startedAt} < ${todayStartIso}::timestamptz THEN ${ingestionLogs.itemsReceived} ELSE 0 END), 0)`.as(
+          "sum_last7_excl_today",
+        ),
+    })
+    .from(ingestionLogs)
+    .where(
+      and(
+        eq(ingestionLogs.source, "sms"),
+        gte(ingestionLogs.startedAt, sevenDaysAgo),
+        lt(ingestionLogs.startedAt, todayEnd),
+      ),
+    )
+    .groupBy(ingestionLogs.userId);
+
+  log.debug(
+    { todayISODate, rowCount: rows.length, event: "sms_drift_query_done" },
+    "sms-drift query complete",
+  );
+
+  return rows.map((r) => ({
+    userId: r.userId,
+    countToday: Number(r.countToday),
+    sumLast7ExcludingToday: Number(r.sumLast7ExcludingToday),
+  }));
+}
+
+/**
+ * Core processor: for each user who had SMS activity in the last 7 days but
+ * sent 0 SMS today, emit an `sms_drift_detected` notification.
+ *
+ * Threshold: avg_7d >= 5 SMS/day (sum of last 7 excl. today ÷ 7).
+ * This avoids false positives for occasional users.
+ *
+ * Dedup: entityId = "sms-drift-{userId}-{YYYY-MM-DD}" — at most one
+ * unread notification per user per calendar day (Bogota).
+ *
+ * Exported separately so tests can invoke it directly without a live Worker.
+ */
+export async function smsDriftCheckProcessor(job: Job<SmsDriftCheckJobData>): Promise<void> {
+  const { todayISODate } = getBogotaDayBoundaries();
+
+  log.info(
+    { event: "sms_drift_check_start", jobId: job.id, todayISODate },
+    "sms-drift-check started",
+  );
+
+  await job.updateProgress({ phase: "querying" });
+  await job.log(`start: checking sms drift for ${todayISODate}`);
+
+  const rows = await detectSmsDrift();
+
+  const THRESHOLD_AVG = 5;
+  let emitted = 0;
+  let skipped = 0;
+  let deduped = 0;
+
+  for (const row of rows) {
+    const avg7d = row.sumLast7ExcludingToday / 7;
+
+    if (row.countToday > 0) {
+      log.debug(
+        { userId: row.userId, countToday: row.countToday, event: "sms_drift_has_activity" },
+        "user has sms today — skip",
+      );
+      skipped++;
+      continue;
+    }
+
+    if (avg7d < THRESHOLD_AVG) {
+      log.debug(
+        { userId: row.userId, avg7d, threshold: THRESHOLD_AVG, event: "sms_drift_below_threshold" },
+        "avg below threshold — skip",
+      );
+      skipped++;
+      continue;
+    }
+
+    // count_today === 0 AND avg_7d >= 5 — emit
+    const entityId = `sms-drift-${row.userId}-${todayISODate}`;
+
+    const result = await emitNotification(row.userId, {
+      type: "sms_drift_detected",
+      entityId,
+      priority: "medium",
+      title: "No recibimos SMS hoy",
+      body: `Tu promedio de los últimos 7 días era ${avg7d.toFixed(1)} SMS/día. Hoy llegaron 0. Revisá si el Shortcut sigue corriendo.`,
+      actionUrl: "/settings/integrations",
+      metadata: { avg7d, count_today: 0, todayISODate },
+    });
+
+    if (result === null) {
+      log.debug(
+        { userId: row.userId, entityId, event: "sms_drift_deduped" },
+        "sms-drift notification deduped",
+      );
+      deduped++;
+    } else {
+      log.info(
+        {
+          userId: row.userId,
+          notificationId: result.id,
+          avg7d,
+          entityId,
+          event: "sms_drift_emitted",
+        },
+        "sms-drift notification emitted",
+      );
+      emitted++;
+    }
+  }
+
+  await job.updateProgress({ done: true, emitted, skipped, deduped });
+  await job.log(
+    `done: users=${rows.length} emitted=${emitted} skipped=${skipped} deduped=${deduped}`,
+  );
+
+  log.info(
+    {
+      event: "sms_drift_check_done",
+      todayISODate,
+      total: rows.length,
+      emitted,
+      skipped,
+      deduped,
+      jobId: job.id,
+    },
+    "sms-drift-check complete",
+  );
+}
+
+/**
+ * Create and register the sms-drift-check BullMQ worker.
+ *
+ * Concurrency 1: the processor fans out over all users synchronously.
+ * Running concurrent jobs would duplicate emits (dedup in Postgres handles
+ * it, but unnecessary load).
+ *
+ * Cron: 22:30 America/Bogota — late enough that a day's SMS window is
+ * effectively closed, early enough to alert before the user sleeps.
+ */
+export function createSmsDriftCheckWorker() {
+  return createWorker<SmsDriftCheckJobData, void>(
+    "sms-drift-check",
+    async (job) => {
+      try {
+        await smsDriftCheckProcessor(job);
+      } catch (err) {
+        log.error(
+          { err, event: "sms_drift_check_failed", jobId: job.id },
+          "sms-drift-check processor threw — BullMQ will retry",
+        );
+        throw err;
+      }
+    },
+    {
+      concurrency: 1,
+    },
+  );
+}


### PR DESCRIPTION
Closes #660

## Summary

New BullMQ recurring job (`sms-drift-check`) runs nightly at 22:30 COT and emits `sms_drift_detected` per user when count_today=0 and the rolling 7-day average is ≥ 5/day.

- Worker: \`src/lib/queue/workers/sms-drift-check.ts\` (222 LOC)
- Tests: \`src/lib/queue/workers/sms-drift-check.test.ts\` (172 LOC)
- Registered in \`src/instrumentation.node.ts\`

Conservative threshold avoids waking users on slow days. Tunable later if needed.

## Test plan

- [x] 4 gates clean (lint + format:check + typecheck + test)
- [x] Tenant safety test: users A and B with distinct ingestion data — only A emits
- [x] Threshold test: avg=3/day → no emit; avg=8/day with count_today=0 → emit
- [x] Dedup: re-running same date → no double emit (entityId = `sms-drift-{userId}-{ISODate}`)
- [ ] CI