### PR TITLE
feat(transactions): include rawData in TxRow for MoneyFrozen wire-up (#528)

### DIFF
--- a/src/components/transactions/forecast-overlay.test.tsx
+++ b/src/components/transactions/forecast-overlay.test.tsx
@@ -103,6 +103,7 @@ function makeTxRow(overrides: Partial<TxRow> = {}): TxRow {
     // #642: transfer pairing defaults
     channel: "bank",
     transferGroupId: null,
+    rawData: null,
     ...overrides,
   };
 }

--- a/src/components/transactions/transaction-table.test.tsx
+++ b/src/components/transactions/transaction-table.test.tsx
@@ -44,6 +44,7 @@ vi.mock("@/components/transactions/needs-review-badge", () => ({
 
 // Import AFTER mocks are registered.
 import { TransactionTable } from "./transaction-table";
+import { MoneyModeProvider } from "@/components/display/money-mode-provider";
 import type { TxRow } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -98,6 +99,7 @@ function makeTxRow(overrides: Partial<TxRow> = {}): TxRow {
     recurringLabel: null,
     channel: "bank",
     transferGroupId: null,
+    rawData: null,
     ...overrides,
   };
 }
@@ -211,5 +213,93 @@ describe("TransactionTable — paired transfer suppresses 'Sin clasificar'", () 
     // ¿Por qué? must still be suppressed.
     const porqueBtns = screen.queryAllByLabelText("¿Por qué esta categoría?");
     expect(porqueBtns).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — #528: real tx amounts use frozen TRM (MoneyFrozen wire-up)
+// ---------------------------------------------------------------------------
+
+const FROZEN_TRM = 3676.92;
+const LIVE_TRM = 4200; // intentionally different so tests can prove which one wins
+
+function fxBlock(trm: number, original: { currency: "USD" | "USDc"; amountCents: bigint }) {
+  return {
+    fx: {
+      originalCurrency: original.currency,
+      originalAmountCents: original.amountCents.toString(),
+      trmToAccountCurrency: trm,
+      trmSource: "statement_frozen",
+    },
+  };
+}
+
+function renderWithMode(
+  rows: TxRow[],
+  opts: { mode: "native" | "all-cop" | "all-usd"; liveRate: number | null },
+) {
+  return render(
+    <MoneyModeProvider
+      mode={opts.mode}
+      fxRate={opts.liveRate === null ? null : { rate: opts.liveRate, source: "live" }}
+    >
+      <TransactionTable rows={rows} {...TABLE_PROPS} />
+    </MoneyModeProvider>,
+  );
+}
+
+describe("TransactionTable — #528 frozen TRM via MoneyFrozen", () => {
+  it("converts a USD tx with frozen TRM (NOT live TRM) when mode=all-cop", () => {
+    // tx: USD 100.00 (10000 cents) with frozen TRM = 3676.92 → COP ~367,692
+    // If MoneyFrozen incorrectly used the live TRM (4200), result would be ~420,000.
+    const tx = makeTxRow({
+      id: 5280,
+      amountCents: BigInt(-10000),
+      currency: "USD" as TxRow["currency"],
+      rawData: fxBlock(FROZEN_TRM, { currency: "USD", amountCents: BigInt(10000) }),
+    });
+
+    renderWithMode([tx], { mode: "all-cop", liveRate: LIVE_TRM });
+
+    // Frozen-TRM tooltip is set on the wrapping <span title="..."> in MoneyFrozen.
+    // It contains the formatted historical TRM (3.676,92 in es-CO locale).
+    const tooltipNodes = document.querySelectorAll('[title*="TRM histórica"]');
+    expect(tooltipNodes.length).toBeGreaterThan(0);
+    // Confirm the historical rate (3.676,92 in es-CO) is the one shown — NOT 4.200.
+    for (const node of tooltipNodes) {
+      const title = node.getAttribute("title") ?? "";
+      expect(title).toMatch(/3\.676,92/);
+      expect(title).not.toMatch(/4\.200/);
+    }
+  });
+
+  it("does not convert in mode=native (regression check for COP-only users)", () => {
+    const tx = makeTxRow({
+      id: 5281,
+      amountCents: BigInt(-10000),
+      currency: "USD" as TxRow["currency"],
+      rawData: fxBlock(FROZEN_TRM, { currency: "USD", amountCents: BigInt(10000) }),
+    });
+
+    renderWithMode([tx], { mode: "native", liveRate: LIVE_TRM });
+
+    // No frozen-TRM tooltip should be rendered when conversion didn't happen.
+    const tooltipNodes = document.querySelectorAll('[title*="TRM histórica"]');
+    expect(tooltipNodes.length).toBe(0);
+  });
+
+  it("falls back to original currency when rawData is null (legacy txs)", () => {
+    const tx = makeTxRow({
+      id: 5282,
+      amountCents: BigInt(-10000),
+      currency: "USD" as TxRow["currency"],
+      rawData: null,
+    });
+
+    renderWithMode([tx], { mode: "all-cop", liveRate: LIVE_TRM });
+
+    // No conversion performed → no tooltip; raw amount renders as-is.
+    const tooltipNodes = document.querySelectorAll('[title*="TRM histórica"]');
+    expect(tooltipNodes.length).toBe(0);
   });
 });

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -13,7 +13,7 @@ import {
   WrenchIcon,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Money } from "@/components/display/money";
+import { Money, MoneyFrozen } from "@/components/display/money";
 import { EmptyState } from "@/components/ui/empty-state";
 import {
   Table,
@@ -505,7 +505,7 @@ export function TransactionTable({
                       )}
                       suppressHydrationWarning
                     >
-                      <Money cents={tx.amountCents} currency={tx.currency} />
+                      <MoneyFrozen tx={tx} />
                     </TableCell>
                     <TableCell className="px-2">
                       <TransactionRowActions
@@ -665,7 +665,7 @@ export function TransactionTable({
                       )}
                       suppressHydrationWarning
                     >
-                      <Money cents={tx.amountCents} currency={tx.currency} />
+                      <MoneyFrozen tx={tx} />
                     </span>
                     <TransactionRowActions
                       txId={tx.id}

--- a/src/lib/transactions/queries.test.ts
+++ b/src/lib/transactions/queries.test.ts
@@ -222,3 +222,105 @@ describe("listTransactions transferGroupId", () => {
     expect(legB!.channel).toBe("transfer");
   });
 });
+
+// ---------------------------------------------------------------------------
+// #528: rawData projection — only fx + merged_statement.fx cross the boundary.
+// Verifies the SQL CASE/jsonb_build_object projection works AND that
+// server-side metadata (parser hints, email subjects) does NOT leak.
+// ---------------------------------------------------------------------------
+describe("listTransactions rawData projection (#528)", () => {
+  afterEach(async () => {
+    await db.execute(
+      sql`DELETE FROM transactions WHERE description_raw LIKE ${"__test_tx_rawdata%"}`,
+    );
+  });
+
+  it("projects only fx and merged_statement.fx — strips other rawData keys", async () => {
+    const fullRawData = {
+      // The two keys that MoneyFrozen needs:
+      fx: {
+        originalCurrency: "USD",
+        originalAmountCents: "10000",
+        trmToAccountCurrency: 3676.92,
+        trmSource: "statement_frozen",
+      },
+      merged_statement: {
+        fx: {
+          originalCurrency: "USD",
+          originalAmountCents: "10000",
+          trmToAccountCurrency: 3700.0,
+          trmSource: "statement_frozen",
+        },
+        // Server-only keys that MUST be stripped:
+        statementId: "secret-internal-id",
+        rawText: "BANCOLOMBIA — internal extract row",
+      },
+      // Top-level server-only keys that MUST be stripped:
+      emailSubject: "Tu compra ha sido procesada — confidencial",
+      parserHints: { confidence: 0.92, source: "sms-bancolombia" },
+      dedupHash: "abc123def456",
+    };
+
+    await db.insert(transactions).values({
+      userId: USER_ID,
+      accountId: ACCOUNT_ID,
+      occurredAt: new Date("2026-04-20T12:00:00Z"),
+      amountCents: BigInt(-10000),
+      currency: "USD",
+      descriptionRaw: "__test_tx_rawdata-projected",
+      categorySlug: "food",
+      classificationMethod: "manual",
+      source: "manual",
+      rawData: fullRawData,
+    });
+
+    const { rows } = await listTransactions(USER_ID, {});
+    const row = rows.find((r) => r.descriptionRaw === "__test_tx_rawdata-projected");
+    expect(row).toBeDefined();
+    expect(row!.rawData).not.toBeNull();
+
+    const projected = row!.rawData as Record<string, unknown>;
+
+    // Allowed keys are present.
+    expect(projected.fx).toMatchObject({
+      originalCurrency: "USD",
+      trmToAccountCurrency: 3676.92,
+    });
+    expect((projected.merged_statement as Record<string, unknown>).fx).toMatchObject({
+      trmToAccountCurrency: 3700.0,
+    });
+
+    // Server-side metadata must NOT cross the boundary.
+    expect(projected.emailSubject).toBeUndefined();
+    expect(projected.parserHints).toBeUndefined();
+    expect(projected.dedupHash).toBeUndefined();
+    expect((projected.merged_statement as Record<string, unknown>).statementId).toBeUndefined();
+    expect((projected.merged_statement as Record<string, unknown>).rawText).toBeUndefined();
+  });
+
+  it("yields fx=null + merged_statement.fx=null for legacy rows (raw_data={})", async () => {
+    // Schema enforces raw_data NOT NULL DEFAULT '{}', so legacy txs have an
+    // empty object, not SQL NULL. The projection returns a shaped object with
+    // both `fx` slots set to null — extractFxMetadataWithFallback handles that.
+    await db.insert(transactions).values({
+      userId: USER_ID,
+      accountId: ACCOUNT_ID,
+      occurredAt: new Date("2026-04-21T12:00:00Z"),
+      amountCents: BigInt(-2000),
+      currency: "COP",
+      descriptionRaw: "__test_tx_rawdata-empty",
+      categorySlug: "food",
+      classificationMethod: "manual",
+      source: "manual",
+      // rawData omitted → DB default '{}'
+    });
+
+    const { rows } = await listTransactions(USER_ID, {});
+    const row = rows.find((r) => r.descriptionRaw === "__test_tx_rawdata-empty");
+    expect(row).toBeDefined();
+    expect(row!.rawData).not.toBeNull();
+    const projected = row!.rawData as Record<string, unknown>;
+    expect(projected.fx).toBeNull();
+    expect((projected.merged_statement as Record<string, unknown>).fx).toBeNull();
+  });
+});

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -133,6 +133,20 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
       // #642: transfer pairing
       channel: transactions.channel,
       transferGroupId: transactions.transferGroupId,
+      // #528: PROJECTED rawData — only `fx` and `merged_statement.fx` are shipped
+      // to the client so MoneyFrozen can resolve the historical TRM. Do NOT add
+      // other rawData keys here without thinking about leaking server-side
+      // metadata (email subjects, parser hints, dedup hashes) to the browser.
+      // Shape stays compatible with TxForConversion / extractFxMetadataWithFallback.
+      rawData: sql<Record<string, unknown> | null>`CASE
+        WHEN ${transactions.rawData} IS NULL THEN NULL
+        ELSE jsonb_build_object(
+          'fx', ${transactions.rawData} -> 'fx',
+          'merged_statement', jsonb_build_object(
+            'fx', ${transactions.rawData} -> 'merged_statement' -> 'fx'
+          )
+        )
+      END`.as("raw_data"),
     })
     .from(transactions)
     .innerJoin(accounts, eq(accounts.id, transactions.accountId))
@@ -153,10 +167,6 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
   const last = page.at(-1);
   const nextCursor = hasMore && last ? encodeCursor(last.occurredAt, last.id) : null;
 
-  // TODO(#528): SELECT transactions.raw_data and add it to TxRow so the
-  // MoneyFrozen component (#519) can display amounts with the historical
-  // TRM tooltip when display_currency_mode != native. The component is
-  // already in src/components/display/money.tsx waiting for this hookup.
   const shaped: TxRow[] = page.map((r) => ({
     id: r.id,
     occurredAt: r.occurredAt,
@@ -192,6 +202,7 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
     recurringLabel: r.recurringLabel ?? null,
     channel: r.channel,
     transferGroupId: r.transferGroupId ?? null,
+    rawData: r.rawData,
   }));
 
   return { rows: shaped, nextCursor };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -92,4 +92,10 @@ export type TxRow = {
   // move (pago TC, intra-account). transferGroupId links the two legs.
   channel: TxChannel;
   transferGroupId: string | null;
+  // #528: PROJECTED subset of transactions.raw_data — only `fx` and
+  // `merged_statement.fx` are populated. MoneyFrozen reads via
+  // extractFxMetadataWithFallback. Do NOT trust other keys to be present;
+  // the SELECT in listTransactions strips them on purpose so server-side
+  // metadata never crosses the RSC boundary.
+  rawData: Record<string, unknown> | null;
 };


### PR DESCRIPTION
## Summary
- Project `transactions.raw_data` via SQL `CASE` + `jsonb_build_object` so only `fx` and `merged_statement.fx` cross the RSC boundary. Server-side metadata (email subjects, parser hints, dedup hashes) stays out of the client payload — defense in depth ahead of the Gmail/ARQ rawData expansion.
- Add `rawData: Record<string, unknown> | null` to `TxRow` with a comment explaining the projection contract.
- Swap `<Money>` → `<MoneyFrozen>` on the two real-tx call sites in `TransactionTable` (lines 508/668). Forecast occurrences (`fc`) keep `<Money>` because they haven't happened yet and have no frozen TRM.

Foundation for #527 / #526 (multi-currency aggregations on `/budgets` and `/insights`).

## Architecture decision
Per-row JS conversion using `convertToDisplayCurrency` — same helper that powers `MoneyFrozen` — over SQL-side JSONB extraction. Single source of truth: if the table shows X, budgets and insights show X.

## Test plan
- [x] \`bun run lint\` — clean
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun run test\` — 189 files, 2287 passed, 1 skipped
- [x] New jsdom integration tests in \`transaction-table.test.tsx\`:
  - frozen TRM (3676.92) wins over live TRM (4200) when \`mode=all-cop\`
  - \`mode=native\` is a regression-free passthrough
  - \`rawData=null\` falls back gracefully
- [x] New DB-level tests in \`queries.test.ts\`:
  - projection strips \`emailSubject\`, \`parserHints\`, \`dedupHash\`, \`merged_statement.statementId\`
  - legacy rows (\`raw_data = '{}'\`) yield \`fx=null\` and \`merged_statement.fx=null\`

Closes #528