### PR TITLE
feat(notifications): Wave 3 flash emitters — gmail/statement/reset/snapshot/insights (#662)

### DIFF
--- a/src/app/(app)/insights/actions.test.ts
+++ b/src/app/(app)/insights/actions.test.ts
@@ -1,0 +1,87 @@
+// Unit test for Wave 3 insights_report_ready emitter (#662).
+// Spies on emitNotification and verifies it is called once after
+// generateInsight successfully inserts a report.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as emitModule from "@/lib/notifications/emit";
+
+// ── module mocks ──────────────────────────────────────────────────────────
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+const sessionMock = { id: 3, email: "test@test.local", name: "Test" };
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockImplementation(async () => sessionMock),
+}));
+
+vi.mock("@/lib/fx/repo", () => ({
+  getCurrentFxRate: vi.fn().mockResolvedValue({ rate: 4200 }),
+}));
+
+vi.mock("@/lib/dashboard/period", () => ({
+  getFinancialPeriod: vi.fn().mockResolvedValue({
+    start: new Date("2026-04-01"),
+    end: new Date("2026-04-30"),
+  }),
+}));
+
+vi.mock("@/lib/ai/insights", () => ({
+  buildInsightsSummary: vi.fn().mockResolvedValue({ summary: "mock" }),
+  generateInsightsReport: vi.fn().mockResolvedValue({
+    markdown: "# Insights\n...",
+    model: "claude-haiku-4",
+    usage: { inputTokens: 100, outputTokens: 200 },
+  }),
+  hashSummary: vi.fn().mockReturnValue("abc123"),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+    delete: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([]),
+    }),
+  },
+}));
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+describe("generateInsight — insights_report_ready emitter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits insights_report_ready once with correct shape", async () => {
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { generateInsight } = await import("./actions");
+    const result = await generateInsight("2026-04");
+
+    expect(result.ym).toBe("2026-04");
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      sessionMock.id,
+      expect.objectContaining({
+        type: "insights_report_ready",
+        entityId: "2026-04",
+        priority: "low",
+        title: "Reporte de insights listo",
+        actionUrl: "/insights?yearMonth=2026-04",
+      }),
+    );
+    expect(spy.mock.calls[0]![1].metadata).toMatchObject({ yearMonth: "2026-04" });
+  });
+
+  it("does NOT emit when yearMonth schema validation fails", async () => {
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { generateInsight } = await import("./actions");
+    await expect(generateInsight("invalid")).rejects.toThrow();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(app)/insights/actions.ts
+++ b/src/app/(app)/insights/actions.ts
@@ -9,6 +9,10 @@ import { getSessionUser } from "@/lib/auth/session";
 import { buildInsightsSummary, generateInsightsReport, hashSummary } from "@/lib/ai/insights";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { getFinancialPeriod } from "@/lib/dashboard/period";
+import { createLogger } from "@/lib/logger";
+import { emitNotification } from "@/lib/notifications/emit";
+
+const log = createLogger({ module: "insights.actions" });
 
 const ymSchema = z.string().regex(/^\d{4}-\d{2}$/);
 
@@ -55,6 +59,27 @@ export async function generateInsight(ym: string) {
     });
 
   revalidatePath("/insights");
+
+  await emitNotification(session.id, {
+    type: "insights_report_ready",
+    entityId: String(parsed),
+    priority: "low",
+    title: "Reporte de insights listo",
+    body: `Tu análisis de ${parsed} está listo para revisar.`,
+    actionUrl: `/insights?yearMonth=${parsed}`,
+    metadata: { yearMonth: parsed },
+  }).catch((emitErr: unknown) => {
+    log.error(
+      {
+        err: emitErr,
+        userId: session.id,
+        yearMonth: parsed,
+        event: "emit_insights_report_ready_failed",
+      },
+      "failed to emit insights_report_ready notification",
+    );
+  });
+
   return { ym: parsed, generatedAt: new Date().toISOString() };
 }
 

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions-emit.test.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions-emit.test.ts
@@ -1,5 +1,5 @@
-// Unit test for Wave 1 reconciliation_flagged_txns emitter (#657).
-// Mocks commitReconciliation to return flagged > 0 and spies on emitNotification.
+// Unit tests for reconciliation emitters — Wave 1 (#657) + Wave 3 (#662).
+// Covers reconciliation_flagged_txns and statement_import_complete.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as emitModule from "@/lib/notifications/emit";
@@ -107,19 +107,21 @@ describe("applyReconcile — reconciliation_flagged_txns emitter", () => {
       userBalanceAtEndCents: null,
     });
 
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(
-      sessionMock.id,
-      expect.objectContaining({
-        type: "reconciliation_flagged_txns",
-        entityId: "55",
-        audience: "user",
-        priority: "high",
-      }),
+    // Both statement_import_complete (#662) and reconciliation_flagged_txns (#657) fire
+    // when status=applied and flagged > 0.
+    const flaggedCall = spy.mock.calls.find(
+      ([, input]) => input.type === "reconciliation_flagged_txns",
     );
+    expect(flaggedCall).toBeDefined();
+    expect(flaggedCall![1]).toMatchObject({
+      type: "reconciliation_flagged_txns",
+      entityId: "55",
+      audience: "user",
+      priority: "high",
+    });
   });
 
-  it("does NOT emit when flagged === 0", async () => {
+  it("does NOT emit reconciliation_flagged_txns when flagged === 0", async () => {
     const { commitReconciliation } = await import("@/lib/reconciliation/commit");
     (commitReconciliation as ReturnType<typeof vi.fn>).mockResolvedValue({
       status: "applied",
@@ -146,7 +148,11 @@ describe("applyReconcile — reconciliation_flagged_txns emitter", () => {
       userBalanceAtEndCents: null,
     });
 
-    expect(spy).not.toHaveBeenCalled();
+    // statement_import_complete fires (flagged=0 still applied), but NOT reconciliation_flagged_txns
+    const flaggedCall = spy.mock.calls.find(
+      ([, input]) => input.type === "reconciliation_flagged_txns",
+    );
+    expect(flaggedCall).toBeUndefined();
   });
 
   it("does NOT emit when result.status is not 'applied'", async () => {
@@ -177,5 +183,83 @@ describe("applyReconcile — reconciliation_flagged_txns emitter", () => {
     });
 
     expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("applyReconcile — statement_import_complete emitter (#662)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits statement_import_complete once when result.status is 'applied'", async () => {
+    const { commitReconciliation } = await import("@/lib/reconciliation/commit");
+    (commitReconciliation as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "applied",
+      inserted: 4,
+      insertedIds: [10, 11, 12, 13],
+      matched: 1,
+      flagged: 0,
+      statementImportId: 88,
+    });
+
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { applyReconcile } = await import("./actions");
+    await applyReconcile({
+      accountId: 7,
+      fileHash: "a".repeat(64),
+      parsed: {
+        format: "bancolombia_savings",
+        periodStart: "2026-04-01T00:00:00.000Z",
+        periodEnd: "2026-04-30T00:00:00.000Z",
+        rows: [],
+      },
+      plan: { toInsert: [], toMatch: [], flaggedExisting: [] },
+      userBalanceAtEndCents: null,
+    });
+
+    // statement_import_complete should have been emitted (once)
+    const statementCall = spy.mock.calls.find(
+      ([, input]) => input.type === "statement_import_complete",
+    );
+    expect(statementCall).toBeDefined();
+    expect(statementCall![1]).toMatchObject({
+      type: "statement_import_complete",
+      entityId: "88",
+      priority: "medium",
+    });
+  });
+
+  it("does NOT emit statement_import_complete when status is 'already_imported'", async () => {
+    const { commitReconciliation } = await import("@/lib/reconciliation/commit");
+    (commitReconciliation as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "already_imported",
+      inserted: 0,
+      insertedIds: [],
+      matched: 0,
+      flagged: 0,
+      statementImportId: 89,
+    });
+
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { applyReconcile } = await import("./actions");
+    await applyReconcile({
+      accountId: 7,
+      fileHash: "a".repeat(64),
+      parsed: {
+        format: "bancolombia_savings",
+        periodStart: "2026-04-01T00:00:00.000Z",
+        periodEnd: "2026-04-30T00:00:00.000Z",
+        rows: [],
+      },
+      plan: { toInsert: [], toMatch: [], flaggedExisting: [] },
+      userBalanceAtEndCents: null,
+    });
+
+    const statementCall = spy.mock.calls.find(
+      ([, input]) => input.type === "statement_import_complete",
+    );
+    expect(statementCall).toBeUndefined();
   });
 });

--- a/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
+++ b/src/app/(app)/settings/accounts/[accountId]/reconcile/actions.ts
@@ -384,6 +384,34 @@ export async function applyReconcile(input: ApplyReconcileInput) {
     "reconciliation applied",
   );
 
+  // #662 — notify user when reconciliation is applied successfully.
+  if (result.status === "applied") {
+    await emitNotification(session.id, {
+      type: "statement_import_complete",
+      entityId: String(result.statementImportId),
+      priority: "medium",
+      title: "Reconciliación aplicada",
+      body: `Importamos el extracto correctamente. ${result.inserted} movimientos nuevos reconciliados.`,
+      actionUrl: `/transactions?accountId=${accountId}`,
+      metadata: {
+        statementImportId: result.statementImportId,
+        inserted: result.inserted,
+        flagged: result.flagged,
+      },
+    }).catch((emitErr: unknown) => {
+      log.error(
+        {
+          err: emitErr,
+          userId: session.id,
+          accountId,
+          statementImportId: result.statementImportId,
+          event: "emit_statement_import_complete_failed",
+        },
+        "failed to emit statement_import_complete notification",
+      );
+    });
+  }
+
   // #657 — notify user when reconciliation flags transactions.
   if (result.status === "applied" && result.flagged > 0) {
     await emitNotification(session.id, {

--- a/src/app/(app)/settings/reset/actions.test.ts
+++ b/src/app/(app)/settings/reset/actions.test.ts
@@ -1,0 +1,75 @@
+// Unit test for Wave 3 reset_complete emitter (#662).
+// Spies on emitNotification and verifies it is called with the correct shape
+// after resetUserData succeeds.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as emitModule from "@/lib/notifications/emit";
+
+// ── module mocks ──────────────────────────────────────────────────────────
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+const sessionMock = { id: 7, email: "test@test.local", name: "Test" };
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockImplementation(async () => sessionMock),
+}));
+
+vi.mock("@/lib/reset/reset", () => ({
+  resetUserData: vi.fn().mockResolvedValue({
+    snapshot: { id: 1, name: "pre-reset-2026-04-30", payloadBytes: BigInt(1024) },
+  }),
+}));
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+describe("resetUserDataAction — reset_complete emitter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits reset_complete once with correct shape when reset succeeds", async () => {
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { resetUserDataAction } = await import("./actions");
+    const result = await resetUserDataAction({ confirm: "RESET" });
+
+    expect(result.status).toBe("ok");
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      sessionMock.id,
+      expect.objectContaining({
+        type: "reset_complete",
+        priority: "medium",
+        title: "Datos reseteados",
+        actionUrl: "/transactions",
+      }),
+    );
+    // entityId must follow the stable pattern "reset-{userId}-{YYYY-MM-DD}"
+    const entityId = spy.mock.calls[0]![1].entityId;
+    expect(entityId).toMatch(/^reset-7-\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("does NOT emit when confirmation text is wrong", async () => {
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { resetUserDataAction } = await import("./actions");
+    // @ts-expect-error — deliberate wrong literal to test validation
+    const result = await resetUserDataAction({ confirm: "wrong" });
+
+    expect(result.status).toBe("error");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT emit when resetUserData throws", async () => {
+    const { resetUserData } = await import("@/lib/reset/reset");
+    (resetUserData as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("db error"));
+
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { resetUserDataAction } = await import("./actions");
+    const result = await resetUserDataAction({ confirm: "RESET" });
+
+    expect(result.status).toBe("error");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(app)/settings/reset/actions.ts
+++ b/src/app/(app)/settings/reset/actions.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { getSessionUser } from "@/lib/auth/session";
 import { createLogger } from "@/lib/logger";
 import { resetUserData } from "@/lib/reset/reset";
+import { emitNotification } from "@/lib/notifications/emit";
 
 const log = createLogger({ module: "reset.actions" });
 
@@ -43,6 +44,22 @@ export async function resetUserDataAction(
     revalidatePath("/insights");
     revalidatePath("/settings/snapshots");
     revalidatePath("/settings/reset");
+
+    const todayISODate = new Date().toISOString().slice(0, 10);
+    await emitNotification(session.id, {
+      type: "reset_complete",
+      entityId: `reset-${session.id}-${todayISODate}`,
+      priority: "medium",
+      title: "Datos reseteados",
+      body: "Tu cuenta volvió al estado inicial. Podés re-importar movimientos cuando quieras.",
+      actionUrl: "/transactions",
+      metadata: { todayISODate },
+    }).catch((emitErr: unknown) => {
+      log.error(
+        { err: emitErr, userId: session.id, event: "emit_reset_complete_failed" },
+        "failed to emit reset_complete notification",
+      );
+    });
 
     return {
       status: "ok",

--- a/src/app/(app)/settings/snapshots/actions.test.ts
+++ b/src/app/(app)/settings/snapshots/actions.test.ts
@@ -1,0 +1,77 @@
+// Unit test for Wave 3 snapshot_restored emitter (#662).
+// Spies on emitNotification and verifies it is called once with the correct
+// shape after restoreSnapshotAction succeeds.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as emitModule from "@/lib/notifications/emit";
+
+// ── module mocks ──────────────────────────────────────────────────────────
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+const sessionMock = { id: 5, email: "test@test.local", name: "Test" };
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockImplementation(async () => sessionMock),
+}));
+
+const { mockRestoreSnapshotForUser } = vi.hoisted(() => ({
+  mockRestoreSnapshotForUser: vi.fn(),
+}));
+
+vi.mock("@/lib/snapshots/create", () => ({
+  createSnapshotForUser: vi.fn(),
+  deleteSnapshotForUser: vi.fn(),
+  restoreSnapshotForUser: mockRestoreSnapshotForUser,
+}));
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+describe("restoreSnapshotAction — snapshot_restored emitter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRestoreSnapshotForUser.mockResolvedValue({ ok: true });
+  });
+
+  it("emits snapshot_restored once with correct shape when restore succeeds", async () => {
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { restoreSnapshotAction } = await import("./actions");
+    const result = await restoreSnapshotAction({ snapshotId: 12 });
+
+    expect(result.status).toBe("ok");
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      sessionMock.id,
+      expect.objectContaining({
+        type: "snapshot_restored",
+        entityId: "12",
+        priority: "medium",
+        title: "Snapshot restaurado",
+        actionUrl: "/transactions",
+      }),
+    );
+    expect(spy.mock.calls[0]![1].metadata).toMatchObject({ snapshotId: 12 });
+  });
+
+  it("does NOT emit when snapshot is not found", async () => {
+    mockRestoreSnapshotForUser.mockResolvedValue({ ok: false, reason: "not_found" });
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { restoreSnapshotAction } = await import("./actions");
+    const result = await restoreSnapshotAction({ snapshotId: 99 });
+
+    expect(result.status).toBe("not_found");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT emit when restore throws", async () => {
+    mockRestoreSnapshotForUser.mockRejectedValueOnce(new Error("db error"));
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { restoreSnapshotAction } = await import("./actions");
+    const result = await restoreSnapshotAction({ snapshotId: 12 });
+
+    expect(result.status).toBe("error");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(app)/settings/snapshots/actions.ts
+++ b/src/app/(app)/settings/snapshots/actions.ts
@@ -10,6 +10,7 @@ import {
   restoreSnapshotForUser,
   type CreatedSnapshot,
 } from "@/lib/snapshots/create";
+import { emitNotification } from "@/lib/notifications/emit";
 
 const log = createLogger({ module: "snapshots.actions" });
 
@@ -81,6 +82,22 @@ export async function restoreSnapshotAction(
     revalidatePath("/settings/snapshots");
     revalidatePath("/");
     revalidatePath("/transactions");
+
+    await emitNotification(session.id, {
+      type: "snapshot_restored",
+      entityId: String(snapshotId),
+      priority: "medium",
+      title: "Snapshot restaurado",
+      body: "Tu cuenta volvió al estado del snapshot seleccionado.",
+      actionUrl: "/transactions",
+      metadata: { snapshotId },
+    }).catch((emitErr: unknown) => {
+      log.error(
+        { err: emitErr, userId: session.id, snapshotId, event: "emit_snapshot_restored_failed" },
+        "failed to emit snapshot_restored notification",
+      );
+    });
+
     return { status: "ok" };
   } catch (err) {
     log.error(

--- a/src/app/api/integrations/gmail/oauth/callback/route.test.ts
+++ b/src/app/api/integrations/gmail/oauth/callback/route.test.ts
@@ -1,0 +1,134 @@
+// Unit test for Wave 3 gmail_connected emitter (#662).
+// Exercises the happy path of the OAuth callback and verifies
+// that emitNotification is called exactly once with the expected shape.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as emitModule from "@/lib/notifications/emit";
+
+// ── hoisted shared state ──────────────────────────────────────────────────
+
+const { mockGetSessionUserOrNull, mockSelectLimit, mockTransactionFn } = vi.hoisted(() => {
+  const mockSelectLimit = vi.fn().mockResolvedValue([{ id: 42 }]);
+  const txInsertOnConflict = vi.fn().mockResolvedValue([]);
+  const txInsertValues = vi.fn().mockReturnValue({ onConflictDoUpdate: txInsertOnConflict });
+  const txInsert = vi.fn().mockReturnValue({ values: txInsertValues });
+  const txUpdateWhere = vi.fn().mockResolvedValue([]);
+  const txUpdateSet = vi.fn().mockReturnValue({ where: txUpdateWhere });
+  const txUpdate = vi.fn().mockReturnValue({ set: txUpdateSet });
+  const txMock = { insert: txInsert, update: txUpdate };
+  const mockTransactionFn = vi
+    .fn()
+    .mockImplementation(async (cb: (tx: typeof txMock) => unknown) => cb(txMock));
+  return {
+    mockGetSessionUserOrNull: vi.fn(),
+    mockSelectLimit,
+    mockTransactionFn,
+  };
+});
+
+// ── module mocks ──────────────────────────────────────────────────────────
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUserOrNull: mockGetSessionUserOrNull,
+}));
+
+vi.mock("@/lib/gmail/oauth-state", () => ({
+  verifyOAuthState: vi.fn().mockReturnValue({ userId: 1 }),
+  InvalidOAuthStateError: class InvalidOAuthStateError extends Error {},
+}));
+
+vi.mock("@/lib/gmail/client", () => ({
+  GMAIL_SCOPES: ["https://www.googleapis.com/auth/gmail.readonly"],
+  newOAuth2ClientForFlow: vi.fn().mockReturnValue({
+    getToken: vi.fn().mockResolvedValue({
+      tokens: {
+        access_token: "acc",
+        refresh_token: "ref",
+        expiry_date: Date.now() + 3_600_000,
+        scope: "https://www.googleapis.com/auth/gmail.readonly",
+      },
+    }),
+    setCredentials: vi.fn(),
+  }),
+}));
+
+vi.mock("googleapis", () => ({
+  google: {
+    oauth2: vi.fn().mockReturnValue({
+      userinfo: {
+        get: vi.fn().mockResolvedValue({ data: { email: "test@gmail.com" } }),
+      },
+    }),
+  },
+}));
+
+vi.mock("@/lib/crypto/gmail-cipher", () => ({
+  gmailCipher: {
+    encrypt: vi.fn((v: string) => `enc:${v}`),
+  },
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: mockSelectLimit,
+        }),
+      }),
+    }),
+    transaction: mockTransactionFn,
+  },
+}));
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+describe("Gmail OAuth callback — gmail_connected emitter", () => {
+  const sessionUser = { id: 1, email: "user@findash.local", name: "User" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionUserOrNull.mockResolvedValue(sessionUser);
+    mockSelectLimit.mockResolvedValue([{ id: 42 }]);
+    process.env.AUTH_URL = "http://localhost:3100";
+  });
+
+  it("emits gmail_connected once with correct shape on successful OAuth", async () => {
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { GET } = await import("./route");
+    const url = "http://localhost:3100/api/integrations/gmail/oauth/callback?code=CODE&state=STATE";
+    const req = new Request(url);
+
+    await GET(req as Parameters<typeof GET>[0]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      sessionUser.id,
+      expect.objectContaining({
+        type: "gmail_connected",
+        entityId: "42",
+        priority: "low",
+        title: "Gmail conectado",
+        actionUrl: "/settings/integrations",
+      }),
+    );
+    expect(spy.mock.calls[0]![1].metadata).toMatchObject({
+      gmailEmail: "test@gmail.com",
+      connectionId: 42,
+    });
+  });
+
+  it("does NOT emit when session is missing", async () => {
+    mockGetSessionUserOrNull.mockResolvedValue(null);
+    const spy = vi.spyOn(emitModule, "emitNotification").mockResolvedValue({ id: 999 });
+
+    const { GET } = await import("./route");
+    const url = "http://localhost:3100/api/integrations/gmail/oauth/callback?code=CODE&state=STATE";
+    const req = new Request(url);
+
+    await GET(req as Parameters<typeof GET>[0]);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/integrations/gmail/oauth/callback/route.ts
+++ b/src/app/api/integrations/gmail/oauth/callback/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { google } from "googleapis";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { gmailConnections } from "@/lib/db/schema";
 import { getSessionUserOrNull } from "@/lib/auth/session";
@@ -8,6 +8,7 @@ import { gmailCipher } from "@/lib/crypto/gmail-cipher";
 import { GMAIL_SCOPES, newOAuth2ClientForFlow } from "@/lib/gmail/client";
 import { InvalidOAuthStateError, verifyOAuthState } from "@/lib/gmail/oauth-state";
 import { createLogger } from "@/lib/logger";
+import { emitNotification } from "@/lib/notifications/emit";
 
 const log = createLogger({ module: "gmail/oauth/callback" });
 
@@ -192,9 +193,41 @@ export async function GET(req: NextRequest) {
       });
   });
 
+  // Fetch the connection id for the notification entityId. The upsert above
+  // either inserted or updated the active row — either way it exists now.
+  const [conn] = await db
+    .select({ id: gmailConnections.id })
+    .from(gmailConnections)
+    .where(
+      and(
+        eq(gmailConnections.userId, sessionUser.id),
+        eq(gmailConnections.gmailEmail, gmailEmail),
+        isNull(gmailConnections.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  const connectionId = conn?.id ?? 0;
+
   log.info(
     { userId: sessionUser.id, gmailEmail, event: "gmail_oauth_connected" },
     "Gmail connected",
   );
+
+  await emitNotification(sessionUser.id, {
+    type: "gmail_connected",
+    entityId: String(connectionId),
+    priority: "low",
+    title: "Gmail conectado",
+    body: `Empezamos a leer recibos desde ${gmailEmail}.`,
+    actionUrl: "/settings/integrations",
+    metadata: { gmailEmail, connectionId },
+  }).catch((emitErr: unknown) => {
+    log.error(
+      { err: emitErr, userId: sessionUser.id, gmailEmail, event: "emit_gmail_connected_failed" },
+      "failed to emit gmail_connected notification",
+    );
+  });
+
   return redirectToSettings("success");
 }


### PR DESCRIPTION
Closes #662

## Summary

Wires 5 flash/low-priority emitters at user-facing transition points.

| Event | File | entityId | Priority |
|---|---|---|---|
| `gmail_connected` | api/integrations/gmail/oauth/callback | `String(connectionId)` | low |
| `statement_import_complete` | settings/accounts/.../reconcile/actions.ts | `String(statementImportId)` | medium |
| `reset_complete` | settings/reset/actions.ts | `reset-{userId}-{ISODate}` | medium |
| `snapshot_restored` | settings/snapshots/actions.ts | `String(snapshotId)` | medium |
| `insights_report_ready` | insights/actions.ts | `String(yearMonth)` | low |

## Notes

- Gmail OAuth callback uses upsert (`onConflictDoUpdate`); added a `SELECT` after the transaction to capture the connection id cleanly.
- `statement_import_complete` lives next to `reconciliation_flagged_txns`; both can fire on the same `applied` result. Existing Wave 1 reconcile tests updated to type-filtered assertions.
- `reset_complete` uses synthetic daily entityId — at most one notif per user per day even if reset is run multiple times.

## Test plan

- [x] 4 gates clean (lint + format:check + typecheck + test 2157/2157 passing)
- [x] One unit test per callsite (10 new tests total)
- [ ] CI