### PR TITLE
feat(transactions): cartera TC transfer pair helpers (#687)

### DIFF
--- a/scripts/backfill-cartera-tc-categories.ts
+++ b/scripts/backfill-cartera-tc-categories.ts
@@ -1,0 +1,62 @@
+// Backfill the `cartera-tc` category seed for every existing active user.
+//
+// The global seed row was added in #687 (seed-reference-data.ts). Each user
+// gets their own materialized copy via copyCategorySeedsToUser, which is
+// idempotent: (user_id, slug) unique + ON CONFLICT DO NOTHING. Running this
+// script again is safe.
+//
+// Usage:
+//   bun scripts/backfill-cartera-tc-categories.ts
+
+import { eq } from "drizzle-orm";
+import { db } from "../src/lib/db";
+import { users } from "../src/lib/db/schema";
+import { copyCategorySeedsToUser } from "../src/lib/auth/signup";
+import { createLogger } from "../src/lib/logger";
+
+const log = createLogger({ module: "backfill-cartera-tc" });
+
+async function run(): Promise<void> {
+  const allUsers = await db
+    .select({ id: users.id, email: users.email })
+    .from(users)
+    .where(eq(users.active, true));
+
+  log.info(
+    { count: allUsers.length, event: "backfill_cartera_tc_start" },
+    "starting cartera-tc category backfill",
+  );
+
+  let totalInserted = 0;
+  for (const u of allUsers) {
+    // copyCategorySeedsToUser copies every row from category_seeds that the
+    // user does not yet have — idempotent via ON CONFLICT DO NOTHING.
+    const inserted = await copyCategorySeedsToUser(u.id);
+    totalInserted += inserted;
+    log.info(
+      { userId: u.id, email: u.email, inserted, event: "backfill_cartera_tc_user" },
+      "processed user",
+    );
+  }
+
+  log.info(
+    {
+      usersProcessed: allUsers.length,
+      totalInserted,
+      event: "backfill_cartera_tc_done",
+    },
+    "cartera-tc category backfill complete",
+  );
+}
+
+if (import.meta.main) {
+  run()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      log.error(
+        { err, event: "backfill_cartera_tc_failed" },
+        "backfill-cartera-tc-categories failed",
+      );
+      process.exit(1);
+    });
+}

--- a/src/lib/db/seed-reference-data.ts
+++ b/src/lib/db/seed-reference-data.ts
@@ -94,6 +94,12 @@ export const categorySeedRows: CategorySeed[] = [
   // installment purchases. Interest accrued IS an expense, so this category is
   // a real child of `deudas` (not a transfer like `pago-tc`).
   { slug: "intereses-tc", name: "Intereses TC", parentSlug: "deudas" },
+  // #687: "Compra de cartera" — Bancolombia disburses cash to savings and the
+  // same amount becomes a TC debit with a fixed-rate installment plan. Modeled
+  // as a transfer pair (channel=transfer, category_slug=null on both legs) so
+  // it does NOT inflate income or expenses. This seed exists for UI label /
+  // reporting purposes and for the rawData.kind="cartera_tc" discriminator.
+  { slug: "cartera-tc", name: "Compra de Cartera TC", parentSlug: "deudas" },
   { slug: "pago-prestamo", name: "Pago Préstamo", parentSlug: "deudas" },
   { slug: "ropa", name: "Ropa", icon: "shirt", color: "#8b5cf6", sortOrder: 110 },
   { slug: "tecnologia", name: "Tecnología", icon: "laptop", color: "#06b6d4", sortOrder: 120 },

--- a/src/lib/reconciliation/cartera-tc-router.test.ts
+++ b/src/lib/reconciliation/cartera-tc-router.test.ts
@@ -1,0 +1,268 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, transactions, users } from "@/lib/db/schema";
+import { copyCategorySeedsToUser } from "@/lib/auth/signup";
+import { insertNewCarteraTcPair } from "./cartera-tc-router";
+
+// #687: Integration tests for insertNewCarteraTcPair.
+// Runs against findash_test (forced by vitest.setup.ts).
+
+const TAG = "CARTERA_TC_TEST";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+async function createUser(tag: string): Promise<number> {
+  const email = `${tag.toLowerCase()}.${Date.now()}@test.local`;
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  return row.id;
+}
+
+async function createAccount(
+  userId: number,
+  opts: {
+    type?: "savings" | "credit_card";
+    currency?: "COP" | "USD";
+  } = {},
+): Promise<number> {
+  const { type = "savings", currency = "COP" } = opts;
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${TAG} ${type} ${currency}`,
+      institution: "Bancolombia",
+      institutionSlug: "bancolombia",
+      type,
+      currency,
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function cleanupUser(userId: number): Promise<void> {
+  await db.delete(transactions).where(eq(transactions.userId, userId));
+  await db.delete(accounts).where(eq(accounts.userId, userId));
+  await db.delete(users).where(eq(users.id, userId));
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const OCCURRED_AT = new Date("2026-04-23T05:00:00Z");
+const AMOUNT = BigInt(2_900_000_00); // $29M COP in cents
+const INSTALLMENTS = 60;
+const RATE = 13900; // 1.39% EM
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("insertNewCarteraTcPair — integration against findash_test", () => {
+  let userId: number;
+  let savingsAccountId: number;
+  let tcAccountId: number;
+
+  beforeAll(async () => {
+    userId = await createUser(TAG);
+    savingsAccountId = await createAccount(userId, { type: "savings", currency: "COP" });
+    tcAccountId = await createAccount(userId, { type: "credit_card", currency: "COP" });
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  it("happy path: inserts 2 paired legs with installment fields on TC debit", async () => {
+    const result = await insertNewCarteraTcPair({
+      userId,
+      savingsAccountId,
+      tcAccountId,
+      amountCents: AMOUNT,
+      currency: "COP",
+      occurredAt: OCCURRED_AT,
+      installmentsTotal: INSTALLMENTS,
+      installmentRateEmX10k: RATE,
+      source: "csv_reconcile",
+      externalIdSavings: `${TAG}-happy-savings`,
+      externalIdTc: `${TAG}-happy-tc`,
+      originalSmsBody: "Desembolso cartera TC $29.000.000 60 cuotas 1.39%",
+    });
+
+    expect(result.status).toBe("inserted");
+    if (result.status !== "inserted") return;
+
+    const rows = await db.execute<{
+      account_id: number;
+      amount_cents: string;
+      channel: string;
+      category_slug: string | null;
+      installments_total: number;
+      installment_rate_bps: number | null;
+      raw_data: Record<string, unknown>;
+      transfer_group_id: string;
+    }>(sql`
+      SELECT
+        account_id,
+        amount_cents::text,
+        channel,
+        category_slug,
+        installments_total,
+        installment_rate_bps,
+        raw_data,
+        transfer_group_id
+      FROM transactions
+      WHERE transfer_group_id = ${result.transferGroupId}::uuid
+        AND user_id = ${userId}
+      ORDER BY amount_cents DESC
+    `);
+
+    expect(rows.length).toBe(2);
+
+    // Both legs share the same transfer_group_id and channel=transfer.
+    for (const row of rows) {
+      expect(row.transfer_group_id).toBe(result.transferGroupId);
+      expect(row.channel).toBe("transfer");
+      expect(row.category_slug).toBeNull();
+    }
+
+    // Σ = 0
+    const sum = rows.reduce((acc, r) => acc + BigInt(r.amount_cents), BigInt(0));
+    expect(sum).toBe(BigInt(0));
+
+    // Savings leg (positive amount)
+    const savingsLeg = rows.find((r) => BigInt(r.amount_cents) > BigInt(0));
+    expect(savingsLeg).toBeDefined();
+    if (!savingsLeg) return;
+    expect(savingsLeg.account_id).toBe(savingsAccountId);
+    expect(BigInt(savingsLeg.amount_cents)).toBe(AMOUNT);
+    expect(savingsLeg.installments_total).toBe(1); // default, not a plan leg
+    expect(savingsLeg.installment_rate_bps).toBeNull();
+    expect(savingsLeg.raw_data).toMatchObject({ kind: "cartera_tc", role: "savings_disbursement" });
+
+    // TC leg (negative amount)
+    const tcLeg = rows.find((r) => BigInt(r.amount_cents) < BigInt(0));
+    expect(tcLeg).toBeDefined();
+    if (!tcLeg) return;
+    expect(tcLeg.account_id).toBe(tcAccountId);
+    expect(BigInt(tcLeg.amount_cents)).toBe(-AMOUNT);
+    expect(tcLeg.installments_total).toBe(INSTALLMENTS);
+    expect(tcLeg.installment_rate_bps).toBe(RATE);
+    expect(tcLeg.raw_data).toMatchObject({
+      kind: "cartera_tc",
+      role: "tc_debit",
+      installmentsTotal: INSTALLMENTS,
+      installmentRateEmX10k: RATE,
+    });
+  });
+
+  it("duplicate detection: returns `duplicated` on second call with same externalIds", async () => {
+    const sharedOpts = {
+      userId,
+      savingsAccountId,
+      tcAccountId,
+      amountCents: BigInt(500_000_00),
+      currency: "COP" as const,
+      occurredAt: new Date("2026-03-01T05:00:00Z"),
+      installmentsTotal: 36,
+      installmentRateEmX10k: 15000,
+      source: "csv_reconcile" as const,
+      externalIdSavings: `${TAG}-dedup-savings`,
+      externalIdTc: `${TAG}-dedup-tc`,
+    };
+
+    const first = await insertNewCarteraTcPair(sharedOpts);
+    expect(first.status).toBe("inserted");
+
+    const second = await insertNewCarteraTcPair(sharedOpts);
+    expect(second.status).toBe("duplicated");
+
+    // Only 2 rows exist (the first insert), not 4.
+    const rows = await db.execute<{ n: string }>(sql`
+      SELECT count(*)::text AS n
+      FROM transactions
+      WHERE user_id = ${userId}
+        AND external_id IN (${`${TAG}-dedup-savings`}, ${`${TAG}-dedup-tc`})
+    `);
+    expect(rows[0].n).toBe("2");
+  });
+
+  it("rejects amountCents = 0", async () => {
+    const result = await insertNewCarteraTcPair({
+      userId,
+      savingsAccountId,
+      tcAccountId,
+      amountCents: BigInt(0),
+      currency: "COP",
+      occurredAt: OCCURRED_AT,
+      installmentsTotal: INSTALLMENTS,
+      installmentRateEmX10k: RATE,
+      source: "csv_reconcile",
+    });
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.errorReason).toMatch(/positive/);
+    }
+  });
+
+  it("rejects negative amountCents", async () => {
+    const result = await insertNewCarteraTcPair({
+      userId,
+      savingsAccountId,
+      tcAccountId,
+      amountCents: BigInt(-100),
+      currency: "COP",
+      occurredAt: OCCURRED_AT,
+      installmentsTotal: INSTALLMENTS,
+      installmentRateEmX10k: RATE,
+      source: "csv_reconcile",
+    });
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.errorReason).toMatch(/positive/);
+    }
+  });
+
+  it("does NOT inflate expense or income totals (channel=transfer, category_slug=null)", async () => {
+    // Baseline expense sum for this user before inserting.
+    const before = await db.execute<{ total: string }>(sql`
+      SELECT COALESCE(SUM(amount_cents), 0)::text AS total
+      FROM transactions
+      WHERE user_id = ${userId}
+        AND deleted_at IS NULL
+        AND channel <> 'transfer'
+    `);
+    const beforeTotal = BigInt(before[0].total);
+
+    await insertNewCarteraTcPair({
+      userId,
+      savingsAccountId,
+      tcAccountId,
+      amountCents: BigInt(1_000_000_00),
+      currency: "COP",
+      occurredAt: new Date("2026-02-01T05:00:00Z"),
+      installmentsTotal: 24,
+      installmentRateEmX10k: 12000,
+      source: "csv_reconcile",
+      externalIdSavings: `${TAG}-nokpi-savings`,
+      externalIdTc: `${TAG}-nokpi-tc`,
+    });
+
+    const after = await db.execute<{ total: string }>(sql`
+      SELECT COALESCE(SUM(amount_cents), 0)::text AS total
+      FROM transactions
+      WHERE user_id = ${userId}
+        AND deleted_at IS NULL
+        AND channel <> 'transfer'
+    `);
+    const afterTotal = BigInt(after[0].total);
+
+    // Non-transfer sum must be unchanged.
+    expect(afterTotal).toBe(beforeTotal);
+  });
+});

--- a/src/lib/reconciliation/cartera-tc-router.test.ts
+++ b/src/lib/reconciliation/cartera-tc-router.test.ts
@@ -265,4 +265,117 @@ describe("insertNewCarteraTcPair — integration against findash_test", () => {
     // Non-transfer sum must be unchanged.
     expect(afterTotal).toBe(beforeTotal);
   });
+
+  // ---------------------------------------------------------------------------
+  // Fix #1 — cross-tenant ownership guard
+  // ---------------------------------------------------------------------------
+
+  it("rejects when savingsAccountId belongs to a different user", async () => {
+    // User B owns the savings account passed as savingsAccountId.
+    const userBId = await createUser(`${TAG}_B`);
+    const userBSavingsId = await createAccount(userBId, { type: "savings", currency: "COP" });
+
+    try {
+      const result = await insertNewCarteraTcPair({
+        userId, // user A's userId
+        savingsAccountId: userBSavingsId, // belongs to user B — ownership fails
+        tcAccountId, // belongs to user A
+        amountCents: BigInt(500_000_00),
+        currency: "COP",
+        occurredAt: OCCURRED_AT,
+        installmentsTotal: INSTALLMENTS,
+        installmentRateEmX10k: RATE,
+        source: "csv_reconcile",
+        externalIdSavings: `${TAG}-xuser-savings`,
+        externalIdTc: `${TAG}-xuser-tc`,
+      });
+
+      expect(result.status).toBe("error");
+      if (result.status === "error") {
+        expect(result.errorReason).toMatch(/does not belong to user/);
+      }
+
+      // Zero transactions must have been inserted for this external_id pair.
+      const rows = await db.execute<{ n: string }>(sql`
+        SELECT count(*)::text AS n
+        FROM transactions
+        WHERE external_id IN (${`${TAG}-xuser-savings`}, ${`${TAG}-xuser-tc`})
+      `);
+      expect(rows[0].n).toBe("0");
+    } finally {
+      await cleanupUser(userBId);
+    }
+  });
+
+  it("rejects when tcAccountId is archived (soft-deleted)", async () => {
+    // Archive the TC account via deleted_at.
+    const archivedTcId = await createAccount(userId, { type: "credit_card", currency: "COP" });
+    await db.execute(sql`
+      UPDATE accounts SET deleted_at = NOW() WHERE id = ${archivedTcId}
+    `);
+
+    const result = await insertNewCarteraTcPair({
+      userId,
+      savingsAccountId,
+      tcAccountId: archivedTcId, // archived — notDeleted filter excludes it
+      amountCents: BigInt(500_000_00),
+      currency: "COP",
+      occurredAt: OCCURRED_AT,
+      installmentsTotal: INSTALLMENTS,
+      installmentRateEmX10k: RATE,
+      source: "csv_reconcile",
+      externalIdSavings: `${TAG}-archived-savings`,
+      externalIdTc: `${TAG}-archived-tc`,
+    });
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.errorReason).toMatch(/does not belong to user/);
+    }
+
+    // Zero transactions inserted.
+    const rows = await db.execute<{ n: string }>(sql`
+      SELECT count(*)::text AS n
+      FROM transactions
+      WHERE external_id IN (${`${TAG}-archived-savings`}, ${`${TAG}-archived-tc`})
+    `);
+    expect(rows[0].n).toBe("0");
+
+    // Cleanup the archived account (hard delete since cleanupUser won't reach it
+    // via deleted_at filter — delete directly).
+    await db.execute(sql`DELETE FROM accounts WHERE id = ${archivedTcId}`);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fix #3 — installmentsTotal boundary guard
+  // ---------------------------------------------------------------------------
+
+  it("rejects installmentsTotal = 1 with cartera-specific error message", async () => {
+    const result = await insertNewCarteraTcPair({
+      userId,
+      savingsAccountId,
+      tcAccountId,
+      amountCents: AMOUNT,
+      currency: "COP",
+      occurredAt: OCCURRED_AT,
+      installmentsTotal: 1, // boundary: must be > 1 for a cartera plan
+      installmentRateEmX10k: RATE,
+      source: "csv_reconcile",
+      externalIdSavings: `${TAG}-inst1-savings`,
+      externalIdTc: `${TAG}-inst1-tc`,
+    });
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.errorReason).toMatch(/installmentsTotal must be > 1/);
+    }
+
+    // No DB rows inserted.
+    const rows = await db.execute<{ n: string }>(sql`
+      SELECT count(*)::text AS n
+      FROM transactions
+      WHERE external_id IN (${`${TAG}-inst1-savings`}, ${`${TAG}-inst1-tc`})
+    `);
+    expect(rows[0].n).toBe("0");
+  });
 });

--- a/src/lib/reconciliation/cartera-tc-router.ts
+++ b/src/lib/reconciliation/cartera-tc-router.ts
@@ -1,0 +1,170 @@
+import { randomUUID } from "node:crypto";
+import { insertTransferGroup } from "@/lib/transactions/transfer-groups";
+import type { DB } from "@/lib/db";
+import { db as defaultDb } from "@/lib/db";
+import type { Currency, TransactionSource } from "@/lib/types";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "reconciliation/cartera-tc-router" });
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface InsertCarteraTcPairOpts {
+  userId: number;
+  savingsAccountId: number;
+  tcAccountId: number;
+  /** Absolute amount in cents (positive bigint). */
+  amountCents: bigint;
+  currency: Currency;
+  occurredAt: Date;
+  /** Number of monthly installments in the plan (e.g. 60). Must be > 1. */
+  installmentsTotal: number;
+  /**
+   * Rate in percent × 10000 (EM/MV). 1.39% EM → 13900.
+   * Non-null required: cartera TC always comes with an explicit rate from the
+   * SMS/extract. Null would fall back to the account bucket, which is wrong
+   * for cartera (its rate is per-contract, not per-account).
+   */
+  installmentRateEmX10k: number;
+  source: TransactionSource;
+  /** External ID for savings leg (dedup key). */
+  externalIdSavings?: string | null;
+  /** External ID for TC leg (dedup key). */
+  externalIdTc?: string | null;
+  /** Raw SMS / email body preserved in rawData for audit. */
+  originalSmsBody?: string;
+  /** Optional override — if provided, used as the transfer group UUID. */
+  existingGroupId?: string;
+  database?: DB;
+}
+
+export type InsertCarteraTcPairResult =
+  | { status: "inserted"; transferGroupId: string }
+  | { status: "duplicated" }
+  | { status: "error"; errorReason: string };
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a "compra de cartera TC" transfer pair (#687).
+ *
+ * Bancolombia disburses cash to savings (credit, +amount) and the same amount
+ * becomes a deferred TC debit (-amount) with a fixed monthly-rate plan.
+ * Both legs share channel='transfer' and category_slug=null — the pair is NOT
+ * an expense or income event, exactly like pago-tc.
+ *
+ * The TC leg carries:
+ *   - installmentsTotal (e.g. 60)
+ *   - installmentRateEmX10k (e.g. 13900 for 1.39% EM)
+ *   - rawData.kind = "cartera_tc", rawData.role = "tc_debit"
+ *
+ * The savings leg carries:
+ *   - rawData.kind = "cartera_tc", rawData.role = "savings_disbursement"
+ *
+ * Mirrors `insertNewPagoTcPair` in pago-tc-router.ts but accepts explicit
+ * account IDs (the caller has already resolved which accounts to use) and
+ * carries the installment plan fields on the TC leg.
+ */
+export async function insertNewCarteraTcPair(
+  opts: InsertCarteraTcPairOpts,
+): Promise<InsertCarteraTcPairResult> {
+  const {
+    userId,
+    savingsAccountId,
+    tcAccountId,
+    amountCents,
+    currency,
+    occurredAt,
+    installmentsTotal,
+    installmentRateEmX10k,
+    source,
+    externalIdSavings,
+    externalIdTc,
+    originalSmsBody,
+    existingGroupId,
+    database = defaultDb,
+  } = opts;
+
+  if (amountCents <= BigInt(0)) {
+    return {
+      status: "error",
+      errorReason: `amountCents must be a positive bigint, got ${amountCents}`,
+    };
+  }
+
+  const transferGroupId = existingGroupId ?? randomUUID();
+  const descriptionRaw = originalSmsBody
+    ? `Compra de Cartera TC (${installmentsTotal}×)`
+    : `Compra de Cartera TC (${installmentsTotal}×)`;
+
+  const insertResult = await insertTransferGroup({
+    userId,
+    existingGroupId: transferGroupId,
+    legs: [
+      {
+        // Savings leg: Bancolombia credits this amount to the savings account.
+        accountId: savingsAccountId,
+        amountCents: amountCents, // positive — inbound cash
+        currency: "COP", // savings are always COP at Bancolombia
+        descriptionRaw,
+        source,
+        occurredAt,
+        externalId: externalIdSavings ?? null,
+        rawData: {
+          kind: "cartera_tc",
+          role: "savings_disbursement",
+          ...(originalSmsBody ? { originalSmsBody } : {}),
+        },
+      },
+      {
+        // TC leg: same amount becomes a deferred debit on the TC.
+        accountId: tcAccountId,
+        amountCents: -amountCents, // negative — the TC owes this
+        currency,
+        descriptionRaw,
+        source,
+        occurredAt,
+        externalId: externalIdTc ?? null,
+        installmentsTotal,
+        installmentRateEmX10k,
+        rawData: {
+          kind: "cartera_tc",
+          role: "tc_debit",
+          installmentsTotal,
+          installmentRateEmX10k,
+          ...(originalSmsBody ? { originalSmsBody } : {}),
+        },
+      },
+    ],
+    database,
+  });
+
+  if (insertResult.status === "inserted") {
+    log.info(
+      {
+        userId,
+        event: "cartera_tc_pair_inserted",
+        savingsAccountId,
+        tcAccountId,
+        amountCents: amountCents.toString(),
+        currency,
+        installmentsTotal,
+        installmentRateEmX10k,
+        transferGroupId: insertResult.transferGroupId,
+        txIds: insertResult.txIds,
+      },
+      "inserted cartera TC transfer pair",
+    );
+    return { status: "inserted", transferGroupId: insertResult.transferGroupId };
+  }
+
+  if (insertResult.status === "duplicated") {
+    return { status: "duplicated" };
+  }
+
+  return { status: "error", errorReason: insertResult.reason };
+}

--- a/src/lib/reconciliation/cartera-tc-router.ts
+++ b/src/lib/reconciliation/cartera-tc-router.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
+import { and, eq, inArray } from "drizzle-orm";
 import { insertTransferGroup } from "@/lib/transactions/transfer-groups";
 import type { DB } from "@/lib/db";
 import { db as defaultDb } from "@/lib/db";
+import { accounts } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
 import type { Currency, TransactionSource } from "@/lib/types";
 import { createLogger } from "@/lib/logger";
 
@@ -96,10 +99,50 @@ export async function insertNewCarteraTcPair(
     };
   }
 
+  // Fix #3 (suggestion): cartera TC always has multiple installments — a
+  // single-installment plan is a regular purchase, not a cartera plan.
+  if (installmentsTotal <= 1) {
+    return {
+      status: "error",
+      errorReason: "installmentsTotal must be > 1 for a cartera TC plan",
+    };
+  }
+
+  // Fix #1 (CRITICAL): verify both accounts belong to userId and are not
+  // archived before passing them to insertTransferGroup. Mirrors the
+  // ownership check in pago-tc-router.ts → insertNewPagoTcPair.
+  const owned = await database
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(
+      and(
+        inArray(accounts.id, [savingsAccountId, tcAccountId]),
+        eq(accounts.userId, userId),
+        notDeleted(accounts.deletedAt),
+      ),
+    );
+
+  if (owned.length !== 2) {
+    log.warn(
+      {
+        userId,
+        savingsAccountId,
+        tcAccountId,
+        foundCount: owned.length,
+        event: "cartera_tc_account_ownership_failed",
+      },
+      "cartera TC pair: one or both accounts do not belong to user or are archived",
+    );
+    return {
+      status: "error",
+      errorReason: "account not found or does not belong to user",
+    };
+  }
+
   const transferGroupId = existingGroupId ?? randomUUID();
-  const descriptionRaw = originalSmsBody
-    ? `Compra de Cartera TC (${installmentsTotal}×)`
-    : `Compra de Cartera TC (${installmentsTotal}×)`;
+  // Fix #2 (warning): both ternary branches were identical — collapse to the
+  // single string. originalSmsBody is preserved in rawData for audit.
+  const descriptionRaw = `Compra de Cartera TC (${installmentsTotal}×)`;
 
   const insertResult = await insertTransferGroup({
     userId,

--- a/src/lib/transactions/transfer-groups.test.ts
+++ b/src/lib/transactions/transfer-groups.test.ts
@@ -299,6 +299,95 @@ describe("archiveTransferGroup / restoreTransferGroup", () => {
   });
 });
 
+describe("installmentsTotal + installmentRateEmX10k on TransferLeg (#687)", () => {
+  it("persists installment fields on the TC debit leg when provided", async () => {
+    const result = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(5_000_000),
+          externalId: "test-tg:installment:savings",
+        }),
+        leg({
+          accountId: VISA_COP_ID,
+          amountCents: BigInt(-5_000_000),
+          externalId: "test-tg:installment:tc",
+          installmentsTotal: 60,
+          installmentRateEmX10k: 13900,
+        }),
+      ],
+    });
+    expect(result.status).toBe("inserted");
+    if (result.status !== "inserted") return;
+
+    const rows = await db.execute<{
+      account_id: number;
+      amount_cents: string;
+      installments_total: number;
+      installment_rate_bps: number | null;
+    }>(sql`
+      SELECT account_id, amount_cents::text, installments_total, installment_rate_bps
+      FROM transactions
+      WHERE transfer_group_id = ${result.transferGroupId}::uuid
+      ORDER BY amount_cents ASC
+    `);
+
+    // TC debit leg (negative amount)
+    const tcLeg = rows.find((r) => BigInt(r.amount_cents) < BigInt(0));
+    expect(tcLeg).toBeDefined();
+    if (!tcLeg) return;
+    expect(tcLeg.installments_total).toBe(60);
+    expect(tcLeg.installment_rate_bps).toBe(13900);
+
+    // Savings leg (positive amount) keeps the default installmentsTotal=1
+    const savingsLeg = rows.find((r) => BigInt(r.amount_cents) > BigInt(0));
+    expect(savingsLeg).toBeDefined();
+    if (!savingsLeg) return;
+    expect(savingsLeg.installments_total).toBe(1);
+    expect(savingsLeg.installment_rate_bps).toBeNull();
+  });
+
+  it("validateTransferGroupLegs rejects a leg with rate but no installment plan", () => {
+    const result = validateTransferGroupLegs([
+      leg({ accountId: SAVINGS_COP_ID, amountCents: BigInt(1000) }),
+      leg({
+        accountId: VISA_COP_ID,
+        amountCents: BigInt(-1000),
+        installmentRateEmX10k: 13900,
+        // installmentsTotal omitted → defaults to undefined → treated as <= 1
+      }),
+    ]);
+    expect(result).toEqual({ ok: false, reason: "rate-without-plan" });
+  });
+
+  it("validateTransferGroupLegs rejects installmentsTotal=1 with a rate", () => {
+    const result = validateTransferGroupLegs([
+      leg({ accountId: SAVINGS_COP_ID, amountCents: BigInt(1000) }),
+      leg({
+        accountId: VISA_COP_ID,
+        amountCents: BigInt(-1000),
+        installmentsTotal: 1,
+        installmentRateEmX10k: 13900,
+      }),
+    ]);
+    expect(result).toEqual({ ok: false, reason: "rate-without-plan" });
+  });
+
+  it("validateTransferGroupLegs accepts installmentsTotal > 1 with a rate", () => {
+    const result = validateTransferGroupLegs([
+      leg({ accountId: SAVINGS_COP_ID, amountCents: BigInt(1000) }),
+      leg({
+        accountId: VISA_COP_ID,
+        amountCents: BigInt(-1000),
+        installmentsTotal: 60,
+        installmentRateEmX10k: 13900,
+      }),
+    ]);
+    expect(result).toEqual({ ok: true });
+  });
+});
+
 describe("no double-counting of debts after the refactor", () => {
   it("a TC statement payment via transfer group does NOT add to `deudas`-sum", async () => {
     // Compute the baseline spend in "deudas" children (real debt servicing).

--- a/src/lib/transactions/transfer-groups.ts
+++ b/src/lib/transactions/transfer-groups.ts
@@ -13,6 +13,11 @@ import type { Currency, TransactionSource } from "@/lib/types";
 // ingest attempt of the same SMS hits the unique (account_id, external_id)
 // index and rolls the group back (status="duplicated"). Callers that don't
 // dedupe (manual UI) pass `null`.
+//
+// `installmentsTotal` and `installmentRateEmX10k` are optional and only
+// meaningful for TC debit legs of a cartera TC pair (#687). Default behavior
+// is unchanged when omitted: installmentsTotal defaults to 1 (single payment)
+// and installmentRateEmX10k defaults to null (inherit from account bucket).
 export type TransferLeg = {
   accountId: number;
   amountCents: bigint;
@@ -26,13 +31,18 @@ export type TransferLeg = {
   externalId?: string | null;
   rawData?: Record<string, unknown>;
   notes?: string | null;
+  /** Number of monthly installments. Only meaningful for cartera TC legs. Defaults to 1. */
+  installmentsTotal?: number;
+  /** Rate in percent × 10000 (EM/MV). 1.39% EM → 13900. Null = inherit from account bucket. */
+  installmentRateEmX10k?: number | null;
 };
 
 export type TransferGroupValidationError =
   | "empty"
   | "single-leg"
   | "unbalanced"
-  | "missing-opposite-signs";
+  | "missing-opposite-signs"
+  | "rate-without-plan";
 
 export type TransferGroupValidationResult =
   | { ok: true }
@@ -55,6 +65,20 @@ export function validateTransferGroupLegs(legs: TransferLeg[]): TransferGroupVal
 
   if (!hasPositive || !hasNegative) return { ok: false, reason: "missing-opposite-signs" };
   if (sum !== BigInt(0)) return { ok: false, reason: "unbalanced" };
+
+  // A non-null installmentRateEmX10k on a leg with installmentsTotal <= 1 is
+  // meaningless — a rate only has meaning when there is a multi-installment
+  // plan. Guard here so callers get a clear error instead of silently storing
+  // a rate that will never be used.
+  for (const leg of legs) {
+    if (
+      leg.installmentRateEmX10k != null &&
+      (leg.installmentsTotal == null || leg.installmentsTotal <= 1)
+    ) {
+      return { ok: false, reason: "rate-without-plan" };
+    }
+  }
+
   return { ok: true };
 }
 
@@ -110,6 +134,8 @@ export async function insertTransferGroup(opts: {
             externalId: leg.externalId ?? null,
             rawData: leg.rawData ?? {},
             notes: leg.notes ?? null,
+            installmentsTotal: leg.installmentsTotal ?? 1,
+            installmentRateEmX10k: leg.installmentRateEmX10k ?? null,
           })
           .onConflictDoNothing({
             target: [transactions.accountId, transactions.externalId],


### PR DESCRIPTION
## Summary

- **`TransferLeg` augmented** with optional `installmentsTotal` and `installmentRateEmX10k` fields; existing callers unchanged (both default to their schema defaults when omitted)
- **`validateTransferGroupLegs`** gains a `rate-without-plan` check: a non-null rate on a leg with `installmentsTotal <= 1` is rejected with a clear error
- **`insertTransferGroup`** propagates the new fields to the INSERT
- **`insertNewCarteraTcPair`** (new helper, `src/lib/reconciliation/cartera-tc-router.ts`): creates a savings-credit + TC-debit transfer pair with installment plan on the TC leg; mirrors `insertNewPagoTcPair` shape; returns `inserted | duplicated | error`
- **`cartera-tc` category seed** added under `deudas` in `seed-reference-data.ts`
- **Backfill script** `scripts/backfill-cartera-tc-categories.ts`: runs `copyCategorySeedsToUser` for every active user (idempotent)

## Test plan

- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test src/lib/transactions/transfer-groups.test.ts` — 18 passed (added 4 new tests)
- [x] `bun run test src/lib/reconciliation/cartera-tc-router.test.ts` — 5 passed (new file)
- [x] `bun run test src/lib/reconciliation/` — 118 passed across 9 test files
- [x] Pre-push hook: full suite 2239 passed, 1 skipped
- [x] `bun run db:seed` — `cartera-tc` category inserted idempotently

Closes #687