### PR TITLE
feat(ingestion): parse Recibiste pago AHORROS + tolerant dedup (#689)

### DIFF
--- a/scripts/backfill-transfer-received-689-logs147-149.sql
+++ b/scripts/backfill-transfer-received-689-logs147-149.sql
@@ -1,0 +1,135 @@
+-- Backfill for issue #689: transfer_received_to_savings
+-- Resolves prod ingestion_logs 147 and 149 (Bancolombia duplicate SMS for the
+-- same $11,740,000 DIAN/Tesoro Nacional refund on 2026-04-30).
+--
+-- What happened:
+--   - Bancolombia sent TWO SMS for a single payment event, 4 minutes apart
+--   - SMS 147: "...el 18:04 a las 30/04/2026..." (first notification)
+--   - SMS 149: "...el 18:08 a las 30/04/2026..." (second notification, duplicate)
+--   - The old externalId algorithm hashed the full body, so different timestamps
+--     produced different hashes → parser would have inserted two transactions
+--   - The new parser (#689) hashes semantic fields only (no timestamp), so both
+--     SMS produce externalId = bcol-sms:5b75ed23c73e5fb408f7f06e
+--
+-- This backfill:
+--   1. Inserts the single correct tx (uses log 147 body as authoritative)
+--      Category = "reembolso" (intentional: this IS a DIAN tax refund, not
+--      generic income; the parser uses "otros-ingresos" because it cannot know)
+--   2. Resolves log 147 → retried_success + resolved_txn_id
+--   3. Resolves log 149 → duplicate (no resolved_txn_id, it's a duplicate)
+--
+-- Idempotent: safe to re-run; checks externalId before inserting.
+--
+-- DO NOT execute without confirming:
+--   a) The migration for #689 has been deployed to prod
+--   b) SELECT id FROM accounts WHERE user_id=1 AND type='savings' AND
+--      currency='COP' AND institution_slug='bancolombia' AND deleted_at IS NULL;
+--      — must return exactly 1 row
+
+BEGIN;
+DO $$
+DECLARE
+  ahorros_id integer;
+  new_tx_id  integer;
+  -- externalId computed by the new transfer_received_to_savings algorithm:
+  -- hashId("bcol-sms", ["transfer-received-to-savings", "bcol-sms",
+  --                     "1174000000", "COP", "2026-04-30", "DIR TESORO NACI"])
+  -- = SHA256("transfer-received-to-savings|bcol-sms|1174000000|COP|2026-04-30|DIR TESORO NACI")
+  --   sliced to 24 hex chars, prefixed with "bcol-sms:"
+  ext_id text := 'bcol-sms:5b75ed23c73e5fb408f7f06e';
+BEGIN
+  -- Resolve Bancolombia COP savings account for user_id=1
+  SELECT id INTO ahorros_id
+  FROM accounts
+  WHERE user_id = 1
+    AND name = 'Bancolombia Ahorros'
+    AND currency = 'COP'
+    AND deleted_at IS NULL;
+
+  IF ahorros_id IS NULL THEN
+    RAISE EXCEPTION 'Bancolombia Ahorros COP not found for user_id=1. Check account name in prod.';
+  END IF;
+
+  -- Idempotency guard
+  IF EXISTS (SELECT 1 FROM transactions WHERE external_id = ext_id) THEN
+    RAISE NOTICE 'Backfill already applied (externalId % exists). Skipping tx insert.', ext_id;
+  ELSE
+    -- Insert the single authoritative tx
+    -- amount_cents = 1174000000 = $11,740,000.00 × 100
+    INSERT INTO transactions (
+      user_id,
+      account_id,
+      occurred_at,
+      amount_cents,
+      currency,
+      description_raw,
+      merchant,
+      channel,
+      category_slug,
+      classification_method,
+      source,
+      external_id,
+      raw_data,
+      created_at,
+      updated_at
+    ) VALUES (
+      1,
+      ahorros_id,
+      '2026-04-30 18:04:00+00'::timestamptz,
+      1174000000,
+      'COP',
+      'Bancolombia: Recibiste un pago por $11,740,000.00 de DIR TESORO NACI a tu cuenta AHORROS, el 18:04 a las 30/04/2026. Si tienes dudas, llamanos al 018000931987. Estamos cerca.',
+      'DIR TESORO NACI',
+      'bank',
+      'reembolso',    -- specifically a DIAN tax refund; parser default is "otros-ingresos"
+      'manual',
+      'manual',       -- backfill; future re-ingestion would produce source="sms"
+      ext_id,
+      jsonb_build_object(
+        'kind',              'transfer_received_to_savings',
+        'originDescriptor',  'DIR TESORO NACI',
+        'occurredTime',      '18:04',
+        'backfill',          '689'
+      ),
+      now(),
+      now()
+    ) RETURNING id INTO new_tx_id;
+
+    RAISE NOTICE 'Inserted tx id=% for DIAN refund $11,740,000 on 2026-04-30', new_tx_id;
+  END IF;
+
+  -- Resolve log 147 (the SMS we treat as authoritative — first delivery at 18:04)
+  UPDATE ingestion_logs
+  SET
+    status         = 'resolved',
+    resolved_at    = now(),
+    resolution     = 'retried_success',
+    resolved_txn_id = (
+      SELECT id FROM transactions WHERE external_id = ext_id LIMIT 1
+    )
+  WHERE id = 147;
+
+  IF NOT FOUND THEN
+    RAISE WARNING 'ingestion_log 147 not found — skipping update';
+  ELSE
+    RAISE NOTICE 'Resolved log 147 → retried_success';
+  END IF;
+
+  -- Resolve log 149 (the Bancolombia duplicate — 4 minutes later at 18:08)
+  UPDATE ingestion_logs
+  SET
+    status          = 'resolved',
+    resolved_at     = now(),
+    resolution      = 'duplicate',
+    resolved_txn_id = NULL   -- duplicate, no new tx
+  WHERE id = 149;
+
+  IF NOT FOUND THEN
+    RAISE WARNING 'ingestion_log 149 not found — skipping update';
+  ELSE
+    RAISE NOTICE 'Resolved log 149 → duplicate (no tx, same event as 147)';
+  END IF;
+
+END
+$$;
+COMMIT;

--- a/src/lib/counterparties/alias-key.ts
+++ b/src/lib/counterparties/alias-key.ts
@@ -46,6 +46,12 @@ export function keyForParsed(parsed: ParsedSms): KeyForKind | null {
         value: normalizeName(parsed.senderName),
         initialDisplayName: parsed.senderName,
       };
+    case "transfer_received_to_savings":
+      return {
+        kind: "name",
+        value: normalizeName(parsed.originDescriptor),
+        initialDisplayName: parsed.originDescriptor,
+      };
     default:
       return null;
   }

--- a/src/lib/ingestion/bancolombia-variants.ts
+++ b/src/lib/ingestion/bancolombia-variants.ts
@@ -68,6 +68,17 @@ export type ParsedBancolombiaTx =
       toKey: string;
       recipientName: string;
     })
+  | (ParsedBancolombiaTxBase & {
+      kind: "transfer_received_to_savings";
+      originDescriptor: string;
+      // Note: occurredTime is stored here for display purposes only. It is NOT
+      // part of the externalId computation for this variant. This is intentional:
+      // Bancolombia has been observed sending the same payment notification twice
+      // with different timestamps (4 minutes apart, prod logs 147+149). Using
+      // semantic fields (sender + amount + date + origin) instead of the raw body
+      // ensures both duplicates hash to the same externalId (#689).
+      occurredTime: string;
+    })
   | {
       // Note: cartera_tc has NO occurredOn/occurredTime — the SMS does not
       // include a date. The caller uses Date.now() / a known reference date.
@@ -328,6 +339,17 @@ const TC_CREDIT_RECEIVED = new RegExp(
 // Bre-b transfer: "<USER>, transferiste AMOUNT a la llave NNNN desde tu cuenta *NNNN a <RECIPIENT_NAME> el DATE a las TIME..."
 const BRE_B_TRANSFER = new RegExp(
   `transferiste\\s+${AMOUNT_GROUP}\\s+a\\s+la\\s+llave\\s+(\\d+)\\s+desde\\s+tu\\s+cuenta\\s+\\*?(\\d{4,})\\s+a\\s+(.+?)\\s+el\\s+${DATE_TIME}`,
+  "i",
+);
+
+// Transfer received to savings (third-party pago landing in cta Ahorros):
+// "Bancolombia: Recibiste un pago por $AMOUNT de ORIGIN a tu cuenta AHORROS, el HH:MM a las DD/MM/YYYY..."
+// Distinct from TRANSFER_RECV_A/B (those involve inter-Bancolombia transfers with a *last4)
+// and from PROVIDER_PAYMENT (that requires the literal "PROVEEDOR" keyword).
+// This shape appears when DIAN, Tesoro Nacional, or any external institution wires
+// money directly to the user's savings account. No account last4 is present.
+const TRANSFER_RECV_TO_SAVINGS = new RegExp(
+  `Recibiste\\s+un\\s+pago\\s+por\\s+${AMOUNT_GROUP}\\s+de\\s+(.+?)\\s+a\\s+tu\\s+cuenta\\s+AHORROS[,.]?\\s+el\\s+${TIME_GROUP}\\s+a\\s+las\\s+${DATE_GROUP}`,
   "i",
 );
 
@@ -780,6 +802,46 @@ export function matchBancolombiaVariant(
           occurredOn,
           occurredTime,
           cents,
+        ]),
+        raw,
+      };
+    }
+  }
+
+  // Transfer received to savings (third-party institution paying directly into
+  // savings account — DIAN, Tesoro Nacional, external employer, etc.)
+  //
+  // ExternalId strategy: uses semantic fields (sender + amount + date + origin)
+  // rather than raw body. Bancolombia has been observed sending the same payment
+  // notification twice with timestamps 4 minutes apart (prod logs 147+149, #689).
+  // Hashing the body would produce different IDs → duplicate tx. Hashing semantic
+  // fields ensures both copies of the notification map to the same externalId.
+  // occurredTime is preserved on the struct for display only, NOT in the hash.
+  // This is variant-specific — other variants keep their body-based hash.
+  {
+    const m = raw.match(TRANSFER_RECV_TO_SAVINGS);
+    if (m) {
+      const { cents, currency } = parseBancolombiaAmount(m[1]);
+      const originDescriptor = m[2].trim();
+      const occurredTime = m[3];
+      const occurredOn = parseBancolombiaDate(m[4]);
+      return {
+        kind: "transfer_received_to_savings",
+        amountCents: cents,
+        currency,
+        originDescriptor,
+        occurredOn,
+        occurredTime,
+        externalId: hashId(prefix, [
+          "transfer-received-to-savings",
+          // sender is the external ID prefix (e.g. "bcol-sms" with its underlying
+          // SMS sender number). We fold the prefix itself (which encodes the sender
+          // channel) together with semantic fields so cross-source dedup stays clean.
+          prefix,
+          String(cents),
+          currency,
+          occurredOn,
+          originDescriptor,
         ]),
         raw,
       };

--- a/src/lib/ingestion/email-bancolombia.ts
+++ b/src/lib/ingestion/email-bancolombia.ts
@@ -189,6 +189,17 @@ function resolveAccountForParsed(
             a.currency === parsed.currency,
         ) ?? null
       );
+    case "transfer_received_to_savings":
+      // Routes to the user's Bancolombia savings account (same strategy as
+      // provider_payment — no last4 in this SMS shape).
+      return (
+        allAccounts.find(
+          (a) =>
+            a.institution === "Bancolombia" &&
+            a.type === "savings" &&
+            a.currency === parsed.currency,
+        ) ?? null
+      );
     case "cartera_tc":
       // Cartera TC is handled by the SMS wire path directly; the email pipeline
       // does not encounter this kind. Return null so the email path skips it.
@@ -330,6 +341,8 @@ function merchantFromParsed(parsed: ParsedBancolombiaTx): string | null {
       return parsed.senderName;
     case "bre_b_transfer":
       return parsed.recipientName;
+    case "transfer_received_to_savings":
+      return parsed.originDescriptor;
     case "transfer_sent":
     case "qr_payment":
     case "tc_payment":

--- a/src/lib/ingestion/sms-bancolombia.test.ts
+++ b/src/lib/ingestion/sms-bancolombia.test.ts
@@ -810,3 +810,154 @@ describe("parseSmsBancolombia — idempotency", () => {
     expect(a.externalId).not.toBe(b.externalId);
   });
 });
+
+// ---------------------------------------------------------------------------
+// transfer_received_to_savings (#689)
+// ---------------------------------------------------------------------------
+
+describe("parseSmsBancolombia — transfer_received_to_savings (#689)", () => {
+  // Exact body from prod ingestion_log 147
+  const SMS_147 =
+    "Bancolombia: Recibiste un pago por $11,740,000.00 de DIR TESORO NACI a tu cuenta AHORROS, el 18:04 a las 30/04/2026. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
+  // Exact body from prod ingestion_log 149 (same event, different timestamp)
+  const SMS_149 =
+    "Bancolombia: Recibiste un pago por $11,740,000.00 de DIR TESORO NACI a tu cuenta AHORROS, el 18:08 a las 30/04/2026. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
+
+  it("parses log 147 (18:04) correctly", () => {
+    const r = parseSmsBancolombia(SMS_147);
+    expect(r.kind).toBe("transfer_received_to_savings");
+    if (r.kind !== "transfer_received_to_savings") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(1_174_000_000));
+    expect(r.currency).toBe("COP");
+    expect(r.originDescriptor).toBe("DIR TESORO NACI");
+    expect(r.occurredOn).toBe("2026-04-30");
+    expect(r.occurredTime).toBe("18:04");
+    expect(r.externalId).toMatch(/^bcol-sms:[a-f0-9]{24}$/);
+  });
+
+  it("parses log 149 (18:08) correctly", () => {
+    const r = parseSmsBancolombia(SMS_149);
+    expect(r.kind).toBe("transfer_received_to_savings");
+    if (r.kind !== "transfer_received_to_savings") throw new Error("type guard");
+    expect(r.amountCents).toBe(BigInt(1_174_000_000));
+    expect(r.currency).toBe("COP");
+    expect(r.originDescriptor).toBe("DIR TESORO NACI");
+    expect(r.occurredOn).toBe("2026-04-30");
+    expect(r.occurredTime).toBe("18:08");
+  });
+
+  // CORE DEDUP ASSERTION: both SMS produce the SAME externalId even though
+  // they differ by 4 minutes in occurredTime. This is the fix for #689 —
+  // hashing semantic fields (not raw body) prevents a duplicate tx.
+  it("produces the SAME externalId for log 147 and log 149 (Bancolombia duplicate SMS)", () => {
+    const a = parseSmsBancolombia(SMS_147);
+    const b = parseSmsBancolombia(SMS_149);
+    if (a.kind !== "transfer_received_to_savings" || b.kind !== "transfer_received_to_savings") {
+      throw new Error(`expected transfer_received_to_savings, got ${a.kind} / ${b.kind}`);
+    }
+    // This is the fundamental dedup contract: same payment = same externalId,
+    // regardless of when Bancolombia sent the notification.
+    expect(a.externalId).toBe(b.externalId);
+    // Sanity: the externalId matches the pre-computed value used in the backfill SQL.
+    expect(a.externalId).toBe("bcol-sms:5b75ed23c73e5fb408f7f06e");
+  });
+
+  it("produces different externalId for a different origin descriptor", () => {
+    const bodyOther =
+      "Bancolombia: Recibiste un pago por $11,740,000.00 de EMPRESA XYZ SAS a tu cuenta AHORROS, el 18:04 a las 30/04/2026. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
+    const a = parseSmsBancolombia(SMS_147);
+    const b = parseSmsBancolombia(bodyOther);
+    if (a.kind !== "transfer_received_to_savings" || b.kind !== "transfer_received_to_savings") {
+      throw new Error("type guard");
+    }
+    expect(a.externalId).not.toBe(b.externalId);
+  });
+
+  it("produces different externalId for a different amount", () => {
+    const bodyOther =
+      "Bancolombia: Recibiste un pago por $5,000,000.00 de DIR TESORO NACI a tu cuenta AHORROS, el 18:04 a las 30/04/2026. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
+    const a = parseSmsBancolombia(SMS_147);
+    const b = parseSmsBancolombia(bodyOther);
+    if (a.kind !== "transfer_received_to_savings" || b.kind !== "transfer_received_to_savings") {
+      throw new Error("type guard");
+    }
+    expect(a.externalId).not.toBe(b.externalId);
+  });
+
+  it("produces different externalId for a different occurredOn", () => {
+    const bodyOther =
+      "Bancolombia: Recibiste un pago por $11,740,000.00 de DIR TESORO NACI a tu cuenta AHORROS, el 18:04 a las 29/04/2026. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
+    const a = parseSmsBancolombia(SMS_147);
+    const b = parseSmsBancolombia(bodyOther);
+    if (a.kind !== "transfer_received_to_savings" || b.kind !== "transfer_received_to_savings") {
+      throw new Error("type guard");
+    }
+    expect(a.externalId).not.toBe(b.externalId);
+  });
+
+  it("does NOT match the existing PROVEEDOR shape", () => {
+    // provider_payment requires the literal word "PROVEEDOR"
+    const body =
+      "Bancolombia: Recibiste un pago PROVEEDOR de PEXTO COLOMBIA por $6,000,000.00 en tu cuenta de Ahorros el 14/04/2026 a las 21:43. Si tienes dudas, llamanos al 018000931987. A tu lado siempre.";
+    const r = parseSmsBancolombia(body);
+    expect(r.kind).toBe("provider_payment");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: existing variants must keep their body-based dedup (#689)
+// Bancolombia re-sends the same transaction SMS occasionally with different
+// timestamps. For purchase and qr_payment the timestamp IS part of the hash —
+// two SMS differing only by HH:MM WILL produce different externalIds. That is
+// intentional: for debit events a timestamp difference means a real event
+// difference (you can buy the same coffee twice same day). Only
+// transfer_received_to_savings switched to semantic-only hashing.
+// ---------------------------------------------------------------------------
+
+describe("parseSmsBancolombia — externalId regression: purchase still uses time", () => {
+  it("two purchase SMS with different times produce DIFFERENT externalIds", () => {
+    const bodyA =
+      "Bancolombia: Compraste COP35.450,00 en DLO*DiDi Food CO Pay con tu T.Cred *2575, el 15/04/2026 a las 20:34. Si tienes dudas, encuentranos aqui: 6045109095 o 018000931987. Estamos cerca.";
+    const bodyB =
+      "Bancolombia: Compraste COP35.450,00 en DLO*DiDi Food CO Pay con tu T.Cred *2575, el 15/04/2026 a las 20:38. Si tienes dudas, encuentranos aqui: 6045109095 o 018000931987. Estamos cerca.";
+    const a = parseSmsBancolombia(bodyA);
+    const b = parseSmsBancolombia(bodyB);
+    expect(a.kind).toBe("purchase");
+    expect(b.kind).toBe("purchase");
+    if (a.kind !== "purchase" || b.kind !== "purchase") throw new Error("type guard");
+    // occurredTime IS in the purchase externalId — two SMS with different times
+    // produce different hashes (the purchase happened twice, or Bancolombia had
+    // a real second notification at a different minute).
+    expect(a.externalId).not.toBe(b.externalId);
+  });
+});
+
+describe("parseSmsBancolombia — externalId regression: qr_payment still uses time", () => {
+  it("two qr_payment SMS with different times produce DIFFERENT externalIds", () => {
+    const bodyA =
+      "Bancolombia: ALEJANDRO RAFAEL MARTINEZ MALDONADO pagaste $92,000.00 por codigo QR desde tu cuenta *6126 a la llave 0091498581 el 15/04/2026 a las 00:20. Con codigo QR es facil y de una. Dudas al 018000912345";
+    const bodyB =
+      "Bancolombia: ALEJANDRO RAFAEL MARTINEZ MALDONADO pagaste $92,000.00 por codigo QR desde tu cuenta *6126 a la llave 0091498581 el 15/04/2026 a las 00:24. Con codigo QR es facil y de una. Dudas al 018000912345";
+    const a = parseSmsBancolombia(bodyA);
+    const b = parseSmsBancolombia(bodyB);
+    expect(a.kind).toBe("qr_payment");
+    expect(b.kind).toBe("qr_payment");
+    if (a.kind !== "qr_payment" || b.kind !== "qr_payment") throw new Error("type guard");
+    expect(a.externalId).not.toBe(b.externalId);
+  });
+});
+
+describe("parseSmsBancolombia — externalId regression: tc_payment still uses time", () => {
+  it("two tc_payment SMS with different times produce DIFFERENT externalIds", () => {
+    const bodyA =
+      "Bancolombia: Pagaste $1,320,564 en la tarjeta de credito *7291 desde la cuenta *6126, el 14/04/2026 21:48. ¿Dudas? Llamanos al 018000912345. Estamos cerca.";
+    const bodyB =
+      "Bancolombia: Pagaste $1,320,564 en la tarjeta de credito *7291 desde la cuenta *6126, el 14/04/2026 21:52. ¿Dudas? Llamanos al 018000912345. Estamos cerca.";
+    const a = parseSmsBancolombia(bodyA);
+    const b = parseSmsBancolombia(bodyB);
+    expect(a.kind).toBe("tc_payment");
+    expect(b.kind).toBe("tc_payment");
+    if (a.kind !== "tc_payment" || b.kind !== "tc_payment") throw new Error("type guard");
+    expect(a.externalId).not.toBe(b.externalId);
+  });
+});

--- a/src/lib/ingestion/sms-pipeline.test.ts
+++ b/src/lib/ingestion/sms-pipeline.test.ts
@@ -1,7 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { desc, eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, categories, parserEvents, transactions, users } from "@/lib/db/schema";
+import {
+  accounts,
+  categories,
+  counterparties,
+  counterpartyAliases,
+  parserEvents,
+  recurringTransactions,
+  transactions,
+  users,
+} from "@/lib/db/schema";
 import { ingestParsed } from "./sms-pipeline";
 import type { ParseResult } from "./sms-bancolombia";
 import { parseSmsBancolombia } from "./sms-bancolombia";
@@ -736,5 +745,134 @@ describe("ingestParsed — transfer_received_to_savings wire path (#689)", () =>
 
     const txs = await db.select().from(transactions).where(eq(transactions.userId, u.id));
     expect(txs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transfer_received_to_savings — counterparty resolution + auto-link (#689)
+// ---------------------------------------------------------------------------
+
+const TAG_TR_CP = "+tr-savings-cp-test@findash.local";
+
+async function setupSavingsUserWithCounterpartyAndRecurring(): Promise<{
+  userId: number;
+  savingsId: number;
+  counterpartyId: number;
+  recurringId: number;
+}> {
+  const [u] = await db
+    .insert(users)
+    .values({
+      email: `${crypto.randomUUID()}${TAG_TR_CP}`,
+      name: "TR Savings CP test",
+      role: "user",
+      active: true,
+      googleSub: `sub-tr-cp-${crypto.randomUUID()}`,
+      featureFlags: {},
+    })
+    .returning({ id: users.id });
+
+  // Seed income category required by transfer_received_to_savings
+  await db.insert(categories).values([
+    { userId: u.id, slug: "ingresos", name: "Ingresos", sortOrder: 150 },
+    {
+      userId: u.id,
+      slug: "otros-ingresos",
+      name: "Otros ingresos",
+      parentSlug: "ingresos",
+      sortOrder: 151,
+    },
+  ]);
+
+  const [savings] = await db
+    .insert(accounts)
+    .values({
+      userId: u.id,
+      institution: "Bancolombia",
+      name: "Ahorros *6126",
+      type: "savings",
+      currency: "COP",
+      active: true,
+      metadata: { last4s: ["6126"] },
+    })
+    .returning({ id: accounts.id });
+
+  // Seed a counterparty with the normalized name matching "DIR TESORO NACI"
+  const [cp] = await db
+    .insert(counterparties)
+    .values({
+      userId: u.id,
+      displayName: "DIR TESORO NACI",
+      type: "unknown",
+      hitCount: 0,
+    })
+    .returning({ id: counterparties.id });
+
+  await db.insert(counterpartyAliases).values({
+    userId: u.id,
+    counterpartyId: cp.id,
+    kind: "name",
+    value: "DIR TESORO NACI", // normalizeName("DIR TESORO NACI") → same (already upper)
+  });
+
+  // Seed a recurring transaction matching the SMS amount + savings account.
+  // dayOfMonth=30, amount=1_174_000_000n matches SMS_TRANSFER_SAVINGS_147 (April 30).
+  const [rec] = await db
+    .insert(recurringTransactions)
+    .values({
+      userId: u.id,
+      accountId: savings.id,
+      label: "Reembolso DIAN mensual",
+      amountCents: BigInt(1_174_000_000),
+      currency: "COP",
+      categorySlug: "otros-ingresos",
+      dayOfMonth: 30,
+      active: true,
+    })
+    .returning({ id: recurringTransactions.id });
+
+  return { userId: u.id, savingsId: savings.id, counterpartyId: cp.id, recurringId: rec.id };
+}
+
+async function cleanupTrCp() {
+  const rows = await db.select({ id: users.id, email: users.email }).from(users);
+  const ids = rows.filter((r) => r.email.endsWith(TAG_TR_CP)).map((r) => r.id);
+  if (ids.length === 0) return;
+  await db.delete(transactions).where(inArray(transactions.userId, ids));
+  await db.delete(recurringTransactions).where(inArray(recurringTransactions.userId, ids));
+  await db.delete(counterpartyAliases).where(inArray(counterpartyAliases.userId, ids));
+  await db.delete(counterparties).where(inArray(counterparties.userId, ids));
+  await db.delete(accounts).where(inArray(accounts.userId, ids));
+  await db.delete(categories).where(inArray(categories.userId, ids));
+  await db.delete(users).where(inArray(users.id, ids));
+}
+
+describe("transfer_received_to_savings resolves counterparty and auto-links recurring (#689)", () => {
+  beforeEach(cleanupTrCp);
+  afterEach(cleanupTrCp);
+
+  it("resolves counterparty from originDescriptor and auto-links matching recurring tx", async () => {
+    const { userId, savingsId, counterpartyId, recurringId } =
+      await setupSavingsUserWithCounterpartyAndRecurring();
+
+    const parsed = parseSmsBancolombia(SMS_TRANSFER_SAVINGS_147);
+    expect(parsed.kind).toBe("transfer_received_to_savings");
+
+    const outcome = await ingestParsed(userId, parsed);
+    expect(outcome.status).toBe("inserted");
+    if (outcome.status !== "inserted") throw new Error("type guard");
+
+    const [tx] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.userId, userId))
+      .limit(1);
+
+    expect(tx.accountId).toBe(savingsId);
+    // counterpartyId must be resolved (not null) — merchant grouping and
+    // inheritedCategory rules depend on this.
+    expect(tx.counterpartyId).toBe(counterpartyId);
+    // recurringId must be set — auto-link matched the savings account + amount.
+    expect(tx.recurringId).toBe(recurringId);
   });
 });

--- a/src/lib/ingestion/sms-pipeline.test.ts
+++ b/src/lib/ingestion/sms-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { desc, eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, parserEvents, transactions, users } from "@/lib/db/schema";
+import { accounts, categories, parserEvents, transactions, users } from "@/lib/db/schema";
 import { ingestParsed } from "./sms-pipeline";
 import type { ParseResult } from "./sms-bancolombia";
 import { parseSmsBancolombia } from "./sms-bancolombia";
@@ -527,6 +527,208 @@ describe("ingestParsed — cartera_tc wire path (#688)", () => {
     ]);
 
     const parsed = parseSmsBancolombia(CARTERA_TC_SMS);
+    const outcome = await ingestParsed(u.id, parsed);
+    expect(outcome.status).toBe("error");
+    if (outcome.status !== "error") throw new Error("type guard");
+    expect(outcome.reason).toContain("ambiguous");
+
+    const txs = await db.select().from(transactions).where(eq(transactions.userId, u.id));
+    expect(txs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transfer_received_to_savings wire path (#689)
+// ---------------------------------------------------------------------------
+
+// Exact SMS bodies from prod ingestion_logs 147 and 149.
+const SMS_TRANSFER_SAVINGS_147 =
+  "Bancolombia: Recibiste un pago por $11,740,000.00 de DIR TESORO NACI a tu cuenta AHORROS, el 18:04 a las 30/04/2026. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
+const SMS_TRANSFER_SAVINGS_149 =
+  "Bancolombia: Recibiste un pago por $11,740,000.00 de DIR TESORO NACI a tu cuenta AHORROS, el 18:08 a las 30/04/2026. Si tienes dudas, llamanos al 018000931987. Estamos cerca.";
+
+const TAG_TR_SAVINGS = "+tr-savings-test@findash.local";
+
+async function setupSavingsUser(): Promise<{
+  userId: number;
+  savingsId: number;
+}> {
+  const [u] = await db
+    .insert(users)
+    .values({
+      email: `${crypto.randomUUID()}${TAG_TR_SAVINGS}`,
+      name: "TR Savings test",
+      role: "user",
+      active: true,
+      googleSub: `sub-trs-${crypto.randomUUID()}`,
+      featureFlags: {},
+    })
+    .returning({ id: users.id });
+  // Seed the income categories required by transfer_received_to_savings.
+  // (categories are user-scoped and the FK on transactions.category_slug
+  // references (user_id, category_slug) → categories(user_id, slug))
+  await db.insert(categories).values([
+    { userId: u.id, slug: "ingresos", name: "Ingresos", sortOrder: 150 },
+    {
+      userId: u.id,
+      slug: "otros-ingresos",
+      name: "Otros ingresos",
+      parentSlug: "ingresos",
+      sortOrder: 151,
+    },
+  ]);
+  const [savings] = await db
+    .insert(accounts)
+    .values({
+      userId: u.id,
+      institution: "Bancolombia",
+      name: "Ahorros *6126",
+      type: "savings",
+      currency: "COP",
+      active: true,
+      metadata: { last4s: ["6126"] },
+    })
+    .returning({ id: accounts.id });
+  return { userId: u.id, savingsId: savings.id };
+}
+
+async function cleanupTrSavings() {
+  const rows = await db.select({ id: users.id, email: users.email }).from(users);
+  const ids = rows.filter((r) => r.email.endsWith(TAG_TR_SAVINGS)).map((r) => r.id);
+  if (ids.length === 0) return;
+  await db.delete(transactions).where(inArray(transactions.userId, ids));
+  await db.delete(parserEvents).where(inArray(parserEvents.userId, ids));
+  await db.delete(accounts).where(inArray(accounts.userId, ids));
+  await db.delete(categories).where(inArray(categories.userId, ids));
+  await db.delete(users).where(inArray(users.id, ids));
+}
+
+describe("ingestParsed — transfer_received_to_savings wire path (#689)", () => {
+  beforeEach(cleanupTrSavings);
+  afterEach(cleanupTrSavings);
+
+  it("SMS 147 → parse → 1 tx inserted with correct fields", async () => {
+    const { userId, savingsId } = await setupSavingsUser();
+
+    const parsed = parseSmsBancolombia(SMS_TRANSFER_SAVINGS_147);
+    expect(parsed.kind).toBe("transfer_received_to_savings");
+
+    const outcome = await ingestParsed(userId, parsed);
+    expect(outcome.status).toBe("inserted");
+    if (outcome.status !== "inserted") throw new Error("type guard");
+
+    const [tx] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.userId, userId))
+      .limit(1);
+
+    expect(tx.accountId).toBe(savingsId);
+    expect(tx.amountCents).toBe(BigInt(1_174_000_000)); // positive (incoming)
+    expect(tx.currency).toBe("COP");
+    expect(tx.merchant).toBe("DIR TESORO NACI");
+    expect(tx.channel).toBe("bank");
+    expect(tx.categorySlug).toBe("otros-ingresos");
+    expect(tx.source).toBe("sms");
+    expect(tx.externalId).toBe("bcol-sms:5b75ed23c73e5fb408f7f06e");
+    const raw = tx.rawData as Record<string, unknown>;
+    expect(raw.kind).toBe("transfer_received_to_savings");
+    expect(raw.originDescriptor).toBe("DIR TESORO NACI");
+    expect(raw.occurredTime).toBe("18:04");
+  });
+
+  it("re-ingesting SMS 147 returns duplicated (idempotent)", async () => {
+    const { userId } = await setupSavingsUser();
+
+    const parsed = parseSmsBancolombia(SMS_TRANSFER_SAVINGS_147);
+    const first = await ingestParsed(userId, parsed);
+    expect(first.status).toBe("inserted");
+
+    const second = await ingestParsed(userId, parsed);
+    expect(second.status).toBe("duplicated");
+
+    const txs = await db.select().from(transactions).where(eq(transactions.userId, userId));
+    expect(txs).toHaveLength(1);
+  });
+
+  it("SMS 149 (different timestamp, same event) deduplicates against SMS 147", async () => {
+    const { userId } = await setupSavingsUser();
+
+    // First ingest SMS 147
+    const parsed147 = parseSmsBancolombia(SMS_TRANSFER_SAVINGS_147);
+    const first = await ingestParsed(userId, parsed147);
+    expect(first.status).toBe("inserted");
+
+    // Then ingest SMS 149 (Bancolombia accidental duplicate, 4 minutes later)
+    const parsed149 = parseSmsBancolombia(SMS_TRANSFER_SAVINGS_149);
+    const second = await ingestParsed(userId, parsed149);
+
+    // Must deduplicate — same externalId despite different body
+    expect(second.status).toBe("duplicated");
+
+    // Still only 1 tx in DB
+    const txs = await db.select().from(transactions).where(eq(transactions.userId, userId));
+    expect(txs).toHaveLength(1);
+  });
+
+  it("returns error when user has 0 active Bancolombia COP savings accounts", async () => {
+    // User with no savings at all
+    const [u] = await db
+      .insert(users)
+      .values({
+        email: `${crypto.randomUUID()}${TAG_TR_SAVINGS}`,
+        name: "No savings user",
+        role: "user",
+        active: true,
+        googleSub: `sub-nosavings2-${crypto.randomUUID()}`,
+        featureFlags: {},
+      })
+      .returning({ id: users.id });
+
+    const parsed = parseSmsBancolombia(SMS_TRANSFER_SAVINGS_147);
+    const outcome = await ingestParsed(u.id, parsed);
+    expect(outcome.status).toBe("error");
+    if (outcome.status !== "error") throw new Error("type guard");
+    expect(outcome.reason).toContain("savings");
+
+    const txs = await db.select().from(transactions).where(eq(transactions.userId, u.id));
+    expect(txs).toHaveLength(0);
+  });
+
+  it("returns error when user has 2+ active Bancolombia COP savings accounts (ambiguous)", async () => {
+    const [u] = await db
+      .insert(users)
+      .values({
+        email: `${crypto.randomUUID()}${TAG_TR_SAVINGS}`,
+        name: "Ambiguous savings user 2",
+        role: "user",
+        active: true,
+        googleSub: `sub-ambig2-${crypto.randomUUID()}`,
+        featureFlags: {},
+      })
+      .returning({ id: users.id });
+    await db.insert(accounts).values([
+      {
+        userId: u.id,
+        institution: "Bancolombia",
+        name: "Ahorros *6126",
+        type: "savings",
+        currency: "COP",
+        active: true,
+        metadata: { last4s: ["6126"] },
+      },
+      {
+        userId: u.id,
+        institution: "Bancolombia",
+        name: "Ahorros *9999",
+        type: "savings",
+        currency: "COP",
+        active: true,
+        metadata: { last4s: ["9999"] },
+      },
+    ]);
+
+    const parsed = parseSmsBancolombia(SMS_TRANSFER_SAVINGS_147);
     const outcome = await ingestParsed(u.id, parsed);
     expect(outcome.status).toBe("error");
     if (outcome.status !== "error") throw new Error("type guard");

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -5,6 +5,7 @@ import { notDeleted } from "@/lib/db/helpers";
 import { classifyByRule } from "@/lib/classification/rules";
 import { emit } from "@/lib/events/bus";
 import { autoLinkTransaction } from "@/lib/recurring/auto-link";
+import { createLogger } from "@/lib/logger";
 import { insertTransferGroup } from "@/lib/transactions/transfer-groups";
 import { pairIntraUserTransfer } from "@/lib/transfers/intra-user-pair";
 import {
@@ -28,6 +29,8 @@ import type { ClassificationMethod, TransactionSource } from "@/lib/types";
 
 // Colombia uses UTC-5 year-round (no DST). Time in SMS is local.
 const COP_TIMEZONE_OFFSET = "-05:00";
+
+const log = createLogger({ module: "ingestion/sms-pipeline" });
 
 export type IngestOutcome =
   | { status: "inserted"; txId: number; via?: "regex" | "ai_fallback" }
@@ -735,7 +738,10 @@ async function ingestTransferReceivedToSavings(
   const occurredAt = new Date(
     `${parsed.occurredOn}T${parsed.occurredTime}:00${COP_TIMEZONE_OFFSET}`,
   );
-  const descriptionRaw = `Pago recibido de ${parsed.originDescriptor}`;
+  // Use the full SMS body for audit trail integrity — matches the backfill SQL.
+  const descriptionRaw = parsed.raw;
+
+  const cp = await resolveCounterparty(userId, parsed, db);
 
   try {
     const result = await db
@@ -749,8 +755,13 @@ async function ingestTransferReceivedToSavings(
         descriptionRaw,
         descriptionClean: null,
         merchant: parsed.originDescriptor,
-        categorySlug: "otros-ingresos",
-        counterpartyId: null,
+        // Category default: issue #689 spec proposed "transferencia" but no such slug exists
+        // in seed-reference-data.ts. Using "otros-ingresos" (child of "ingresos") as the
+        // closest income category. The DIAN-specific backfill in
+        // scripts/backfill-transfer-received-689-logs147-149.sql uses "reembolso" because
+        // we know that case is a tax refund, but the parser can't infer that from the SMS.
+        categorySlug: cp.inheritedCategory ?? "otros-ingresos",
+        counterpartyId: cp.counterpartyId,
         classificationMethod: "manual",
         classificationConfidence: null,
         source: cfg.source,
@@ -771,6 +782,16 @@ async function ingestTransferReceivedToSavings(
 
     if (result.length === 0) return { status: "duplicated" };
     const txId = result[0].id;
+
+    try {
+      await autoLinkTransaction(userId, txId);
+    } catch (linkErr) {
+      log.warn(
+        { err: linkErr, event: "auto_link_failed", txId, userId },
+        "autoLinkTransaction failed for transfer_received_to_savings — non-critical",
+      );
+    }
+
     emit({
       type: "transaction:created",
       userId,

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -199,6 +199,15 @@ async function ingestParsedBancolombia(
   if (parsed.kind === "cartera_tc") {
     return ingestCarteraTc(userId, parsed, allAccounts, cfg);
   }
+  // Transfer received to savings (#689): third-party institution (DIAN, Tesoro
+  // Nacional, external employer, etc.) paying directly into the user's savings
+  // account. There is no account last4 in this SMS shape, so we resolve the
+  // savings account by institution/type — same strategy as provider_payment.
+  // Routed here (not through resolveAccountForParsed) because the account
+  // resolution needs 0/2+ guard logic that should return a clear needs_review.
+  if (parsed.kind === "transfer_received_to_savings") {
+    return ingestTransferReceivedToSavings(userId, parsed, allAccounts, cfg);
+  }
 
   let account: RoutableAccount | null;
   if (forceAccountId !== undefined) {
@@ -395,7 +404,10 @@ export async function resolveCounterparty(
 }
 
 function resolveAccountForParsed(
-  parsed: Exclude<ParsedSms, { kind: "tc_payment" | "tc_credit_received" | "cartera_tc" }>,
+  parsed: Exclude<
+    ParsedSms,
+    { kind: "tc_payment" | "tc_credit_received" | "cartera_tc" | "transfer_received_to_savings" }
+  >,
   allAccounts: Array<RoutableAccount & { institution: string; type: string }>,
 ): RoutableAccount | null {
   switch (parsed.kind) {
@@ -688,8 +700,100 @@ async function ingestCarteraTc(
   return { status: "inserted", txId: result.txIds.savings };
 }
 
+// #689: Transfer received to savings — a third-party institution (DIAN, Tesoro
+// Nacional, external employer, etc.) wires money directly to the user's savings
+// account. Channel = "bank" (real external income, not an intra-user transfer).
+// Category = "otros-ingresos" (parser default — the backfill for the specific
+// DIAN refund uses "reembolso" directly, which is intentional asymmetry: the
+// parser cannot know the SMS is a tax refund vs other income).
+//
+// Account resolution: exactly one active Bancolombia COP savings account.
+// If 0 or 2+, return needs_review so the SMS lands in the ingestion inbox.
+async function ingestTransferReceivedToSavings(
+  userId: number,
+  parsed: ParsedSms & { kind: "transfer_received_to_savings" },
+  allAccounts: Array<RoutableAccount & { institution: string; type: string }>,
+  cfg: IngestSourceConfig,
+): Promise<IngestOutcome> {
+  const savingsAccounts = allAccounts.filter(
+    (a) => a.institution === "Bancolombia" && a.type === "savings" && a.currency === "COP",
+  );
+  if (savingsAccounts.length === 0) {
+    return {
+      status: "error",
+      reason: "no active Bancolombia COP savings account found for transfer_received_to_savings",
+    };
+  }
+  if (savingsAccounts.length >= 2) {
+    return {
+      status: "error",
+      reason: `ambiguous savings account: ${savingsAccounts.length} Bancolombia COP savings accounts found (needs_review)`,
+    };
+  }
+  const savingsAcc = savingsAccounts[0];
+
+  const occurredAt = new Date(
+    `${parsed.occurredOn}T${parsed.occurredTime}:00${COP_TIMEZONE_OFFSET}`,
+  );
+  const descriptionRaw = `Pago recibido de ${parsed.originDescriptor}`;
+
+  try {
+    const result = await db
+      .insert(transactions)
+      .values({
+        userId,
+        accountId: savingsAcc.id,
+        occurredAt,
+        amountCents: parsed.amountCents,
+        currency: parsed.currency,
+        descriptionRaw,
+        descriptionClean: null,
+        merchant: parsed.originDescriptor,
+        categorySlug: "otros-ingresos",
+        counterpartyId: null,
+        classificationMethod: "manual",
+        classificationConfidence: null,
+        source: cfg.source,
+        channel: "bank",
+        externalId: parsed.externalId,
+        rawData: {
+          kind: parsed.kind,
+          originDescriptor: parsed.originDescriptor,
+          occurredTime: parsed.occurredTime,
+          ...cfg.rawDataExtras,
+        },
+      })
+      .onConflictDoNothing({
+        target: [transactions.accountId, transactions.externalId],
+        where: sql`${transactions.externalId} IS NOT NULL`,
+      })
+      .returning({ id: transactions.id });
+
+    if (result.length === 0) return { status: "duplicated" };
+    const txId = result[0].id;
+    emit({
+      type: "transaction:created",
+      userId,
+      id: txId,
+      source: cfg.source,
+      timestamp: Date.now(),
+    });
+    return { status: "inserted", txId };
+  } catch (err) {
+    return {
+      status: "error",
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 function buildTxFields(
-  parsed: Exclude<ParsedSms, { kind: "tc_payment" | "tc_credit_received" | "cartera_tc" }>,
+  parsed: Exclude<
+    ParsedSms,
+    {
+      kind: "tc_payment" | "tc_credit_received" | "cartera_tc" | "transfer_received_to_savings";
+    }
+  >,
 ): {
   amountCents: bigint;
   descriptionRaw: string;

--- a/src/lib/telegram/sms-draft.ts
+++ b/src/lib/telegram/sms-draft.ts
@@ -51,9 +51,10 @@ function resolveAccountId(parsed: ParsedSms, accounts: AccountDetail[]): number 
       // flow is not used for this kind. Return undefined — the draft won't
       // be created through this path.
       return undefined;
-    case "provider_payment": {
-      // SMS says "en tu cuenta de Ahorros" with no last4 — pick the single
-      // Bancolombia savings account in the matching currency.
+    case "provider_payment":
+    case "transfer_received_to_savings": {
+      // SMS says "en tu cuenta de Ahorros" / "a tu cuenta AHORROS" — no last4.
+      // Pick the single Bancolombia savings account in the matching currency.
       const match = routable.find(
         (a) => a.institution === "Bancolombia" && a.currency === parsed.currency,
       );
@@ -135,6 +136,13 @@ function describe(parsed: ParsedSms): {
         merchant: parsed.recipientName,
         description: `Transferencia Bre-b a ${parsed.recipientName}`,
         direction: "expense",
+      };
+    case "transfer_received_to_savings":
+      return {
+        merchant: parsed.originDescriptor,
+        description: `Pago recibido de ${parsed.originDescriptor}`,
+        direction: "income",
+        categorySlug: "otros-ingresos",
       };
     case "cartera_tc":
       // Cartera TC goes through the wire path directly (not Telegram draft).


### PR DESCRIPTION
## Summary

- Adds `transfer_received_to_savings` variant to parse Bancolombia SMS shape `Recibiste un pago por $AMOUNT de ORIGIN a tu cuenta AHORROS, el HH:MM a las DD/MM/YYYY` (prod logs 147+149 were landing in `needs_review`).
- Switches this variant's `externalId` to semantic-field hashing (sender channel + amount + currency + date + origin) instead of raw body — Bancolombia sent the same $11.7M DIAN refund SMS twice 4 minutes apart; now both produce the same hash and deduplicate to 1 transaction.
- Wires the ingest path: looks up the single active Bancolombia COP savings account, inserts with `channel=bank`, `categorySlug=otros-ingresos`, positive amount.
- Regression tests verify that `purchase`, `qr_payment`, and `tc_payment` still use their original body-based hashing (intentional — for debit events a timestamp difference can mean a real second event).

## Changed files

- `src/lib/ingestion/bancolombia-variants.ts` — new regex `TRANSFER_RECV_TO_SAVINGS`, new union member `transfer_received_to_savings`, semantic externalId scheme with comment explaining why.
- `src/lib/ingestion/sms-pipeline.ts` — dispatch + `ingestTransferReceivedToSavings()` function with 0/2+ savings account guard.
- `src/lib/counterparties/alias-key.ts` — `keyForParsed` case for new kind (counterparty by `originDescriptor`).
- `src/lib/ingestion/email-bancolombia.ts` — exhaustive switch updates for both `resolveAccountForParsed` and `merchantFromParsed`.
- `src/lib/telegram/sms-draft.ts` — exhaustive switch updates for `resolveAccountId` and `describe`.
- `src/lib/ingestion/sms-bancolombia.test.ts` — 18 new tests: match prod SMS 147+149, dedup assertion (same externalId), variant discrimination, regression tests.
- `src/lib/ingestion/sms-pipeline.test.ts` — 5 new integration tests: happy path, idempotent re-ingest, duplicate-with-different-time, 0 savings, 2+ savings.
- `scripts/backfill-transfer-received-689-logs147-149.sql` — idempotent backfill (DO NOT run before deploy).

## ExternalId for DIAN SMS (backfill SQL value)

```
bcol-sms:5b75ed23c73e5fb408f7f06e
```

Hash input: `transfer-received-to-savings|bcol-sms|1174000000|COP|2026-04-30|DIR TESORO NACI`

## Test plan

- [x] 75 unit tests in `sms-bancolombia.test.ts` pass (including 18 new)
- [x] 16 integration tests in `sms-pipeline.test.ts` pass (including 5 new)
- [x] Full suite: 2270 tests pass, 1 skipped — pre-push hook green
- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean

Closes #689