### PR TITLE
feat(notifications): classification_auto_uncategorized + recurring_proposal_ready (#661)

### DIFF
--- a/src/lib/queue/workers/classification-auto-uncategorize.test.ts
+++ b/src/lib/queue/workers/classification-auto-uncategorize.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   dbUpdateSet: vi.fn(),
   dbUpdateSetWhere: vi.fn(),
   dbUpdateSetWhereReturning: vi.fn(),
+  emitNotification: vi.fn(),
   logInfo: vi.fn(),
   logError: vi.fn(),
 }));
@@ -28,6 +29,10 @@ vi.mock("@/lib/db", () => {
   };
 });
 
+vi.mock("@/lib/notifications/emit", () => ({
+  emitNotification: mocks.emitNotification,
+}));
+
 vi.mock("@/lib/logger", () => ({
   createLogger: () => ({
     info: mocks.logInfo,
@@ -42,6 +47,8 @@ vi.mock("@/lib/db/schema", () => ({
     classificationConfidence: "classification_confidence",
     occurredAt: "occurred_at",
     deletedAt: "deleted_at",
+    id: "id",
+    userId: "user_id",
   },
 }));
 
@@ -79,6 +86,9 @@ describe("classificationAutoUncategorizeProcessor", () => {
     const whereFn = mocks.dbUpdateSetWhere.mockReturnValue({ returning: returningFn });
     const setFn = mocks.dbUpdateSet.mockReturnValue({ where: whereFn });
     mocks.dbUpdate.mockReturnValue({ set: setFn });
+
+    // Default: emitNotification resolves successfully.
+    mocks.emitNotification.mockResolvedValue({ id: 999 });
   });
 
   afterAll(() => {
@@ -86,7 +96,10 @@ describe("classificationAutoUncategorizeProcessor", () => {
   });
 
   it("calls db.update with the correct set values", async () => {
-    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([{ id: 1 }, { id: 2 }]);
+    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([
+      { id: 1, userId: 10 },
+      { id: 2, userId: 10 },
+    ]);
 
     await classificationAutoUncategorizeProcessor(makeJob());
 
@@ -101,23 +114,28 @@ describe("classificationAutoUncategorizeProcessor", () => {
   });
 
   it("returns rowsUpdated equal to the number of affected rows", async () => {
-    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([{ id: 10 }, { id: 20 }, { id: 30 }]);
+    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([
+      { id: 10, userId: 1 },
+      { id: 20, userId: 2 },
+      { id: 30, userId: 2 },
+    ]);
 
     const result = await classificationAutoUncategorizeProcessor(makeJob());
 
     expect(result).toEqual({ rowsUpdated: 3 });
   });
 
-  it("returns rowsUpdated=0 when no rows match", async () => {
+  it("returns rowsUpdated=0 when no rows match and does NOT emit", async () => {
     mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([]);
 
     const result = await classificationAutoUncategorizeProcessor(makeJob());
 
     expect(result).toEqual({ rowsUpdated: 0 });
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
   });
 
   it("logs a completion event with rowsUpdated", async () => {
-    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([{ id: 5 }]);
+    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([{ id: 5, userId: 42 }]);
 
     await classificationAutoUncategorizeProcessor(makeJob());
 
@@ -139,7 +157,10 @@ describe("classificationAutoUncategorizeProcessor", () => {
   });
 
   it("calls updateProgress at start and done — Bull-Board contract", async () => {
-    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([{ id: 1 }, { id: 2 }]);
+    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([
+      { id: 1, userId: 10 },
+      { id: 2, userId: 10 },
+    ]);
 
     const job = makeJob();
     await classificationAutoUncategorizeProcessor(job);
@@ -160,5 +181,121 @@ describe("classificationAutoUncategorizeProcessor", () => {
       action: "auto_uncategorized",
       reason: "30d_inbox_stragglers",
     });
+  });
+
+  // ── New: notification emitter tests ─────────────────────────────────────
+
+  it("emits one notification per distinct userId when rows are affected", async () => {
+    // 3 rows: userA gets 2 txs, userB gets 1 tx.
+    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([
+      { id: 1, userId: 100 },
+      { id: 2, userId: 100 },
+      { id: 3, userId: 200 },
+    ]);
+
+    await classificationAutoUncategorizeProcessor(makeJob());
+
+    // Should emit exactly 2 notifications, one per user.
+    expect(mocks.emitNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it("emits with correct type and entityId for each userId", async () => {
+    const todayBogota = new Date().toLocaleDateString("en-CA", {
+      timeZone: "America/Bogota",
+    });
+
+    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([{ id: 1, userId: 42 }]);
+
+    await classificationAutoUncategorizeProcessor(makeJob());
+
+    expect(mocks.emitNotification).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({
+        type: "classification_auto_uncategorized",
+        entityId: `auto-uncat-42-${todayBogota}`,
+        priority: "medium",
+      }),
+    );
+  });
+
+  it("emits correct batchSize in metadata per user", async () => {
+    // userId 10 → 3 txs, userId 20 → 1 tx.
+    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([
+      { id: 1, userId: 10 },
+      { id: 2, userId: 10 },
+      { id: 3, userId: 10 },
+      { id: 4, userId: 20 },
+    ]);
+
+    await classificationAutoUncategorizeProcessor(makeJob());
+
+    const callsForUser10 = mocks.emitNotification.mock.calls.filter(
+      (args: unknown[]) => args[0] === 10,
+    );
+    const callsForUser20 = mocks.emitNotification.mock.calls.filter(
+      (args: unknown[]) => args[0] === 20,
+    );
+
+    expect((callsForUser10[0][1] as { metadata: { batchSize: number } }).metadata.batchSize).toBe(
+      3,
+    );
+    expect((callsForUser20[0][1] as { metadata: { batchSize: number } }).metadata.batchSize).toBe(
+      1,
+    );
+  });
+
+  it("dedup: same entityId on second run — emitNotification called but idempotent dedup is in emit.ts", async () => {
+    // entityId is stable by (userId, date) — the dedup happens inside emitNotification
+    // via the DB unique index. Here we just verify the entityId is the same across calls.
+    const todayBogota = new Date().toLocaleDateString("en-CA", {
+      timeZone: "America/Bogota",
+    });
+
+    mocks.dbUpdateSetWhereReturning.mockResolvedValue([{ id: 1, userId: 77 }]);
+
+    await classificationAutoUncategorizeProcessor(makeJob());
+    await classificationAutoUncategorizeProcessor(makeJob());
+
+    const entityIds = mocks.emitNotification.mock.calls.map(
+      (args: unknown[]) => (args[1] as { entityId: string }).entityId,
+    );
+    // Both calls use the same entityId.
+    expect(entityIds).toEqual([`auto-uncat-77-${todayBogota}`, `auto-uncat-77-${todayBogota}`]);
+  });
+
+  it("tenant safety: each userId gets its own emit, not mixed", async () => {
+    // Users A=1, B=2, C=3 — each with different counts.
+    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([
+      { id: 1, userId: 1 },
+      { id: 2, userId: 2 },
+      { id: 3, userId: 3 },
+      { id: 4, userId: 1 }, // userA gets a second tx
+    ]);
+
+    await classificationAutoUncategorizeProcessor(makeJob());
+
+    type EmitCall = [number, { metadata: { batchSize: number } }];
+    const calls = mocks.emitNotification.mock.calls as EmitCall[];
+    const userIds = calls.map((c) => c[0]).sort();
+    expect(userIds).toEqual([1, 2, 3]);
+
+    const user1Call = calls.find((c) => c[0] === 1);
+    expect(user1Call?.[1].metadata.batchSize).toBe(2);
+
+    const user2Call = calls.find((c) => c[0] === 2);
+    expect(user2Call?.[1].metadata.batchSize).toBe(1);
+  });
+
+  it("emits actionUrl pointing to /transactions?categorySlug=otros", async () => {
+    mocks.dbUpdateSetWhereReturning.mockResolvedValueOnce([{ id: 1, userId: 5 }]);
+
+    await classificationAutoUncategorizeProcessor(makeJob());
+
+    expect(mocks.emitNotification).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({
+        actionUrl: "/transactions?categorySlug=otros",
+      }),
+    );
   });
 });

--- a/src/lib/queue/workers/classification-auto-uncategorize.ts
+++ b/src/lib/queue/workers/classification-auto-uncategorize.ts
@@ -4,6 +4,7 @@ import { and, inArray, isNull, lt, sql } from "drizzle-orm";
 import { createLogger } from "@/lib/logger";
 import { db } from "@/lib/db";
 import { transactions } from "@/lib/db/schema";
+import { emitNotification } from "@/lib/notifications/emit";
 import { createWorker } from "@/lib/queue";
 
 const log = createLogger({ module: "worker/classification-auto-uncategorize" });
@@ -57,7 +58,7 @@ export async function classificationAutoUncategorizeProcessor(
         isNull(transactions.deletedAt),
       ),
     )
-    .returning({ id: transactions.id });
+    .returning({ id: transactions.id, userId: transactions.userId });
 
   const rowsUpdated = result.length;
 
@@ -66,7 +67,36 @@ export async function classificationAutoUncategorizeProcessor(
     "auto-uncategorize batch finished",
   );
 
-  await job.updateProgress({ done: true, totalMoved: rowsUpdated, totalUsers: 0 });
+  // Group by userId and emit one notification per affected user.
+  // Build the map outside the if so totalUsers is always in scope for updateProgress.
+  const countByUser = new Map<number, number>();
+  for (const row of result) {
+    countByUser.set(row.userId, (countByUser.get(row.userId) ?? 0) + 1);
+  }
+
+  if (countByUser.size > 0) {
+    // todayISODate in America/Bogota timezone for stable daily entityId.
+    const todayISODate = new Date().toLocaleDateString("en-CA", { timeZone: "America/Bogota" });
+
+    for (const [userId, batchSize] of countByUser) {
+      await emitNotification(userId, {
+        type: "classification_auto_uncategorized",
+        entityId: `auto-uncat-${userId}-${todayISODate}`,
+        priority: "medium",
+        title: 'Movimientos archivados a "otros"',
+        body: 'Algunos movimientos sin categoría desde hace tiempo se movieron a "otros". Revisá si querés re-categorizarlos.',
+        actionUrl: "/transactions?categorySlug=otros",
+        metadata: { todayISODate, batchSize },
+      });
+
+      log.info(
+        { event: "auto_uncategorize_notification_emitted", userId, batchSize, todayISODate },
+        "classification_auto_uncategorized notification emitted",
+      );
+    }
+  }
+
+  await job.updateProgress({ done: true, totalMoved: rowsUpdated, totalUsers: countByUser.size });
   await job.log(`done: moved=${rowsUpdated} rows to category=otros`);
 
   return { rowsUpdated };

--- a/src/lib/queue/workers/recurring-learning.test.ts
+++ b/src/lib/queue/workers/recurring-learning.test.ts
@@ -26,6 +26,13 @@ vi.mock("@/lib/queue", () => ({
   }),
 }));
 
+// emitNotification is mocked to avoid hitting the notifications table and the
+// SSE bus during integration tests. We spy on it to assert emit calls.
+const emitMocks = vi.hoisted(() => ({ emitNotification: vi.fn() }));
+vi.mock("@/lib/notifications/emit", () => ({
+  emitNotification: emitMocks.emitNotification,
+}));
+
 // ---------------------------------------------------------------------------
 // Lazy import (after mocks)
 // ---------------------------------------------------------------------------
@@ -125,6 +132,8 @@ describe("recurringLearningProcessor", () => {
   let recurringAId: number;
 
   beforeEach(async () => {
+    emitMocks.emitNotification.mockReset();
+    emitMocks.emitNotification.mockResolvedValue({ id: 1 });
     await cleanup();
     userAId = await seedUser(`${TAG}-userA@test.local`);
     accountAId = await seedAccount(userAId);
@@ -456,5 +465,268 @@ describe("recurringLearningProcessor", () => {
     await db.execute(sql`DELETE FROM recurring_transactions WHERE id = ${recurringBId}`);
     await db.execute(sql`DELETE FROM accounts WHERE id = ${accountBId}`);
     await db.execute(sql`DELETE FROM users WHERE id = ${userBId}`);
+  });
+
+  // ── New: notification emitter tests ─────────────────────────────────────
+
+  it("emits recurring_proposal_ready when an amount_update proposal is created", async () => {
+    const tx1 = await seedTx(userAId, accountAId, BigInt(-44900));
+    const tx2 = await seedTx(userAId, accountAId, BigInt(-44900));
+
+    await db.insert(recurringLinkObservations).values([
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx1,
+        yearMonth: "2026-03",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx2,
+        yearMonth: "2026-04",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+    ]);
+
+    await recurringLearningProcessor(mockJob());
+
+    expect(emitMocks.emitNotification).toHaveBeenCalledOnce();
+
+    const [calledUserId, calledInput] = emitMocks.emitNotification.mock.calls[0] as [
+      number,
+      {
+        type: string;
+        entityId: string;
+        metadata: { proposalKind: string; recurringId: number; proposalId: number };
+      },
+    ];
+
+    expect(calledUserId).toBe(userAId);
+    expect(calledInput.type).toBe("recurring_proposal_ready");
+    expect(calledInput.metadata.proposalKind).toBe("amount_update");
+    expect(calledInput.metadata.recurringId).toBe(recurringAId);
+    // entityId must be the stringified proposalId (never null).
+    expect(calledInput.entityId).toBe(String(calledInput.metadata.proposalId));
+    expect(calledInput.metadata.proposalId).toBeGreaterThan(0);
+  });
+
+  it("emits recurring_proposal_ready when a variable_flag proposal is created", async () => {
+    const tx1 = await seedTx(userAId, accountAId, BigInt(-42000));
+    const tx2 = await seedTx(userAId, accountAId, BigInt(-55000));
+    const tx3 = await seedTx(userAId, accountAId, BigInt(-31000));
+
+    await db.insert(recurringLinkObservations).values([
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx1,
+        yearMonth: "2026-02",
+        realAmountCents: BigInt(-42000),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx2,
+        yearMonth: "2026-03",
+        realAmountCents: BigInt(-55000),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx3,
+        yearMonth: "2026-04",
+        realAmountCents: BigInt(-31000),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+    ]);
+
+    await recurringLearningProcessor(mockJob());
+
+    expect(emitMocks.emitNotification).toHaveBeenCalledOnce();
+
+    const [, calledInput] = emitMocks.emitNotification.mock.calls[0] as [
+      number,
+      { metadata: { proposalKind: string } },
+    ];
+    expect(calledInput.metadata.proposalKind).toBe("variable_flag");
+  });
+
+  it("does NOT emit when existing pending proposal causes skip (idempotent guard)", async () => {
+    const tx1 = await seedTx(userAId, accountAId, BigInt(-44900));
+    const tx2 = await seedTx(userAId, accountAId, BigInt(-44900));
+
+    await db.insert(recurringLinkObservations).values([
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx1,
+        yearMonth: "2026-03",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: tx2,
+        yearMonth: "2026-04",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+    ]);
+
+    // Pre-existing pending proposal — the processor should skip and NOT emit.
+    await db.insert(recurringProposals).values({
+      userId: userAId,
+      recurringId: recurringAId,
+      proposalType: "amount_update",
+      payload: { existing: true },
+      status: "pending",
+    });
+
+    await recurringLearningProcessor(mockJob());
+
+    expect(emitMocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("emits one notification per user in a multi-user run", async () => {
+    const userBId = await seedUser(`${TAG}-userB@test.local`);
+    const accountBId = await seedAccount(userBId);
+    const recurringBId = await seedRecurring(userBId, accountBId, BigInt(-42000));
+
+    // UserA: 2 qualifying observations.
+    const txA1 = await seedTx(userAId, accountAId, BigInt(-44900));
+    const txA2 = await seedTx(userAId, accountAId, BigInt(-44900));
+
+    // UserB: 2 qualifying observations (different amount, same drift).
+    const txB1 = await seedTx(userBId, accountBId, BigInt(-50000));
+    const txB2 = await seedTx(userBId, accountBId, BigInt(-50000));
+
+    await db.insert(recurringLinkObservations).values([
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: txA1,
+        yearMonth: "2026-03",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userAId,
+        recurringId: recurringAId,
+        txId: txA2,
+        yearMonth: "2026-04",
+        realAmountCents: BigInt(-44900),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountAId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userBId,
+        recurringId: recurringBId,
+        txId: txB1,
+        yearMonth: "2026-03",
+        realAmountCents: BigInt(-50000),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountBId,
+        manual: true,
+        applied: false,
+      },
+      {
+        userId: userBId,
+        recurringId: recurringBId,
+        txId: txB2,
+        yearMonth: "2026-04",
+        realAmountCents: BigInt(-50000),
+        realCurrency: "COP",
+        descriptionRaw: `${TAG}-tx`,
+        accountId: accountBId,
+        manual: true,
+        applied: false,
+      },
+    ]);
+
+    await recurringLearningProcessor(mockJob());
+
+    // One emit per user.
+    expect(emitMocks.emitNotification).toHaveBeenCalledTimes(2);
+
+    const calledUserIds = emitMocks.emitNotification.mock.calls.map(
+      (args: unknown[]) => args[0] as number,
+    );
+    expect(calledUserIds).toContain(userAId);
+    expect(calledUserIds).toContain(userBId);
+
+    // Cleanup userB
+    await db.execute(sql`DELETE FROM recurring_proposals WHERE user_id = ${userBId}`);
+    await db.execute(sql`DELETE FROM recurring_link_observations WHERE user_id = ${userBId}`);
+    await db.execute(
+      sql`DELETE FROM transactions WHERE description_raw = ${TAG + "-tx"} AND user_id = ${userBId}`,
+    );
+    await db.execute(sql`DELETE FROM recurring_transactions WHERE id = ${recurringBId}`);
+    await db.execute(sql`DELETE FROM accounts WHERE id = ${accountBId}`);
+    await db.execute(sql`DELETE FROM users WHERE id = ${userBId}`);
+  });
+
+  it("does NOT emit when no proposals are created (observations below threshold)", async () => {
+    // Only 1 observation — below MIN_OBSERVATIONS_FOR_AMOUNT_UPDATE (2).
+    const tx1 = await seedTx(userAId, accountAId, BigInt(-44900));
+
+    await db.insert(recurringLinkObservations).values({
+      userId: userAId,
+      recurringId: recurringAId,
+      txId: tx1,
+      yearMonth: "2026-04",
+      realAmountCents: BigInt(-44900),
+      realCurrency: "COP",
+      descriptionRaw: `${TAG}-tx`,
+      accountId: accountAId,
+      manual: true,
+      applied: false,
+    });
+
+    await recurringLearningProcessor(mockJob());
+
+    expect(emitMocks.emitNotification).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/queue/workers/recurring-learning.ts
+++ b/src/lib/queue/workers/recurring-learning.ts
@@ -18,7 +18,8 @@ import { and, eq, lte, sql } from "drizzle-orm";
 
 import { createLogger } from "@/lib/logger";
 import { db } from "@/lib/db";
-import { recurringProposals } from "@/lib/db/schema";
+import { recurringProposals, recurringTransactions } from "@/lib/db/schema";
+import { emitNotification } from "@/lib/notifications/emit";
 import { createWorker } from "@/lib/queue";
 
 const log = createLogger({ module: "worker/recurring-learning" });
@@ -54,6 +55,10 @@ export type LearningResult = {
   proposalsCreated: number;
   errors: number;
 };
+
+type ProposalOutcome =
+  | { count: 0 }
+  | { count: 1; proposalId: number; proposalKind: "variable_flag" | "amount_update" };
 
 /**
  * Core processor — exported separately for tests (no live Worker needed).
@@ -153,7 +158,7 @@ export async function recurringLearningProcessor(
     try {
       // Wrap SELECT + INSERT in a transaction to prevent race conditions from
       // a manual Bull-Board trigger racing with the scheduled daily run.
-      const created = await db.transaction(async (trx) => {
+      const outcome = await db.transaction(async (trx): Promise<ProposalOutcome> => {
         // Check for an existing pending proposal of any type for this recurring.
         const [existingPending] = await trx
           .select({ id: recurringProposals.id })
@@ -169,7 +174,7 @@ export async function recurringLearningProcessor(
 
         if (existingPending) {
           // A proposal is already pending — skip until user decides.
-          return 0;
+          return { count: 0 };
         }
 
         const distinctAmounts = [...new Set(amounts.map((a) => a.toString()))].map((s) =>
@@ -185,12 +190,15 @@ export async function recurringLearningProcessor(
             observationCount: obsCount,
           };
 
-          await trx.insert(recurringProposals).values({
-            userId,
-            recurringId,
-            proposalType: "variable_flag",
-            payload,
-          });
+          const [inserted] = await trx
+            .insert(recurringProposals)
+            .values({
+              userId,
+              recurringId,
+              proposalType: "variable_flag",
+              payload,
+            })
+            .returning({ id: recurringProposals.id });
 
           log.info(
             {
@@ -199,11 +207,12 @@ export async function recurringLearningProcessor(
               recurringId,
               obsCount,
               distinctAmountsCount: distinctAmounts.length,
+              proposalId: inserted?.id,
             },
             "variable_flag proposal created",
           );
 
-          return 1;
+          return { count: 1, proposalId: inserted!.id, proposalKind: "variable_flag" };
         }
 
         // ── Amount-update check ─────────────────────────────────────────────
@@ -220,7 +229,7 @@ export async function recurringLearningProcessor(
           const absEst = Math.abs(estimatedAmountNum);
 
           // Avoid divide-by-zero for zero-amount recurrings.
-          if (absEst === 0) return 0;
+          if (absEst === 0) return { count: 0 };
 
           // Express drift as a fraction. Using Number() is safe here — we only
           // need a rough 5% comparison, not bigint precision.
@@ -234,12 +243,15 @@ export async function recurringLearningProcessor(
               observationCount: obsCount,
             };
 
-            await trx.insert(recurringProposals).values({
-              userId,
-              recurringId,
-              proposalType: "amount_update",
-              payload,
-            });
+            const [inserted] = await trx
+              .insert(recurringProposals)
+              .values({
+                userId,
+                recurringId,
+                proposalType: "amount_update",
+                payload,
+              })
+              .returning({ id: recurringProposals.id });
 
             log.info(
               {
@@ -250,18 +262,54 @@ export async function recurringLearningProcessor(
                 newAmount: newAmount.toString(),
                 driftPct: Math.round(drift * 100),
                 obsCount,
+                proposalId: inserted?.id,
               },
               "amount_update proposal created",
             );
 
-            return 1;
+            return { count: 1, proposalId: inserted!.id, proposalKind: "amount_update" };
           }
         }
 
-        return 0;
+        return { count: 0 };
       });
 
-      result.proposalsCreated += created;
+      result.proposalsCreated += outcome.count;
+
+      // Emit notification if a proposal was created.
+      if (outcome.count === 1) {
+        // Fetch the recurring label for the notification body.
+        const [recurring] = await db
+          .select({ label: recurringTransactions.label })
+          .from(recurringTransactions)
+          .where(eq(recurringTransactions.id, recurringId))
+          .limit(1);
+
+        await emitNotification(userId, {
+          type: "recurring_proposal_ready",
+          entityId: String(outcome.proposalId),
+          priority: "medium",
+          title: "Sugerencia para recurrente",
+          body: `Detectamos un patrón nuevo en ${recurring?.label ?? "un recurrente"}. Revisá la propuesta.`,
+          actionUrl: "/recurring",
+          metadata: {
+            proposalId: outcome.proposalId,
+            recurringId,
+            proposalKind: outcome.proposalKind,
+          },
+        });
+
+        log.info(
+          {
+            event: "recurring_proposal_notification_emitted",
+            userId,
+            recurringId,
+            proposalId: outcome.proposalId,
+            proposalKind: outcome.proposalKind,
+          },
+          "recurring_proposal_ready notification emitted",
+        );
+      }
     } catch (err) {
       log.error(
         {


### PR DESCRIPTION
Closes #661

## Summary

Wires two emitters in existing classification + recurring workers.

### `classification_auto_uncategorized` — `src/lib/queue/workers/classification-auto-uncategorize.ts`
- Bulk UPDATE now returns `(id, userId)` instead of just `id`
- Post-update aggregates affected users via `Map<userId, count>`
- One emit per affected user with metadata.batchSize
- entityId = `auto-uncat-{userId}-{ISODate}` (synthetic, daily — dedup means at most one notif per user per day)

### `recurring_proposal_ready` — `src/lib/queue/workers/recurring-learning.ts`
- Both proposal inserts (`amount_update` + `variable_flag`) now `.returning({ id })`
- Emits per inserted proposal with entityId = `String(proposalId)`
- Per-user loop already provides `userId` in scope

## Test plan

- [x] 4 gates clean (lint + format:check + typecheck + test 2133/2133 passing)
- [x] Tenant safety: 3 users → 3 emits with correct batchSize per user
- [x] Dedup: synthetic entityId per user-day prevents double-emit
- [x] Recurring: both proposal kinds emit with stable entityId
- [ ] CI