### PR TITLE
fix(ingestion): resolveAccountFromLast4 falls back to physical_cards.last4 (#693)

### DIFF
--- a/src/lib/ingestion/bancolombia-variants.ts
+++ b/src/lib/ingestion/bancolombia-variants.ts
@@ -869,17 +869,21 @@ export type RoutableAccount = {
 };
 
 /**
- * Resolves an account by (last4, currency) against a list of accounts.
+ * Resolve an account by last4 + currency from a list of routable accounts.
  *
  * Two-source resolution to handle the multi-currency drift class (#693):
- *   - metadata.last4s is the per-account list (form-managed, can be empty)
- *   - physicalCardLast4 is the parent card's last4 (always present when linked)
+ *   1. metadata.last4s (per-account list, form-managed; can be empty/inconsistent)
+ *   2. physicalCardLast4 (parent card's last4 from physical_cards.last4; always
+ *      present when the account is linked to a physical card)
  *
- * Match if EITHER source includes last4 AND currency matches. Prefer
- * metadata.last4s first (existing behavior, no change for correct data).
- * Falls back to physicalCardLast4 only when metadata.last4s has no match.
+ * Within an account, source #1 is checked first. Source #2 is the FALLBACK —
+ * consulted ONLY when metadata.last4s does not contain the sought last4 for
+ * THAT account. So an account with metadata.last4s=["X"] and
+ * physicalCardLast4="Y" called with last4="Y" matches via the fallback;
+ * called with last4="Z" (which neither source contains) does not match.
  *
- * Returns null when no account claims that last4+currency pair.
+ * Currency must match in either case. Returns the first account that
+ * satisfies the conditions, or null if none does.
  */
 export function resolveAccountFromLast4(
   last4: string,

--- a/src/lib/ingestion/bancolombia-variants.ts
+++ b/src/lib/ingestion/bancolombia-variants.ts
@@ -859,12 +859,25 @@ export type RoutableAccount = {
   id: number;
   currency: Currency;
   metadata: AccountMetadata | null;
+  /**
+   * The parent physical_card's last4, when this account is linked to one.
+   * Null for standalone accounts (savings, single-currency debit, etc.).
+   * Used as a fallback by resolveAccountFromLast4 when metadata.last4s is
+   * empty — handles the multi-currency drift class (#693).
+   */
+  physicalCardLast4: string | null;
 };
 
 /**
- * Resolves an account by (last4, currency) against a list of accounts whose
- * `metadata.last4s` declares the identifiers that route to them. Both must
- * match for dual-currency cards (e.g. Mastercard *7291 COP vs USD) to work.
+ * Resolves an account by (last4, currency) against a list of accounts.
+ *
+ * Two-source resolution to handle the multi-currency drift class (#693):
+ *   - metadata.last4s is the per-account list (form-managed, can be empty)
+ *   - physicalCardLast4 is the parent card's last4 (always present when linked)
+ *
+ * Match if EITHER source includes last4 AND currency matches. Prefer
+ * metadata.last4s first (existing behavior, no change for correct data).
+ * Falls back to physicalCardLast4 only when metadata.last4s has no match.
  *
  * Returns null when no account claims that last4+currency pair.
  */
@@ -874,10 +887,10 @@ export function resolveAccountFromLast4(
   accounts: RoutableAccount[],
 ): RoutableAccount | null {
   for (const acc of accounts) {
+    if (acc.currency !== currency) continue;
     const last4s = acc.metadata?.last4s ?? [];
-    if (last4s.includes(last4) && acc.currency === currency) {
-      return acc;
-    }
+    if (last4s.includes(last4)) return acc;
+    if (acc.physicalCardLast4 === last4) return acc;
   }
   return null;
 }

--- a/src/lib/ingestion/email-bancolombia.ts
+++ b/src/lib/ingestion/email-bancolombia.ts
@@ -1,6 +1,12 @@
 import { and, eq, gte, lte, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, emailReceipts, transactions, type SourceMismatchDetails } from "@/lib/db/schema";
+import {
+  accounts,
+  emailReceipts,
+  physicalCards,
+  transactions,
+  type SourceMismatchDetails,
+} from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { createLogger } from "@/lib/logger";
 import { ingestBancolombiaTransaction, type IngestOutcome } from "@/lib/ingestion/sms-pipeline";
@@ -86,8 +92,18 @@ export async function ingestParsedEmail(
       metadata: accounts.metadata,
       institution: accounts.institution,
       type: accounts.type,
+      physicalCardLast4: physicalCards.last4,
     })
     .from(accounts)
+    .leftJoin(
+      physicalCards,
+      and(
+        eq(physicalCards.id, accounts.physicalCardId),
+        // Tenancy guard: never join across users even if a FK were ever
+        // corrupted (see engram `per-user-table-join-tenant-safety`).
+        eq(physicalCards.userId, accounts.userId),
+      ),
+    )
     .where(and(eq(accounts.userId, userId), notDeleted(accounts.deletedAt)))) as Array<
     RoutableAccount & { institution: string; type: string }
   >;

--- a/src/lib/ingestion/sms-bancolombia.test.ts
+++ b/src/lib/ingestion/sms-bancolombia.test.ts
@@ -665,13 +665,29 @@ describe("parseSmsBancolombia — skip reasons", () => {
 });
 
 describe("resolveAccountFromLast4", () => {
+  // Base fixtures — no physical_card parent (standalone accounts).
   const accounts: RoutableAccount[] = [
-    { id: 1, currency: "COP", metadata: { last4s: ["6126", "1802"] } },
-    { id: 2, currency: "USD", metadata: { last4s: ["7073", "1356"] } },
-    { id: 5, currency: "COP", metadata: { last4s: ["2575"], network: "visa" } },
-    { id: 6, currency: "COP", metadata: { last4s: ["7291"], network: "mastercard" } },
-    { id: 7, currency: "USD", metadata: { last4s: ["7291"], network: "mastercard" } },
-    { id: 3, currency: "COP", metadata: null },
+    { id: 1, currency: "COP", metadata: { last4s: ["6126", "1802"] }, physicalCardLast4: null },
+    { id: 2, currency: "USD", metadata: { last4s: ["7073", "1356"] }, physicalCardLast4: null },
+    {
+      id: 5,
+      currency: "COP",
+      metadata: { last4s: ["2575"], network: "visa" },
+      physicalCardLast4: null,
+    },
+    {
+      id: 6,
+      currency: "COP",
+      metadata: { last4s: ["7291"], network: "mastercard" },
+      physicalCardLast4: null,
+    },
+    {
+      id: 7,
+      currency: "USD",
+      metadata: { last4s: ["7291"], network: "mastercard" },
+      physicalCardLast4: null,
+    },
+    { id: 3, currency: "COP", metadata: null, physicalCardLast4: null },
   ];
 
   it("routes savings account via its account number last-4", () => {
@@ -702,6 +718,60 @@ describe("resolveAccountFromLast4", () => {
     expect(resolveAccountFromLast4("6126", "COP", accounts)?.id).toBe(1);
     // account with metadata: null (id=3) should not match anything
     expect(resolveAccountFromLast4("", "COP", accounts)).toBeNull();
+  });
+
+  // physical_card fallback tests (#693) ————————————————————————————————————
+  // Models the real prod drift: metadata.last4s is empty on the child account
+  // but the parent physical_card has the correct last4.
+
+  it("falls back to physicalCardLast4 when metadata.last4s is empty", () => {
+    // Simulates MC *8268 USD child with empty metadata — the real prod failure
+    // (ingestion_log 153, DigitalOcean USD$12.30).
+    const withFallback: RoutableAccount[] = [
+      { id: 10, currency: "USD", metadata: { last4s: [] }, physicalCardLast4: "8268" },
+    ];
+    expect(resolveAccountFromLast4("8268", "USD", withFallback)?.id).toBe(10);
+  });
+
+  it("falls back to physicalCardLast4 when metadata is null", () => {
+    const withFallback: RoutableAccount[] = [
+      { id: 11, currency: "COP", metadata: null, physicalCardLast4: "5367" },
+    ];
+    expect(resolveAccountFromLast4("5367", "COP", withFallback)?.id).toBe(11);
+  });
+
+  it("matches via metadata.last4s when both sources are consistent", () => {
+    // Consistent child — metadata path should fire first; result is the same.
+    const consistent: RoutableAccount[] = [
+      { id: 12, currency: "COP", metadata: { last4s: ["8268"] }, physicalCardLast4: "8268" },
+    ];
+    expect(resolveAccountFromLast4("8268", "COP", consistent)?.id).toBe(12);
+  });
+
+  it("does not match via physicalCardLast4 when currency mismatches", () => {
+    // physicalCardLast4 matches the digit but the account is USD, not COP.
+    const wrongCurrency: RoutableAccount[] = [
+      { id: 13, currency: "USD", metadata: { last4s: [] }, physicalCardLast4: "8268" },
+    ];
+    expect(resolveAccountFromLast4("8268", "COP", wrongCurrency)).toBeNull();
+  });
+
+  it("does not match when both sources are empty/null", () => {
+    const noMatch: RoutableAccount[] = [
+      { id: 14, currency: "COP", metadata: { last4s: [] }, physicalCardLast4: null },
+    ];
+    expect(resolveAccountFromLast4("8268", "COP", noMatch)).toBeNull();
+  });
+
+  it("disambiguates multi-currency pair via physicalCardLast4 fallback", () => {
+    // Real-world: same physical card, 2 child accounts. COP child has metadata,
+    // USD child has empty metadata but physicalCardLast4 set (#693 scenario).
+    const pair: RoutableAccount[] = [
+      { id: 20, currency: "COP", metadata: { last4s: ["8268"] }, physicalCardLast4: "8268" },
+      { id: 21, currency: "USD", metadata: { last4s: [] }, physicalCardLast4: "8268" },
+    ];
+    expect(resolveAccountFromLast4("8268", "COP", pair)?.id).toBe(20);
+    expect(resolveAccountFromLast4("8268", "USD", pair)?.id).toBe(21);
   });
 });
 

--- a/src/lib/ingestion/sms-bancolombia.test.ts
+++ b/src/lib/ingestion/sms-bancolombia.test.ts
@@ -773,6 +773,16 @@ describe("resolveAccountFromLast4", () => {
     expect(resolveAccountFromLast4("8268", "COP", pair)?.id).toBe(20);
     expect(resolveAccountFromLast4("8268", "USD", pair)?.id).toBe(21);
   });
+
+  it("falls back to physicalCardLast4 when metadata.last4s holds a different last4", () => {
+    // Account where metadata is non-empty but contains the WRONG last4 —
+    // the fallback must still fire because the sought value is absent from
+    // metadata.last4s for THIS account (per-account check, not per-list).
+    const acc: RoutableAccount[] = [
+      { id: 99, currency: "USD", metadata: { last4s: ["9999"] }, physicalCardLast4: "8268" },
+    ];
+    expect(resolveAccountFromLast4("8268", "USD", acc)?.id).toBe(99);
+  });
 });
 
 describe("parseSmsBancolombia — cartera_tc (#688)", () => {

--- a/src/lib/ingestion/sms-pipeline.ts
+++ b/src/lib/ingestion/sms-pipeline.ts
@@ -1,6 +1,6 @@
 import { and, eq, sql } from "drizzle-orm";
 import { db, type DB } from "@/lib/db";
-import { accounts, transactions } from "@/lib/db/schema";
+import { accounts, physicalCards, transactions } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { classifyByRule } from "@/lib/classification/rules";
 import { emit } from "@/lib/events/bus";
@@ -177,8 +177,18 @@ async function ingestParsedBancolombia(
       metadata: accounts.metadata,
       institution: accounts.institution,
       type: accounts.type,
+      physicalCardLast4: physicalCards.last4,
     })
     .from(accounts)
+    .leftJoin(
+      physicalCards,
+      and(
+        eq(physicalCards.id, accounts.physicalCardId),
+        // Tenancy guard: never join across users even if a FK were ever
+        // corrupted (see engram `per-user-table-join-tenant-safety`).
+        eq(physicalCards.userId, accounts.userId),
+      ),
+    )
     .where(and(eq(accounts.userId, userId), notDeleted(accounts.deletedAt)))) as Array<
     RoutableAccount & { institution: string; type: string }
   >;

--- a/src/lib/telegram/sms-draft.ts
+++ b/src/lib/telegram/sms-draft.ts
@@ -22,6 +22,9 @@ function toRoutable(accounts: AccountDetail[]): Array<RoutableAccount & { instit
       currency: a.currency,
       metadata: a.metadata,
       institution: a.institution,
+      // Fall back to the parent physical_card's last4 when metadata.last4s is
+      // empty — handles the multi-currency drift class (#693).
+      physicalCardLast4: a.physicalCard?.last4 ?? null,
     }));
 }
 


### PR DESCRIPTION
## Summary

- Adds `physicalCardLast4: string | null` to `RoutableAccount` type so the matcher can read from the parent physical_card row
- Augments `resolveAccountFromLast4` to check `metadata.last4s` first (existing path, no behavior change), then fall back to `physicalCardLast4` when the metadata list has no match
- LEFT JOINs `physical_cards` in every `allAccounts` SELECT that feeds the matcher (3 call sites: `sms-pipeline.ts`, `email-bancolombia.ts`, `sms-draft.ts::toRoutable`)

## Call sites updated

| File | Change |
|------|--------|
| `src/lib/ingestion/bancolombia-variants.ts` | Type + function logic |
| `src/lib/ingestion/sms-pipeline.ts` | LEFT JOIN physical_cards in allAccounts SELECT |
| `src/lib/ingestion/email-bancolombia.ts` | LEFT JOIN physical_cards in allAccounts SELECT |
| `src/lib/telegram/sms-draft.ts` | Map `physicalCard?.last4` in `toRoutable()` |

## Tests

Added 6 new test cases to `sms-bancolombia.test.ts` (`resolveAccountFromLast4` describe block):

- Empty `metadata.last4s` + `physicalCardLast4` set → matches (the real prod failure case)
- `metadata: null` + `physicalCardLast4` set → matches
- Both sources consistent → matches via metadata path (no behavior change)
- `physicalCardLast4` matches but currency mismatches → no match
- Both sources empty/null → no match
- Multi-currency pair: COP child with metadata, USD child with empty metadata + physicalCardLast4 → disambiguates correctly by currency

Full pre-push suite: **2277 passed, 1 skipped** (no regressions).

Closes #693