### PR TITLE
feat(notifications): gmail_pull_completed subscriber emitter (#664)

### DIFF
--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -104,6 +104,12 @@ export async function registerNode() {
   const { registerAutoMarkRead } = await import("@/lib/notifications/auto-mark-read");
   registerAutoMarkRead();
 
+  // #664: Emit gmail_pull_completed notification when a user-triggered Gmail sync finishes.
+  const { registerGmailPullCompletionEmitter } = await import(
+    "@/lib/notifications/gmail-pull-completion"
+  );
+  registerGmailPullCompletionEmitter();
+
   // -------------------------------------------------------------------------
   // Register recurring schedules
   // -------------------------------------------------------------------------

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -105,9 +105,8 @@ export async function registerNode() {
   registerAutoMarkRead();
 
   // #664: Emit gmail_pull_completed notification when a user-triggered Gmail sync finishes.
-  const { registerGmailPullCompletionEmitter } = await import(
-    "@/lib/notifications/gmail-pull-completion"
-  );
+  const { registerGmailPullCompletionEmitter } =
+    await import("@/lib/notifications/gmail-pull-completion");
   registerGmailPullCompletionEmitter();
 
   // -------------------------------------------------------------------------

--- a/src/lib/notifications/gmail-pull-completion.test.ts
+++ b/src/lib/notifications/gmail-pull-completion.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emit } from "@/lib/events/bus";
+import { registerGmailPullCompletionEmitter } from "./gmail-pull-completion";
+
+// ---------------------------------------------------------------------------
+// emitNotification mock — hoisted so factories run before module-level code
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => ({
+  emitNotification: vi.fn().mockResolvedValue({ id: 999 }),
+}));
+
+vi.mock("@/lib/notifications/emit", () => ({
+  emitNotification: mocks.emitNotification,
+}));
+
+// ---------------------------------------------------------------------------
+// Flush helper — await microtask queue so async bus subscribers settle
+// ---------------------------------------------------------------------------
+async function flush(): Promise<void> {
+  // Two rounds ensure both the immediate microtask and any awaited-within-
+  // subscribers work is settled without hitting real I/O.
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("registerGmailPullCompletionEmitter", () => {
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    mocks.emitNotification.mockClear();
+    mocks.emitNotification.mockResolvedValue({ id: 999 });
+    unsubscribe = registerGmailPullCompletionEmitter();
+  });
+
+  afterEach(() => {
+    unsubscribe();
+  });
+
+  it("emits notification when job:done fires for gmail-pull with newTxCount > 0", async () => {
+    emit({
+      type: "job:done",
+      jobName: "gmail-pull",
+      jobId: "job-abc-123",
+      userId: 1,
+      newTxCount: 5,
+      processedCount: 12,
+      timestamp: Date.now(),
+    });
+    await flush();
+
+    expect(mocks.emitNotification).toHaveBeenCalledOnce();
+
+    const [calledUserId, calledInput] = mocks.emitNotification.mock.calls[0]! as [
+      number,
+      {
+        type: string;
+        entityId: string;
+        priority: string;
+        title: string;
+        body: string;
+        actionUrl: string;
+        metadata: { newTxCount: number; processedCount: number; jobId: string };
+      },
+    ];
+
+    expect(calledUserId).toBe(1);
+    expect(calledInput.type).toBe("gmail_pull_completed");
+    expect(calledInput.entityId).toBe("job-abc-123");
+    expect(calledInput.priority).toBe("low");
+    expect(calledInput.title).toBe("Sincronización Gmail completada");
+    expect(calledInput.body).toBe("Encontramos 5 movimiento(s) nuevos.");
+    expect(calledInput.actionUrl).toBe("/transactions");
+    expect(calledInput.metadata.newTxCount).toBe(5);
+    expect(calledInput.metadata.processedCount).toBe(12);
+    expect(calledInput.metadata.jobId).toBe("job-abc-123");
+  });
+
+  it("emits notification with 'no new transactions' body when newTxCount === 0", async () => {
+    emit({
+      type: "job:done",
+      jobName: "gmail-pull",
+      jobId: "job-def-456",
+      userId: 2,
+      newTxCount: 0,
+      processedCount: 8,
+      timestamp: Date.now(),
+    });
+    await flush();
+
+    expect(mocks.emitNotification).toHaveBeenCalledOnce();
+
+    const [, calledInput] = mocks.emitNotification.mock.calls[0]! as [
+      number,
+      { body: string; metadata: { newTxCount: number } },
+    ];
+
+    expect(calledInput.body).toBe("No encontramos movimientos nuevos.");
+    expect(calledInput.metadata.newTxCount).toBe(0);
+  });
+
+  it("does NOT emit for job:done with jobName classify-tx", async () => {
+    emit({
+      type: "job:done",
+      jobName: "classify-tx",
+      jobId: "job-classify-789",
+      userId: 1,
+      classifiedCount: 10,
+      skippedCount: 2,
+      timestamp: Date.now(),
+    });
+    await flush();
+
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("does NOT emit for job:progress events", async () => {
+    emit({
+      type: "job:progress",
+      jobName: "gmail-pull",
+      jobId: "job-progress-111",
+      userId: 1,
+      phase: "pulling",
+      timestamp: Date.now(),
+    });
+    await flush();
+
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("stops emitting after the returned unsubscribe fn is called", async () => {
+    // Unsubscribe immediately (before any event).
+    unsubscribe();
+
+    emit({
+      type: "job:done",
+      jobName: "gmail-pull",
+      jobId: "job-unsub-222",
+      userId: 1,
+      newTxCount: 3,
+      processedCount: 3,
+      timestamp: Date.now(),
+    });
+    await flush();
+
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+
+    // Prevent afterEach double-unsubscribe (safe but avoids noisy log).
+    unsubscribe = () => undefined;
+  });
+});

--- a/src/lib/notifications/gmail-pull-completion.ts
+++ b/src/lib/notifications/gmail-pull-completion.ts
@@ -1,0 +1,70 @@
+import { subscribe } from "@/lib/events/bus";
+import { emitNotification } from "@/lib/notifications/emit";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "notifications/gmail-pull-completion" });
+
+/**
+ * Registers a bus subscriber that emits a `gmail_pull_completed` notification
+ * when a user-triggered Gmail sync job finishes.
+ *
+ * Only `job:done` events with `jobName === "gmail-pull"` are handled — the
+ * cron `mode: "all"` path never reaches this subscriber because the worker
+ * only emits `job:done` for `mode: "single-user"` jobs.
+ *
+ * Returns the unsubscribe function.
+ */
+export function registerGmailPullCompletionEmitter(): () => void {
+  const unsubscribe = subscribe(async (event) => {
+    if (event.type !== "job:done" || event.jobName !== "gmail-pull") return;
+
+    const { userId, jobId, newTxCount, processedCount } = event;
+
+    const body =
+      newTxCount > 0
+        ? `Encontramos ${newTxCount} movimiento(s) nuevos.`
+        : "No encontramos movimientos nuevos.";
+
+    try {
+      const result = await emitNotification(userId, {
+        type: "gmail_pull_completed",
+        entityId: jobId,
+        priority: "low",
+        title: "Sincronización Gmail completada",
+        body,
+        actionUrl: "/transactions",
+        metadata: { newTxCount, processedCount, jobId },
+      });
+
+      if (result !== null) {
+        log.info(
+          {
+            userId,
+            jobId,
+            newTxCount,
+            processedCount,
+            notificationId: result.id,
+            event: "gmail_pull_completion_emitted",
+          },
+          "gmail_pull_completed notification emitted",
+        );
+      } else {
+        log.debug(
+          { userId, jobId, event: "gmail_pull_completion_dedup" },
+          "gmail_pull_completed notification deduped",
+        );
+      }
+    } catch (err) {
+      log.error(
+        { err, userId, jobId, event: "gmail_pull_completion_failed" },
+        "failed to emit gmail_pull_completed notification",
+      );
+    }
+  });
+
+  log.info(
+    { event: "gmail_pull_completion_registered" },
+    "gmail-pull-completion emitter registered",
+  );
+  return unsubscribe;
+}


### PR DESCRIPTION
Closes #664

## Summary

- New subscriber `src/lib/notifications/gmail-pull-completion.ts` listens for `job:done` events with `jobName: "gmail-pull"` and emits a `gmail_pull_completed` notification.
- The `job:done` event for gmail-pull only fires in `mode: "single-user"` (the user-triggered manual sync), so the manual-only filter is implicit — no `triggeredBy` payload field needed.
- Registered in `src/instrumentation.node.ts` next to `registerAutoMarkRead()`.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] 5 unit tests cover: emit when newTxCount > 0, emit when newTxCount === 0 (different body), no emit for classify-tx, no emit for job:progress, unsubscribe stops emissions
- [x] Full test suite green (181 files / 2188 tests)