### PR TITLE
feat(notifications): browser native notifications via Permissions API (#663)

### DIFF
--- a/src/components/layout/bell-button.test.tsx
+++ b/src/components/layout/bell-button.test.tsx
@@ -15,9 +15,37 @@ const mocks = vi.hoisted(() => {
   const unreadCount = vi.fn<() => Promise<{ count: number }>>();
   const toastFn = vi.fn();
   const toastError = vi.fn();
+  const routerPush = vi.fn();
 
-  return { listNotifications, markAsRead, markAllAsRead, unreadCount, toastFn, toastError };
+  return {
+    listNotifications,
+    markAsRead,
+    markAllAsRead,
+    unreadCount,
+    toastFn,
+    toastError,
+    routerPush,
+  };
 });
+
+// ---------------------------------------------------------------------------
+// Mock next/navigation — useRouter requires App Router context in tests
+// ---------------------------------------------------------------------------
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.routerPush }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock browser notification helpers — avoid touching real Notification API
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/notifications/browser-permissions", () => ({
+  getBrowserNotificationPermission: vi.fn().mockReturnValue("denied"),
+  requestBrowserNotificationPermission: vi.fn().mockResolvedValue("denied"),
+}));
+
+vi.mock("@/lib/notifications/browser-display", () => ({
+  maybeShowBrowserNotification: vi.fn(),
+}));
 
 // ---------------------------------------------------------------------------
 // Mock server actions

--- a/src/components/layout/bell-button.tsx
+++ b/src/components/layout/bell-button.tsx
@@ -2,6 +2,7 @@
 
 import { useTransition, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { BellIcon } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -22,6 +23,11 @@ import {
 import { formatRelativeTime } from "@/lib/format-relative-time";
 import type { NotificationRow } from "@/app/(app)/notifications/_types";
 import { cn } from "@/lib/utils";
+import {
+  getBrowserNotificationPermission,
+  requestBrowserNotificationPermission,
+} from "@/lib/notifications/browser-permissions";
+import { maybeShowBrowserNotification } from "@/lib/notifications/browser-display";
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -151,6 +157,7 @@ type BellButtonProps = {
 };
 
 export function BellButton({ initialCount }: BellButtonProps) {
+  const router = useRouter();
   const [count, setCount] = useState(initialCount);
   const [items, setItems] = useState<NotificationRow[]>([]);
   const [loading, setLoading] = useState(false);
@@ -189,6 +196,29 @@ export function BellButton({ initialCount }: BellButtonProps) {
           toast(event.payload.title, {
             description: event.payload.body,
           });
+
+          // ---------------------------------------------------------------------------
+          // Browser-native notification (Phase 6): fires only when the tab is hidden.
+          // Request permission lazily on the first high-priority event if not yet set.
+          // ---------------------------------------------------------------------------
+          void (async () => {
+            const permission = getBrowserNotificationPermission();
+            const effectivePermission =
+              permission === "default" ? await requestBrowserNotificationPermission() : permission;
+
+            if (effectivePermission === "granted") {
+              maybeShowBrowserNotification(
+                {
+                  title: event.payload.title,
+                  body: event.payload.body,
+                  tag: String(event.notificationId),
+                  priority: event.payload.priority,
+                  actionUrl: event.payload.actionUrl,
+                },
+                (url) => router.push(url),
+              );
+            }
+          })();
         }
       }
     },

--- a/src/lib/notifications/browser-display.test.ts
+++ b/src/lib/notifications/browser-display.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { maybeShowBrowserNotification } from "./browser-display";
+import type { DisplayNotificationInput } from "./browser-display";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeInput(overrides?: Partial<DisplayNotificationInput>): DisplayNotificationInput {
+  return {
+    title: "Alerta de presupuesto",
+    body: "Superaste el límite mensual de Restaurantes",
+    tag: "notif-42",
+    priority: "high",
+    actionUrl: "/budgets",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Notification mock setup
+//
+// We need a real constructor (function, not arrow) for `new Notification(...)`.
+// `vi.fn()` alone isn't constructable — use mockImplementation with a regular
+// function so the instance tracking still works.
+// ---------------------------------------------------------------------------
+
+type NotifInstance = {
+  onclick: ((e: Event) => void) | null;
+  close: ReturnType<typeof vi.fn>;
+};
+
+// Shared instance slot — the constructor assigns `this` here so tests can
+// inspect the instance after `new Notification(...)` is called.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let lastInstance: any;
+
+// The constructor mock must be a proper function (not an arrow) for `new`.
+// We assign static properties (permission, requestPermission) after creation.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let NotificationMock: any;
+
+function buildNotificationMock(permission: NotificationPermission = "granted") {
+  function FakeNotification(this: NotifInstance, _title: string, _opts: NotificationOptions) {
+    // Capture `this` so tests can read back properties set by production code
+    // (e.g. onclick) after the constructor returns.
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    lastInstance = this;
+    this.onclick = null;
+    this.close = vi.fn();
+  }
+  FakeNotification.permission = permission;
+  FakeNotification.requestPermission = vi.fn().mockResolvedValue("granted");
+
+  return FakeNotification;
+}
+
+beforeEach(() => {
+  NotificationMock = buildNotificationMock("granted");
+  vi.stubGlobal("Notification", NotificationMock);
+
+  // Default: tab is hidden (primary use-case for native notifications).
+  Object.defineProperty(document, "hidden", { value: true, writable: true, configurable: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("maybeShowBrowserNotification", () => {
+  it("returns null when Notification is not in window", () => {
+    // Delete the own property so `"Notification" in window` is false.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).Notification;
+    const result = maybeShowBrowserNotification(makeInput(), vi.fn());
+    expect(result).toBeNull();
+  });
+
+  it("returns null when permission is 'denied'", () => {
+    NotificationMock = buildNotificationMock("denied");
+    vi.stubGlobal("Notification", NotificationMock);
+    const result = maybeShowBrowserNotification(makeInput(), vi.fn());
+    expect(result).toBeNull();
+  });
+
+  it("returns null when permission is 'default' (not yet granted)", () => {
+    NotificationMock = buildNotificationMock("default");
+    vi.stubGlobal("Notification", NotificationMock);
+    const result = maybeShowBrowserNotification(makeInput(), vi.fn());
+    expect(result).toBeNull();
+  });
+
+  it("returns null when document is visible (tab in focus)", () => {
+    Object.defineProperty(document, "hidden", { value: false, configurable: true });
+    const result = maybeShowBrowserNotification(makeInput(), vi.fn());
+    expect(result).toBeNull();
+  });
+
+  it("returns null when priority is 'low'", () => {
+    const result = maybeShowBrowserNotification(makeInput({ priority: "low" }), vi.fn());
+    expect(result).toBeNull();
+  });
+
+  it("returns null when priority is 'medium'", () => {
+    const result = maybeShowBrowserNotification(makeInput({ priority: "medium" }), vi.fn());
+    expect(result).toBeNull();
+  });
+
+  it("calls Notification constructor with correct title and options when all conditions are met", () => {
+    const constructorSpy = vi.fn();
+    // Wrap the fake constructor to intercept calls.
+    function SpiedNotification(this: NotifInstance, title: string, opts: NotificationOptions) {
+      constructorSpy(title, opts);
+      Object.assign(this, lastInstance ?? {});
+    }
+    SpiedNotification.permission = "granted" as NotificationPermission;
+    SpiedNotification.requestPermission = vi.fn();
+    vi.stubGlobal("Notification", SpiedNotification);
+
+    const input = makeInput();
+    const result = maybeShowBrowserNotification(input, vi.fn());
+
+    expect(result).not.toBeNull();
+    expect(constructorSpy).toHaveBeenCalledOnce();
+    expect(constructorSpy).toHaveBeenCalledWith(input.title, {
+      body: input.body,
+      tag: input.tag,
+    });
+  });
+
+  it("uses the tag field for OS-level dedup", () => {
+    const constructorSpy = vi.fn();
+    function SpiedNotification(this: NotifInstance, title: string, opts: NotificationOptions) {
+      constructorSpy(title, opts);
+      Object.assign(this, lastInstance ?? {});
+    }
+    SpiedNotification.permission = "granted" as NotificationPermission;
+    SpiedNotification.requestPermission = vi.fn();
+    vi.stubGlobal("Notification", SpiedNotification);
+
+    maybeShowBrowserNotification(makeInput({ tag: "entity-99" }), vi.fn());
+    const [, options] = constructorSpy.mock.calls[0]!;
+    expect((options as { tag: string }).tag).toBe("entity-99");
+  });
+
+  it("onclick calls window.focus and navigate with actionUrl", () => {
+    const navigate = vi.fn();
+    const focusSpy = vi.spyOn(window, "focus").mockImplementation(() => undefined);
+
+    maybeShowBrowserNotification(makeInput({ actionUrl: "/budgets" }), navigate);
+
+    expect(lastInstance.onclick).toBeTypeOf("function");
+    lastInstance.onclick!(new Event("click"));
+
+    expect(focusSpy).toHaveBeenCalledOnce();
+    expect(navigate).toHaveBeenCalledWith("/budgets");
+    expect(lastInstance.close).toHaveBeenCalledOnce();
+  });
+
+  it("onclick does not call navigate when actionUrl is undefined", () => {
+    const navigate = vi.fn();
+    vi.spyOn(window, "focus").mockImplementation(() => undefined);
+
+    maybeShowBrowserNotification(makeInput({ actionUrl: undefined }), navigate);
+    lastInstance.onclick!(new Event("click"));
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/notifications/browser-display.ts
+++ b/src/lib/notifications/browser-display.ts
@@ -1,0 +1,45 @@
+import type { NotificationPriority } from "./emit";
+
+export interface DisplayNotificationInput {
+  title: string;
+  body: string;
+  /** Used as OS-level tag for dedup/replace — same entityId replaces prior banner. */
+  tag: string;
+  priority: NotificationPriority;
+  actionUrl?: string;
+}
+
+/**
+ * Show a browser-native notification when ALL of the following hold:
+ *  - The Notification API is supported and permission is "granted"
+ *  - The document is hidden (avoids double-firing when the tab is in focus)
+ *  - The priority is "high" (low/medium stay in the bell dropdown)
+ *
+ * The `navigate` callback is called with `actionUrl` when the user clicks the
+ * banner. Pass `router.push` from `next/navigation`.
+ *
+ * Returns the Notification instance for click/close wiring, or null if skipped.
+ */
+export function maybeShowBrowserNotification(
+  input: DisplayNotificationInput,
+  navigate: (url: string) => void,
+): Notification | null {
+  if (typeof window === "undefined") return null;
+  if (!("Notification" in window)) return null;
+  if (Notification.permission !== "granted") return null;
+  if (!document.hidden) return null;
+  if (input.priority !== "high") return null;
+
+  const n = new Notification(input.title, {
+    body: input.body,
+    tag: input.tag,
+  });
+
+  n.onclick = () => {
+    window.focus();
+    if (input.actionUrl) navigate(input.actionUrl);
+    n.close();
+  };
+
+  return n;
+}

--- a/src/lib/notifications/browser-permissions.test.ts
+++ b/src/lib/notifications/browser-permissions.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  getBrowserNotificationPermission,
+  requestBrowserNotificationPermission,
+} from "./browser-permissions";
+
+// These tests run in node env (default). We simulate SSR/browser conditions by
+// stubbing globals directly — no jsdom needed since we only test API branching.
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getBrowserNotificationPermission", () => {
+  it("returns 'unsupported' when window is undefined (SSR)", () => {
+    vi.stubGlobal("window", undefined);
+    expect(getBrowserNotificationPermission()).toBe("unsupported");
+  });
+
+  it("returns 'unsupported' when Notification is not in window", () => {
+    // window exists but Notification is absent
+    const windowWithoutNotification = {} as Window;
+    vi.stubGlobal("window", windowWithoutNotification);
+    expect(getBrowserNotificationPermission()).toBe("unsupported");
+  });
+
+  it("returns the current permission when API is available", () => {
+    vi.stubGlobal("window", { Notification: true });
+    vi.stubGlobal("Notification", {
+      permission: "granted",
+      requestPermission: vi.fn(),
+    });
+    expect(getBrowserNotificationPermission()).toBe("granted");
+  });
+
+  it("returns 'denied' when permission is denied", () => {
+    vi.stubGlobal("window", { Notification: true });
+    vi.stubGlobal("Notification", {
+      permission: "denied",
+      requestPermission: vi.fn(),
+    });
+    expect(getBrowserNotificationPermission()).toBe("denied");
+  });
+});
+
+describe("requestBrowserNotificationPermission", () => {
+  it("returns 'unsupported' when window is undefined (SSR)", async () => {
+    vi.stubGlobal("window", undefined);
+    await expect(requestBrowserNotificationPermission()).resolves.toBe("unsupported");
+  });
+
+  it("returns 'unsupported' when Notification is not in window", async () => {
+    vi.stubGlobal("window", {} as Window);
+    await expect(requestBrowserNotificationPermission()).resolves.toBe("unsupported");
+  });
+
+  it("returns existing permission without calling requestPermission when already granted", async () => {
+    const requestPermission = vi.fn();
+    vi.stubGlobal("window", { Notification: true });
+    vi.stubGlobal("Notification", { permission: "granted", requestPermission });
+    const result = await requestBrowserNotificationPermission();
+    expect(result).toBe("granted");
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("returns existing permission without calling requestPermission when already denied", async () => {
+    const requestPermission = vi.fn();
+    vi.stubGlobal("window", { Notification: true });
+    vi.stubGlobal("Notification", { permission: "denied", requestPermission });
+    const result = await requestBrowserNotificationPermission();
+    expect(result).toBe("denied");
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("calls requestPermission and returns user's choice when permission is default", async () => {
+    const requestPermission = vi.fn().mockResolvedValue("granted");
+    vi.stubGlobal("window", { Notification: true });
+    vi.stubGlobal("Notification", { permission: "default", requestPermission });
+    const result = await requestBrowserNotificationPermission();
+    expect(requestPermission).toHaveBeenCalledOnce();
+    expect(result).toBe("granted");
+  });
+
+  it("propagates 'denied' from requestPermission when user rejects the prompt", async () => {
+    const requestPermission = vi.fn().mockResolvedValue("denied");
+    vi.stubGlobal("window", { Notification: true });
+    vi.stubGlobal("Notification", { permission: "default", requestPermission });
+    const result = await requestBrowserNotificationPermission();
+    expect(result).toBe("denied");
+  });
+});

--- a/src/lib/notifications/browser-permissions.ts
+++ b/src/lib/notifications/browser-permissions.ts
@@ -1,0 +1,27 @@
+export type BrowserNotificationPermission = "default" | "granted" | "denied" | "unsupported";
+
+/**
+ * Returns the current browser notification permission state without side effects.
+ * Returns "unsupported" when the Notification API is unavailable (SSR, iOS Safari
+ * without home-screen PWA, etc.).
+ */
+export function getBrowserNotificationPermission(): BrowserNotificationPermission {
+  if (typeof window === "undefined" || !("Notification" in window)) return "unsupported";
+  return Notification.permission as BrowserNotificationPermission;
+}
+
+/**
+ * Requests browser notification permission lazily (only when permission is
+ * "default"). Returns the resulting permission state.
+ *
+ * Safe to call on iOS Safari — if `Notification` is not in window, returns
+ * "unsupported" without throwing.
+ */
+export async function requestBrowserNotificationPermission(): Promise<BrowserNotificationPermission> {
+  if (typeof window === "undefined" || !("Notification" in window)) return "unsupported";
+  if (Notification.permission !== "default") {
+    return Notification.permission as BrowserNotificationPermission;
+  }
+  const result = await Notification.requestPermission();
+  return result as BrowserNotificationPermission;
+}


### PR DESCRIPTION
Closes #663

## Summary

Adds OS-level browser notifications for high-priority events when the user's tab is hidden. Reuses the Phase 1-3 SSE infrastructure (no service worker, no VAPID, no push library).

### Architecture

- **`src/lib/notifications/browser-permissions.ts`** — SSR-safe helpers to read and request `Notification.permission`. Returns `"unsupported"` cleanly on iOS Safari without home-screen PWA.
- **`src/lib/notifications/browser-display.ts`** — `maybeShowBrowserNotification()` with 4 guards: API supported, permission granted, `document.hidden` true, priority high. Returns `null` (skip) if any guard fails.
- **`bell-button.tsx`** — wires the lazy permission prompt. First high-priority `notification:created` event with `permission === "default"` triggers the prompt. Subsequent events display banners.

### Behavior

- Tab hidden + permission granted + priority high → OS-level banner with `tag = String(notificationId)` for replace-on-resolution.
- Tab visible → in-app toast/bell covers it; native banner skipped to avoid double-notify.
- Click banner → `window.focus()` + `router.push(actionUrl)`.

## Test plan

- [x] 4 gates (lint + format:check + typecheck + test 30/30 in scope)
- [x] Permission helper: SSR / unsupported / default / granted / denied paths
- [x] Display helper: all 4 guards + tag dedup + onclick wiring
- [ ] CI
- [ ] Manual smoke: trigger Gmail re-auth flow with tab in background — confirm banner appears, click navigates to /settings/integrations