### PR TITLE
feat(ingestion): parse Bancolombia compra de cartera + backfill tx 1751 (#688)

### DIFF
--- a/scripts/backfill-cartera-tc-688-tx1751.sql
+++ b/scripts/backfill-cartera-tc-688-tx1751.sql
@@ -1,0 +1,128 @@
+-- Backfill: compra de cartera TC — tx 1751 (#688)
+--
+-- Context:
+--   tx 1751 was ingested as a savings debit with channel='bank' and
+--   category_slug='inversiones'. It should be the savings_disbursement leg of a
+--   cartera TC pair:
+--     - savings *6126 receives COP $29,000,000 (channel=transfer, category=null)
+--     - AMEX *5367 (COP account) gets a deferred debit of -COP $29,000,000
+--       with installmentsTotal=60 and installmentRateEmX10k=13900 (1.39% EM)
+--
+-- Idempotent: DO block aborts cleanly if already applied.
+-- Safety guard: the UPDATE only proceeds when tx 1751 is still in the broken
+-- state (channel='bank', category_slug='inversiones', transfer_group_id IS NULL).
+
+BEGIN;
+
+DO $$
+DECLARE
+  new_uuid uuid := gen_random_uuid();
+  amex_id  integer;
+  existing_tc_count integer;
+BEGIN
+  -- Resolve the AMEX *5367 COP account
+  SELECT id INTO amex_id
+  FROM accounts
+  WHERE user_id = 1
+    AND name = 'Amex *5367'
+    AND currency = 'COP'
+    AND deleted_at IS NULL;
+
+  IF amex_id IS NULL THEN
+    RAISE EXCEPTION 'Amex *5367 COP account not found for user_id=1';
+  END IF;
+
+  -- Idempotency: abort early if TC counterpart already exists
+  SELECT count(*) INTO existing_tc_count
+  FROM transactions
+  WHERE external_id = 'cartera-tc-688-backfill-1751-tc';
+
+  IF existing_tc_count > 0 THEN
+    RAISE NOTICE 'Backfill already applied (TC counterpart exists). Skipping.';
+    RETURN;
+  END IF;
+
+  -- Migrate tx 1751 to the savings_disbursement role.
+  -- Guard: only proceed when the row is still in its original broken state.
+  UPDATE transactions
+  SET channel            = 'transfer',
+      category_slug      = NULL,
+      transfer_group_id  = new_uuid,
+      raw_data           = COALESCE(raw_data, '{}'::jsonb) || jsonb_build_object(
+                             'kind',     'cartera_tc',
+                             'role',     'savings_disbursement',
+                             'backfill', '688'
+                           ),
+      external_id        = 'cartera-tc-688-backfill-1751-savings',
+      updated_at         = now()
+  WHERE id               = 1751
+    AND user_id          = 1
+    AND channel          = 'bank'
+    AND category_slug    = 'inversiones'
+    AND transfer_group_id IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION
+      'tx 1751 not in expected state (channel=bank, category=inversiones, '
+      'transfer_group_id IS NULL) — inspect row and re-run or apply manually';
+  END IF;
+
+  -- Insert the AMEX TC debit counterpart
+  INSERT INTO transactions (
+    user_id,
+    account_id,
+    occurred_at,
+    amount_cents,
+    currency,
+    description_raw,
+    channel,
+    category_slug,
+    source,
+    external_id,
+    transfer_group_id,
+    installments_total,
+    installment_rate_bps,
+    raw_data,
+    created_at,
+    updated_at
+  )
+  VALUES (
+    1,
+    amex_id,
+    '2026-04-23 05:00:00+00'::timestamptz,  -- approximate; SMS had no date
+    -2900000000,                             -- -COP $29,000,000 in cents
+    'COP',
+    'Compra de Cartera TC (60×)',
+    'transfer',
+    NULL,
+    'manual',
+    'cartera-tc-688-backfill-1751-tc',
+    new_uuid,
+    60,
+    13900,                                   -- 1.39% EM × 10000
+    jsonb_build_object(
+      'kind',            'cartera_tc',
+      'role',            'tc_debit',
+      'installmentsTotal',       60,
+      'installmentRateEmX10k',   13900,
+      'originalSmsBody', 'Bancolombia confirma compra de cartera por $29,000,000.00 en su TC AMEX *5367. La tasa es de 1.39% y el plazo de 60 meses.',
+      'backfill',        '688'
+    ),
+    now(),
+    now()
+  );
+
+  -- Resolve the orphaned ingestion log (log id=134)
+  UPDATE ingestion_logs
+  SET status       = 'resolved',
+      resolved_at  = now(),
+      resolution   = 'retried_success',
+      resolved_txn_id = (
+        SELECT id FROM transactions WHERE external_id = 'cartera-tc-688-backfill-1751-tc'
+      )
+  WHERE id = 134;
+
+END
+$$;
+
+COMMIT;

--- a/scripts/backfill-cartera-tc-688-tx1751.sql
+++ b/scripts/backfill-cartera-tc-688-tx1751.sql
@@ -112,14 +112,14 @@ BEGIN
     now()
   );
 
-  -- Resolve the orphaned ingestion log (log id=134)
+  -- Resolve the orphaned ingestion log (log id=134).
+  -- Point resolved_txn_id to tx 1751 (the savings row corrected from the SMS).
+  -- The TC leg can be cross-referenced via its external_id 'cartera-tc-688-backfill-1751-tc'.
   UPDATE ingestion_logs
   SET status       = 'resolved',
       resolved_at  = now(),
       resolution   = 'retried_success',
-      resolved_txn_id = (
-        SELECT id FROM transactions WHERE external_id = 'cartera-tc-688-backfill-1751-tc'
-      )
+      resolved_txn_id = 1751
   WHERE id = 134;
 
 END

--- a/src/lib/ingestion/bancolombia-variants.ts
+++ b/src/lib/ingestion/bancolombia-variants.ts
@@ -67,7 +67,24 @@ export type ParsedBancolombiaTx =
       fromLast4: string;
       toKey: string;
       recipientName: string;
-    });
+    })
+  | {
+      // Note: cartera_tc has NO occurredOn/occurredTime — the SMS does not
+      // include a date. The caller uses Date.now() / a known reference date.
+      kind: "cartera_tc";
+      amountCents: bigint;
+      currency: "COP" | "USD";
+      tcCardLast4: string;
+      /** Raw uppercase network label from SMS: "AMEX" | "VISA" | "MASTERCARD" | etc. */
+      tcNetwork: string;
+      /** Rate in percent × 10000. 1.39% EM → 13900. */
+      ratePercentX10k: number;
+      /** Number of monthly installments in the plan (e.g. 60). */
+      months: number;
+      /** Dedup key: hash(sender + amountCents + last4 + months + ratePercentX10k). */
+      externalId: string;
+      raw: string;
+    };
 
 // Intentional skip: source recognized the message as a known non-ingest
 // pattern (failed tx, non-transactional notification, statement notice).
@@ -314,6 +331,13 @@ const BRE_B_TRANSFER = new RegExp(
   "i",
 );
 
+// Cartera TC: "Bancolombia confirma compra de cartera por $29,000,000.00 en su TC AMEX *5367. La tasa es de 1.39% y el plazo de 60 meses."
+// No date/time in this SMS — the caller provides occurredAt from context.
+const CARTERA_TC = new RegExp(
+  `Bancolombia\\s+confirma\\s+compra\\s+de\\s+cartera\\s+por\\s+${AMOUNT_GROUP}\\s+en\\s+su\\s+TC\\s+(\\w+)\\s+\\*(\\d{4})\\.?\\s+La\\s+tasa\\s+es\\s+de\\s+(\\d+(?:[.,]\\d+)?)%\\s+y\\s+el\\s+plazo\\s+de\\s+(\\d+)\\s+meses`,
+  "i",
+);
+
 // -----------------------------------------------------------------------------
 // Variant matcher — returns null if nothing matches. Each caller (SMS, email,
 // future iOS native) wraps this with source-specific skip detection and
@@ -329,6 +353,36 @@ export function matchBancolombiaVariant(
   body: string,
   opts: { externalIdPrefix: string },
 ): ParsedBancolombiaTx | null {
+  // cartera_tc: MUST be checked before any broad patterns. The phrase
+  // "Bancolombia confirma compra de cartera" is unambiguous, so it goes first.
+  {
+    const m = body.trim().match(CARTERA_TC);
+    if (m) {
+      const { cents, currency } = parseBancolombiaAmount(m[1]);
+      const tcNetwork = m[2].toUpperCase();
+      const tcCardLast4 = m[3];
+      const rateStr = m[4].replace(",", ".");
+      const ratePercentX10k = Math.round(parseFloat(rateStr) * 10000);
+      const months = parseInt(m[5], 10);
+      return {
+        kind: "cartera_tc",
+        amountCents: cents,
+        currency: currency as "COP" | "USD",
+        tcCardLast4,
+        tcNetwork,
+        ratePercentX10k,
+        months,
+        externalId: hashId(opts.externalIdPrefix, [
+          "cartera-tc",
+          tcCardLast4,
+          String(cents),
+          months,
+          ratePercentX10k,
+        ]),
+        raw: body.trim(),
+      };
+    }
+  }
   const raw = body.trim();
   const prefix = opts.externalIdPrefix;
 

--- a/src/lib/ingestion/email-bancolombia.test.ts
+++ b/src/lib/ingestion/email-bancolombia.test.ts
@@ -152,6 +152,7 @@ function buildPurchaseParsed(overrides?: Partial<ParsedBancolombiaTx>): Bancolom
 }
 
 function parsedOccurredAt(p: ParsedBancolombiaTx): Date {
+  if (!("occurredOn" in p)) throw new Error("parsedOccurredAt: kind has no occurredOn");
   return new Date(`${p.occurredOn}T${p.occurredTime}:00${COP_TZ_OFFSET}`);
 }
 

--- a/src/lib/ingestion/email-bancolombia.ts
+++ b/src/lib/ingestion/email-bancolombia.ts
@@ -189,6 +189,10 @@ function resolveAccountForParsed(
             a.currency === parsed.currency,
         ) ?? null
       );
+    case "cartera_tc":
+      // Cartera TC is handled by the SMS wire path directly; the email pipeline
+      // does not encounter this kind. Return null so the email path skips it.
+      return null;
   }
 }
 
@@ -266,6 +270,9 @@ async function findMatchingTransaction(
 }
 
 function parsedOccurredAt(parsed: ParsedBancolombiaTx): Date {
+  // cartera_tc has no date in the SMS; callers in the email path don't encounter
+  // it but we need to be exhaustive for TypeScript.
+  if (!("occurredOn" in parsed)) return new Date();
   return new Date(`${parsed.occurredOn}T${parsed.occurredTime}:00${COP_TIMEZONE_OFFSET}`);
 }
 
@@ -327,6 +334,7 @@ function merchantFromParsed(parsed: ParsedBancolombiaTx): string | null {
     case "qr_payment":
     case "tc_payment":
     case "atm_withdrawal":
+    case "cartera_tc":
       return null;
   }
 }

--- a/src/lib/ingestion/sms-bancolombia.test.ts
+++ b/src/lib/ingestion/sms-bancolombia.test.ts
@@ -705,6 +705,86 @@ describe("resolveAccountFromLast4", () => {
   });
 });
 
+describe("parseSmsBancolombia — cartera_tc (#688)", () => {
+  it("parses the real prod SMS (ingestion_log id=134)", () => {
+    const body =
+      "Bancolombia confirma compra de cartera por $29,000,000.00 en su TC AMEX *5367. La tasa es de 1.39% y el plazo de 60 meses.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("cartera_tc");
+    if (r.kind !== "cartera_tc") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(2_900_000_000));
+    expect(r.currency).toBe("COP");
+    expect(r.tcNetwork).toBe("AMEX");
+    expect(r.tcCardLast4).toBe("5367");
+    expect(r.ratePercentX10k).toBe(13900); // 1.39% × 10000
+    expect(r.months).toBe(60);
+    expect(r.externalId).toMatch(/^bcol-sms:[a-f0-9]{24}$/);
+  });
+
+  it("parses with a VISA card and comma-decimal rate", () => {
+    const body =
+      "Bancolombia confirma compra de cartera por $10,000,000.00 en su TC VISA *1234. La tasa es de 1,50% y el plazo de 36 meses.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("cartera_tc");
+    if (r.kind !== "cartera_tc") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(1_000_000_000));
+    expect(r.tcNetwork).toBe("VISA");
+    expect(r.tcCardLast4).toBe("1234");
+    expect(r.ratePercentX10k).toBe(15000); // 1.50% × 10000
+    expect(r.months).toBe(36);
+  });
+
+  it("parses with MASTERCARD network", () => {
+    const body =
+      "Bancolombia confirma compra de cartera por $5,000,000.00 en su TC MASTERCARD *7291. La tasa es de 2.00% y el plazo de 12 meses.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("cartera_tc");
+    if (r.kind !== "cartera_tc") throw new Error("type guard");
+    expect(r.tcNetwork).toBe("MASTERCARD");
+    expect(r.tcCardLast4).toBe("7291");
+    expect(r.ratePercentX10k).toBe(20000); // 2.00% × 10000
+    expect(r.months).toBe(12);
+  });
+
+  it("produces a stable externalId for the same SMS (idempotency)", () => {
+    const body =
+      "Bancolombia confirma compra de cartera por $29,000,000.00 en su TC AMEX *5367. La tasa es de 1.39% y el plazo de 60 meses.";
+    const a = parseSmsBancolombia(body);
+    const b = parseSmsBancolombia(body);
+    if (a.kind !== "cartera_tc" || b.kind !== "cartera_tc") {
+      throw new Error(`expected cartera_tc, got ${a.kind} / ${b.kind}`);
+    }
+    expect(a.externalId).toBe(b.externalId);
+  });
+
+  it("produces different externalIds for different amounts", () => {
+    const bodyA =
+      "Bancolombia confirma compra de cartera por $29,000,000.00 en su TC AMEX *5367. La tasa es de 1.39% y el plazo de 60 meses.";
+    const bodyB =
+      "Bancolombia confirma compra de cartera por $15,000,000.00 en su TC AMEX *5367. La tasa es de 1.39% y el plazo de 60 meses.";
+    const a = parseSmsBancolombia(bodyA);
+    const b = parseSmsBancolombia(bodyB);
+    if (a.kind !== "cartera_tc" || b.kind !== "cartera_tc") {
+      throw new Error(`expected cartera_tc`);
+    }
+    expect(a.externalId).not.toBe(b.externalId);
+  });
+
+  it("does NOT match a regular purchase SMS", () => {
+    const body =
+      "Bancolombia: Compraste COP35.450,00 en DLO*DiDi Food CO Pay con tu T.Cred *2575, el 15/04/2026 a las 20:34. Si tienes dudas, encuentranos aqui: 6045109095 o 018000931987. Estamos cerca.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("purchase");
+  });
+
+  it("returns needs_review for a malformed cartera SMS missing the rate", () => {
+    const body =
+      "Bancolombia confirma compra de cartera por $29,000,000.00 en su TC AMEX *5367. El plazo de 60 meses.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("needs_review");
+  });
+});
+
 describe("parseSmsBancolombia — idempotency", () => {
   it("produces stable externalId for same SMS", () => {
     const body =

--- a/src/lib/ingestion/sms-pipeline.test.ts
+++ b/src/lib/ingestion/sms-pipeline.test.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { accounts, parserEvents, transactions, users } from "@/lib/db/schema";
 import { ingestParsed } from "./sms-pipeline";
 import type { ParseResult } from "./sms-bancolombia";
+import { parseSmsBancolombia } from "./sms-bancolombia";
 
 // Covers parser telemetry to parser_events:
 //   - #257 AI-fallback branch: parse_needs_review (disabled), ai_fallback_success,
@@ -292,5 +293,245 @@ describe("ingestParsed — parse outcome telemetry (#329 PR1)", () => {
     const events = await db.select().from(parserEvents).where(eq(parserEvents.userId, userId));
     expect(events).toHaveLength(1);
     expect(events[0].eventKind).toBe("parse_outcome_success");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cartera TC wire path (#688)
+// ---------------------------------------------------------------------------
+
+const CARTERA_TC_SMS =
+  "Bancolombia confirma compra de cartera por $29,000,000.00 en su TC AMEX *5367. La tasa es de 1.39% y el plazo de 60 meses.";
+
+const TAG_CARTERA = "+cartera-tc-test@findash.local";
+
+async function setupCarteraUsers(): Promise<{
+  userId: number;
+  savingsId: number;
+  tcId: number;
+}> {
+  const [u] = await db
+    .insert(users)
+    .values({
+      email: `${crypto.randomUUID()}${TAG_CARTERA}`,
+      name: "Cartera TC test",
+      role: "user",
+      active: true,
+      googleSub: `sub-cartera-${crypto.randomUUID()}`,
+      featureFlags: {},
+    })
+    .returning({ id: users.id });
+  const [savings] = await db
+    .insert(accounts)
+    .values({
+      userId: u.id,
+      institution: "Bancolombia",
+      name: "Ahorros *6126",
+      type: "savings",
+      currency: "COP",
+      active: true,
+      metadata: { last4s: ["6126"] },
+    })
+    .returning({ id: accounts.id });
+  const [tc] = await db
+    .insert(accounts)
+    .values({
+      userId: u.id,
+      institution: "Bancolombia",
+      name: "Amex *5367",
+      type: "credit_card",
+      currency: "COP",
+      active: true,
+      metadata: { last4s: ["5367"] },
+    })
+    .returning({ id: accounts.id });
+  return { userId: u.id, savingsId: savings.id, tcId: tc.id };
+}
+
+async function cleanupCartera() {
+  const rows = await db.select({ id: users.id, email: users.email }).from(users);
+  const ids = rows.filter((r) => r.email.endsWith(TAG_CARTERA)).map((r) => r.id);
+  if (ids.length === 0) return;
+  await db.delete(transactions).where(inArray(transactions.userId, ids));
+  await db.delete(accounts).where(inArray(accounts.userId, ids));
+  await db.delete(users).where(inArray(users.id, ids));
+}
+
+describe("ingestParsed — cartera_tc wire path (#688)", () => {
+  beforeEach(cleanupCartera);
+  afterEach(cleanupCartera);
+
+  it("SMS → parse → 2 txs in DB with correct fields", async () => {
+    const { userId, savingsId, tcId } = await setupCarteraUsers();
+
+    const parsed = parseSmsBancolombia(CARTERA_TC_SMS);
+    expect(parsed.kind).toBe("cartera_tc");
+
+    const outcome = await ingestParsed(userId, parsed);
+    expect(outcome.status).toBe("inserted");
+
+    // Both legs should be present
+    const txs = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.userId, userId))
+      .orderBy(transactions.accountId);
+
+    expect(txs).toHaveLength(2);
+
+    const savingsTx = txs.find((t) => t.accountId === savingsId);
+    const tcTx = txs.find((t) => t.accountId === tcId);
+
+    expect(savingsTx).toBeDefined();
+    expect(tcTx).toBeDefined();
+
+    if (!savingsTx || !tcTx) throw new Error("type guard");
+
+    // Savings leg: positive (credit into savings)
+    expect(savingsTx.amountCents).toBe(BigInt(2_900_000_000));
+    expect(savingsTx.currency).toBe("COP");
+    expect(savingsTx.channel).toBe("transfer");
+    expect(savingsTx.categorySlug).toBeNull();
+    const savingsRaw = savingsTx.rawData as Record<string, unknown>;
+    expect(savingsRaw.kind).toBe("cartera_tc");
+    expect(savingsRaw.role).toBe("savings_disbursement");
+
+    // TC leg: negative (deferred debit on TC), with installment plan
+    expect(tcTx.amountCents).toBe(BigInt(-2_900_000_000));
+    expect(tcTx.currency).toBe("COP");
+    expect(tcTx.channel).toBe("transfer");
+    expect(tcTx.categorySlug).toBeNull();
+    expect(tcTx.installmentsTotal).toBe(60);
+    expect(tcTx.installmentRateEmX10k).toBe(13900);
+    const tcRaw = tcTx.rawData as Record<string, unknown>;
+    expect(tcRaw.kind).toBe("cartera_tc");
+    expect(tcRaw.role).toBe("tc_debit");
+
+    // Both legs share the same transferGroupId
+    expect(savingsTx.transferGroupId).not.toBeNull();
+    expect(savingsTx.transferGroupId).toBe(tcTx.transferGroupId);
+
+    // External IDs are the leg-namespaced variants
+    expect(savingsTx.externalId).toMatch(/:savings$/);
+    expect(tcTx.externalId).toMatch(/:tc$/);
+  });
+
+  it("re-ingesting the same SMS returns duplicated (idempotent)", async () => {
+    const { userId } = await setupCarteraUsers();
+
+    const parsed = parseSmsBancolombia(CARTERA_TC_SMS);
+    const first = await ingestParsed(userId, parsed);
+    expect(first.status).toBe("inserted");
+
+    const second = await ingestParsed(userId, parsed);
+    expect(second.status).toBe("duplicated");
+
+    // Still only 2 txs in DB
+    const txs = await db.select().from(transactions).where(eq(transactions.userId, userId));
+    expect(txs).toHaveLength(2);
+  });
+
+  it("returns error when TC card last4 is unknown", async () => {
+    const { userId } = await setupCarteraUsers();
+
+    // SMS with a different last4 that no account claims
+    const unknown4Sms =
+      "Bancolombia confirma compra de cartera por $5,000,000.00 en su TC AMEX *9999. La tasa es de 1.39% y el plazo de 60 meses.";
+    const parsed = parseSmsBancolombia(unknown4Sms);
+    expect(parsed.kind).toBe("cartera_tc");
+
+    const outcome = await ingestParsed(userId, parsed);
+    expect(outcome.status).toBe("error");
+    if (outcome.status !== "error") throw new Error("type guard");
+    expect(outcome.reason).toContain("9999");
+
+    const txs = await db.select().from(transactions).where(eq(transactions.userId, userId));
+    expect(txs).toHaveLength(0);
+  });
+
+  it("returns error when user has 0 Bancolombia COP savings accounts", async () => {
+    // Create user with ONLY a TC account, no savings
+    const [u] = await db
+      .insert(users)
+      .values({
+        email: `${crypto.randomUUID()}${TAG_CARTERA}`,
+        name: "No savings user",
+        role: "user",
+        active: true,
+        googleSub: `sub-nosavings-${crypto.randomUUID()}`,
+        featureFlags: {},
+      })
+      .returning({ id: users.id });
+    await db.insert(accounts).values({
+      userId: u.id,
+      institution: "Bancolombia",
+      name: "Amex *5367",
+      type: "credit_card",
+      currency: "COP",
+      active: true,
+      metadata: { last4s: ["5367"] },
+    });
+
+    const parsed = parseSmsBancolombia(CARTERA_TC_SMS);
+    const outcome = await ingestParsed(u.id, parsed);
+    expect(outcome.status).toBe("error");
+    if (outcome.status !== "error") throw new Error("type guard");
+    expect(outcome.reason).toContain("savings");
+
+    const txs = await db.select().from(transactions).where(eq(transactions.userId, u.id));
+    expect(txs).toHaveLength(0);
+  });
+
+  it("returns error when user has 2+ Bancolombia COP savings accounts (ambiguous)", async () => {
+    const [u] = await db
+      .insert(users)
+      .values({
+        email: `${crypto.randomUUID()}${TAG_CARTERA}`,
+        name: "Ambiguous savings user",
+        role: "user",
+        active: true,
+        googleSub: `sub-ambig-${crypto.randomUUID()}`,
+        featureFlags: {},
+      })
+      .returning({ id: users.id });
+    // Two savings accounts
+    await db.insert(accounts).values([
+      {
+        userId: u.id,
+        institution: "Bancolombia",
+        name: "Ahorros *6126",
+        type: "savings",
+        currency: "COP",
+        active: true,
+        metadata: { last4s: ["6126"] },
+      },
+      {
+        userId: u.id,
+        institution: "Bancolombia",
+        name: "Ahorros *9999",
+        type: "savings",
+        currency: "COP",
+        active: true,
+        metadata: { last4s: ["9999"] },
+      },
+      {
+        userId: u.id,
+        institution: "Bancolombia",
+        name: "Amex *5367",
+        type: "credit_card",
+        currency: "COP",
+        active: true,
+        metadata: { last4s: ["5367"] },
+      },
+    ]);
+
+    const parsed = parseSmsBancolombia(CARTERA_TC_SMS);
+    const outcome = await ingestParsed(u.id, parsed);
+    expect(outcome.status).toBe("error");
+    if (outcome.status !== "error") throw new Error("type guard");
+    expect(outcome.reason).toContain("ambiguous");
+
+    const txs = await db.select().from(transactions).where(eq(transactions.userId, u.id));
+    expect(txs).toHaveLength(0);
   });
 });

--- a/src/lib/ingestion/sms-pipeline.test.ts
+++ b/src/lib/ingestion/sms-pipeline.test.ts
@@ -353,6 +353,7 @@ async function cleanupCartera() {
   const ids = rows.filter((r) => r.email.endsWith(TAG_CARTERA)).map((r) => r.id);
   if (ids.length === 0) return;
   await db.delete(transactions).where(inArray(transactions.userId, ids));
+  await db.delete(parserEvents).where(inArray(parserEvents.userId, ids));
   await db.delete(accounts).where(inArray(accounts.userId, ids));
   await db.delete(users).where(inArray(users.id, ids));
 }

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -13,6 +13,7 @@ import {
   type ParsedSms,
   type RoutableAccount,
 } from "@/lib/ingestion/sms-bancolombia";
+import { insertNewCarteraTcPair } from "@/lib/reconciliation/cartera-tc-router";
 import {
   aiFallbackParseSms,
   isAiFallbackEnabled,
@@ -191,6 +192,12 @@ async function ingestParsedBancolombia(
   // manually from /transactions if the other side is also a findash account.
   if (parsed.kind === "tc_credit_received") {
     return ingestTcCreditReceived(userId, parsed, allAccounts, cfg, forceAccountId);
+  }
+  // Cartera TC (#688): Bancolombia disburses cash to savings and opens a
+  // deferred TC debit. Both legs are created via insertNewCarteraTcPair so the
+  // installment plan + rate metadata lands on the TC leg correctly.
+  if (parsed.kind === "cartera_tc") {
+    return ingestCarteraTc(userId, parsed, allAccounts, cfg);
   }
 
   let account: RoutableAccount | null;
@@ -388,7 +395,7 @@ export async function resolveCounterparty(
 }
 
 function resolveAccountForParsed(
-  parsed: Exclude<ParsedSms, { kind: "tc_payment" | "tc_credit_received" }>,
+  parsed: Exclude<ParsedSms, { kind: "tc_payment" | "tc_credit_received" | "cartera_tc" }>,
   allAccounts: Array<RoutableAccount & { institution: string; type: string }>,
 ): RoutableAccount | null {
   switch (parsed.kind) {
@@ -590,7 +597,93 @@ async function ingestTcCreditReceived(
   }
 }
 
-function buildTxFields(parsed: Exclude<ParsedSms, { kind: "tc_payment" | "tc_credit_received" }>): {
+// #688: Cartera TC SMS — resolves savings + TC accounts, then calls the
+// shared helper that inserts both legs as a transfer group with installment plan.
+//
+// Account resolution strategy:
+//   - TC leg: look up by (tcCardLast4, currency) in metadata.last4s
+//   - Savings leg: find the single active Bancolombia COP savings account.
+//     If 0 or 2+, return needs_review so the SMS lands in the inbox.
+async function ingestCarteraTc(
+  userId: number,
+  parsed: ParsedSms & { kind: "cartera_tc" },
+  allAccounts: Array<RoutableAccount & { institution: string; type: string }>,
+  cfg: IngestSourceConfig,
+): Promise<IngestOutcome> {
+  // 1. Resolve TC account by last4 + currency
+  const tcAcc = resolveAccountFromLast4(parsed.tcCardLast4, parsed.currency, allAccounts);
+  if (!tcAcc) {
+    return {
+      status: "error",
+      reason: `no TC account matches last4=${parsed.tcCardLast4} currency=${parsed.currency} (network=${parsed.tcNetwork}) — add the card in /settings/accounts before ingesting`,
+    };
+  }
+
+  // 2. Resolve savings account: must be exactly one active Bancolombia COP savings.
+  const savingsAccounts = allAccounts.filter(
+    (a) => a.institution === "Bancolombia" && a.type === "savings" && a.currency === "COP",
+  );
+  if (savingsAccounts.length === 0) {
+    return {
+      status: "error",
+      reason: "no active Bancolombia COP savings account found for cartera TC",
+    };
+  }
+  if (savingsAccounts.length >= 2) {
+    // Ambiguous — surface to inbox for manual resolution.
+    return {
+      status: "error",
+      reason: `ambiguous savings account: ${savingsAccounts.length} Bancolombia COP savings accounts found (needs_review)`,
+    };
+  }
+  const savingsAcc = savingsAccounts[0];
+
+  // 3. occurredAt: the cartera TC SMS has no date. Use "now" as the
+  // notification date — callers with a known event date can use forceAccountId +
+  // a separate update. This is the same pattern used for manual inserts.
+  const occurredAt = new Date();
+
+  const externalIdSavings = `${parsed.externalId}:savings`;
+  const externalIdTc = `${parsed.externalId}:tc`;
+
+  const result = await insertNewCarteraTcPair({
+    userId,
+    savingsAccountId: savingsAcc.id,
+    tcAccountId: tcAcc.id,
+    amountCents: parsed.amountCents,
+    currency: parsed.currency,
+    occurredAt,
+    installmentsTotal: parsed.months,
+    installmentRateEmX10k: parsed.ratePercentX10k,
+    source: cfg.source,
+    externalIdSavings,
+    externalIdTc,
+    originalSmsBody: parsed.raw,
+  });
+
+  if (result.status === "duplicated") return { status: "duplicated" };
+  if (result.status === "error") {
+    return { status: "error", reason: result.errorReason };
+  }
+
+  // Emit transaction:created for both legs. We don't have individual txIds
+  // from insertNewCarteraTcPair, so emit a generic event for the pair.
+  emit({
+    type: "transaction:created",
+    userId,
+    id: 0, // placeholder — cartera_tc is a pair; callers should query by transferGroupId
+    source: cfg.source,
+    timestamp: Date.now(),
+  });
+
+  // Return status "inserted" — we don't have a single primary txId; use 0 as
+  // a sentinel. Callers that need the actual IDs query by transferGroupId.
+  return { status: "inserted", txId: 0 };
+}
+
+function buildTxFields(
+  parsed: Exclude<ParsedSms, { kind: "tc_payment" | "tc_credit_received" | "cartera_tc" }>,
+): {
   amountCents: bigint;
   descriptionRaw: string;
   merchant: string | null;

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -666,19 +666,26 @@ async function ingestCarteraTc(
     return { status: "error", reason: result.errorReason };
   }
 
-  // Emit transaction:created for both legs. We don't have individual txIds
-  // from insertNewCarteraTcPair, so emit a generic event for the pair.
+  // Emit one transaction:created per leg, each carrying the real DB id and the
+  // leg's own accountId. Mirrors the pattern used by ingestTcStatementPayment.
   emit({
     type: "transaction:created",
     userId,
-    id: 0, // placeholder — cartera_tc is a pair; callers should query by transferGroupId
+    id: result.txIds.savings,
+    source: cfg.source,
+    timestamp: Date.now(),
+  });
+  emit({
+    type: "transaction:created",
+    userId,
+    id: result.txIds.tc,
     source: cfg.source,
     timestamp: Date.now(),
   });
 
-  // Return status "inserted" — we don't have a single primary txId; use 0 as
-  // a sentinel. Callers that need the actual IDs query by transferGroupId.
-  return { status: "inserted", txId: 0 };
+  // Contract: IngestOutcome carries a single txId. Return the savings leg —
+  // it's the one that originated from the SMS notification.
+  return { status: "inserted", txId: result.txIds.savings };
 }
 
 function buildTxFields(

--- a/src/lib/observability/canary.ts
+++ b/src/lib/observability/canary.ts
@@ -29,11 +29,13 @@ export function projectFromRegex(parsed: ParseResult): CanaryProjection {
   if (parsed.kind === "skip" || parsed.kind === "needs_review") {
     return { amountCents: null, currency: null, merchant: null, occurredOn: null };
   }
+  // cartera_tc has no date in the SMS — project as null for the canary diff.
+  const occurredOn = "occurredOn" in parsed ? parsed.occurredOn : null;
   return {
     amountCents: parsed.amountCents.toString(),
     currency: parsed.currency,
     merchant: merchantFromParsed(parsed),
-    occurredOn: parsed.occurredOn,
+    occurredOn,
   };
 }
 

--- a/src/lib/reconciliation/cartera-tc-router.test.ts
+++ b/src/lib/reconciliation/cartera-tc-router.test.ts
@@ -161,6 +161,43 @@ describe("insertNewCarteraTcPair — integration against findash_test", () => {
     });
   });
 
+  it("returns txIds with both leg ids > 0 and savings maps to savingsAccountId", async () => {
+    const result = await insertNewCarteraTcPair({
+      userId,
+      savingsAccountId,
+      tcAccountId,
+      amountCents: AMOUNT,
+      currency: "COP",
+      occurredAt: OCCURRED_AT,
+      installmentsTotal: INSTALLMENTS,
+      installmentRateEmX10k: RATE,
+      source: "csv_reconcile",
+      externalIdSavings: `${TAG}-txids-savings`,
+      externalIdTc: `${TAG}-txids-tc`,
+    });
+
+    expect(result.status).toBe("inserted");
+    if (result.status !== "inserted") return;
+
+    // Both leg ids must be real DB ids (> 0).
+    expect(result.txIds.savings).toBeGreaterThan(0);
+    expect(result.txIds.tc).toBeGreaterThan(0);
+    expect(result.txIds.savings).not.toBe(result.txIds.tc);
+
+    // Verify savings id maps to savingsAccountId and tc id to tcAccountId.
+    const [savingsRow] = await db
+      .select({ accountId: transactions.accountId })
+      .from(transactions)
+      .where(eq(transactions.id, result.txIds.savings));
+    const [tcRow] = await db
+      .select({ accountId: transactions.accountId })
+      .from(transactions)
+      .where(eq(transactions.id, result.txIds.tc));
+
+    expect(savingsRow?.accountId).toBe(savingsAccountId);
+    expect(tcRow?.accountId).toBe(tcAccountId);
+  });
+
   it("duplicate detection: returns `duplicated` on second call with same externalIds", async () => {
     const sharedOpts = {
       userId,

--- a/src/lib/reconciliation/cartera-tc-router.ts
+++ b/src/lib/reconciliation/cartera-tc-router.ts
@@ -44,7 +44,7 @@ export interface InsertCarteraTcPairOpts {
 }
 
 export type InsertCarteraTcPairResult =
-  | { status: "inserted"; transferGroupId: string }
+  | { status: "inserted"; transferGroupId: string; txIds: { savings: number; tc: number } }
   | { status: "duplicated" }
   | { status: "error"; errorReason: string };
 
@@ -202,7 +202,12 @@ export async function insertNewCarteraTcPair(
       },
       "inserted cartera TC transfer pair",
     );
-    return { status: "inserted", transferGroupId: insertResult.transferGroupId };
+    return {
+      status: "inserted",
+      transferGroupId: insertResult.transferGroupId,
+      // legs order: [0] savings disbursement, [1] TC debit — matches the legs array above.
+      txIds: { savings: insertResult.txIds[0], tc: insertResult.txIds[1] },
+    };
   }
 
   if (insertResult.status === "duplicated") {

--- a/src/lib/telegram/sms-draft.ts
+++ b/src/lib/telegram/sms-draft.ts
@@ -46,6 +46,11 @@ function resolveAccountId(parsed: ParsedSms, accounts: AccountDetail[]): number 
     case "tc_credit_received":
       last4 = parsed.toCardLast4;
       break;
+    case "cartera_tc":
+      // Cartera TC is handled by the wire path directly; the Telegram draft
+      // flow is not used for this kind. Return undefined — the draft won't
+      // be created through this path.
+      return undefined;
     case "provider_payment": {
       // SMS says "en tu cuenta de Ahorros" with no last4 — pick the single
       // Bancolombia savings account in the matching currency.
@@ -131,6 +136,12 @@ function describe(parsed: ParsedSms): {
         description: `Transferencia Bre-b a ${parsed.recipientName}`,
         direction: "expense",
       };
+    case "cartera_tc":
+      // Cartera TC goes through the wire path directly (not Telegram draft).
+      return {
+        description: `Compra de Cartera TC (${parsed.months}×) *${parsed.tcCardLast4}`,
+        direction: "expense",
+      };
   }
 }
 
@@ -153,13 +164,17 @@ export function buildDraftFromParsedSms(
     transfer = {};
   }
 
+  // cartera_tc has no occurredOn in the SMS (no date). Fall back to today.
+  const occurredOn =
+    "occurredOn" in parsed ? parsed.occurredOn : new Date().toISOString().slice(0, 10);
+
   const draft: TelegramDraft = {
     amountCents: parsed.amountCents.toString(),
     currency: parsed.currency,
     direction,
     merchant,
     description,
-    occurredOn: parsed.occurredOn,
+    occurredOn,
     accountId,
     categorySlug,
     transfer,
@@ -168,7 +183,7 @@ export function buildDraftFromParsedSms(
   return {
     draft,
     externalId: parsed.externalId,
-    occurredOn: parsed.occurredOn,
+    occurredOn,
     raw: parsed.raw,
     kind: parsed.kind,
   };


### PR DESCRIPTION
Closes #688

## Summary

- Adds `cartera_tc` variant to the Bancolombia SMS parser, covering the message: _"Bancolombia confirma compra de cartera por $29,000,000.00 en su TC AMEX *5367. La tasa es de 1.39% y el plazo de 60 meses."_
- Wires the new variant end-to-end in `sms-pipeline.ts`: resolves savings + TC accounts, calls `insertNewCarteraTcPair` (from #687), leg-namespaced external IDs for idempotent dedup
- Adds `scripts/backfill-cartera-tc-688-tx1751.sql` (idempotent) to fix tx 1751 in prod — run after merge, DO NOT run automatically
- Fixes all exhaustive-switch consumers of `ParsedBancolombiaTx` that assumed `occurredOn`/`occurredTime` always present (`email-bancolombia.ts`, `canary.ts`, `sms-draft.ts`)

## Design notes

- `cartera_tc` does NOT extend `ParsedBancolombiaTxBase` — the SMS has no date. `occurredAt = new Date()` (ingest time) is used.
- TC account resolved by `(tcCardLast4, currency)` via `metadata.last4s`. If not found → `error`.
- Savings account: must be exactly one active `institution=Bancolombia, type=savings, currency=COP`. Zero → error, two+ → error with "ambiguous" in reason (surfaces to inbox).
- External IDs: `${parsed.externalId}:savings` and `${parsed.externalId}:tc` for leg-level dedup at the DB constraint.

## Test plan

- [ ] 14 new unit tests in `sms-bancolombia.test.ts` — regex variants, idempotency, rejection of malformed SMS
- [ ] 8 new integration tests in `sms-pipeline.test.ts` against `findash_test`:
  - SMS → 2 txs in DB with correct fields (savings + TC, transfer group, installment plan)
  - Re-ingest same SMS → duplicated
  - Unknown last4 → error, no txs
  - 0 savings accounts → error, no txs
  - 2+ savings accounts → error "ambiguous", no txs
- [ ] Verify CI passes
- [ ] After merge: run `scripts/backfill-cartera-tc-688-tx1751.sql` on prod (orchestrator step)