### PR TITLE
feat(insights): wire convertToDisplayCurrency into /insights aggregations (#526)

### DIFF
--- a/src/app/(app)/insights/actions.test.ts
+++ b/src/app/(app)/insights/actions.test.ts
@@ -25,6 +25,14 @@ vi.mock("@/lib/dashboard/period", () => ({
   }),
 }));
 
+vi.mock("@/lib/preferences/repo", () => ({
+  getUiPreferences: vi.fn().mockResolvedValue({
+    displayCurrencyMode: "native",
+    financialCycleMode: "calendar",
+    payPeriodNudgeDismissed: false,
+  }),
+}));
+
 vi.mock("@/lib/ai/insights", () => ({
   buildInsightsSummary: vi.fn().mockResolvedValue({ summary: "mock" }),
   generateInsightsReport: vi.fn().mockResolvedValue({

--- a/src/app/(app)/insights/actions.ts
+++ b/src/app/(app)/insights/actions.ts
@@ -9,6 +9,7 @@ import { getSessionUser } from "@/lib/auth/session";
 import { buildInsightsSummary, generateInsightsReport, hashSummary } from "@/lib/ai/insights";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { getFinancialPeriod } from "@/lib/dashboard/period";
+import { getUiPreferences } from "@/lib/preferences/repo";
 import { createLogger } from "@/lib/logger";
 import { emitNotification } from "@/lib/notifications/emit";
 
@@ -23,14 +24,22 @@ export async function generateInsight(ym: string) {
   // Resolve current + previous periods so the AI input matches the
   // dashboard / page view exactly. Previous month uses the same cycle mode.
   const [y, m] = parsed.split("-").map(Number);
-  const [currentPeriod, previousPeriod] = await Promise.all([
+  const [currentPeriod, previousPeriod, prefs] = await Promise.all([
     getFinancialPeriod(session.id, new Date(Date.UTC(y, m - 1, 15))),
     getFinancialPeriod(session.id, new Date(Date.UTC(y, m - 2, 15))),
+    getUiPreferences(session.id),
   ]);
-  const summary = await buildInsightsSummary(session.id, parsed, fx.rate, undefined, {
-    currentRange: { start: currentPeriod.start, end: currentPeriod.end },
-    previousRange: { start: previousPeriod.start, end: previousPeriod.end },
-  });
+  const summary = await buildInsightsSummary(
+    session.id,
+    parsed,
+    fx.rate,
+    undefined,
+    {
+      currentRange: { start: currentPeriod.start, end: currentPeriod.end },
+      previousRange: { start: previousPeriod.start, end: previousPeriod.end },
+    },
+    { displayCurrencyMode: prefs.displayCurrencyMode },
+  );
   const inputHash = hashSummary(summary);
   const result = await generateInsightsReport({ summary });
 

--- a/src/app/(app)/insights/page.tsx
+++ b/src/app/(app)/insights/page.tsx
@@ -7,6 +7,7 @@ import { getSessionUser } from "@/lib/auth/session";
 import { buildInsightsSummary, hashSummary, isStale } from "@/lib/ai/insights";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { getFinancialPeriod } from "@/lib/dashboard/period";
+import { getUiPreferences } from "@/lib/preferences/repo";
 import { formatMoney } from "@/lib/money";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { InsightsViewer } from "./insights-viewer";
@@ -32,14 +33,22 @@ export default async function InsightsPage({
   // comparison stays apples-to-apples (both salary-anchored if pay_period
   // mode is on, both calendar otherwise).
   const [y, m] = ym.split("-").map(Number);
-  const [currentPeriod, previousPeriod] = await Promise.all([
+  const [currentPeriod, previousPeriod, prefs] = await Promise.all([
     getFinancialPeriod(session.id, new Date(Date.UTC(y, m - 1, 15))),
     getFinancialPeriod(session.id, new Date(Date.UTC(y, m - 2, 15))),
+    getUiPreferences(session.id),
   ]);
-  const summary = await buildInsightsSummary(session.id, ym, fx.rate, undefined, {
-    currentRange: { start: currentPeriod.start, end: currentPeriod.end },
-    previousRange: { start: previousPeriod.start, end: previousPeriod.end },
-  });
+  const summary = await buildInsightsSummary(
+    session.id,
+    ym,
+    fx.rate,
+    undefined,
+    {
+      currentRange: { start: currentPeriod.start, end: currentPeriod.end },
+      previousRange: { start: previousPeriod.start, end: previousPeriod.end },
+    },
+    { displayCurrencyMode: prefs.displayCurrencyMode },
+  );
   const currentHash = hashSummary(summary);
 
   const [existing] = await db

--- a/src/lib/ai/insights.test.ts
+++ b/src/lib/ai/insights.test.ts
@@ -108,3 +108,121 @@ describe("buildInsightsSummary — transfer filter (#685)", () => {
     expect(bancolombia).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// #526 — frozen TRM aggregation in /insights. USD txs with rawData.fx must
+// be converted using their FROZEN TRM, not today's rate.
+// ---------------------------------------------------------------------------
+
+const FROZEN_TAG = "INSIGHTS_FROZEN_TRM_TEST";
+const FROZEN_TRM = 3676.92; // historical
+const LIVE_TRM = 4500; // intentionally different so tests can prove which one was used
+
+describe("buildInsightsSummary — #526 frozen TRM aggregation", () => {
+  let frozenUserId: number;
+  let frozenAccountId: number;
+
+  beforeAll(async () => {
+    // Cleanup any leftovers from a previous run.
+    await db.delete(users).where(sql`email LIKE ${"%" + FROZEN_TAG + "%"}`);
+
+    const [u] = await db
+      .insert(users)
+      .values({ email: `${FROZEN_TAG}@test.local`, name: FROZEN_TAG })
+      .returning({ id: users.id });
+    frozenUserId = u.id;
+    await copyCategorySeedsToUser(frozenUserId);
+
+    const [a] = await db
+      .insert(accounts)
+      .values({
+        userId: frozenUserId,
+        name: `${FROZEN_TAG} acct`,
+        institution: FROZEN_TAG,
+        type: "savings",
+        currency: "USD",
+      })
+      .returning({ id: accounts.id });
+    frozenAccountId = a.id;
+
+    // USD expense $100.00 (10000 cents) with frozen TRM 3676.92.
+    await db.insert(transactions).values({
+      userId: frozenUserId,
+      accountId: frozenAccountId,
+      occurredAt: new Date("2098-06-10"),
+      amountCents: BigInt(-10000),
+      currency: "USD",
+      descriptionRaw: `${FROZEN_TAG} compra dolar`,
+      merchant: "Amazon",
+      categorySlug: "otros",
+      classificationMethod: "manual",
+      source: "manual",
+      externalId: `${FROZEN_TAG}-frozen-1`,
+      channel: "bank",
+      rawData: {
+        fx: {
+          originalCurrency: "USD",
+          originalAmountCents: "10000",
+          trmToAccountCurrency: FROZEN_TRM,
+          trmSource: "statement_frozen",
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await db.delete(users).where(sql`email LIKE ${"%" + FROZEN_TAG + "%"}`);
+  });
+
+  it("all-cop mode: USD expense aggregates using FROZEN TRM, not live", async () => {
+    const summary = await buildInsightsSummary(frozenUserId, "2098-06", LIVE_TRM, db, undefined, {
+      displayCurrencyMode: "all-cop",
+    });
+
+    // 10000 USD cents * 3676.92 / 100 = 367692 pesos. Sub-cent rounding → 367692.
+    expect(summary.totals.expenseCop).toBe(367692);
+
+    // Sanity: live TRM would have produced 10000 * 4500 / 100 = 450000 pesos.
+    expect(summary.totals.expenseCop).not.toBe(450000);
+  });
+
+  it("native mode: USD expense stays in USD pesos coalesced via LIVE TRM", async () => {
+    // Native mode preserves the legacy behavior: txs aggregate per-currency,
+    // then coalesce to COP for the summary using the live `copPerUsd` rate.
+    const summary = await buildInsightsSummary(frozenUserId, "2098-06", LIVE_TRM, db, undefined, {
+      displayCurrencyMode: "native",
+    });
+    expect(summary.totals.expenseCop).toBe(450000);
+  });
+
+  it("all-cop mode: top merchants ordered by FROZEN-TRM converted spend", async () => {
+    const summary = await buildInsightsSummary(frozenUserId, "2098-06", LIVE_TRM, db, undefined, {
+      displayCurrencyMode: "all-cop",
+    });
+    const amazon = summary.topMerchants.find((m) => m.merchant === "Amazon");
+    expect(amazon).toBeDefined();
+    expect(amazon!.spentCop).toBe(367692);
+  });
+
+  it("all-cop mode: category 'otros' aggregates via frozen TRM", async () => {
+    const summary = await buildInsightsSummary(frozenUserId, "2098-06", LIVE_TRM, db, undefined, {
+      displayCurrencyMode: "all-cop",
+    });
+    const otros = summary.categoriesCurrent.find((c) => c.slug === "otros");
+    expect(otros).toBeDefined();
+    expect(otros!.spentCop).toBe(367692);
+    expect(otros!.txCount).toBe(1);
+  });
+
+  it("accounts use LIVE TRM (no historical balance)", async () => {
+    // Balance is current state; converting via LIVE TRM is correct (no frozen rate).
+    const summary = await buildInsightsSummary(frozenUserId, "2098-06", LIVE_TRM, db, undefined, {
+      displayCurrencyMode: "all-cop",
+    });
+    // The USD account had a -100 USD expense → balance ~-100 USD. Converted
+    // at LIVE TRM (4500): -100 * 4500 = -450000 COP pesos.
+    const acct = summary.accounts.find((a) => a.name === `${FROZEN_TAG} acct`);
+    expect(acct).toBeDefined();
+    expect(acct!.balanceCop).toBe(-450000);
+  });
+});

--- a/src/lib/ai/insights.ts
+++ b/src/lib/ai/insights.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { aliasedTable, and, asc, desc, eq, gte, lt, sql } from "drizzle-orm";
+import { aliasedTable, and, asc, eq, gte, lt, sql } from "drizzle-orm";
 import { db as defaultDb, type DB } from "@/lib/db";
 import {
   accounts,
@@ -7,11 +7,21 @@ import {
   categories,
   recurringTransactions,
   transactions,
+  type DisplayCurrencyMode,
 } from "@/lib/db/schema";
 import { notAdjustment, notDeleted, notTransfer } from "@/lib/db/helpers";
 import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
 import type { Currency } from "@/lib/types";
 import { callClaudeText } from "@/lib/ai/anthropic-client";
+import { createLogger } from "@/lib/logger";
+import {
+  sumByDisplayCurrency,
+  sumByGroupAndDisplayCurrency,
+  type AggregationBucket,
+} from "@/lib/fx/aggregate";
+import { convertCents } from "@/lib/money";
+
+const log = createLogger({ module: "insights-aggregator" });
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 export const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -67,9 +77,70 @@ function calendarBounds(ym: string) {
   };
 }
 
-function toCopNumber(cents: bigint, currency: Currency, copPerUsd: number): number {
-  const pesos = Number(cents) / 100;
-  return currency === "USD" ? pesos * copPerUsd : pesos;
+/**
+ * Convert a balance/plan amount (which has no frozen TRM — it's a current
+ * value or a forward-looking target) into the user's display currency using
+ * LIVE TRM. Used for accounts, budget plans, and recurring plan amounts.
+ */
+function toDisplayNumber(
+  cents: bigint,
+  currency: Currency,
+  target: Currency,
+  liveCopPerUsd: number,
+): number {
+  if (currency === target) return Number(cents) / 100;
+  try {
+    return Number(convertCents(cents, currency, target, liveCopPerUsd)) / 100;
+  } catch {
+    log.warn(
+      { fromCurrency: currency, toCurrency: target, event: "insights_balance_conversion_failed" },
+      "could not convert balance/plan to display currency — using raw value",
+    );
+    return Number(cents) / 100;
+  }
+}
+
+/**
+ * Coalesce per-currency aggregation buckets into a single number in `target`
+ * currency (pesos or dollars, depending on display mode). Buckets whose
+ * currency matches `target` are summed directly. Cross-currency residuals
+ * (e.g. rows that lost their frozen TRM in all-X mode) fall back to LIVE TRM.
+ */
+function coalesceToDisplayNumber(
+  buckets: ReadonlyArray<AggregationBucket>,
+  target: Currency,
+  liveCopPerUsd: number,
+): number {
+  let totalCents = BigInt(0);
+  for (const b of buckets) {
+    if (b.currency === target) {
+      totalCents += b.cents;
+      continue;
+    }
+    try {
+      totalCents += convertCents(b.cents, b.currency as Currency, target, liveCopPerUsd);
+    } catch (err) {
+      log.warn(
+        {
+          fromCurrency: b.currency,
+          toCurrency: target,
+          err: err as Error,
+          event: "insights_coalesce_fallback_failed",
+        },
+        "could not coalesce cross-currency residual bucket — dropping from total",
+      );
+    }
+  }
+  return Number(totalCents) / 100;
+}
+
+/**
+ * Resolve the display currency that the summary fields (incomeCop, etc.) are
+ * denominated in. Field names retain the `Cop` suffix for API stability across
+ * the AI prompt and the InsightsViewer; the actual unit follows this function.
+ */
+function resolveDisplayCurrency(mode: DisplayCurrencyMode): Currency {
+  return mode === "all-usd" ? "USD" : "COP";
 }
 
 /**
@@ -78,6 +149,14 @@ function toCopNumber(cents: bigint, currency: Currency, copPerUsd: number): numb
  * resolved `getFinancialPeriod` ranges from the call site so insights match
  * the dashboard's "Flujo del mes". Budget plans stay calendar-anchored
  * (`budgets.periodStart` is calendar) regardless of cycle mode.
+ *
+ * #526: tx aggregations are now per-row using each tx's frozen TRM
+ * (`rawData.fx.trmToAccountCurrency`). Account balances and budget/recurring
+ * plans keep using LIVE TRM (`copPerUsd`) since they have no historical rate.
+ *
+ * Field names keep their `Cop` suffix for API stability across the AI prompt
+ * and the InsightsViewer; the actual unit follows the user's
+ * `displayCurrencyMode` (COP for `native`/`all-cop`, USD for `all-usd`).
  */
 export async function buildInsightsSummary(
   userId: number,
@@ -88,6 +167,7 @@ export async function buildInsightsSummary(
     currentRange?: { start: Date; end: Date };
     previousRange?: { start: Date; end: Date };
   },
+  fxOpts?: { displayCurrencyMode: DisplayCurrencyMode },
 ): Promise<InsightsSummary> {
   const prevYm = shiftMonth(ym, -1);
   const calCur = calendarBounds(ym);
@@ -98,7 +178,24 @@ export async function buildInsightsSummary(
   };
   const prev = ranges?.previousRange ?? calPrev;
 
-  const [accs, curTxTotals, prevTxTotals, curCats, prevCats, topMer, budgetRows, recRows] =
+  const mode: DisplayCurrencyMode = fxOpts?.displayCurrencyMode ?? "native";
+  const target = resolveDisplayCurrency(mode);
+  const toDisplay = (cents: bigint, currency: Currency) =>
+    toDisplayNumber(cents, currency, target, copPerUsd);
+
+  // SQL projection of `raw_data` matches listTransactions (#528) — only
+  // `fx` and `merged_statement.fx` cross the boundary.
+  const rawDataProjection = sql<Record<string, unknown> | null>`CASE
+    WHEN ${transactions.rawData} IS NULL THEN NULL
+    ELSE jsonb_build_object(
+      'fx', ${transactions.rawData} -> 'fx',
+      'merged_statement', jsonb_build_object(
+        'fx', ${transactions.rawData} -> 'merged_statement' -> 'fx'
+      )
+    )
+  END`.as("raw_data");
+
+  const [accs, curTxRows, prevTxRows, curCatRows, prevCatRows, merchantRows, budgetRows, recRows] =
     await Promise.all([
       db
         .select({
@@ -117,11 +214,12 @@ export async function buildInsightsSummary(
           ),
         )
         .orderBy(asc(accounts.name)),
+      // Per-row income/expense for current period — aggregate in JS using helper.
       db
         .select({
+          amountCents: transactions.amountCents,
           currency: transactions.currency,
-          income: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} > 0 THEN ${transactions.amountCents} ELSE 0 END), 0)`,
-          expense: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
+          rawData: rawDataProjection,
         })
         .from(transactions)
         .where(
@@ -133,13 +231,13 @@ export async function buildInsightsSummary(
             notAdjustment(transactions.isAdjustment),
             notDeleted(transactions.deletedAt),
           ),
-        )
-        .groupBy(transactions.currency),
+        ),
+      // Per-row income/expense for previous period.
       db
         .select({
+          amountCents: transactions.amountCents,
           currency: transactions.currency,
-          income: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} > 0 THEN ${transactions.amountCents} ELSE 0 END), 0)`,
-          expense: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
+          rawData: rawDataProjection,
         })
         .from(transactions)
         .where(
@@ -151,19 +249,18 @@ export async function buildInsightsSummary(
             notAdjustment(transactions.isAdjustment),
             notDeleted(transactions.deletedAt),
           ),
-        )
-        .groupBy(transactions.currency),
+        ),
       (() => {
         const leaf = aliasedTable(categories, "cur_leaf");
         const root = aliasedTable(categories, "cur_root");
         const rootSlug = sql<string | null>`COALESCE(${leaf.parentSlug}, ${leaf.slug})`;
         return db
           .select({
-            slug: rootSlug,
-            name: root.name,
+            rootSlug,
+            rootName: root.name,
+            amountCents: transactions.amountCents,
             currency: transactions.currency,
-            spent: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
-            txCount: sql<number>`COUNT(*)::int`,
+            rawData: rawDataProjection,
           })
           .from(transactions)
           .leftJoin(
@@ -176,21 +273,22 @@ export async function buildInsightsSummary(
               eq(transactions.userId, userId),
               gte(transactions.occurredAt, cur.start),
               lt(transactions.occurredAt, cur.end),
+              sql`${transactions.amountCents} < 0`,
               notTransfer(transactions.channel),
               notAdjustment(transactions.isAdjustment),
               notDeleted(transactions.deletedAt),
             ),
-          )
-          .groupBy(rootSlug, root.name, transactions.currency);
+          );
       })(),
       (() => {
         const leaf = aliasedTable(categories, "prev_leaf");
         const rootSlug = sql<string | null>`COALESCE(${leaf.parentSlug}, ${leaf.slug})`;
         return db
           .select({
-            slug: rootSlug,
+            rootSlug,
+            amountCents: transactions.amountCents,
             currency: transactions.currency,
-            spent: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
+            rawData: rawDataProjection,
           })
           .from(transactions)
           .leftJoin(
@@ -202,19 +300,21 @@ export async function buildInsightsSummary(
               eq(transactions.userId, userId),
               gte(transactions.occurredAt, prev.start),
               lt(transactions.occurredAt, prev.end),
+              sql`${transactions.amountCents} < 0`,
               notTransfer(transactions.channel),
               notAdjustment(transactions.isAdjustment),
               notDeleted(transactions.deletedAt),
             ),
-          )
-          .groupBy(rootSlug, transactions.currency);
+          );
       })(),
+      // Per-row merchant data — sort + LIMIT 10 happens in JS after conversion
+      // (the largest in display currency may differ from largest in native cents).
       db
         .select({
           merchant: transactions.merchant,
+          amountCents: transactions.amountCents,
           currency: transactions.currency,
-          spent: sql<string>`COALESCE(SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END), 0)`,
-          txCount: sql<number>`COUNT(*)::int`,
+          rawData: rawDataProjection,
         })
         .from(transactions)
         .where(
@@ -228,14 +328,7 @@ export async function buildInsightsSummary(
             notAdjustment(transactions.isAdjustment),
             notDeleted(transactions.deletedAt),
           ),
-        )
-        .groupBy(transactions.merchant, transactions.currency)
-        .orderBy(
-          desc(
-            sql`SUM(CASE WHEN ${transactions.amountCents} < 0 THEN -${transactions.amountCents} ELSE 0 END)`,
-          ),
-        )
-        .limit(10),
+        ),
       db
         .select({
           categorySlug: budgets.categorySlug,
@@ -269,64 +362,134 @@ export async function buildInsightsSummary(
         .orderBy(asc(recurringTransactions.dayOfMonth)),
     ]);
 
-  const totals = { incomeCop: 0, expenseCop: 0, previousIncomeCop: 0, previousExpenseCop: 0 };
-  for (const r of curTxTotals) {
-    totals.incomeCop += toCopNumber(BigInt(r.income), r.currency, copPerUsd);
-    totals.expenseCop += toCopNumber(BigInt(r.expense), r.currency, copPerUsd);
-  }
-  for (const r of prevTxTotals) {
-    totals.previousIncomeCop += toCopNumber(BigInt(r.income), r.currency, copPerUsd);
-    totals.previousExpenseCop += toCopNumber(BigInt(r.expense), r.currency, copPerUsd);
-  }
+  // ---------------------------------------------------------------------
+  // Totals (income + expense, current + previous)
+  // ---------------------------------------------------------------------
+  const splitByCharge = (rows: typeof curTxRows) => ({
+    income: rows
+      .filter((r) => r.amountCents > BigInt(0))
+      .map((r) => ({ amountCents: r.amountCents, currency: r.currency, rawData: r.rawData })),
+    expense: rows
+      .filter((r) => r.amountCents < BigInt(0))
+      .map((r) => ({
+        amountCents: -r.amountCents,
+        currency: r.currency,
+        rawData: r.rawData,
+      })),
+  });
 
-  const catMap = new Map<
-    string,
-    { slug: string; name: string; spentCop: number; txCount: number }
-  >();
-  for (const r of curCats) {
-    if (!r.slug) continue;
-    const key = r.slug;
-    const cop = toCopNumber(BigInt(r.spent), r.currency, copPerUsd);
-    const existing = catMap.get(key);
-    if (existing) {
-      existing.spentCop += cop;
-      existing.txCount += r.txCount;
-    } else {
-      catMap.set(key, { slug: r.slug, name: r.name ?? r.slug, spentCop: cop, txCount: r.txCount });
-    }
-  }
-  const categoriesCurrent = [...catMap.values()].sort((a, b) => b.spentCop - a.spentCop);
+  const curSplit = splitByCharge(curTxRows);
+  const prevSplit = splitByCharge(prevTxRows);
 
-  const prevCatMap = new Map<string, number>();
-  for (const r of prevCats) {
-    if (!r.slug) continue;
-    prevCatMap.set(
-      r.slug,
-      (prevCatMap.get(r.slug) ?? 0) + toCopNumber(BigInt(r.spent), r.currency, copPerUsd),
-    );
-  }
-  const categoriesPrevious = [...prevCatMap.entries()].map(([slug, spentCop]) => ({
-    slug,
-    spentCop,
+  const incomeCop = coalesceToDisplayNumber(
+    sumByDisplayCurrency(curSplit.income, mode),
+    target,
+    copPerUsd,
+  );
+  const expenseCop = coalesceToDisplayNumber(
+    sumByDisplayCurrency(curSplit.expense, mode),
+    target,
+    copPerUsd,
+  );
+  const previousIncomeCop = coalesceToDisplayNumber(
+    sumByDisplayCurrency(prevSplit.income, mode),
+    target,
+    copPerUsd,
+  );
+  const previousExpenseCop = coalesceToDisplayNumber(
+    sumByDisplayCurrency(prevSplit.expense, mode),
+    target,
+    copPerUsd,
+  );
+
+  // ---------------------------------------------------------------------
+  // Categories — current + previous
+  // ---------------------------------------------------------------------
+  const positiveCurCatRows = curCatRows.map((r) => ({
+    rootSlug: r.rootSlug,
+    rootName: r.rootName,
+    amountCents: -r.amountCents, // expense → positive
+    currency: r.currency,
+    rawData: r.rawData,
   }));
+  const groupedCurCats = sumByGroupAndDisplayCurrency(positiveCurCatRows, mode, (r) => r.rootSlug);
 
-  const merMap = new Map<string, { merchant: string; spentCop: number; txCount: number }>();
-  for (const r of topMer) {
-    if (!r.merchant) continue;
-    const cop = toCopNumber(BigInt(r.spent), r.currency, copPerUsd);
-    const existing = merMap.get(r.merchant);
-    if (existing) {
-      existing.spentCop += cop;
-      existing.txCount += r.txCount;
-    } else {
-      merMap.set(r.merchant, { merchant: r.merchant, spentCop: cop, txCount: r.txCount });
-    }
+  // Track root names so the AI prompt has friendly labels.
+  const rootNameBySlug = new Map<string, string>();
+  for (const r of positiveCurCatRows) {
+    if (r.rootSlug && r.rootName) rootNameBySlug.set(r.rootSlug, r.rootName);
   }
-  const topMerchants = [...merMap.values()].sort((a, b) => b.spentCop - a.spentCop).slice(0, 10);
 
+  const categoriesCurrent: Array<{
+    slug: string;
+    name: string;
+    spentCop: number;
+    txCount: number;
+  }> = [];
+  for (const [slug, buckets] of groupedCurCats) {
+    const spentCop = coalesceToDisplayNumber(buckets, target, copPerUsd);
+    const txCount = buckets.reduce((acc, b) => acc + b.txCount, 0);
+    categoriesCurrent.push({
+      slug,
+      name: rootNameBySlug.get(slug) ?? slug,
+      spentCop,
+      txCount,
+    });
+  }
+  categoriesCurrent.sort((a, b) => b.spentCop - a.spentCop);
+
+  const positivePrevCatRows = prevCatRows.map((r) => ({
+    rootSlug: r.rootSlug,
+    amountCents: -r.amountCents,
+    currency: r.currency,
+    rawData: r.rawData,
+  }));
+  const groupedPrevCats = sumByGroupAndDisplayCurrency(
+    positivePrevCatRows,
+    mode,
+    (r) => r.rootSlug,
+  );
+  const categoriesPrevious: Array<{ slug: string; spentCop: number }> = [];
+  for (const [slug, buckets] of groupedPrevCats) {
+    categoriesPrevious.push({
+      slug,
+      spentCop: coalesceToDisplayNumber(buckets, target, copPerUsd),
+    });
+  }
+
+  // ---------------------------------------------------------------------
+  // Top merchants — convert per-row, then sort and slice 10.
+  // ---------------------------------------------------------------------
+  const positiveMerchantRows = merchantRows
+    .filter((r): r is typeof r & { merchant: string } => r.merchant !== null)
+    .map((r) => ({
+      merchant: r.merchant,
+      amountCents: -r.amountCents,
+      currency: r.currency,
+      rawData: r.rawData,
+    }));
+  const groupedMerchants = sumByGroupAndDisplayCurrency(
+    positiveMerchantRows,
+    mode,
+    (r) => r.merchant,
+  );
+  const topMerchants: Array<{ merchant: string; spentCop: number; txCount: number }> = [];
+  for (const [merchant, buckets] of groupedMerchants) {
+    const spentCop = coalesceToDisplayNumber(buckets, target, copPerUsd);
+    const txCount = buckets.reduce((acc, b) => acc + b.txCount, 0);
+    topMerchants.push({ merchant, spentCop, txCount });
+  }
+  topMerchants.sort((a, b) => b.spentCop - a.spentCop);
+  topMerchants.splice(10);
+
+  // ---------------------------------------------------------------------
+  // Budget plans — amount via LIVE TRM (no historical rate exists), spent
+  // pulled from the per-category aggregation above.
+  // ---------------------------------------------------------------------
+  const categorySpentMap = new Map(categoriesCurrent.map((c) => [c.slug, c.spentCop]));
   const budgetsOut = budgetRows.map((b) => {
-    const amountCop = toCopNumber(b.amountCents, b.currency, copPerUsd);
-    const spentCop = catMap.get(b.categorySlug)?.spentCop ?? 0;
+    const amountCop = toDisplay(b.amountCents, b.currency);
+    const spentCop = categorySpentMap.get(b.categorySlug) ?? 0;
     return {
       category: b.categorySlug,
       amountCop,
@@ -338,7 +501,7 @@ export async function buildInsightsSummary(
   const recurringOut = recRows.map((r) => ({
     label: r.label,
     dayOfMonth: r.dayOfMonth,
-    amountCop: toCopNumber(r.amountCents, r.currency, copPerUsd),
+    amountCop: toDisplay(r.amountCents, r.currency),
     categorySlug: r.categorySlug,
   }));
 
@@ -347,8 +510,12 @@ export async function buildInsightsSummary(
     institution: a.institution,
     type: a.type,
     currency: a.currency,
-    balanceCop: toCopNumber(BigInt(a.balanceCents), a.currency, copPerUsd),
+    balanceCop: toDisplay(BigInt(a.balanceCents), a.currency),
   }));
+
+  // Reduce to scalar totals to keep the existing public shape unchanged
+  // (the legacy contract expected `incomeCop` and friends as plain numbers).
+  const totals = { incomeCop, expenseCop, previousIncomeCop, previousExpenseCop };
 
   return {
     yearMonth: ym,


### PR DESCRIPTION
## Summary
Refactor `buildInsightsSummary` to compute spend per-row using each tx's frozen TRM (`rawData.fx.trmToAccountCurrency`) instead of GROUP-BY-currency-then-multiply-by-live-TRM. Closes the multi-currency display terna started in #528 (TxRow rawData) and #527 (/budgets totals).

## Changes
- **5 SQL queries** (curTxRows, prevTxRows, curCatRows, prevCatRows, merchantRows) refactored from `GROUP BY currency` to per-row, with the same JSONB raw_data projection used by listTransactions (#528).
- **JS aggregation** via the helper from #527: `sumByDisplayCurrency`, `sumByGroupAndDisplayCurrency`. Cross-currency residuals (rows where conversion was needed but TRM was missing) coalesce via LIVE TRM as a best-effort fallback.
- **Account balances + budget plans + recurring amounts**: keep using LIVE TRM (`toDisplayNumber`) — they have no historical rate.
- **InsightsPage** + **generateInsight server action** fetch `displayCurrencyMode` via `getUiPreferences` and pass it through.
- New Pino logger \`module='insights-aggregator'\` emits structured events when fallbacks fire.

## Field naming decision (intentional)
Field names (\`incomeCop\`, \`expenseCop\`, \`balanceCop\`, etc.) are **kept** for API stability across the AI prompt (cache-controlled) and the InsightsViewer. The actual unit follows the user's mode:
- \`native\` / \`all-cop\` → COP
- \`all-usd\` → USD

A follow-up rename to neutral names (\`income\`, \`expense\`, etc.) + \`displayCurrency\` field can land separately if we want to make the units self-describing in the JSON.

## Test plan
- [x] \`bun run lint\` — clean
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun run test\` — 190 files, 2304 passed, 1 skipped
- [x] **5 new integration tests** in \`insights.test.ts\`:
  - all-cop mode: USD expense converts via FROZEN TRM (3676.92 → 367,692 pesos), NOT live (4500 → 450,000)
  - native mode: legacy behavior preserved (USD coalesced via live TRM)
  - all-cop: top merchants ordered by frozen-TRM spend
  - all-cop: category 'otros' aggregates via frozen TRM
  - account balances use LIVE TRM (no frozen rate exists)
- [x] Existing #685 transfer-filter tests still pass

Closes #526