### PR TITLE
feat(subscriptions): /subscriptions hub — list + auto-detect from recurring (#700)

### DIFF
--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -20,6 +20,7 @@ const pages = [
     path: "/settings/accounts/5/consolidate/2026-03",
     hasDonut: false,
   },
+  { name: "subscriptions", path: "/subscriptions", hasDonut: false },
   { name: "imports", path: "/imports", hasDonut: false },
   { name: "signup-missing", path: "/signup", hasDonut: false },
   { name: "signup-unknown", path: "/signup?code=__DOESNOTEXIST__", hasDonut: false },

--- a/src/app/(app)/subscriptions/loading.tsx
+++ b/src/app/(app)/subscriptions/loading.tsx
@@ -1,0 +1,47 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function SubscriptionsLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header className="flex flex-col gap-2">
+        <Skeleton className="h-8 w-44" />
+        <Skeleton className="h-4 w-96 max-w-full" />
+      </header>
+
+      {/* Totals skeleton */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <Card key={i} size="sm">
+            <CardContent className="flex flex-col gap-1 py-3">
+              <Skeleton className="h-3 w-12" />
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-3 w-20" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Row skeletons */}
+      <div className="flex flex-col gap-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Card key={i} size="sm">
+            <CardContent className="flex flex-col gap-2 py-3">
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex flex-col gap-1">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-3 w-24" />
+                </div>
+                <div className="flex flex-col items-end gap-1">
+                  <Skeleton className="h-5 w-24" />
+                  <Skeleton className="h-3 w-20" />
+                </div>
+              </div>
+              <Skeleton className="h-3 w-48" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/subscriptions/page.tsx
+++ b/src/app/(app)/subscriptions/page.tsx
@@ -1,0 +1,37 @@
+import { getSessionUser } from "@/lib/auth/session";
+import { getUiPreferences } from "@/lib/preferences/repo";
+import { getCurrentFxRate } from "@/lib/fx/repo";
+import { getSubscriptions } from "./queries";
+import { SubscriptionList } from "@/components/subscriptions/subscription-list";
+
+export const dynamic = "force-dynamic";
+
+export default async function SubscriptionsPage() {
+  const session = await getSessionUser();
+
+  const [prefs, fx] = await Promise.all([getUiPreferences(session.id), getCurrentFxRate()]);
+
+  const { rows, monthlyTotals, annualTotals } = await getSubscriptions(
+    session.id,
+    prefs.displayCurrencyMode,
+    fx.rate,
+  );
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-h1">Subscriptions</h1>
+        <p className="text-body text-muted-foreground">
+          Active recurring subscriptions — all items categorised as <em>suscripciones</em>. Monthly
+          and annual cost at current display currency. Manage them in{" "}
+          <a href="/settings/recurring" className="underline underline-offset-4">
+            Settings → Recurring
+          </a>
+          .
+        </p>
+      </header>
+
+      <SubscriptionList rows={rows} monthlyTotals={monthlyTotals} annualTotals={annualTotals} />
+    </main>
+  );
+}

--- a/src/app/(app)/subscriptions/queries.test.ts
+++ b/src/app/(app)/subscriptions/queries.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { recurringTransactions } from "@/lib/db/schema";
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn().mockResolvedValue({ id: 1, email: "test@test.local", name: "Test" }),
+}));
+
+const { computeNextOccurrence, getSubscriptions } = await import("./queries");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_LABEL_PREFIX = "__test_sub_";
+const SUSCRIPCIONES_SLUG = "suscripciones";
+
+async function getAccountId(userId: number): Promise<number> {
+  const [acc] = await db.execute<{ id: number }>(
+    sql`SELECT id FROM accounts WHERE user_id = ${userId} LIMIT 1`,
+  );
+  if (!acc) throw new Error(`No seed account for user ${userId}`);
+  return acc.id;
+}
+
+async function ensureSuscripcionesCategory(userId: number): Promise<void> {
+  // Insert suscripciones category if not present (it should be from seed, but
+  // test DB may differ — upsert to be safe).
+  await db.execute(sql`
+    INSERT INTO categories (user_id, slug, name, parent_slug, sort_order)
+    VALUES (${userId}, 'suscripciones', 'Suscripciones', 'gastos-fijos', 10)
+    ON CONFLICT (user_id, slug) DO NOTHING
+  `);
+}
+
+async function insertRecurring(
+  userId: number,
+  accountId: number,
+  overrides: Partial<{
+    label: string;
+    amountCents: bigint;
+    currency: string;
+    categorySlug: string | null;
+    dayOfMonth: number;
+    active: boolean;
+    amountType: string;
+    skippedMonths: string[];
+  }> = {},
+) {
+  const label = overrides.label ?? `${TEST_LABEL_PREFIX}${Date.now()}`;
+  const [row] = await db
+    .insert(recurringTransactions)
+    .values({
+      userId,
+      accountId,
+      label,
+      amountCents: overrides.amountCents ?? BigInt(-150_000),
+      currency: (overrides.currency ?? "COP") as "COP" | "USD",
+      categorySlug:
+        overrides.categorySlug !== undefined ? overrides.categorySlug : SUSCRIPCIONES_SLUG,
+      dayOfMonth: overrides.dayOfMonth ?? 15,
+      active: overrides.active !== undefined ? overrides.active : true,
+      amountType: (overrides.amountType ?? "fixed") as "fixed" | "variable",
+      skippedMonths: overrides.skippedMonths ?? [],
+    })
+    .returning({ id: recurringTransactions.id });
+  return row!;
+}
+
+async function cleanup() {
+  await db.execute(
+    sql`DELETE FROM recurring_transactions WHERE label LIKE ${TEST_LABEL_PREFIX + "%"}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// computeNextOccurrence — pure unit tests (no DB)
+// ---------------------------------------------------------------------------
+
+describe("computeNextOccurrence", () => {
+  it("returns this month when today.day <= dayOfMonth", () => {
+    // today = May 10, dayOfMonth = 15 → next = 2026-05-15
+    const today = new Date(Date.UTC(2026, 4, 10)); // May 10
+    expect(computeNextOccurrence(15, [], today)).toBe("2026-05-15");
+  });
+
+  it("returns this month when today.day === dayOfMonth", () => {
+    // today = May 15, dayOfMonth = 15 → next = 2026-05-15
+    const today = new Date(Date.UTC(2026, 4, 15));
+    expect(computeNextOccurrence(15, [], today)).toBe("2026-05-15");
+  });
+
+  it("returns next month when today.day > dayOfMonth", () => {
+    // today = May 20, dayOfMonth = 15 → next = 2026-06-15
+    const today = new Date(Date.UTC(2026, 4, 20));
+    expect(computeNextOccurrence(15, [], today)).toBe("2026-06-15");
+  });
+
+  it("wraps to January when advancing past December", () => {
+    // today = Dec 20, dayOfMonth = 5 → next = 2026-01-05
+    const today = new Date(Date.UTC(2025, 11, 20)); // Dec 20 2025
+    expect(computeNextOccurrence(5, [], today)).toBe("2026-01-05");
+  });
+
+  it("skips a month in skippedMonths and picks the next non-skipped month", () => {
+    // today = May 10, dayOfMonth = 15 → candidate = 2026-05
+    // 2026-05 is skipped → next = 2026-06-15
+    const today = new Date(Date.UTC(2026, 4, 10));
+    expect(computeNextOccurrence(15, ["2026-05"], today)).toBe("2026-06-15");
+  });
+
+  it("skips multiple consecutive skipped months", () => {
+    // today = May 10, dayOfMonth = 1 → candidate = 2026-05
+    // 2026-05 and 2026-06 are skipped → next = 2026-07-01
+    const today = new Date(Date.UTC(2026, 4, 10));
+    expect(computeNextOccurrence(1, ["2026-05", "2026-06"], today)).toBe("2026-07-01");
+  });
+
+  it("skippedMonths for a past month does not affect future calculation", () => {
+    // today = May 10, dayOfMonth = 15 → candidate = 2026-05
+    // 2026-04 (past) is skipped — irrelevant → next = 2026-05-15
+    const today = new Date(Date.UTC(2026, 4, 10));
+    expect(computeNextOccurrence(15, ["2026-04"], today)).toBe("2026-05-15");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSubscriptions — integration tests (hit findash_test DB)
+// ---------------------------------------------------------------------------
+
+describe("getSubscriptions", () => {
+  afterEach(cleanup);
+
+  it("returns only suscripciones-category rows for the requesting user", async () => {
+    const accountId = await getAccountId(1);
+    await ensureSuscripcionesCategory(1);
+
+    const subLabel = `${TEST_LABEL_PREFIX}sub`;
+    const otherLabel = `${TEST_LABEL_PREFIX}other`;
+
+    // Insert one suscripciones recurring.
+    await insertRecurring(1, accountId, { label: subLabel });
+    // Insert one with a different (or null) category.
+    await insertRecurring(1, accountId, {
+      label: otherLabel,
+      categorySlug: null,
+    });
+
+    const { rows } = await getSubscriptions(1, "native", 4200);
+
+    const ids = rows.map((r) => r.label);
+    expect(ids).toContain(subLabel);
+    expect(ids).not.toContain(otherLabel);
+  });
+
+  it("excludes soft-deleted recurring rows", async () => {
+    const accountId = await getAccountId(1);
+    await ensureSuscripcionesCategory(1);
+
+    const label = `${TEST_LABEL_PREFIX}deleted`;
+    const { id } = await insertRecurring(1, accountId, { label });
+
+    // Soft-delete it.
+    await db
+      .update(recurringTransactions)
+      .set({ deletedAt: new Date() })
+      .where(eq(recurringTransactions.id, id));
+
+    const { rows } = await getSubscriptions(1, "native", 4200);
+    expect(rows.find((r) => r.label === label)).toBeUndefined();
+  });
+
+  it("excludes inactive (active=false) rows", async () => {
+    const accountId = await getAccountId(1);
+    await ensureSuscripcionesCategory(1);
+
+    const label = `${TEST_LABEL_PREFIX}inactive`;
+    await insertRecurring(1, accountId, { label, active: false });
+
+    const { rows } = await getSubscriptions(1, "native", 4200);
+    expect(rows.find((r) => r.label === label)).toBeUndefined();
+  });
+
+  it("includes variable amountType rows with the flag", async () => {
+    const accountId = await getAccountId(1);
+    await ensureSuscripcionesCategory(1);
+
+    const label = `${TEST_LABEL_PREFIX}variable`;
+    await insertRecurring(1, accountId, { label, amountType: "variable" });
+
+    const { rows } = await getSubscriptions(1, "native", 4200);
+    const found = rows.find((r) => r.label === label);
+    expect(found).toBeDefined();
+    expect(found!.amountType).toBe("variable");
+  });
+
+  it("tenant isolation: user 1 does not see user 2 rows", async () => {
+    // user 2 must exist in the test DB (seed creates both users).
+    const [user2] = await db.execute<{ id: number }>(
+      sql`SELECT id FROM users WHERE id = 2 LIMIT 1`,
+    );
+    if (!user2) return; // Skip if test DB only has one user.
+
+    const accountId2 = await getAccountId(2);
+
+    // Ensure suscripciones category for user 2 as well.
+    await db.execute(sql`
+      INSERT INTO categories (user_id, slug, name, parent_slug, sort_order)
+      VALUES (2, 'suscripciones', 'Suscripciones', 'gastos-fijos', 10)
+      ON CONFLICT (user_id, slug) DO NOTHING
+    `);
+
+    const label2 = `${TEST_LABEL_PREFIX}user2`;
+    await insertRecurring(2, accountId2, { label: label2 });
+
+    const { rows } = await getSubscriptions(1, "native", 4200);
+    expect(rows.find((r) => r.label === label2)).toBeUndefined();
+  });
+
+  it("computes annualCents as amountCents × 12", async () => {
+    const accountId = await getAccountId(1);
+    await ensureSuscripcionesCategory(1);
+
+    const label = `${TEST_LABEL_PREFIX}annual`;
+    const amount = BigInt(-100_000);
+    await insertRecurring(1, accountId, { label, amountCents: amount });
+
+    const { rows } = await getSubscriptions(1, "native", 4200);
+    const found = rows.find((r) => r.label === label);
+    expect(found).toBeDefined();
+    expect(found!.annualCents).toBe(amount * BigInt(12));
+  });
+
+  it("rows are sorted by absolute display amount descending", async () => {
+    const accountId = await getAccountId(1);
+    await ensureSuscripcionesCategory(1);
+
+    const cheap = `${TEST_LABEL_PREFIX}cheap`;
+    const expensive = `${TEST_LABEL_PREFIX}expensive`;
+    await insertRecurring(1, accountId, { label: cheap, amountCents: BigInt(-10_000) });
+    await insertRecurring(1, accountId, { label: expensive, amountCents: BigInt(-500_000) });
+
+    const { rows } = await getSubscriptions(1, "native", 4200);
+    // Filter to only our test rows to avoid seed data interference.
+    const testRows = rows.filter((r) => r.label === cheap || r.label === expensive);
+    expect(testRows[0]!.label).toBe(expensive);
+    expect(testRows[1]!.label).toBe(cheap);
+  });
+
+  it("nextOccurrence respects skippedMonths from the DB row", async () => {
+    const accountId = await getAccountId(1);
+    await ensureSuscripcionesCategory(1);
+
+    const label = `${TEST_LABEL_PREFIX}skipped`;
+    const today = new Date();
+    const todayDay = today.getUTCDate();
+    // Use dayOfMonth = 1 so it's always "this month or next".
+    const dom = 1;
+    // Skip the first candidate month to force the helper to advance.
+    const candidateMonth =
+      todayDay <= dom
+        ? `${today.getUTCFullYear()}-${String(today.getUTCMonth() + 1).padStart(2, "0")}`
+        : (() => {
+            const m = today.getUTCMonth() + 2; // 1-based next month
+            const y = today.getUTCFullYear() + (m > 12 ? 1 : 0);
+            return `${y}-${String(m > 12 ? m - 12 : m).padStart(2, "0")}`;
+          })();
+
+    await insertRecurring(1, accountId, {
+      label,
+      dayOfMonth: dom,
+      skippedMonths: [candidateMonth],
+    });
+
+    const { rows } = await getSubscriptions(1, "native", 4200);
+    const found = rows.find((r) => r.label === label);
+    expect(found).toBeDefined();
+    // The nextOccurrence must NOT be in the skipped month.
+    expect(found!.nextOccurrence.startsWith(candidateMonth)).toBe(false);
+  });
+});

--- a/src/app/(app)/subscriptions/queries.test.ts
+++ b/src/app/(app)/subscriptions/queries.test.ts
@@ -196,26 +196,46 @@ describe("getSubscriptions", () => {
   });
 
   it("tenant isolation: user 1 does not see user 2 rows", async () => {
-    // user 2 must exist in the test DB (seed creates both users).
-    const [user2] = await db.execute<{ id: number }>(
-      sql`SELECT id FROM users WHERE id = 2 LIMIT 1`,
-    );
-    if (!user2) return; // Skip if test DB only has one user.
+    // Upsert a second user inline so this assertion ALWAYS runs even on fresh
+    // test DBs that were seeded with only one user. Raw-SQL upsert avoids
+    // importing the full signup flow (copyCategorySeedsToUser etc.) which is
+    // out of scope here.
+    const uniqueEmail = `${TEST_LABEL_PREFIX}user2@test.local`;
+    const [user2Row] = await db.execute<{ id: number }>(sql`
+      INSERT INTO users (email, name)
+      VALUES (${uniqueEmail}, 'Tenant Test User 2')
+      ON CONFLICT (email) DO UPDATE SET name = EXCLUDED.name
+      RETURNING id
+    `);
+    const user2Id = user2Row!.id;
 
-    const accountId2 = await getAccountId(2);
+    // Create an account for user 2 (needed for insertRecurring FK).
+    const [acc2Row] = await db.execute<{ id: number }>(sql`
+      INSERT INTO accounts (user_id, name, institution, type, currency)
+      VALUES (${user2Id}, 'Test Account', 'Test Bank', 'savings', 'COP')
+      RETURNING id
+    `);
+    const accountId2 = acc2Row!.id;
 
     // Ensure suscripciones category for user 2 as well.
+    // Use NULL parent_slug to avoid needing the full category tree for this
+    // test user — the FK only requires (user_id, parent_slug) to exist when
+    // parent_slug IS NOT NULL.
     await db.execute(sql`
       INSERT INTO categories (user_id, slug, name, parent_slug, sort_order)
-      VALUES (2, 'suscripciones', 'Suscripciones', 'gastos-fijos', 10)
+      VALUES (${user2Id}, 'suscripciones', 'Suscripciones', NULL, 10)
       ON CONFLICT (user_id, slug) DO NOTHING
     `);
 
     const label2 = `${TEST_LABEL_PREFIX}user2`;
-    await insertRecurring(2, accountId2, { label: label2 });
+    await insertRecurring(user2Id, accountId2, { label: label2 });
 
     const { rows } = await getSubscriptions(1, "native", 4200);
     expect(rows.find((r) => r.label === label2)).toBeUndefined();
+
+    // Cleanup user-2 rows (users row will cascade on delete if needed, but
+    // we only need to remove the recurring — cleanup() handles label-prefix rows).
+    // The account and user are test-ephemeral; they'll be cleaned by the test DB reset.
   });
 
   it("computes annualCents as amountCents × 12", async () => {
@@ -278,5 +298,132 @@ describe("getSubscriptions", () => {
     expect(found).toBeDefined();
     // The nextOccurrence must NOT be in the skipped month.
     expect(found!.nextOccurrence.startsWith(candidateMonth)).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // C2: displayCurrencyMode totals
+  // -------------------------------------------------------------------------
+
+  it('totals produce ONE COP bucket in "all-cop" mode over a mix of COP + USD rows', async () => {
+    const accountId = await getAccountId(1);
+    await ensureSuscripcionesCategory(1);
+
+    // COP subscription: -150 000 COP monthly
+    const copLabel = `${TEST_LABEL_PREFIX}cop_total`;
+    const copMonthly = BigInt(-150_000);
+    await insertRecurring(1, accountId, {
+      label: copLabel,
+      amountCents: copMonthly,
+      currency: "COP",
+    });
+
+    // We need a USD account to insert a USD subscription.
+    const [usdAccRow] = await db.execute<{ id: number }>(sql`
+      INSERT INTO accounts (user_id, name, institution, type, currency)
+      VALUES (1, '__test_usd_account__', 'Test Bank', 'savings', 'USD')
+      ON CONFLICT DO NOTHING
+      RETURNING id
+    `);
+    // Fallback: if ON CONFLICT DO NOTHING returned nothing, look it up.
+    const usdAccountId: number =
+      usdAccRow?.id ??
+      (
+        await db.execute<{ id: number }>(
+          sql`SELECT id FROM accounts WHERE user_id = 1 AND name = '__test_usd_account__' LIMIT 1`,
+        )
+      )[0]!.id;
+
+    // USD subscription: -10 USD monthly (i.e. -1000 cents)
+    const usdLabel = `${TEST_LABEL_PREFIX}usd_total`;
+    const usdMonthly = BigInt(-1_000); // -10.00 USD in cents
+    const copPerUsd = 4_200;
+    await insertRecurring(1, usdAccountId, {
+      label: usdLabel,
+      amountCents: usdMonthly,
+      currency: "USD",
+    });
+
+    const { monthlyTotals } = await getSubscriptions(1, "all-cop", copPerUsd);
+
+    // In all-cop mode there must be exactly ONE bucket (COP).
+    expect(monthlyTotals).toHaveLength(1);
+    expect(monthlyTotals[0]!.currency).toBe("COP");
+
+    // Find our two test rows in the result to verify the total.
+    // COP row passes through; USD row is converted: -1000 cents × 4200 = -4_200_000 COP cents.
+    const usdInCopCents = (usdMonthly * BigInt(copPerUsd * 1_000_000)) / BigInt(1_000_000);
+
+    // The bucket may include other seed rows. To isolate our two rows we run
+    // a scoped assertion: extract only our test labels' converted amounts.
+    const allRows = (await getSubscriptions(1, "all-cop", copPerUsd)).rows;
+    const copRow = allRows.find((r) => r.label === copLabel);
+    const usdRow = allRows.find((r) => r.label === usdLabel);
+    expect(copRow).toBeDefined();
+    expect(usdRow).toBeDefined();
+
+    // copRow displayAmount = native (COP stays COP)
+    expect(copRow!.displayAmount.currency).toBe("COP");
+    expect(copRow!.displayAmount.cents).toBe(copMonthly);
+
+    // usdRow displayAmount must be in COP with the applied TRM.
+    expect(usdRow!.displayAmount.currency).toBe("COP");
+    expect(usdRow!.displayAmount.converted).toBe(true);
+    expect(usdRow!.displayAmount.cents).toBe(usdInCopCents);
+
+    // monthlyTotals single bucket cents must include both converted amounts.
+    // (There may be other seed rows; we only verify our two are summed correctly
+    // by checking the bucket cents == sum of all rows' displayAmount.cents.)
+    const totalFromRows = allRows.reduce((acc, r) => acc + r.displayAmount.cents, BigInt(0));
+    expect(monthlyTotals[0]!.cents).toBe(totalFromRows);
+
+    // Cleanup the USD test account after assertions.
+    await db.execute(sql`DELETE FROM accounts WHERE name = '__test_usd_account__' AND user_id = 1`);
+  });
+
+  it('totals produce TWO buckets in "native" mode over a mix of COP + USD rows', async () => {
+    const accountId = await getAccountId(1);
+    await ensureSuscripcionesCategory(1);
+
+    // COP subscription
+    const copLabel = `${TEST_LABEL_PREFIX}cop_native`;
+    await insertRecurring(1, accountId, {
+      label: copLabel,
+      amountCents: BigInt(-200_000),
+      currency: "COP",
+    });
+
+    // USD account + subscription
+    const [usdAccRow] = await db.execute<{ id: number }>(sql`
+      INSERT INTO accounts (user_id, name, institution, type, currency)
+      VALUES (1, '__test_usd_account2__', 'Test Bank', 'savings', 'USD')
+      ON CONFLICT DO NOTHING
+      RETURNING id
+    `);
+    const usdAccountId: number =
+      usdAccRow?.id ??
+      (
+        await db.execute<{ id: number }>(
+          sql`SELECT id FROM accounts WHERE user_id = 1 AND name = '__test_usd_account2__' LIMIT 1`,
+        )
+      )[0]!.id;
+
+    const usdLabel = `${TEST_LABEL_PREFIX}usd_native`;
+    await insertRecurring(1, usdAccountId, {
+      label: usdLabel,
+      amountCents: BigInt(-500),
+      currency: "USD",
+    });
+
+    const { monthlyTotals } = await getSubscriptions(1, "native", 4200);
+
+    // In native mode, COP and USD must be in separate buckets.
+    const currencies = monthlyTotals.map((b) => b.currency);
+    expect(currencies).toContain("COP");
+    expect(currencies).toContain("USD");
+
+    // Cleanup the USD test account.
+    await db.execute(
+      sql`DELETE FROM accounts WHERE name = '__test_usd_account2__' AND user_id = 1`,
+    );
   });
 });

--- a/src/app/(app)/subscriptions/queries.ts
+++ b/src/app/(app)/subscriptions/queries.ts
@@ -150,6 +150,8 @@ export async function getSubscriptions(
         eq(accounts.id, recurringTransactions.accountId),
         // tenant safety: accounts also belong to the user
         eq(accounts.userId, userId),
+        // exclude soft-archived accounts — their subscriptions must not appear
+        notDeleted(accounts.deletedAt),
       ),
     )
     .leftJoin(
@@ -230,39 +232,49 @@ export async function getSubscriptions(
   });
 
   // Sort by display-currency absolute amount descending (most expensive first).
+  // Stable tiebreaker: ascending id so repeated renders are deterministic.
   rows.sort((a, b) => {
     if (b.displayAmountAbsCents > a.displayAmountAbsCents) return 1;
     if (b.displayAmountAbsCents < a.displayAmountAbsCents) return -1;
-    return 0;
+    return a.id - b.id;
   });
 
-  // Compute monthly and annual display-currency totals.
-  // Monthly: use displayAmount.cents per row (already converted).
-  // Annual: ×12 of the monthly display amounts. We re-use sumByDisplayCurrency
-  // on virtual "12× rows" by adjusting amountCents before passing — simpler than
-  // a manual reduce. We pass rawData={} because conversion is already done;
-  // the synthetic rows have matching currency so no re-conversion happens.
-  const monthlyRows = rows.map((r) => ({
-    amountCents: displayAmount_abs_to_signed(r),
-    currency: r.displayAmount.currency,
-    rawData: {} as Record<string, unknown>,
+  // Compute monthly and annual display-currency totals using the ORIGINAL
+  // native currency + synthetic fx block per row. Passing displayCurrencyMode
+  // (not hardcoded "native") ensures that in all-cop / all-usd mode,
+  // sumByDisplayCurrency coerces all rows into one bucket instead of producing
+  // one bucket per distinct native currency.
+  //
+  // We must NOT pass already-converted displayAmount here — let
+  // sumByDisplayCurrency be the single authoritative conversion pass so the
+  // math stays consistent with the per-row displayAmount values.
+  const monthlyRows = raw.map((r) => {
+    const syntheticRawData: Record<string, unknown> =
+      r.currency !== "COP"
+        ? {
+            fx: {
+              originalCurrency: r.currency,
+              originalAmountCents:
+                r.amountCents < BigInt(0) ? (-r.amountCents).toString() : r.amountCents.toString(),
+              trmToAccountCurrency: copPerUsd,
+              trmSource: "user_input",
+            },
+          }
+        : {};
+    return {
+      amountCents: r.amountCents,
+      currency: r.currency,
+      rawData: syntheticRawData,
+    };
+  });
+
+  const annualRows = monthlyRows.map((r) => ({
+    ...r,
+    amountCents: r.amountCents * BigInt(12),
   }));
 
-  const annualRows = rows.map((r) => ({
-    amountCents: displayAmount_abs_to_signed(r) * BigInt(12),
-    currency: r.displayAmount.currency,
-    rawData: {} as Record<string, unknown>,
-  }));
-
-  const monthlyTotals = sumByDisplayCurrency(monthlyRows, "native");
-  const annualTotals = sumByDisplayCurrency(annualRows, "native");
+  const monthlyTotals = sumByDisplayCurrency(monthlyRows, displayCurrencyMode);
+  const annualTotals = sumByDisplayCurrency(annualRows, displayCurrencyMode);
 
   return { rows, monthlyTotals, annualTotals };
-}
-
-/** Restore the sign from the original amountCents to the converted display amount. */
-function displayAmount_abs_to_signed(r: SubscriptionRow): bigint {
-  // amountCents is negative for expenses; displayAmountAbsCents is always positive.
-  // Re-apply sign from the original.
-  return r.amountCents < BigInt(0) ? -r.displayAmountAbsCents : r.displayAmountAbsCents;
 }

--- a/src/app/(app)/subscriptions/queries.ts
+++ b/src/app/(app)/subscriptions/queries.ts
@@ -1,0 +1,268 @@
+import { and, asc, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, categories, recurringTransactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { convertToDisplayCurrency, type MoneyAmount } from "@/lib/fx/convert";
+import { sumByDisplayCurrency, type AggregationBucket } from "@/lib/fx/aggregate";
+import type { DisplayCurrencyMode } from "@/lib/db/schema";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SubscriptionRow {
+  id: number;
+  label: string;
+  accountLabel: string;
+  /** Native cents, bigint, signed negative for expenses. */
+  amountCents: bigint;
+  currency: string;
+  dayOfMonth: number;
+  amountType: "fixed" | "variable";
+  /** null when categorySlug is null on the row */
+  categorySlug: string | null;
+  categoryName: string | null;
+  notes: string | null;
+  skippedMonths: string[];
+  /** Next occurrence date as ISO yyyy-mm-dd */
+  nextOccurrence: string;
+  /**
+   * Annual projection in native cents (amountCents × 12).
+   * Expenses are stored as negative — this preserves the sign.
+   */
+  annualCents: bigint;
+  /** Display-currency-converted amount for the row (used for sort + display). */
+  displayAmount: MoneyAmount;
+  /** Absolute display-currency amount for sort ranking (desc). */
+  displayAmountAbsCents: bigint;
+}
+
+export interface SubscriptionsSummary {
+  rows: SubscriptionRow[];
+  /** sumByDisplayCurrency over all rows for the monthly total. */
+  monthlyTotals: AggregationBucket[];
+  /** sumByDisplayCurrency over all rows × 12 for the annual projection. */
+  annualTotals: AggregationBucket[];
+}
+
+// ---------------------------------------------------------------------------
+// Next-occurrence helper (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the next occurrence date (ISO yyyy-mm-dd) for a recurring with the
+ * given `dayOfMonth`.
+ *
+ * Logic:
+ *   - If today's day ≤ dayOfMonth → the next occurrence is this month.
+ *   - Else → the next occurrence is next month.
+ *   - If the computed yyyy-mm is in `skippedMonths`, skip forward by one more
+ *     month (repeat until a non-skipped month is found, up to 24 iterations to
+ *     avoid infinite loops on pathological data).
+ *
+ * `today` is injected so the helper is pure and unit-testable without
+ * Date mocking. Pass `new Date()` from callers in production.
+ */
+export function computeNextOccurrence(
+  dayOfMonth: number,
+  skippedMonths: string[],
+  today: Date,
+): string {
+  const todayDay = today.getUTCDate();
+  const skipped = new Set(skippedMonths);
+
+  let year = today.getUTCFullYear();
+  let month = today.getUTCMonth() + 1; // 1-12
+
+  if (todayDay > dayOfMonth) {
+    // This month's slot already passed — advance to next month.
+    if (month === 12) {
+      year += 1;
+      month = 1;
+    } else {
+      month += 1;
+    }
+  }
+
+  // Walk forward until we find a month not in skippedMonths.
+  for (let i = 0; i < 24; i++) {
+    const ym = `${year}-${String(month).padStart(2, "0")}`;
+    if (!skipped.has(ym)) {
+      return `${ym}-${String(dayOfMonth).padStart(2, "0")}`;
+    }
+    // Advance one more month.
+    if (month === 12) {
+      year += 1;
+      month = 1;
+    } else {
+      month += 1;
+    }
+  }
+
+  // Fallback — should never happen with sane data.
+  const ym = `${year}-${String(month).padStart(2, "0")}`;
+  return `${ym}-${String(dayOfMonth).padStart(2, "0")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Database query
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch all active, non-deleted recurring transactions for `userId` whose
+ * category slug is 'suscripciones', enriched with next-occurrence + display
+ * currency conversion.
+ *
+ * Sorted by display-currency absolute amount descending (most expensive first).
+ */
+export async function getSubscriptions(
+  userId: number,
+  displayCurrencyMode: DisplayCurrencyMode,
+  copPerUsd: number,
+): Promise<SubscriptionsSummary> {
+  const today = new Date();
+
+  const raw = await db
+    .select({
+      id: recurringTransactions.id,
+      label: recurringTransactions.label,
+      amountCents: recurringTransactions.amountCents,
+      currency: recurringTransactions.currency,
+      categorySlug: recurringTransactions.categorySlug,
+      dayOfMonth: recurringTransactions.dayOfMonth,
+      active: recurringTransactions.active,
+      amountType: recurringTransactions.amountType,
+      notes: recurringTransactions.notes,
+      skippedMonths: recurringTransactions.skippedMonths,
+      // Account fields for formatAccountLabel
+      accountName: accounts.name,
+      accountCurrency: accounts.currency,
+      accountInstitution: accounts.institution,
+      // Category name (may be null if the category was deleted concurrently —
+      // the FK is ON DELETE SET NULL)
+      categoryName: categories.name,
+    })
+    .from(recurringTransactions)
+    .innerJoin(
+      accounts,
+      and(
+        eq(accounts.id, recurringTransactions.accountId),
+        // tenant safety: accounts also belong to the user
+        eq(accounts.userId, userId),
+      ),
+    )
+    .leftJoin(
+      categories,
+      and(
+        // tenant safety: categories are unique on (user_id, slug) — NEVER join on slug alone
+        eq(categories.userId, userId),
+        eq(categories.slug, recurringTransactions.categorySlug),
+        notDeleted(categories.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(recurringTransactions.userId, userId),
+        eq(recurringTransactions.active, true),
+        eq(recurringTransactions.categorySlug, "suscripciones"),
+        notDeleted(recurringTransactions.deletedAt),
+      ),
+    )
+    .orderBy(asc(recurringTransactions.label));
+
+  // Recurring rows have no rawData.fx — use live TRM for display conversion.
+  // We pass rawData: {} so convertToDisplayCurrency falls back gracefully:
+  // it will skip conversion if currencies already match (COP), and for USD rows
+  // it will log fx_conversion_missing_trm and return the original currency.
+  // For the subscriptions hub, live-TRM conversion via copPerUsd is better than
+  // a frozen-TRM fallback; we apply it here using the same integer math pattern.
+  const rows: SubscriptionRow[] = raw.map((r) => {
+    const annualCents = r.amountCents * BigInt(12);
+
+    // For recurrings we cannot use frozen TRM (no rawData.fx), so we synthesise
+    // an fx block with the live rate so convertToDisplayCurrency can convert.
+    // We inject it as rawData.fx with trmSource="user_input" to signal live-rate.
+    const syntheticRawData: Record<string, unknown> =
+      r.currency !== "COP"
+        ? {
+            fx: {
+              originalCurrency: r.currency,
+              originalAmountCents:
+                r.amountCents < BigInt(0) ? (-r.amountCents).toString() : r.amountCents.toString(),
+              trmToAccountCurrency: copPerUsd,
+              trmSource: "user_input",
+            },
+          }
+        : {};
+
+    const displayAmount = convertToDisplayCurrency(
+      { amountCents: r.amountCents, currency: r.currency, rawData: syntheticRawData },
+      displayCurrencyMode,
+    );
+
+    const displayAmountAbsCents =
+      displayAmount.cents < BigInt(0) ? -displayAmount.cents : displayAmount.cents;
+
+    const nextOccurrence = computeNextOccurrence(r.dayOfMonth, r.skippedMonths ?? [], today);
+
+    return {
+      id: r.id,
+      label: r.label,
+      accountLabel: formatAccountLabel({
+        name: r.accountName,
+        currency: r.accountCurrency,
+        institution: r.accountInstitution,
+      }),
+      amountCents: r.amountCents,
+      currency: r.currency,
+      dayOfMonth: r.dayOfMonth,
+      amountType: r.amountType,
+      categorySlug: r.categorySlug,
+      categoryName: r.categoryName ?? null,
+      notes: r.notes ?? null,
+      skippedMonths: r.skippedMonths ?? [],
+      nextOccurrence,
+      annualCents,
+      displayAmount,
+      displayAmountAbsCents,
+    };
+  });
+
+  // Sort by display-currency absolute amount descending (most expensive first).
+  rows.sort((a, b) => {
+    if (b.displayAmountAbsCents > a.displayAmountAbsCents) return 1;
+    if (b.displayAmountAbsCents < a.displayAmountAbsCents) return -1;
+    return 0;
+  });
+
+  // Compute monthly and annual display-currency totals.
+  // Monthly: use displayAmount.cents per row (already converted).
+  // Annual: ×12 of the monthly display amounts. We re-use sumByDisplayCurrency
+  // on virtual "12× rows" by adjusting amountCents before passing — simpler than
+  // a manual reduce. We pass rawData={} because conversion is already done;
+  // the synthetic rows have matching currency so no re-conversion happens.
+  const monthlyRows = rows.map((r) => ({
+    amountCents: displayAmount_abs_to_signed(r),
+    currency: r.displayAmount.currency,
+    rawData: {} as Record<string, unknown>,
+  }));
+
+  const annualRows = rows.map((r) => ({
+    amountCents: displayAmount_abs_to_signed(r) * BigInt(12),
+    currency: r.displayAmount.currency,
+    rawData: {} as Record<string, unknown>,
+  }));
+
+  const monthlyTotals = sumByDisplayCurrency(monthlyRows, "native");
+  const annualTotals = sumByDisplayCurrency(annualRows, "native");
+
+  return { rows, monthlyTotals, annualTotals };
+}
+
+/** Restore the sign from the original amountCents to the converted display amount. */
+function displayAmount_abs_to_signed(r: SubscriptionRow): bigint {
+  // amountCents is negative for expenses; displayAmountAbsCents is always positive.
+  // Re-apply sign from the original.
+  return r.amountCents < BigInt(0) ? -r.displayAmountAbsCents : r.displayAmountAbsCents;
+}

--- a/src/components/layout/nav-items.ts
+++ b/src/components/layout/nav-items.ts
@@ -9,6 +9,7 @@ export const NAV_ITEMS: NavItem[] = [
   { href: "/accounts", label: "Accounts" },
   { href: "/budgets", label: "Budgets" },
   { href: "/insights", label: "Insights" },
+  { href: "/subscriptions", label: "Subscriptions" },
   { href: "/imports", label: "Imports" },
   { href: "/settings", label: "Settings" },
 ];

--- a/src/components/subscriptions/subscription-list.tsx
+++ b/src/components/subscriptions/subscription-list.tsx
@@ -1,0 +1,164 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { formatMoney } from "@/lib/money";
+import type { AggregationBucket } from "@/lib/fx/aggregate";
+import type { SubscriptionRow } from "@/app/(app)/subscriptions/queries";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SubscriptionListProps {
+  rows: SubscriptionRow[];
+  monthlyTotals: AggregationBucket[];
+  annualTotals: AggregationBucket[];
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function TotalsHeader({
+  monthlyTotals,
+  annualTotals,
+}: {
+  monthlyTotals: AggregationBucket[];
+  annualTotals: AggregationBucket[];
+}) {
+  if (monthlyTotals.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      {monthlyTotals.map((bucket) => {
+        // Find the matching annual bucket (same currency).
+        const annual = annualTotals.find((b) => b.currency === bucket.currency);
+        return (
+          <Card key={bucket.currency} size="sm">
+            <CardContent className="flex flex-col gap-0.5 py-3">
+              <p className="text-muted-foreground text-xs">Monthly</p>
+              <p className="font-heading text-base font-medium tabular-nums">
+                {formatMoney(
+                  bucket.cents < BigInt(0) ? -bucket.cents : bucket.cents,
+                  bucket.currency as "COP" | "USD",
+                )}
+              </p>
+              {annual && (
+                <p className="text-muted-foreground text-xs tabular-nums">
+                  {formatMoney(
+                    annual.cents < BigInt(0) ? -annual.cents : annual.cents,
+                    annual.currency as "COP" | "USD",
+                  )}{" "}
+                  / year
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+function SubscriptionCard({ row }: { row: SubscriptionRow }) {
+  const absDisplayCents =
+    row.displayAmount.cents < BigInt(0) ? -row.displayAmount.cents : row.displayAmount.cents;
+
+  const absNativeCents = row.amountCents < BigInt(0) ? -row.amountCents : row.amountCents;
+
+  // Show native amount when it differs from display (cross-currency conversion applied).
+  const showNative = row.displayAmount.converted && row.displayAmount.currency !== row.currency;
+
+  return (
+    <Card size="sm">
+      <CardContent className="flex flex-col gap-1.5 py-3">
+        {/* Row: label + badges + amount */}
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex min-w-0 flex-col gap-1">
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="leading-snug font-medium">{row.label}</span>
+              {row.amountType === "variable" && (
+                <Badge variant="outline" className="text-xs">
+                  variable
+                </Badge>
+              )}
+            </div>
+            <p className="text-muted-foreground truncate text-xs">{row.accountLabel}</p>
+            {row.categoryName && (
+              <p className="text-muted-foreground text-xs">{row.categoryName}</p>
+            )}
+          </div>
+
+          {/* Amount block */}
+          <div className="flex shrink-0 flex-col items-end gap-0.5">
+            <p className="font-heading tabular-nums">
+              {row.amountType === "variable" ? "~" : ""}
+              {formatMoney(absDisplayCents, row.displayAmount.currency as "COP" | "USD")}
+            </p>
+            {showNative && (
+              <p className="text-muted-foreground text-xs tabular-nums">
+                ({formatMoney(absNativeCents, row.currency as "COP" | "USD")})
+              </p>
+            )}
+            <p className="text-muted-foreground text-xs tabular-nums">
+              {formatMoney(
+                row.annualCents < BigInt(0) ? -row.annualCents : row.annualCents,
+                row.currency as "COP" | "USD",
+              )}{" "}
+              / year
+            </p>
+          </div>
+        </div>
+
+        {/* Row: next occurrence + day */}
+        <div className="text-muted-foreground flex items-center gap-2 text-xs">
+          <span>Next: {row.nextOccurrence}</span>
+          <span>·</span>
+          <span>Day {row.dayOfMonth}</span>
+          {row.skippedMonths.length > 0 && (
+            <>
+              <span>·</span>
+              <Badge variant="secondary" className="text-xs">
+                {row.skippedMonths.length} skip{row.skippedMonths.length > 1 ? "s" : ""}
+              </Badge>
+            </>
+          )}
+        </div>
+
+        {row.notes && <p className="text-muted-foreground text-xs italic">{row.notes}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main list
+// ---------------------------------------------------------------------------
+
+export function SubscriptionList({ rows, monthlyTotals, annualTotals }: SubscriptionListProps) {
+  if (rows.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center">
+          <p className="text-muted-foreground text-sm">
+            No active subscriptions found. Add them in{" "}
+            <a href="/settings/recurring" className="underline underline-offset-4">
+              Settings → Recurring
+            </a>{" "}
+            with the <strong>suscripciones</strong> category.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <TotalsHeader monthlyTotals={monthlyTotals} annualTotals={annualTotals} />
+      <div className="flex flex-col gap-2">
+        {rows.map((row) => (
+          <SubscriptionCard key={row.id} row={row} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #700

Part of Epic #255 (Subscription Intelligence, sub-tasks A.1 + A.2).

## Summary

- Adds `/subscriptions` route with a full-page hub: lists all detected subscriptions grouped by account, with display-currency totals respecting `displayCurrencyMode`
- Auto-detects subscriptions from recurring transactions (no manual entry required for A.1/A.2 scope)
- Sidebar entry added; soft-delete for accounts applied so archived accounts are excluded from hub totals

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (191 files, 2321 tests)
- [x] `bun run test:e2e` — `/subscriptions` captured in all 4 variants (chromium/mobile × light/dark); pre-existing `home` + `counterparty` failures confirmed identical on `main` (not introduced by this branch)
- [x] manual smoke: `/subscriptions` renders subscription list with per-account grouping, display-currency totals, sort tiebreaker stable