### PR TITLE
feat(budgets): wire convertToDisplayCurrency into /budgets totals (#527)

### DIFF
--- a/src/app/(app)/budgets/budgets-manager.tsx
+++ b/src/app/(app)/budgets/budgets-manager.tsx
@@ -43,6 +43,9 @@ type BudgetRow = {
   amountCents: string;
   spentCents: string;
   currency: Currency;
+  // #527: tooltip + data-quality flags from the per-row frozen-TRM aggregation.
+  hadFrozenTrmConversion?: boolean;
+  missingTrmCount?: number;
 };
 
 type EditorState = { open: boolean; editing: BudgetRow | null };
@@ -232,7 +235,16 @@ function BudgetCard({
           />
         </div>
         <div className="flex items-center justify-between text-xs tabular-nums">
-          <span className={cn(over ? "font-medium text-rose-600" : "text-muted-foreground")}>
+          <span
+            className={cn(over ? "font-medium text-rose-600" : "text-muted-foreground")}
+            title={
+              row.hadFrozenTrmConversion
+                ? `Convertido con TRM histórica${
+                    row.missingTrmCount ? ` · ${row.missingTrmCount} sin TRM` : ""
+                  }`
+                : undefined
+            }
+          >
             <Money cents={spent} currency={row.currency} /> /{" "}
             <Money cents={amount} currency={row.currency} />
           </span>

--- a/src/app/(app)/budgets/page.tsx
+++ b/src/app/(app)/budgets/page.tsx
@@ -1,6 +1,8 @@
 import { getSessionUser } from "@/lib/auth/session";
 import { getBudgetsOverview } from "@/lib/budgets/queries";
 import { getFinancialPeriod } from "@/lib/dashboard/period";
+import { getUiPreferences } from "@/lib/preferences/repo";
+import { getCurrentFxRate } from "@/lib/fx/repo";
 import { BudgetsManager } from "./budgets-manager";
 
 export const dynamic = "force-dynamic";
@@ -27,12 +29,18 @@ export default async function BudgetsPage({
   // statements) are NOT in scope here.
   const [y, m] = ym.split("-").map(Number);
   const refDate = new Date(Date.UTC(y, m - 1, 15));
-  const period = await getFinancialPeriod(session.id, refDate);
+  const [period, prefs, fx] = await Promise.all([
+    getFinancialPeriod(session.id, refDate),
+    getUiPreferences(session.id),
+    getCurrentFxRate(),
+  ]);
 
-  const { categories: cats, items } = await getBudgetsOverview(session.id, ym, {
-    start: period.start,
-    end: period.end,
-  });
+  const { categories: cats, items } = await getBudgetsOverview(
+    session.id,
+    ym,
+    { start: period.start, end: period.end },
+    { displayCurrencyMode: prefs.displayCurrencyMode, copPerUsd: fx.rate },
+  );
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">

--- a/src/lib/budgets/queries.test.ts
+++ b/src/lib/budgets/queries.test.ts
@@ -143,3 +143,174 @@ describe("getBudgetsOverview", () => {
     expect(result.categories.length).toBeGreaterThan(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #527 — frozen-TRM aggregation. Independent fixture so we can mix USD txs
+// with their own rawData.fx blocks and verify per-row conversion.
+// ---------------------------------------------------------------------------
+
+const FROZEN_TAG = "BUDGET_FROZEN_TRM_TEST";
+const FROZEN_TRM = 3676.92; // historical
+const LIVE_TRM = 4500; // intentionally different — proves frozen, not live, was used
+
+async function createUserFrozen(email: string): Promise<number> {
+  const [row] = await db.insert(users).values({ email, name: email }).returning({ id: users.id });
+  await copyCategorySeedsToUser(row.id);
+  return row.id;
+}
+
+async function createCopAccount(userId: number, label: string): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({
+      userId,
+      name: `${FROZEN_TAG} ${label}`,
+      institution: FROZEN_TAG,
+      type: "savings",
+      currency: "COP",
+    })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function insertUsdTxWithFrozenTrm(
+  userId: number,
+  accountId: number,
+  amountCents: bigint,
+  trm: number | null,
+  occurredAt: Date,
+  seq: number,
+): Promise<void> {
+  const fxBlock =
+    trm === null
+      ? {} // simulate a legacy USD tx that never got an fx block
+      : {
+          fx: {
+            originalCurrency: "USD",
+            originalAmountCents: amountCents.toString().replace(/^-/, ""),
+            trmToAccountCurrency: trm,
+            trmSource: "statement_frozen",
+          },
+        };
+  await db.insert(transactions).values({
+    userId,
+    accountId,
+    occurredAt,
+    amountCents,
+    currency: "USD",
+    descriptionRaw: `${FROZEN_TAG} tx-${seq}`,
+    categorySlug: "otros",
+    classificationMethod: "manual",
+    source: "manual",
+    externalId: `${FROZEN_TAG}-tx-${seq}`,
+    channel: "bank",
+    rawData: fxBlock,
+  });
+}
+
+describe("getBudgetsOverview — #527 frozen TRM aggregation", () => {
+  let frozenUserId: number;
+  let frozenAccountId: number;
+  const ym = "2098-06"; // distinct from the suite above
+  const periodStartIso = `${ym}-01`;
+  const start = new Date(Date.UTC(2098, 5, 1));
+  const end = new Date(Date.UTC(2098, 6, 1));
+
+  beforeAll(async () => {
+    frozenUserId = await createUserFrozen(`${FROZEN_TAG}-user@example.com`);
+    frozenAccountId = await createCopAccount(frozenUserId, "main");
+
+    // COP budget: $400,000 limit for category "otros".
+    await db.insert(budgets).values({
+      userId: frozenUserId,
+      categorySlug: "otros",
+      amountCents: BigInt(400_000_00),
+      currency: "COP",
+      periodStart: periodStartIso,
+      periodEnd: `${ym}-30`,
+      active: true,
+    });
+
+    // USD tx 1: $100 USD with frozen TRM 3676.92 → 367,692 COP equivalent
+    await insertUsdTxWithFrozenTrm(
+      frozenUserId,
+      frozenAccountId,
+      BigInt(-10000),
+      FROZEN_TRM,
+      start,
+      1,
+    );
+
+    // USD tx 2: $50 USD WITHOUT a frozen TRM (legacy row)
+    await insertUsdTxWithFrozenTrm(frozenUserId, frozenAccountId, BigInt(-5000), null, start, 2);
+  });
+
+  afterAll(async () => {
+    await db.delete(users).where(sql`email LIKE ${"%" + FROZEN_TAG + "%"}`);
+  });
+
+  it("native mode: USD txs do NOT contribute to a COP budget (no cross-currency mixing)", async () => {
+    const result = await getBudgetsOverview(
+      frozenUserId,
+      ym,
+      { start, end },
+      { displayCurrencyMode: "native", copPerUsd: LIVE_TRM },
+    );
+    const item = result.items.find((i) => i.categorySlug === "otros")!;
+    expect(item.currency).toBe("COP");
+    expect(BigInt(item.spentCents)).toBe(BigInt(0));
+    expect(BigInt(item.amountCents)).toBe(BigInt(400_000_00));
+    expect(item.hadFrozenTrmConversion).toBe(false);
+  });
+
+  it("all-cop mode: USD txs converted via FROZEN TRM (not live)", async () => {
+    const result = await getBudgetsOverview(
+      frozenUserId,
+      ym,
+      { start, end },
+      { displayCurrencyMode: "all-cop", copPerUsd: LIVE_TRM },
+    );
+    const item = result.items.find((i) => i.categorySlug === "otros")!;
+    expect(item.currency).toBe("COP");
+
+    // tx1 (10000 cents USD * 3676.92) = 36,769,200 cents COP. tx2 (5000) lacks
+    // TRM → falls back to USD, ends up in a separate bucket → does NOT enter
+    // the COP total. Expected spent in COP = 36,769,200.
+    expect(BigInt(item.spentCents)).toBe(BigInt(36_769_200));
+
+    // Sanity: live TRM would have produced (10000 + 5000) * 4500 = 67,500,000.
+    // Confirm the result is NOT that.
+    expect(BigInt(item.spentCents)).not.toBe(BigInt(15000) * BigInt(LIVE_TRM));
+
+    expect(item.hadFrozenTrmConversion).toBe(true);
+    expect(item.missingTrmCount).toBe(1); // tx2 had no TRM
+  });
+
+  it("all-cop mode: budget amount converts via LIVE TRM (plans have no frozen rate)", async () => {
+    // Budget is in COP, mode is all-cop → no conversion needed. Use a USD-budget
+    // user to actually exercise the LIVE TRM conversion path.
+    const usdUserId = await createUserFrozen(`${FROZEN_TAG}-usdbudget@example.com`);
+    await createCopAccount(usdUserId, "usd-budget-acct");
+    await db.insert(budgets).values({
+      userId: usdUserId,
+      categorySlug: "otros",
+      amountCents: BigInt(500_00), // $500.00 USD
+      currency: "USD",
+      periodStart: periodStartIso,
+      periodEnd: `${ym}-30`,
+      active: true,
+    });
+
+    const result = await getBudgetsOverview(
+      usdUserId,
+      ym,
+      { start, end },
+      { displayCurrencyMode: "all-cop", copPerUsd: LIVE_TRM },
+    );
+    const item = result.items.find((i) => i.categorySlug === "otros")!;
+    expect(item.currency).toBe("COP");
+
+    // 500_00 USD cents * 4500 = 2,250,000 COP cents.
+    expect(BigInt(item.amountCents)).toBe(BigInt(500_00) * BigInt(LIVE_TRM));
+  });
+});

--- a/src/lib/budgets/queries.ts
+++ b/src/lib/budgets/queries.ts
@@ -3,6 +3,13 @@ import { db } from "@/lib/db";
 import { budgets, categories, transactions } from "@/lib/db/schema";
 import { notAdjustment, notDeleted, notTransfer } from "@/lib/db/helpers";
 import type { Currency } from "@/lib/types";
+import type { DisplayCurrencyMode } from "@/lib/db/schema";
+import { convertCents, displayCurrencyFor } from "@/lib/money";
+import {
+  pickBucket,
+  sumByGroupAndDisplayCurrency,
+  type AggregationBucket,
+} from "@/lib/fx/aggregate";
 
 export type BudgetCategory = {
   slug: string;
@@ -14,9 +21,36 @@ export type BudgetOverviewItem = {
   id: number;
   categorySlug: string;
   categoryName: string;
+  /**
+   * Amount the user budgeted, in `currency`. In `all-cop` / `all-usd` modes
+   * this is converted from the budget's native currency using LIVE TRM
+   * (budget plans are forward-looking targets — no frozen TRM exists for them).
+   */
   amountCents: string;
+  /**
+   * Spend in `currency`, computed per-row using each tx's FROZEN TRM
+   * (`rawData.fx.trmToAccountCurrency`). Converting before summing keeps
+   * historical accuracy — a 2024 USD purchase contributes its 2024 COP
+   * equivalent, not today's TRM × USD.
+   */
   spentCents: string;
+  /**
+   * Display currency for both `amountCents` and `spentCents`. In native mode
+   * this matches the budget's plan currency. In all-X modes this matches the
+   * mode target (COP or USD).
+   */
   currency: Currency;
+  /**
+   * #527: true when at least one tx in this category was converted via
+   * frozen TRM. Drives the "convertido con TRM histórica" tooltip.
+   */
+  hadFrozenTrmConversion: boolean;
+  /**
+   * #527: number of txs in this category whose conversion was needed but
+   * the frozen TRM was missing. Surfaces data-quality gaps without breaking
+   * the total — those rows still contribute at their native value.
+   */
+  missingTrmCount: number;
 };
 
 export type BudgetsOverview = {
@@ -37,16 +71,28 @@ function defaultCalendarRange(ym: string) {
  * pay-period users see consistent numbers across the dashboard and budgets
  * page. Pass `spendRange` resolved from `getFinancialPeriod` at the call
  * site; omit it to fall back to the calendar month implied by `yearMonth`.
+ *
+ * #527: aggregation is now per-row using `convertToDisplayCurrency` so each
+ * USD/USDc tx contributes its frozen-TRM equivalent — not today's rate.
+ *  - `displayCurrencyMode='native'`: spent stays in budget currency, only
+ *    same-currency txs contribute (cross-currency spend is suppressed by
+ *    `pickBucket` and surfaced as a non-zero `missingTrmCount` indirectly).
+ *  - `'all-cop'` / `'all-usd'`: every tx is converted to the target via its
+ *    own frozen TRM; budget amounts are converted via LIVE TRM (`copPerUsd`)
+ *    since plans are forward-looking and have no frozen rate.
  */
 export async function getBudgetsOverview(
   userId: number,
   yearMonth: string,
   spendRange?: { start: Date; end: Date },
+  fxOpts?: { displayCurrencyMode: DisplayCurrencyMode; copPerUsd: number },
 ): Promise<BudgetsOverview> {
   const startIso = `${yearMonth}-01`;
   const { start, end } = spendRange ?? defaultCalendarRange(yearMonth);
+  const mode: DisplayCurrencyMode = fxOpts?.displayCurrencyMode ?? "native";
+  const copPerUsd = fxOpts?.copPerUsd ?? 0;
 
-  const [cats, rows, spentRows] = await Promise.all([
+  const [cats, rows, txRows] = await Promise.all([
     db
       .select({
         slug: categories.slug,
@@ -83,7 +129,20 @@ export async function getBudgetsOverview(
       return db
         .select({
           rootSlug,
-          spentCents: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
+          amountCents: transactions.amountCents,
+          currency: transactions.currency,
+          // Project rawData the same way as listTransactions (#528): only `fx`
+          // and `merged_statement.fx` cross the boundary. `convertToDisplayCurrency`
+          // → `extractFxMetadataWithFallback` reads exactly these two paths.
+          rawData: sql<Record<string, unknown> | null>`CASE
+            WHEN ${transactions.rawData} IS NULL THEN NULL
+            ELSE jsonb_build_object(
+              'fx', ${transactions.rawData} -> 'fx',
+              'merged_statement', jsonb_build_object(
+                'fx', ${transactions.rawData} -> 'merged_statement' -> 'fx'
+              )
+            )
+          END`.as("raw_data"),
         })
         .from(transactions)
         .leftJoin(
@@ -101,25 +160,58 @@ export async function getBudgetsOverview(
             notTransfer(transactions.channel),
             notAdjustment(transactions.isAdjustment),
             notDeleted(transactions.deletedAt),
+            sql`${transactions.amountCents} < 0`,
           ),
-        )
-        .groupBy(rootSlug);
+        );
     })(),
   ]);
 
-  const spentMap = new Map<string, bigint>();
-  for (const s of spentRows) {
-    if (s.rootSlug) spentMap.set(s.rootSlug, BigInt(s.spentCents));
-  }
-
-  const items: BudgetOverviewItem[] = rows.map((r) => ({
-    id: r.id,
-    categorySlug: r.categorySlug,
-    categoryName: r.categoryName ?? r.categorySlug,
-    amountCents: r.amountCents.toString(),
-    spentCents: (spentMap.get(r.categorySlug) ?? BigInt(0)).toString(),
+  // Per-row aggregation in the user's display currency. Rows with rootSlug=null
+  // (no category) are dropped — same semantics as the previous SQL GROUP BY.
+  // We sum ABSOLUTE expense (negate the amountCents) so callers consume a
+  // non-negative spent value, matching the legacy contract.
+  const positiveRows = txRows.map((r) => ({
+    rootSlug: r.rootSlug,
+    amountCents: -r.amountCents,
     currency: r.currency,
+    rawData: r.rawData,
   }));
+  const grouped = sumByGroupAndDisplayCurrency(positiveRows, mode, (r) => r.rootSlug);
+
+  const items: BudgetOverviewItem[] = rows.map((r) => {
+    const buckets = grouped.get(r.categorySlug) ?? [];
+    const targetCurrency: Currency =
+      mode === "native" ? r.currency : displayCurrencyFor(mode, r.currency);
+
+    const matched = pickBucket(buckets, targetCurrency);
+
+    // Sum missingTrmCount across ALL buckets for this category (any tx that
+    // needed conversion but had no TRM is a data-quality flag, regardless of
+    // which bucket it ended up in).
+    const missingTrmCount = buckets.reduce(
+      (acc: number, b: AggregationBucket) => acc + b.missingTrmCount,
+      0,
+    );
+    const hadFrozenTrmConversion = buckets.some((b) => b.convertedCount > 0);
+
+    // Convert budget amount via LIVE TRM in all-X modes — plans have no
+    // frozen rate. Native mode is a passthrough.
+    const budgetAmountCents =
+      mode === "native"
+        ? r.amountCents
+        : convertCents(r.amountCents, r.currency, targetCurrency, copPerUsd);
+
+    return {
+      id: r.id,
+      categorySlug: r.categorySlug,
+      categoryName: r.categoryName ?? r.categorySlug,
+      amountCents: budgetAmountCents.toString(),
+      spentCents: matched.cents.toString(),
+      currency: targetCurrency,
+      hadFrozenTrmConversion,
+      missingTrmCount,
+    };
+  });
 
   return { categories: cats, items };
 }

--- a/src/lib/fx/aggregate.test.ts
+++ b/src/lib/fx/aggregate.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import type { TxForConversion } from "./convert";
+import { pickBucket, sumByDisplayCurrency, sumByGroupAndDisplayCurrency } from "./aggregate";
+
+const FROZEN_TRM_HISTORICAL = 3676.92; // historical TRM from a 2024 USD purchase
+const FROZEN_TRM_RECENT = 4123.45; // a different historical TRM, more recent
+const LIVE_TRM_TODAY = 4500; // intentionally different from any frozen rate so
+//                              tests can prove frozen TRM, not live, was used.
+
+function txUSD(cents: bigint, frozenTrm: number): TxForConversion {
+  return {
+    amountCents: cents,
+    currency: "USD",
+    rawData: {
+      fx: {
+        originalCurrency: "USD",
+        originalAmountCents: cents.toString().replace(/^-/, ""),
+        trmToAccountCurrency: frozenTrm,
+        trmSource: "statement_frozen",
+      },
+    },
+  };
+}
+
+function txCOP(cents: bigint): TxForConversion {
+  return { amountCents: cents, currency: "COP", rawData: null };
+}
+
+function txUSDMissingTrm(cents: bigint): TxForConversion {
+  return { amountCents: cents, currency: "USD", rawData: null };
+}
+
+describe("sumByDisplayCurrency — native mode", () => {
+  it("returns one bucket per native currency, no conversion", () => {
+    const rows: TxForConversion[] = [
+      txCOP(BigInt(-100000)),
+      txCOP(BigInt(-50000)),
+      txUSD(BigInt(-2500), FROZEN_TRM_HISTORICAL),
+    ];
+    const buckets = sumByDisplayCurrency(rows, "native");
+    expect(buckets).toHaveLength(2);
+
+    const cop = pickBucket(buckets, "COP");
+    expect(cop.cents).toBe(BigInt(-150000));
+    expect(cop.txCount).toBe(2);
+    expect(cop.missingTrmCount).toBe(0);
+
+    const usd = pickBucket(buckets, "USD");
+    expect(usd.cents).toBe(BigInt(-2500));
+    expect(usd.txCount).toBe(1);
+    expect(usd.missingTrmCount).toBe(0);
+  });
+
+  it("does not count missing TRM in native mode (no conversion needed)", () => {
+    const rows: TxForConversion[] = [txUSDMissingTrm(BigInt(-1000))];
+    const buckets = sumByDisplayCurrency(rows, "native");
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0]!.currency).toBe("USD");
+    expect(buckets[0]!.missingTrmCount).toBe(0);
+  });
+});
+
+describe("sumByDisplayCurrency — all-cop mode", () => {
+  it("converts USD rows using FROZEN TRM, not live", () => {
+    // 1 USD = 100 cents. Historical TRM 3676.92 → 367.692 COP cents per USD cent.
+    // tx amountCents = -10000 (= -$100 USD) → expected COP cents = -10000 * 3676.92 / 1 = -36769200 (cents).
+    const rows: TxForConversion[] = [
+      txUSD(BigInt(-10000), FROZEN_TRM_HISTORICAL),
+      txCOP(BigInt(-50000)),
+    ];
+    const buckets = sumByDisplayCurrency(rows, "all-cop");
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0]!.currency).toBe("COP");
+
+    // -10000 * 3676920000 / 1000000 = -36769200
+    const expectedConvertedUsd = BigInt(-36769200);
+    const expectedTotal = expectedConvertedUsd + BigInt(-50000);
+    expect(buckets[0]!.cents).toBe(expectedTotal);
+    expect(buckets[0]!.txCount).toBe(2);
+    expect(buckets[0]!.missingTrmCount).toBe(0);
+  });
+
+  it("uses each tx's OWN frozen TRM (different rates do not pool)", () => {
+    const rows: TxForConversion[] = [
+      txUSD(BigInt(-10000), FROZEN_TRM_HISTORICAL), // 100 USD @ 3676.92 → -36,769,200
+      txUSD(BigInt(-10000), FROZEN_TRM_RECENT), //    100 USD @ 4123.45 → -41,234,500
+    ];
+    const buckets = sumByDisplayCurrency(rows, "all-cop");
+    expect(buckets).toHaveLength(1);
+    // Each tx converted with its own TRM, then summed.
+    expect(buckets[0]!.cents).toBe(BigInt(-36769200) + BigInt(-41234500));
+
+    // Sanity: the result must NOT match what we'd get from live TRM applied uniformly.
+    const wrongIfLiveTrmUsed =
+      (BigInt(-20000) * BigInt(LIVE_TRM_TODAY * 1_000_000)) / BigInt(1_000_000);
+    expect(buckets[0]!.cents).not.toBe(wrongIfLiveTrmUsed);
+  });
+
+  it("flags rows with missing TRM but still includes them at original value", () => {
+    const rows: TxForConversion[] = [
+      txUSD(BigInt(-10000), FROZEN_TRM_HISTORICAL),
+      txUSDMissingTrm(BigInt(-5000)),
+    ];
+    const buckets = sumByDisplayCurrency(rows, "all-cop");
+    // The missing-TRM row stays in USD → distinct bucket from converted COP.
+    expect(buckets).toHaveLength(2);
+    const usd = pickBucket(buckets, "USD");
+    expect(usd.cents).toBe(BigInt(-5000));
+    expect(usd.missingTrmCount).toBe(1);
+
+    const cop = pickBucket(buckets, "COP");
+    expect(cop.cents).toBe(BigInt(-36769200));
+    expect(cop.missingTrmCount).toBe(0);
+  });
+});
+
+describe("sumByDisplayCurrency — all-usd mode", () => {
+  it("converts COP rows to USD using frozen TRM", () => {
+    // COP tx with frozen TRM in rawData.fx (set as if the COP tx came from a USD-paired transfer).
+    const tx: TxForConversion = {
+      amountCents: BigInt(-3676920), // -36,769.20 COP cents (= -$10 USD at TRM 3676.92)
+      currency: "COP",
+      rawData: {
+        fx: {
+          originalCurrency: "COP",
+          originalAmountCents: "3676920",
+          trmToAccountCurrency: FROZEN_TRM_HISTORICAL,
+          trmSource: "statement_frozen",
+        },
+      },
+    };
+    const buckets = sumByDisplayCurrency([tx], "all-usd");
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0]!.currency).toBe("USD");
+    // -3676920 * 1000000 / 3676920000 = -1000 (USD cents = -$10)
+    expect(buckets[0]!.cents).toBe(BigInt(-1000));
+  });
+});
+
+describe("sumByGroupAndDisplayCurrency — root-category aggregation", () => {
+  type Row = TxForConversion & { categorySlug: string | null };
+
+  it("groups by categorySlug and converts per row", () => {
+    const rows: Row[] = [
+      { ...txCOP(BigInt(-30000)), categorySlug: "food" },
+      { ...txCOP(BigInt(-20000)), categorySlug: "food" },
+      { ...txUSD(BigInt(-5000), FROZEN_TRM_HISTORICAL), categorySlug: "food" },
+      { ...txCOP(BigInt(-100000)), categorySlug: "transport" },
+      { ...txCOP(BigInt(-7000)), categorySlug: null }, // dropped
+    ];
+
+    const grouped = sumByGroupAndDisplayCurrency(rows, "all-cop", (r) => r.categorySlug);
+    expect(grouped.size).toBe(2);
+
+    const foodBuckets = grouped.get("food")!;
+    expect(foodBuckets).toHaveLength(1);
+    expect(foodBuckets[0]!.currency).toBe("COP");
+    // 30000 + 20000 + 5000*3676.92 = 50000 + 18384600 = 18434600 (negative)
+    expect(foodBuckets[0]!.cents).toBe(BigInt(-30000) + BigInt(-20000) + BigInt(-18384600));
+    expect(foodBuckets[0]!.txCount).toBe(3);
+
+    const transportBuckets = grouped.get("transport")!;
+    expect(transportBuckets[0]!.cents).toBe(BigInt(-100000));
+    expect(transportBuckets[0]!.txCount).toBe(1);
+  });
+
+  it("preserves multiple buckets per group when missing TRM forces a fallback bucket", () => {
+    type R = TxForConversion & { categorySlug: string };
+    const rows: R[] = [
+      { ...txUSD(BigInt(-1000), FROZEN_TRM_HISTORICAL), categorySlug: "food" },
+      { ...txUSDMissingTrm(BigInt(-500)), categorySlug: "food" },
+    ];
+    const grouped = sumByGroupAndDisplayCurrency(rows, "all-cop", (r) => r.categorySlug);
+    const buckets = grouped.get("food")!;
+    expect(buckets).toHaveLength(2);
+    const cop = pickBucket(buckets, "COP");
+    const usd = pickBucket(buckets, "USD");
+    expect(cop.cents).toBe(BigInt(-3676920));
+    expect(usd.cents).toBe(BigInt(-500));
+    expect(usd.missingTrmCount).toBe(1);
+  });
+});
+
+describe("pickBucket", () => {
+  it("returns a zero-bucket when target is missing", () => {
+    const result = pickBucket([], "COP");
+    expect(result).toEqual({
+      currency: "COP",
+      cents: BigInt(0),
+      txCount: 0,
+      missingTrmCount: 0,
+      convertedCount: 0,
+    });
+  });
+});

--- a/src/lib/fx/aggregate.ts
+++ b/src/lib/fx/aggregate.ts
@@ -1,0 +1,153 @@
+import {
+  convertToDisplayCurrency,
+  type DisplayCurrency,
+  type TxForConversion,
+} from "@/lib/fx/convert";
+import { displayCurrencyFor } from "@/lib/money";
+import type { DisplayCurrencyMode } from "@/lib/db/schema";
+import type { Currency } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Aggregation primitives — sum bigint cents across rows respecting the user's
+// `displayCurrencyMode` and each row's frozen TRM (`rawData.fx`). Designed to
+// replace SQL `SUM(amount_cents) GROUP BY currency` patterns that silently
+// rewrite history with today's TRM.
+//
+// SAME helper that powers `MoneyFrozen` — the row-level math is exactly
+// `convertToDisplayCurrency`, so any visual mismatch between the table and a
+// summary becomes a single-source-of-truth bug, not a divergence.
+//
+// Designed for /budgets and /insights. Volume is ~500 rows/month/user → JS
+// aggregation is fine and trades a small payload increase for the clarity of
+// not duplicating FX logic in SQL.
+// ---------------------------------------------------------------------------
+
+export interface AggregationBucket {
+  /** Display currency for this bucket. Equals row currency in native mode. */
+  currency: DisplayCurrency;
+  /** Summed amount in `currency`, integer cents. Sign-preserving. */
+  cents: bigint;
+  /** Number of rows that landed in this bucket. */
+  txCount: number;
+  /** Rows where conversion was needed but the frozen TRM was missing. */
+  missingTrmCount: number;
+  /** Rows where frozen TRM was applied successfully. Drives "convertido" UX. */
+  convertedCount: number;
+}
+
+function resolveTargetCurrency(nativeCurrency: string, mode: DisplayCurrencyMode): string {
+  if (mode === "native") return nativeCurrency;
+  // `displayCurrencyFor` only knows the strict Currency enum ("COP" | "USD").
+  // USDc (a USD-denominated cents-style internal currency) routes via USD.
+  const routing = nativeCurrency === "USDc" ? "USD" : (nativeCurrency as Currency);
+  return displayCurrencyFor(mode, routing);
+}
+
+/**
+ * Aggregate a flat row set into one bucket per display currency.
+ *
+ * In `all-cop` / `all-usd` the result is a single bucket (every row is
+ * coerced to the target currency). In `native` you get one bucket per
+ * distinct row currency.
+ *
+ * "Missing TRM" only counts rows where conversion was *needed* (target
+ * differs from native) but the row had no frozen TRM. Same-currency rows
+ * are not penalised — they just pass through.
+ */
+export function sumByDisplayCurrency(
+  rows: Iterable<TxForConversion>,
+  mode: DisplayCurrencyMode,
+): AggregationBucket[] {
+  const buckets = new Map<string, AggregationBucket>();
+  for (const r of rows) {
+    const result = convertToDisplayCurrency(r, mode);
+    const target = resolveTargetCurrency(r.currency, mode);
+    const conversionWasNeeded = target !== r.currency;
+    const missingTrm = conversionWasNeeded && !result.converted;
+
+    let bucket = buckets.get(result.currency);
+    if (!bucket) {
+      bucket = {
+        currency: result.currency,
+        cents: BigInt(0),
+        txCount: 0,
+        missingTrmCount: 0,
+        convertedCount: 0,
+      };
+      buckets.set(result.currency, bucket);
+    }
+    bucket.cents += result.cents;
+    bucket.txCount += 1;
+    if (missingTrm) bucket.missingTrmCount += 1;
+    if (result.converted) bucket.convertedCount += 1;
+  }
+  return [...buckets.values()];
+}
+
+/**
+ * Like {@link sumByDisplayCurrency} but groups rows by an arbitrary key first
+ * (e.g. category root slug, merchant). Returns `Map<groupKey, buckets[]>`.
+ *
+ * Rows whose `keyOf(row)` is `null` are skipped (mirrors the SQL semantics
+ * where a NULL grouping key drops the row from the result).
+ */
+export function sumByGroupAndDisplayCurrency<T extends TxForConversion>(
+  rows: Iterable<T>,
+  mode: DisplayCurrencyMode,
+  keyOf: (row: T) => string | null,
+): Map<string, AggregationBucket[]> {
+  const out = new Map<string, Map<string, AggregationBucket>>();
+  for (const r of rows) {
+    const groupKey = keyOf(r);
+    if (groupKey === null) continue;
+
+    let inner = out.get(groupKey);
+    if (!inner) {
+      inner = new Map();
+      out.set(groupKey, inner);
+    }
+
+    const result = convertToDisplayCurrency(r, mode);
+    const target = resolveTargetCurrency(r.currency, mode);
+    const conversionWasNeeded = target !== r.currency;
+    const missingTrm = conversionWasNeeded && !result.converted;
+
+    let bucket = inner.get(result.currency);
+    if (!bucket) {
+      bucket = {
+        currency: result.currency,
+        cents: BigInt(0),
+        txCount: 0,
+        missingTrmCount: 0,
+        convertedCount: 0,
+      };
+      inner.set(result.currency, bucket);
+    }
+    bucket.cents += result.cents;
+    bucket.txCount += 1;
+    if (missingTrm) bucket.missingTrmCount += 1;
+    if (result.converted) bucket.convertedCount += 1;
+  }
+
+  return new Map(Array.from(out.entries()).map(([k, v]) => [k, [...v.values()]]));
+}
+
+/**
+ * Pick the bucket whose currency matches `target` from a list, or return a
+ * zero-bucket in `target` currency. Useful when a caller wants one number per
+ * group in a known display currency (e.g. "spent in COP for `food`").
+ */
+export function pickBucket(
+  buckets: ReadonlyArray<AggregationBucket>,
+  target: DisplayCurrency,
+): AggregationBucket {
+  return (
+    buckets.find((b) => b.currency === target) ?? {
+      currency: target,
+      cents: BigInt(0),
+      txCount: 0,
+      missingTrmCount: 0,
+      convertedCount: 0,
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- Replace currency-naive `SUM(amount_cents) GROUP BY rootSlug` in `getBudgetsOverview` with **per-row JS aggregation** that converts each tx via its own frozen TRM (`rawData.fx.trmToAccountCurrency`).
- New helper `src/lib/fx/aggregate.ts` — `sumByDisplayCurrency`, `sumByGroupAndDisplayCurrency`, `pickBucket`. Reused by #526 next.
- `getBudgetsOverview` now takes optional `fxOpts: { displayCurrencyMode, copPerUsd }`. Spent → frozen TRM. Budget amount → LIVE TRM (plans are forward-looking, no historical rate exists).
- `BudgetsManager` renders a tooltip ("Convertido con TRM histórica · N sin TRM" when applicable) on the spent/amount span when `hadFrozenTrmConversion` is true.

## Architecture
Each `AggregationBucket` tracks `txCount`, `convertedCount` (drives "convertido" UX), and `missingTrmCount` (data-quality flag). Same `convertToDisplayCurrency` helper that powers `MoneyFrozen` — single source of truth between table and budget bar.

## Behavior matrix
| `displayCurrencyMode` | spent currency | amount currency | conversion |
|---|---|---|---|
| `native` | budget currency | budget currency | none (only same-currency txs counted) |
| `all-cop` | COP | COP | per-row frozen TRM (spent) + live TRM (amount) |
| `all-usd` | USD | USD | per-row frozen TRM (spent) + live TRM (amount) |

## Test plan
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun run lint\` — clean
- [x] \`bun run test\` — 190 files, 2299 passed, 1 skipped
- [x] New unit tests in \`aggregate.test.ts\` (9 cases): native/all-cop/all-usd, missing-TRM bucketing, group-by, zero-bucket fallback
- [x] New integration tests in \`budgets/queries.test.ts\` (DB-backed):
  - native mode: USD txs do NOT contribute to a COP budget
  - all-cop mode: USD tx with frozen TRM 3676.92 → 36,769,200 COP cents (NOT live 4500 × 10000)
  - all-cop mode: missing-TRM tx is excluded from COP total + flagged via \`missingTrmCount\`
  - all-cop mode: USD-budget user has \`amountCents\` converted via LIVE TRM

Closes #527