### PR TITLE
feat(insights): TC health check — statement cutoff + utilization alerts (#705)

### DIFF
--- a/src/app/(app)/insights/page.tsx
+++ b/src/app/(app)/insights/page.tsx
@@ -10,9 +10,27 @@ import { getFinancialPeriod } from "@/lib/dashboard/period";
 import { getUiPreferences } from "@/lib/preferences/repo";
 import { formatMoney } from "@/lib/money";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { nowInBogota } from "@/lib/widgets/handlers/_shared";
+import { fetchUserTcSnapshots } from "@/lib/queue/workers/tc-health-check";
+import {
+  computeTcAlerts,
+  type TcCardSnapshot,
+  type TcAlertTrigger,
+} from "@/lib/insights/tc-health";
 import { InsightsViewer } from "./insights-viewer";
 
 export const dynamic = "force-dynamic";
+
+function triggerLabel(trigger: TcAlertTrigger, snap: TcCardSnapshot): string {
+  if (trigger === "statement") {
+    const d = snap.daysToCutoff!;
+    if (d === 0) return "corte hoy";
+    if (d === 1) return "corte mañana";
+    return `corte en ${d} días`;
+  }
+  const pct = snap.utilizationPct;
+  return `cupo al ${pct}%`;
+}
 
 function currentYearMonth(): string {
   const now = new Date();
@@ -77,6 +95,13 @@ export default async function InsightsPage({
   const uncategorizedCount = uncategorized?.count ?? 0;
   const uncategorizedCents = BigInt(uncategorized?.totalCents ?? "0");
 
+  // TC Health card — real-time snapshot of all the user's TCs (#705)
+  const today = nowInBogota(new Date());
+  const tcSnapshots = await fetchUserTcSnapshots(session.id, fx.rate, today);
+  const tcAlerts: Array<{ snap: TcCardSnapshot; triggers: TcAlertTrigger[] }> = tcSnapshots
+    .map((snap) => ({ snap, triggers: computeTcAlerts(snap) }))
+    .filter((a) => a.triggers.length > 0);
+
   return (
     <main className="mx-auto flex w-full max-w-4xl flex-col gap-4 p-4 sm:p-6">
       <header>
@@ -111,6 +136,32 @@ export default async function InsightsPage({
                 Revisar →
               </Link>
             </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* TC Health card (#705) */}
+      <Card className="border-rose-200 bg-rose-50/40 dark:border-rose-900 dark:bg-rose-950/15">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-rose-900 dark:text-rose-200">
+            Salud de tarjetas
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {tcAlerts.length === 0 ? (
+            <p className="text-muted-foreground text-sm">Todas las tarjetas están en orden.</p>
+          ) : (
+            <ul className="flex flex-col gap-1">
+              {tcAlerts.map(({ snap, triggers }) => (
+                <li key={snap.cardId} className="flex items-start justify-between gap-2 text-sm">
+                  <span>
+                    <span className="font-medium">{snap.label}</span>
+                    {" · "}
+                    {triggers.map((t) => triggerLabel(t, snap)).join(" · ")}
+                  </span>
+                </li>
+              ))}
+            </ul>
           )}
         </CardContent>
       </Card>

--- a/src/app/(app)/insights/page.tsx
+++ b/src/app/(app)/insights/page.tsx
@@ -10,8 +10,7 @@ import { getFinancialPeriod } from "@/lib/dashboard/period";
 import { getUiPreferences } from "@/lib/preferences/repo";
 import { formatMoney } from "@/lib/money";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { nowInBogota } from "@/lib/widgets/handlers/_shared";
-import { fetchUserTcSnapshots } from "@/lib/queue/workers/tc-health-check";
+import { fetchUserTcSnapshots, nowInBogota } from "@/lib/insights/tc-health-queries";
 import {
   computeTcAlerts,
   type TcCardSnapshot,

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -44,6 +44,7 @@ export async function registerNode() {
   const { createBudgetCheckWorker } = await import("@/lib/queue/workers/budget-check");
   const { createSmsDriftCheckWorker } = await import("@/lib/queue/workers/sms-drift-check");
   const { createRuleProposalsWorker } = await import("@/lib/queue/workers/rule-proposals");
+  const { createTcHealthCheckWorker } = await import("@/lib/queue/workers/tc-health-check");
   const log = createLogger({ module: "instrumentation" });
 
   // -------------------------------------------------------------------------
@@ -100,6 +101,10 @@ export async function registerNode() {
   // rule-proposals: daily 05:00 COT — detect correction patterns and propose classification rules
   const ruleProposalsQueue = createQueue("rule-proposals");
   createRuleProposalsWorker();
+
+  // tc-health-check: daily 08:00 COT — cutoff ≤3 days + utilization ≥80/90/95%
+  const tcHealthCheckQueue = createQueue("tc-health-check");
+  createTcHealthCheckWorker();
 
   // Graceful shutdown is idempotent — safe to call once after all workers are
   // registered.
@@ -233,9 +238,19 @@ export async function registerNode() {
     },
   );
 
+  // 08:00 COT daily — statement cutoff ≤3 days or utilization ≥80/90/95% (#705)
+  await tcHealthCheckQueue.add(
+    "tc-health-check",
+    {},
+    {
+      repeat: { pattern: "0 8 * * *", tz: "America/Bogota" },
+      jobId: "tc-health-check-recurring",
+    },
+  );
+
   log.info(
     { event: "workers_registered" },
-    "BullMQ workers registered: fx-refresh (15 6,18 * * *), recurring-gap (0 6 5 * *), health-snapshots (0 3 * * *), slo-alerts (*/30 * * * *), gmail-pull (*/5 * * * *), classification-auto-uncategorize (0 4 * * *), recurring-learning (0 4 * * *), budget-check (0 4 * * *), sms-drift-check (30 22 * * *), rule-proposals (0 5 * * *) America/Bogota; classify-tx on-demand",
+    "BullMQ workers registered: fx-refresh (15 6,18 * * *), recurring-gap (0 6 5 * *), health-snapshots (0 3 * * *), slo-alerts (*/30 * * * *), gmail-pull (*/5 * * * *), classification-auto-uncategorize (0 4 * * *), recurring-learning (0 4 * * *), budget-check (0 4 * * *), sms-drift-check (30 22 * * *), rule-proposals (0 5 * * *), tc-health-check (0 8 * * *) America/Bogota; classify-tx on-demand",
   );
 
   // -------------------------------------------------------------------------

--- a/src/lib/insights/tc-health-queries.test.ts
+++ b/src/lib/insights/tc-health-queries.test.ts
@@ -1,0 +1,359 @@
+// Tests for tc-health-queries.ts — snapshot builders and fetchUserTcSnapshots.
+// The DB round-trips are mocked; only the pure logic is tested here.
+
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoist shared mock references
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => ({
+  // db.select chain — two round-trips (multi + single currency)
+  dbSelect: vi.fn(),
+
+  // Multi-currency query chain: .from().leftJoin().where().groupBy()
+  dbMultiFrom: vi.fn(),
+  dbMultiLeftJoin: vi.fn(),
+  dbMultiWhere: vi.fn(),
+  dbMultiGroupBy: vi.fn(),
+
+  // Single-currency query chain: .from().where()
+  dbSingleFrom: vi.fn(),
+  dbSingleWhere: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/db", () => {
+  // Multi-currency chain: .from().leftJoin().where().groupBy()
+  const groupByFn = mocks.dbMultiGroupBy;
+  const multiWhereFn = mocks.dbMultiWhere.mockReturnValue({ groupBy: groupByFn });
+  const leftJoinFn = mocks.dbMultiLeftJoin.mockReturnValue({ where: multiWhereFn });
+  const fromMultiFn = mocks.dbMultiFrom.mockReturnValue({ leftJoin: leftJoinFn });
+
+  // Single-currency chain: .from().where()
+  const whereFn = mocks.dbSingleWhere;
+  const fromSingleFn = mocks.dbSingleFrom.mockReturnValue({ where: whereFn });
+
+  // db.select alternates: 1st call = multi, 2nd call = single
+  mocks.dbSelect.mockImplementation(() => {
+    const callCount = mocks.dbSelect.mock.calls.length;
+    if (callCount === 1) {
+      return { from: fromMultiFn };
+    }
+    return { from: fromSingleFn };
+  });
+
+  return {
+    db: {
+      select: mocks.dbSelect,
+    },
+  };
+});
+
+vi.mock("@/lib/db/schema", () => ({
+  accounts: {
+    id: "id",
+    userId: "user_id",
+    name: "name",
+    institution: "institution",
+    currency: "currency",
+    type: "type",
+    metadata: "metadata",
+    physicalCardId: "physical_card_id",
+    deletedAt: "deleted_at",
+  },
+  physicalCards: {
+    id: "id",
+    userId: "user_id",
+    name: "name",
+    institution: "institution",
+    network: "network",
+    last4: "last4",
+    creditLimitCents: "credit_limit_cents",
+    statementCutoffDay: "statement_cutoff_day",
+  },
+}));
+
+vi.mock("@/lib/db/helpers", () => ({
+  notDeleted: vi.fn(() => "notDeleted()"),
+}));
+
+vi.mock("@/lib/accounts/queries", () => ({
+  derivedBalanceCentsSql: "derived_balance_cents_sql",
+}));
+
+vi.mock("@/lib/accounts/format", () => ({
+  formatAccountLabel: vi.fn((a: { name: string; currency: string }) => `${a.name} (${a.currency})`),
+}));
+
+vi.mock("@/lib/money", () => ({
+  toCop: vi.fn((cents: bigint, _currency: string, _rate: number) => cents),
+}));
+
+vi.mock("@/lib/widgets/handlers/_shared", () => ({
+  nowInBogota: vi.fn(() => ({ year: 2026, month: 5, day: 1 })),
+  roundUtilizationPct: vi.fn((used: bigint, limit: bigint) => {
+    if (limit === BigInt(0)) return 0;
+    return Math.round((Number(used) / Number(limit)) * 100);
+  }),
+}));
+
+vi.mock("@/lib/widgets/handlers/tc-focus", () => ({
+  computeNextCutoff: vi.fn(
+    (_cutoffDay: number, today: { day: number; month: number; year: number }) => {
+      const daysTo = _cutoffDay - today.day;
+      return { next: `2026-05-${String(_cutoffDay).padStart(2, "0")}`, daysTo };
+    },
+  ),
+}));
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const original = await importOriginal<typeof import("drizzle-orm")>();
+  return {
+    ...original,
+    sql: vi.fn(() => "sql()"),
+    isNull: vi.fn(() => "isNull()"),
+    eq: vi.fn(() => "eq()"),
+    and: vi.fn(() => "and()"),
+  };
+});
+
+import {
+  buildMultiSnapshot,
+  buildSingleSnapshot,
+  fetchUserTcSnapshots,
+  type MultiCurrencyRow,
+  type SingleCurrencyRow,
+} from "./tc-health-queries";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rewireDbMock() {
+  const groupByFn = mocks.dbMultiGroupBy;
+  const multiWhereFn = mocks.dbMultiWhere.mockReturnValue({ groupBy: groupByFn });
+  const leftJoinFn = mocks.dbMultiLeftJoin.mockReturnValue({ where: multiWhereFn });
+  const fromMultiFn = mocks.dbMultiFrom.mockReturnValue({ leftJoin: leftJoinFn });
+
+  const whereFn = mocks.dbSingleWhere;
+  const fromSingleFn = mocks.dbSingleFrom.mockReturnValue({ where: whereFn });
+
+  mocks.dbSelect.mockImplementation(() => {
+    const callCount = mocks.dbSelect.mock.calls.length;
+    if (callCount === 1) {
+      return { from: fromMultiFn };
+    }
+    return { from: fromSingleFn };
+  });
+}
+
+const TODAY = { year: 2026, month: 5, day: 1 };
+
+// ---------------------------------------------------------------------------
+// buildMultiSnapshot
+// ---------------------------------------------------------------------------
+
+describe("buildMultiSnapshot", () => {
+  it("computes utilizationPct and usedCents from COP debt", () => {
+    const row: MultiCurrencyRow = {
+      id: "uuid-1",
+      name: "Visa",
+      institution: "Bancolombia",
+      network: "visa",
+      last4: "1234",
+      creditLimitCents: BigInt(10_000_000),
+      statementCutoffDay: null,
+      userId: 1,
+      copDebtCents: BigInt(-9_500_000), // negative = owed
+      usdDebtCents: BigInt(0),
+    };
+    // toCop mock returns cents as-is; usdDebtInCop = 0
+    // available = 10_000_000 + (-9_500_000) + 0 = 500_000
+    // used = 10_000_000 - 500_000 = 9_500_000 → 95%
+    const snap = buildMultiSnapshot(row, 4000, TODAY);
+    expect(snap.cardId).toBe("pc-uuid-1");
+    expect(snap.kind).toBe("physical");
+    expect(snap.currency).toBe("COP");
+    expect(snap.usedCents).toBe(BigInt(9_500_000));
+    expect(snap.utilizationPct).toBe(95);
+  });
+
+  it("clamps usedCents to 0 when debt is positive (credit balance)", () => {
+    const row: MultiCurrencyRow = {
+      id: "uuid-2",
+      name: null,
+      institution: "Banco",
+      network: null,
+      last4: null,
+      creditLimitCents: BigInt(5_000_000),
+      statementCutoffDay: null,
+      userId: 1,
+      copDebtCents: BigInt(100_000), // positive = credit balance (overpaid)
+      usdDebtCents: BigInt(0),
+    };
+    // available = 5_000_000 + 100_000 = 5_100_000 → usedCents = 5_000_000 - 5_100_000 = -100_000 → clamped to 0
+    const snap = buildMultiSnapshot(row, 4000, TODAY);
+    expect(snap.usedCents).toBe(BigInt(0));
+    expect(snap.utilizationPct).toBe(0);
+  });
+
+  it("sets daysToCutoff from statementCutoffDay — mock returns cutoffDay - today.day", () => {
+    const row: MultiCurrencyRow = {
+      id: "uuid-3",
+      name: "Card",
+      institution: "Banco",
+      network: null,
+      last4: null,
+      creditLimitCents: BigInt(1_000_000),
+      statementCutoffDay: 4, // today.day=1 → daysTo=3
+      userId: 1,
+      copDebtCents: BigInt(0),
+      usdDebtCents: BigInt(0),
+    };
+    const snap = buildMultiSnapshot(row, 4000, TODAY);
+    expect(snap.daysToCutoff).toBe(3);
+    expect(snap.cutoffDay).toBe(4);
+  });
+
+  it("uses institution + last4 as label when name is null", () => {
+    const row: MultiCurrencyRow = {
+      id: "uuid-4",
+      name: null,
+      institution: "Davivienda",
+      network: null,
+      last4: "5678",
+      creditLimitCents: BigInt(1_000_000),
+      statementCutoffDay: null,
+      userId: 1,
+      copDebtCents: BigInt(0),
+      usdDebtCents: BigInt(0),
+    };
+    const snap = buildMultiSnapshot(row, 4000, TODAY);
+    expect(snap.label).toBe("Davivienda *5678");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSingleSnapshot
+// ---------------------------------------------------------------------------
+
+describe("buildSingleSnapshot", () => {
+  it("carries native currency on the snapshot", () => {
+    const row: SingleCurrencyRow = {
+      id: 99,
+      name: "USD Card",
+      institution: "Amex",
+      currency: "USD",
+      metadata: { creditLimitCents: 100_000, cutoffDay: 15 },
+      userId: 2,
+      balanceCents: BigInt(-80_000),
+    };
+    const snap = buildSingleSnapshot(row, 4000, TODAY);
+    expect(snap.currency).toBe("USD");
+    expect(snap.cardId).toBe("acc-99");
+    expect(snap.kind).toBe("account");
+  });
+
+  it("usedCents is absolute of negative balance; zero when balance >= 0", () => {
+    const rowDebt: SingleCurrencyRow = {
+      id: 10,
+      name: "COP Card",
+      institution: "Bancolombia",
+      currency: "COP",
+      metadata: { creditLimitCents: 5_000_000 },
+      userId: 1,
+      balanceCents: BigInt(-2_000_000),
+    };
+    const snapDebt = buildSingleSnapshot(rowDebt, 4000, TODAY);
+    expect(snapDebt.usedCents).toBe(BigInt(2_000_000));
+
+    const rowCredit: SingleCurrencyRow = { ...rowDebt, balanceCents: BigInt(100_000) };
+    const snapCredit = buildSingleSnapshot(rowCredit, 4000, TODAY);
+    expect(snapCredit.usedCents).toBe(BigInt(0));
+  });
+
+  it("daysToCutoff is null when cutoffDay is null", () => {
+    const row: SingleCurrencyRow = {
+      id: 11,
+      name: "No Cutoff",
+      institution: "Nequi",
+      currency: "COP",
+      metadata: { creditLimitCents: 1_000_000 },
+      userId: 1,
+      balanceCents: BigInt(0),
+    };
+    const snap = buildSingleSnapshot(row, 4000, TODAY);
+    expect(snap.daysToCutoff).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchUserTcSnapshots
+// ---------------------------------------------------------------------------
+
+describe("fetchUserTcSnapshots", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    rewireDbMock();
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty array when no cards exist", async () => {
+    mocks.dbMultiGroupBy.mockResolvedValueOnce([]);
+    mocks.dbSingleWhere.mockResolvedValueOnce([]);
+
+    const snaps = await fetchUserTcSnapshots(1, 4000, TODAY);
+    expect(snaps).toEqual([]);
+  });
+
+  it("skips multi-currency cards with no cutoff AND zero limit", async () => {
+    mocks.dbMultiGroupBy.mockResolvedValueOnce([
+      {
+        id: "skip",
+        name: null,
+        institution: "Banco",
+        network: null,
+        last4: null,
+        // Drizzle returns bigint for this column; the map pass-through keeps it as-is
+        creditLimitCents: BigInt(0),
+        statementCutoffDay: null,
+        userId: 1,
+        copDebtCents: "0",
+        usdDebtCents: "0",
+      },
+    ]);
+    mocks.dbSingleWhere.mockResolvedValueOnce([]);
+
+    const snaps = await fetchUserTcSnapshots(1, 4000, TODAY);
+    expect(snaps).toHaveLength(0);
+  });
+
+  it("includes a multi-currency card that has a non-zero limit", async () => {
+    mocks.dbMultiGroupBy.mockResolvedValueOnce([
+      {
+        id: "uuid-5",
+        name: "Visa",
+        institution: "Bancolombia",
+        network: "visa",
+        last4: "0001",
+        creditLimitCents: BigInt(10_000_000),
+        statementCutoffDay: null,
+        userId: 1,
+        copDebtCents: "-5000000",
+        usdDebtCents: "0",
+      },
+    ]);
+    mocks.dbSingleWhere.mockResolvedValueOnce([]);
+
+    const snaps = await fetchUserTcSnapshots(1, 4000, TODAY);
+    expect(snaps).toHaveLength(1);
+    expect(snaps[0]!.cardId).toBe("pc-uuid-5");
+    expect(snaps[0]!.currency).toBe("COP");
+  });
+});

--- a/src/lib/insights/tc-health-queries.ts
+++ b/src/lib/insights/tc-health-queries.ts
@@ -1,0 +1,272 @@
+/**
+ * TC health-check DB helpers — pure data fetching, no BullMQ dependency.
+ *
+ * Extracted from the worker so the /insights page (RSC) can import these
+ * without transitively pulling BullMQ / ioredis into the route module graph.
+ *
+ * Two query paths:
+ *   - fetchMultiCurrencyCards: physical_cards LEFT JOIN accounts, aggregated into
+ *     COP + USD debt buckets.
+ *   - fetchSingleCurrencyCards: plain credit_card accounts (no physicalCardId).
+ *
+ * Snapshot builders convert raw DB rows into TcCardSnapshot values ready for
+ * computeTcAlerts().
+ */
+
+import { and, eq, isNull, sql } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { accounts, physicalCards, type AccountMetadata } from "@/lib/db/schema";
+import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
+import { notDeleted } from "@/lib/db/helpers";
+import { toCop } from "@/lib/money";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { nowInBogota, roundUtilizationPct, type BogotaYmd } from "@/lib/widgets/handlers/_shared";
+import { computeNextCutoff } from "@/lib/widgets/handlers/tc-focus";
+import type { TcCardSnapshot } from "@/lib/insights/tc-health";
+
+// ---------------------------------------------------------------------------
+// Internal row types
+// ---------------------------------------------------------------------------
+
+export type MultiCurrencyRow = {
+  id: string;
+  name: string | null;
+  institution: string;
+  network: string | null;
+  last4: string | null;
+  creditLimitCents: bigint;
+  statementCutoffDay: number | null;
+  userId: number;
+  /** SUM of COP sub-account balances (negative when in debt) */
+  copDebtCents: bigint;
+  /** SUM of USD sub-account balances (negative when in debt), in USD cents */
+  usdDebtCents: bigint;
+};
+
+export type SingleCurrencyRow = {
+  id: number;
+  name: string;
+  institution: string;
+  currency: "COP" | "USD";
+  metadata: AccountMetadata;
+  userId: number;
+  balanceCents: bigint;
+};
+
+const BI_ZERO = BigInt(0);
+
+// ---------------------------------------------------------------------------
+// Queries — two round-trips for the whole tenant roster, not N+1.
+// Tenant safety: JOIN ON pairs user_id (memory per-user-table-join-tenant-safety).
+// ---------------------------------------------------------------------------
+
+export async function fetchMultiCurrencyCards(userId?: number): Promise<MultiCurrencyRow[]> {
+  const rows = await db
+    .select({
+      id: physicalCards.id,
+      name: physicalCards.name,
+      institution: physicalCards.institution,
+      network: physicalCards.network,
+      last4: physicalCards.last4,
+      creditLimitCents: physicalCards.creditLimitCents,
+      statementCutoffDay: physicalCards.statementCutoffDay,
+      userId: physicalCards.userId,
+      copDebtCents: sql<string>`
+        COALESCE(SUM(CASE WHEN ${accounts.currency} = 'COP' THEN ${derivedBalanceCentsSql} ELSE 0 END), 0)
+      `,
+      usdDebtCents: sql<string>`
+        COALESCE(SUM(CASE WHEN ${accounts.currency} = 'USD' THEN ${derivedBalanceCentsSql} ELSE 0 END), 0)
+      `,
+    })
+    .from(physicalCards)
+    .leftJoin(
+      accounts,
+      and(
+        eq(accounts.physicalCardId, physicalCards.id),
+        // Tenancy guard: pair user_id in the JOIN ON clause (memory per-user-table-join-tenant-safety)
+        eq(accounts.userId, physicalCards.userId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .where(userId !== undefined ? eq(physicalCards.userId, userId) : undefined)
+    .groupBy(
+      physicalCards.id,
+      physicalCards.name,
+      physicalCards.institution,
+      physicalCards.network,
+      physicalCards.last4,
+      physicalCards.creditLimitCents,
+      physicalCards.statementCutoffDay,
+      physicalCards.userId,
+    );
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    institution: r.institution,
+    network: r.network,
+    last4: r.last4,
+    creditLimitCents: r.creditLimitCents,
+    statementCutoffDay: r.statementCutoffDay ?? null,
+    userId: r.userId,
+    copDebtCents: BigInt(r.copDebtCents),
+    usdDebtCents: BigInt(r.usdDebtCents),
+  }));
+}
+
+export async function fetchSingleCurrencyCards(userId?: number): Promise<SingleCurrencyRow[]> {
+  const rows = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      institution: accounts.institution,
+      currency: accounts.currency,
+      metadata: accounts.metadata,
+      userId: accounts.userId,
+      balanceCents: derivedBalanceCentsSql,
+    })
+    .from(accounts)
+    .where(
+      and(
+        userId !== undefined ? eq(accounts.userId, userId) : undefined,
+        eq(accounts.type, "credit_card"),
+        // Absence of physicalCardId distinguishes "plain" TCs from multi-currency sub-accounts
+        isNull(accounts.physicalCardId),
+        notDeleted(accounts.deletedAt),
+      ),
+    );
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    institution: r.institution,
+    currency: r.currency as "COP" | "USD",
+    metadata: (r.metadata ?? {}) as AccountMetadata,
+    userId: r.userId,
+    balanceCents: BigInt(r.balanceCents),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot builders — bigint math, no float coercions
+// ---------------------------------------------------------------------------
+
+export function buildMultiSnapshot(
+  row: MultiCurrencyRow,
+  copPerUsd: number,
+  today: BogotaYmd,
+): TcCardSnapshot {
+  // Mirrors projectMultiCurrency in mis-tcs.ts
+  const usdDebtInCop = toCop(row.usdDebtCents, "USD", copPerUsd);
+  const availableCents = row.creditLimitCents + row.copDebtCents + usdDebtInCop;
+  const usedCents = row.creditLimitCents - availableCents;
+  const usedClamped = usedCents < BI_ZERO ? BI_ZERO : usedCents;
+
+  const utilizationPct = roundUtilizationPct(usedClamped, row.creditLimitCents);
+
+  const label =
+    row.name?.trim() ||
+    [row.institution, row.last4 ? `*${row.last4}` : null].filter(Boolean).join(" ") ||
+    "Tarjeta de crédito";
+
+  const daysToCutoff =
+    row.statementCutoffDay !== null
+      ? computeNextCutoff(row.statementCutoffDay, today).daysTo
+      : null;
+
+  return {
+    cardId: `pc-${row.id}`,
+    kind: "physical",
+    label,
+    cutoffDay: row.statementCutoffDay,
+    // Multi-currency cards aggregate all debt into COP
+    currency: "COP",
+    creditLimitCents: row.creditLimitCents,
+    usedCents: usedClamped,
+    utilizationPct,
+    daysToCutoff,
+  };
+}
+
+export function buildSingleSnapshot(
+  row: SingleCurrencyRow,
+  copPerUsd: number,
+  today: BogotaYmd,
+): TcCardSnapshot {
+  // Mirrors projectSingleCurrency in mis-tcs.ts
+  const limitNativeCents = BigInt(row.metadata.creditLimitCents ?? 0);
+  const usedNativeCents = row.balanceCents < BI_ZERO ? -row.balanceCents : BI_ZERO;
+
+  // Utilization on native cents (ratio is invariant under positive-rate scaling)
+  const utilizationPct = roundUtilizationPct(usedNativeCents, limitNativeCents);
+
+  const cutoffDay = row.metadata.cutoffDay ?? null;
+  const daysToCutoff = cutoffDay !== null ? computeNextCutoff(cutoffDay, today).daysTo : null;
+
+  const label = formatAccountLabel(
+    {
+      name: row.name,
+      currency: row.currency,
+      institution: row.institution,
+      metadata: { last4s: row.metadata.last4s ?? null },
+    },
+    { withInstitution: true },
+  );
+
+  return {
+    cardId: `acc-${row.id}`,
+    kind: "account",
+    label,
+    cutoffDay,
+    // Single-currency card retains its native currency (COP or USD)
+    currency: row.currency,
+    creditLimitCents: limitNativeCents,
+    usedCents: usedNativeCents,
+    utilizationPct,
+    daysToCutoff,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-user snapshot fetch — used by the /insights page card.
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch and build TcCardSnapshot[] for a single user. Used by the /insights
+ * page real-time card. Cards with no cupo AND no cutoff are excluded.
+ *
+ * @param userId   The authenticated user's id.
+ * @param fxRate   Current COP/USD FX rate (from `getCurrentFxRate().rate`).
+ * @param today    Bogota date (from `nowInBogota(new Date())`).
+ */
+export async function fetchUserTcSnapshots(
+  userId: number,
+  fxRate: number,
+  today: BogotaYmd,
+): Promise<TcCardSnapshot[]> {
+  const [multiRows, singleRows] = await Promise.all([
+    fetchMultiCurrencyCards(userId),
+    fetchSingleCurrencyCards(userId),
+  ]);
+
+  const snapshots: TcCardSnapshot[] = [];
+
+  for (const row of multiRows) {
+    if (row.statementCutoffDay === null && row.creditLimitCents === BI_ZERO) continue;
+    snapshots.push(buildMultiSnapshot(row, fxRate, today));
+  }
+
+  for (const row of singleRows) {
+    const limitCents = BigInt(row.metadata.creditLimitCents ?? 0);
+    const cutoffDay = row.metadata.cutoffDay ?? null;
+    if (cutoffDay === null && limitCents === BI_ZERO) continue;
+    snapshots.push(buildSingleSnapshot(row, fxRate, today));
+  }
+
+  return snapshots;
+}
+
+// Re-export nowInBogota so callers that only use this module don't need to
+// import _shared separately.
+export { nowInBogota };

--- a/src/lib/insights/tc-health.test.ts
+++ b/src/lib/insights/tc-health.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { computeTcAlerts, type TcCardSnapshot } from "./tc-health";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSnapshot(overrides: Partial<TcCardSnapshot> = {}): TcCardSnapshot {
+  return {
+    cardId: "pc-test-uuid",
+    kind: "physical",
+    label: "Visa *1234",
+    cutoffDay: null,
+    creditLimitCents: BigInt(10_000_000), // $100 000 COP
+    usedCents: BigInt(0),
+    utilizationPct: 0,
+    daysToCutoff: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Utilization threshold tests
+// ---------------------------------------------------------------------------
+
+describe("computeTcAlerts — utilization", () => {
+  it("returns [] when util is 0%", () => {
+    const s = makeSnapshot({ utilizationPct: 0, usedCents: BigInt(0) });
+    expect(computeTcAlerts(s)).toEqual([]);
+  });
+
+  it("returns [] when util is 79%", () => {
+    const s = makeSnapshot({ utilizationPct: 79 });
+    expect(computeTcAlerts(s)).toEqual([]);
+  });
+
+  it("returns ['util-80'] when util is exactly 80%", () => {
+    const s = makeSnapshot({ utilizationPct: 80 });
+    expect(computeTcAlerts(s)).toEqual(["util-80"]);
+  });
+
+  it("returns ['util-80'] when util is 85% (between 80 and 90)", () => {
+    const s = makeSnapshot({ utilizationPct: 85 });
+    expect(computeTcAlerts(s)).toEqual(["util-80"]);
+  });
+
+  it("returns ['util-90'] when util is exactly 90% — NOT util-80", () => {
+    const s = makeSnapshot({ utilizationPct: 90 });
+    expect(computeTcAlerts(s)).toEqual(["util-90"]);
+  });
+
+  it("returns ['util-90'] when util is 92%", () => {
+    const s = makeSnapshot({ utilizationPct: 92 });
+    expect(computeTcAlerts(s)).toEqual(["util-90"]);
+  });
+
+  it("returns ['util-95'] when util is exactly 95% — NOT util-90", () => {
+    const s = makeSnapshot({ utilizationPct: 95 });
+    expect(computeTcAlerts(s)).toEqual(["util-95"]);
+  });
+
+  it("returns ['util-95'] when util is 100%", () => {
+    const s = makeSnapshot({ utilizationPct: 100 });
+    expect(computeTcAlerts(s)).toEqual(["util-95"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Statement cutoff tests
+// ---------------------------------------------------------------------------
+
+describe("computeTcAlerts — statement cutoff", () => {
+  it("returns [] when cutoffDay is null", () => {
+    const s = makeSnapshot({ daysToCutoff: null });
+    expect(computeTcAlerts(s)).toEqual([]);
+  });
+
+  it("returns [] when daysToCutoff is 4 (outside window)", () => {
+    const s = makeSnapshot({ daysToCutoff: 4 });
+    expect(computeTcAlerts(s)).toEqual([]);
+  });
+
+  it("returns ['statement'] when daysToCutoff is exactly 3 (boundary)", () => {
+    const s = makeSnapshot({ daysToCutoff: 3 });
+    expect(computeTcAlerts(s)).toContain("statement");
+  });
+
+  it("returns ['statement'] when daysToCutoff is 2", () => {
+    const s = makeSnapshot({ daysToCutoff: 2 });
+    expect(computeTcAlerts(s)).toContain("statement");
+  });
+
+  it("returns ['statement'] when daysToCutoff is 1", () => {
+    const s = makeSnapshot({ daysToCutoff: 1 });
+    expect(computeTcAlerts(s)).toContain("statement");
+  });
+
+  it("returns ['statement'] when daysToCutoff is 0 (today is cutoff day)", () => {
+    const s = makeSnapshot({ daysToCutoff: 0 });
+    expect(computeTcAlerts(s)).toContain("statement");
+  });
+
+  it("returns [] when daysToCutoff is -1 (cutoff passed this cycle)", () => {
+    const s = makeSnapshot({ daysToCutoff: -1 });
+    expect(computeTcAlerts(s)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Combined triggers
+// ---------------------------------------------------------------------------
+
+describe("computeTcAlerts — combined triggers", () => {
+  it("returns ['util-90', 'statement'] when both fire together", () => {
+    const s = makeSnapshot({ utilizationPct: 92, daysToCutoff: 2 });
+    const result = computeTcAlerts(s);
+    expect(result).toContain("util-90");
+    expect(result).toContain("statement");
+    // Util comes before statement in the return order
+    expect(result.indexOf("util-90")).toBeLessThan(result.indexOf("statement"));
+  });
+
+  it("returns ['util-95', 'statement'] at 97% util + 0 days", () => {
+    const s = makeSnapshot({ utilizationPct: 97, daysToCutoff: 0 });
+    const result = computeTcAlerts(s);
+    expect(result).toContain("util-95");
+    expect(result).toContain("statement");
+    expect(result).not.toContain("util-90");
+    expect(result).not.toContain("util-80");
+  });
+
+  it("returns only util when cutoff is far", () => {
+    const s = makeSnapshot({ utilizationPct: 83, daysToCutoff: 10 });
+    const result = computeTcAlerts(s);
+    expect(result).toEqual(["util-80"]);
+  });
+
+  it("returns only statement when util is low", () => {
+    const s = makeSnapshot({ utilizationPct: 30, daysToCutoff: 1 });
+    const result = computeTcAlerts(s);
+    expect(result).toEqual(["statement"]);
+  });
+
+  it("returns [] when both util is 0% and no cutoff", () => {
+    const s = makeSnapshot({
+      utilizationPct: 0,
+      daysToCutoff: null,
+      creditLimitCents: BigInt(0),
+      usedCents: BigInt(0),
+    });
+    expect(computeTcAlerts(s)).toEqual([]);
+  });
+});

--- a/src/lib/insights/tc-health.test.ts
+++ b/src/lib/insights/tc-health.test.ts
@@ -11,6 +11,7 @@ function makeSnapshot(overrides: Partial<TcCardSnapshot> = {}): TcCardSnapshot {
     kind: "physical",
     label: "Visa *1234",
     cutoffDay: null,
+    currency: "COP",
     creditLimitCents: BigInt(10_000_000), // $100 000 COP
     usedCents: BigInt(0),
     utilizationPct: 0,

--- a/src/lib/insights/tc-health.ts
+++ b/src/lib/insights/tc-health.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure TC health-check logic — no DB, no side effects.
+ *
+ * Consumed by two callers:
+ *  1. The daily cron worker (`src/lib/queue/workers/tc-health-check.ts`) that
+ *     emits notifications for each triggered card.
+ *  2. The `/insights` page card that runs the same logic in real-time for the
+ *     signed-in user.
+ *
+ * Two alert kinds are detected:
+ *  - Statement cutoff approaching: `daysToCutoff` in [0, 3].
+ *    "0" means today is the cutoff day. Negative (cutoff already passed this
+ *    cycle) produces no alert — the next cycle begins immediately.
+ *  - Utilization threshold crossed: highest of 80 / 90 / 95% crossed.
+ *    Only the highest bucket is returned (additive by entityId in the worker,
+ *    but `computeTcAlerts` returns the worst tier, not all tiers).
+ *
+ * Multi-currency cards with `cutoffDay = null` AND `creditLimitCents = 0` are
+ * silently skipped by callers — there is nothing to alert on (no cutoff, no cupo).
+ */
+
+export type TcAlertTrigger = "statement" | "util-80" | "util-90" | "util-95";
+
+export type TcCardSnapshot = {
+  /** physicalCard.id (uuid) prefixed "pc-" OR account.id (number) prefixed "acc-" */
+  cardId: string;
+  kind: "physical" | "account";
+  /** Ready-formatted card name for display and notification titles */
+  label: string;
+  cutoffDay: number | null;
+  creditLimitCents: bigint;
+  usedCents: bigint;
+  /** Pre-computed — roundUtilizationPct(usedCents, creditLimitCents) */
+  utilizationPct: number;
+  /** Days to next statement cutoff as of `today`, or null if cutoffDay is null */
+  daysToCutoff: number | null;
+};
+
+/** Number of days before the statement cutoff that triggers the alert */
+const STATEMENT_WINDOW_DAYS = 3;
+
+/** Utilization thresholds in ascending order */
+const UTIL_THRESHOLDS = [80, 90, 95] as const;
+
+/**
+ * Given a snapshot, return the list of alert triggers that have fired.
+ * Order: utilization alert first (if any), then statement alert.
+ *
+ * Rules:
+ * - Util: returns AT MOST ONE trigger — the highest bucket crossed. A card at
+ *   92% gets `["util-90"]`, not `["util-80", "util-90"]`. The worker assigns
+ *   distinct entityIds per bucket so crossing 95% later still fires a new
+ *   notification.
+ * - Statement: fires when `daysToCutoff` is in [0, STATEMENT_WINDOW_DAYS].
+ *   daysToCutoff < 0 (cutoff already passed) → no alert.
+ * - Cards with `creditLimitCents = 0` AND `cutoffDay = null` return [].
+ */
+export function computeTcAlerts(snapshot: TcCardSnapshot): TcAlertTrigger[] {
+  const triggers: TcAlertTrigger[] = [];
+
+  // Utilization check — highest bucket only
+  for (let i = UTIL_THRESHOLDS.length - 1; i >= 0; i--) {
+    if (snapshot.utilizationPct >= UTIL_THRESHOLDS[i]!) {
+      triggers.push(`util-${UTIL_THRESHOLDS[i]}` as TcAlertTrigger);
+      break;
+    }
+  }
+
+  // Statement cutoff check
+  if (
+    snapshot.daysToCutoff !== null &&
+    snapshot.daysToCutoff >= 0 &&
+    snapshot.daysToCutoff <= STATEMENT_WINDOW_DAYS
+  ) {
+    triggers.push("statement");
+  }
+
+  return triggers;
+}

--- a/src/lib/insights/tc-health.ts
+++ b/src/lib/insights/tc-health.ts
@@ -28,6 +28,12 @@ export type TcCardSnapshot = {
   /** Ready-formatted card name for display and notification titles */
   label: string;
   cutoffDay: number | null;
+  /**
+   * Currency of creditLimitCents and usedCents.
+   * Multi-currency physical cards aggregate all debt into COP.
+   * Single-currency accounts carry their native currency (COP or USD).
+   */
+  currency: "COP" | "USD";
   creditLimitCents: bigint;
   usedCents: bigint;
   /** Pre-computed — roundUtilizationPct(usedCents, creditLimitCents) */

--- a/src/lib/notifications/emit.ts
+++ b/src/lib/notifications/emit.ts
@@ -29,7 +29,8 @@ export type NotificationType =
   | "invite_code_exhausted"
   | "classification_auto_uncategorized"
   | "recurring_proposal_ready"
-  | "subscription_price_hike";
+  | "subscription_price_hike"
+  | "tc_health_alert";
 
 export type NotificationAudience = "user" | "admin";
 export type NotificationPriority = "high" | "medium" | "low";

--- a/src/lib/queue/workers/tc-health-check.test.ts
+++ b/src/lib/queue/workers/tc-health-check.test.ts
@@ -1,0 +1,406 @@
+// Tests for the tc-health-check BullMQ worker.
+// The processor is tested directly — no Worker instantiation needed.
+
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoist shared mock references so they work inside vi.mock factories.
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => ({
+  // db.select chain — two round-trips (multi + single currency)
+  dbSelect: vi.fn(),
+
+  // Multi-currency query chain: .from().leftJoin().where().groupBy()
+  dbMultiFrom: vi.fn(),
+  dbMultiLeftJoin: vi.fn(),
+  dbMultiWhere: vi.fn(),
+  dbMultiGroupBy: vi.fn(),
+
+  // Single-currency query chain: .from().where()
+  dbSingleFrom: vi.fn(),
+  dbSingleWhere: vi.fn(),
+
+  // emitNotification
+  emitNotification: vi.fn(),
+
+  // getCurrentFxRate
+  getCurrentFxRate: vi.fn(),
+
+  // logger
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+  logDebug: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/db", () => {
+  // Multi-currency chain: .from().leftJoin().where().groupBy()
+  const groupByFn = mocks.dbMultiGroupBy;
+  const multiWhereFn = mocks.dbMultiWhere.mockReturnValue({ groupBy: groupByFn });
+  const leftJoinFn = mocks.dbMultiLeftJoin.mockReturnValue({ where: multiWhereFn });
+  const fromMultiFn = mocks.dbMultiFrom.mockReturnValue({ leftJoin: leftJoinFn });
+
+  // Single-currency chain: .from().where()
+  const whereFn = mocks.dbSingleWhere;
+  const fromSingleFn = mocks.dbSingleFrom.mockReturnValue({ where: whereFn });
+
+  // db.select alternates: 1st call = multi, 2nd call = single
+  mocks.dbSelect.mockImplementation(() => {
+    const callCount = mocks.dbSelect.mock.calls.length;
+    if (callCount === 1) {
+      return { from: fromMultiFn };
+    }
+    return { from: fromSingleFn };
+  });
+
+  return {
+    db: {
+      select: mocks.dbSelect,
+    },
+  };
+});
+
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: mocks.logInfo,
+    error: mocks.logError,
+    debug: mocks.logDebug,
+    warn: mocks.logWarn,
+  }),
+}));
+
+vi.mock("@/lib/notifications/emit", () => ({
+  emitNotification: mocks.emitNotification,
+}));
+
+vi.mock("@/lib/fx/repo", () => ({
+  getCurrentFxRate: mocks.getCurrentFxRate,
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  accounts: {
+    id: "id",
+    userId: "user_id",
+    name: "name",
+    institution: "institution",
+    currency: "currency",
+    type: "type",
+    metadata: "metadata",
+    physicalCardId: "physical_card_id",
+    deletedAt: "deleted_at",
+  },
+  physicalCards: {
+    id: "id",
+    userId: "user_id",
+    name: "name",
+    institution: "institution",
+    network: "network",
+    last4: "last4",
+    creditLimitCents: "credit_limit_cents",
+    statementCutoffDay: "statement_cutoff_day",
+  },
+}));
+
+vi.mock("@/lib/db/helpers", () => ({
+  notDeleted: vi.fn(() => "notDeleted()"),
+}));
+
+vi.mock("@/lib/accounts/queries", () => ({
+  derivedBalanceCentsSql: "derived_balance_cents_sql",
+}));
+
+vi.mock("@/lib/accounts/format", () => ({
+  formatAccountLabel: vi.fn((a: { name: string; currency: string }) => `${a.name} (${a.currency})`),
+}));
+
+vi.mock("@/lib/money", () => ({
+  toCop: vi.fn((cents: bigint, _currency: string, _rate: number) => cents),
+}));
+
+vi.mock("@/lib/widgets/handlers/_shared", () => ({
+  nowInBogota: vi.fn(() => ({ year: 2026, month: 5, day: 1 })),
+  roundUtilizationPct: vi.fn((used: bigint, limit: bigint) => {
+    if (limit === BigInt(0)) return 0;
+    return Math.round((Number(used) / Number(limit)) * 100);
+  }),
+}));
+
+vi.mock("@/lib/widgets/handlers/tc-focus", () => ({
+  computeNextCutoff: vi.fn(
+    (_cutoffDay: number, today: { day: number; month: number; year: number }) => {
+      // Simple mock: cutoff is cutoffDay - today.day days away
+      const daysTo = _cutoffDay - today.day;
+      return { next: `2026-05-${String(_cutoffDay).padStart(2, "0")}`, daysTo };
+    },
+  ),
+}));
+
+// aliasedTable stub
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const original = await importOriginal<typeof import("drizzle-orm")>();
+  return {
+    ...original,
+    sql: vi.fn(() => "sql()"),
+    isNull: vi.fn(() => "isNull()"),
+    eq: vi.fn(() => "eq()"),
+    and: vi.fn(() => "and()"),
+  };
+});
+
+import type { Job } from "bullmq";
+import {
+  tcHealthCheckProcessor,
+  getCurrentYearMonth,
+  type TcHealthCheckJobData,
+} from "./tc-health-check";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeJob(data: TcHealthCheckJobData = {}): Job<TcHealthCheckJobData> {
+  return {
+    id: "test-job-tc-health",
+    data,
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Job<TcHealthCheckJobData>;
+}
+
+/** Reset and re-wire mock chains after vi.resetAllMocks. */
+function rewireDbMock() {
+  const groupByFn = mocks.dbMultiGroupBy;
+  const multiWhereFn = mocks.dbMultiWhere.mockReturnValue({ groupBy: groupByFn });
+  const leftJoinFn = mocks.dbMultiLeftJoin.mockReturnValue({ where: multiWhereFn });
+  const fromMultiFn = mocks.dbMultiFrom.mockReturnValue({ leftJoin: leftJoinFn });
+
+  const whereFn = mocks.dbSingleWhere;
+  const fromSingleFn = mocks.dbSingleFrom.mockReturnValue({ where: whereFn });
+
+  mocks.dbSelect.mockImplementation(() => {
+    const callCount = mocks.dbSelect.mock.calls.length;
+    if (callCount === 1) {
+      return { from: fromMultiFn };
+    }
+    return { from: fromSingleFn };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// getCurrentYearMonth
+// ---------------------------------------------------------------------------
+
+describe("getCurrentYearMonth", () => {
+  it("returns a string matching YYYY-MM format", () => {
+    const ym = getCurrentYearMonth();
+    expect(ym).toMatch(/^\d{4}-\d{2}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tcHealthCheckProcessor
+// ---------------------------------------------------------------------------
+
+describe("tcHealthCheckProcessor", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    rewireDbMock();
+    // Default FX rate — not used unless USD involved
+    mocks.getCurrentFxRate.mockResolvedValue({ rate: 4000, source: "db", fetchedAt: new Date() });
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 1: No cards — completes cleanly without emit
+  // -------------------------------------------------------------------------
+  it("completes without error or emit when no cards exist", async () => {
+    mocks.dbMultiGroupBy.mockResolvedValueOnce([]);
+    mocks.dbSingleWhere.mockResolvedValueOnce([]);
+
+    await expect(tcHealthCheckProcessor(makeJob())).resolves.toBeUndefined();
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: Multi-currency card with high utilization → emit util-95
+  // -------------------------------------------------------------------------
+  it("emits util-95 notification for a multi-currency card at 95% utilization", async () => {
+    // creditLimit = 10_000_000, cop debt = 9_500_000 → used=9_500_000 → 95%
+    const limit = BigInt(10_000_000);
+    const debt = BigInt(-9_500_000); // balances are negative = debt
+    mocks.dbMultiGroupBy.mockResolvedValueOnce([
+      {
+        id: "uuid-card-1",
+        name: "Visa Premium",
+        institution: "Bancolombia",
+        network: "visa",
+        last4: "1234",
+        creditLimitCents: limit,
+        statementCutoffDay: null, // no cutoff
+        userId: 1,
+        copDebtCents: debt.toString(),
+        usdDebtCents: "0",
+      },
+    ]);
+    mocks.dbSingleWhere.mockResolvedValueOnce([]);
+    mocks.emitNotification.mockResolvedValue({ id: 10 });
+
+    await tcHealthCheckProcessor(makeJob());
+
+    expect(mocks.emitNotification).toHaveBeenCalledOnce();
+    const [userId, input] = mocks.emitNotification.mock.calls[0] as [
+      number,
+      Parameters<typeof mocks.emitNotification>[1],
+    ];
+    expect(userId).toBe(1);
+    expect(input.type).toBe("tc_health_alert");
+    expect(input.entityId).toMatch(/^tc-alert-pc-uuid-card-1-\d{4}-\d{2}-util-/);
+    expect(input.priority).toBe("medium");
+    expect(input.actionUrl).toBe("/insights");
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: Single-currency card with statement approaching → emit statement
+  // -------------------------------------------------------------------------
+  it("emits statement notification for a single-currency card with cutoff in 2 days", async () => {
+    mocks.dbMultiGroupBy.mockResolvedValueOnce([]);
+    mocks.dbSingleWhere.mockResolvedValueOnce([
+      {
+        id: 42,
+        name: "MasterCard",
+        institution: "Davivienda",
+        currency: "COP",
+        metadata: {
+          creditLimitCents: 5_000_000,
+          cutoffDay: 3, // mocked today.day = 1 → daysTo = 2
+        },
+        userId: 2,
+        balanceCents: "0", // no debt
+      },
+    ]);
+    mocks.emitNotification.mockResolvedValue({ id: 20 });
+
+    await tcHealthCheckProcessor(makeJob());
+
+    expect(mocks.emitNotification).toHaveBeenCalledOnce();
+    const [userId, input] = mocks.emitNotification.mock.calls[0] as [
+      number,
+      Parameters<typeof mocks.emitNotification>[1],
+    ];
+    expect(userId).toBe(2);
+    expect(input.type).toBe("tc_health_alert");
+    expect(input.entityId).toMatch(/statement$/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4: Dedup — emitNotification returns null, no error
+  // -------------------------------------------------------------------------
+  it("handles dedup gracefully when emitNotification returns null", async () => {
+    mocks.dbMultiGroupBy.mockResolvedValueOnce([]);
+    mocks.dbSingleWhere.mockResolvedValueOnce([
+      {
+        id: 7,
+        name: "Card",
+        institution: "Nequi",
+        currency: "COP",
+        metadata: { creditLimitCents: 2_000_000, cutoffDay: 2 }, // daysTo = 1
+        userId: 3,
+        balanceCents: "0",
+      },
+    ]);
+    mocks.emitNotification.mockResolvedValue(null); // deduped
+
+    await expect(tcHealthCheckProcessor(makeJob())).resolves.toBeUndefined();
+    expect(mocks.emitNotification).toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 5: Per-card emit failure is contained — other cards still process
+  // -------------------------------------------------------------------------
+  it("logs error and continues when one emit fails — other cards still fire", async () => {
+    mocks.dbMultiGroupBy.mockResolvedValueOnce([]);
+    mocks.dbSingleWhere.mockResolvedValueOnce([
+      {
+        id: 1,
+        name: "Card A",
+        institution: "Banco A",
+        currency: "COP",
+        metadata: { creditLimitCents: 1_000_000, cutoffDay: 2 }, // daysTo = 1 → statement
+        userId: 1,
+        balanceCents: "0",
+      },
+      {
+        id: 2,
+        name: "Card B",
+        institution: "Banco B",
+        currency: "COP",
+        metadata: { creditLimitCents: 1_000_000, cutoffDay: 3 }, // daysTo = 2 → statement
+        userId: 2,
+        balanceCents: "0",
+      },
+    ]);
+
+    mocks.emitNotification
+      .mockRejectedValueOnce(new Error("db timeout"))
+      .mockResolvedValueOnce({ id: 99 });
+
+    // Must NOT throw
+    await expect(tcHealthCheckProcessor(makeJob())).resolves.toBeUndefined();
+    expect(mocks.emitNotification).toHaveBeenCalledTimes(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 6: Skip cards with no cutoff AND zero limit
+  // -------------------------------------------------------------------------
+  it("skips multi-currency cards with null cutoffDay AND zero creditLimit", async () => {
+    mocks.dbMultiGroupBy.mockResolvedValueOnce([
+      {
+        id: "uuid-skip",
+        name: null,
+        institution: "Banco",
+        network: null,
+        last4: null,
+        creditLimitCents: BigInt(0), // no cupo
+        statementCutoffDay: null,
+        userId: 1,
+        copDebtCents: "0",
+        usdDebtCents: "0",
+      },
+    ]);
+    mocks.dbSingleWhere.mockResolvedValueOnce([]);
+
+    await tcHealthCheckProcessor(makeJob());
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 7: DB failure propagates for BullMQ retry
+  // -------------------------------------------------------------------------
+  it("propagates DB errors for BullMQ retry", async () => {
+    mocks.dbMultiGroupBy.mockRejectedValueOnce(new Error("connection refused"));
+
+    await expect(tcHealthCheckProcessor(makeJob())).rejects.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 8: updateProgress called at start and done
+  // -------------------------------------------------------------------------
+  it("calls updateProgress at start and done", async () => {
+    mocks.dbMultiGroupBy.mockResolvedValueOnce([]);
+    mocks.dbSingleWhere.mockResolvedValueOnce([]);
+
+    const job = makeJob();
+    await tcHealthCheckProcessor(job);
+
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ phase: "fetching" }));
+    expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ done: true }));
+    expect(job.log).toHaveBeenCalled();
+  });
+});

--- a/src/lib/queue/workers/tc-health-check.test.ts
+++ b/src/lib/queue/workers/tc-health-check.test.ts
@@ -1,5 +1,8 @@
 // Tests for the tc-health-check BullMQ worker.
 // The processor is tested directly — no Worker instantiation needed.
+//
+// After W1 (review fixup), the worker delegates all DB access to
+// @/lib/insights/tc-health-queries. The mocks here reflect that boundary.
 
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -7,18 +10,11 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 // Hoist shared mock references so they work inside vi.mock factories.
 // ---------------------------------------------------------------------------
 const mocks = vi.hoisted(() => ({
-  // db.select chain — two round-trips (multi + single currency)
-  dbSelect: vi.fn(),
-
-  // Multi-currency query chain: .from().leftJoin().where().groupBy()
-  dbMultiFrom: vi.fn(),
-  dbMultiLeftJoin: vi.fn(),
-  dbMultiWhere: vi.fn(),
-  dbMultiGroupBy: vi.fn(),
-
-  // Single-currency query chain: .from().where()
-  dbSingleFrom: vi.fn(),
-  dbSingleWhere: vi.fn(),
+  // @/lib/insights/tc-health-queries — four query/builder functions
+  fetchMultiCurrencyCards: vi.fn(),
+  fetchSingleCurrencyCards: vi.fn(),
+  buildMultiSnapshot: vi.fn(),
+  buildSingleSnapshot: vi.fn(),
 
   // emitNotification
   emitNotification: vi.fn(),
@@ -37,32 +33,13 @@ const mocks = vi.hoisted(() => ({
 // Mocks
 // ---------------------------------------------------------------------------
 
-vi.mock("@/lib/db", () => {
-  // Multi-currency chain: .from().leftJoin().where().groupBy()
-  const groupByFn = mocks.dbMultiGroupBy;
-  const multiWhereFn = mocks.dbMultiWhere.mockReturnValue({ groupBy: groupByFn });
-  const leftJoinFn = mocks.dbMultiLeftJoin.mockReturnValue({ where: multiWhereFn });
-  const fromMultiFn = mocks.dbMultiFrom.mockReturnValue({ leftJoin: leftJoinFn });
-
-  // Single-currency chain: .from().where()
-  const whereFn = mocks.dbSingleWhere;
-  const fromSingleFn = mocks.dbSingleFrom.mockReturnValue({ where: whereFn });
-
-  // db.select alternates: 1st call = multi, 2nd call = single
-  mocks.dbSelect.mockImplementation(() => {
-    const callCount = mocks.dbSelect.mock.calls.length;
-    if (callCount === 1) {
-      return { from: fromMultiFn };
-    }
-    return { from: fromSingleFn };
-  });
-
-  return {
-    db: {
-      select: mocks.dbSelect,
-    },
-  };
-});
+vi.mock("@/lib/insights/tc-health-queries", () => ({
+  fetchMultiCurrencyCards: mocks.fetchMultiCurrencyCards,
+  fetchSingleCurrencyCards: mocks.fetchSingleCurrencyCards,
+  buildMultiSnapshot: mocks.buildMultiSnapshot,
+  buildSingleSnapshot: mocks.buildSingleSnapshot,
+  nowInBogota: vi.fn(() => ({ year: 2026, month: 5, day: 1 })),
+}));
 
 vi.mock("@/lib/logger", () => ({
   createLogger: () => ({
@@ -81,75 +58,13 @@ vi.mock("@/lib/fx/repo", () => ({
   getCurrentFxRate: mocks.getCurrentFxRate,
 }));
 
-vi.mock("@/lib/db/schema", () => ({
-  accounts: {
-    id: "id",
-    userId: "user_id",
-    name: "name",
-    institution: "institution",
-    currency: "currency",
-    type: "type",
-    metadata: "metadata",
-    physicalCardId: "physical_card_id",
-    deletedAt: "deleted_at",
-  },
-  physicalCards: {
-    id: "id",
-    userId: "user_id",
-    name: "name",
-    institution: "institution",
-    network: "network",
-    last4: "last4",
-    creditLimitCents: "credit_limit_cents",
-    statementCutoffDay: "statement_cutoff_day",
-  },
-}));
-
-vi.mock("@/lib/db/helpers", () => ({
-  notDeleted: vi.fn(() => "notDeleted()"),
-}));
-
-vi.mock("@/lib/accounts/queries", () => ({
-  derivedBalanceCentsSql: "derived_balance_cents_sql",
-}));
-
-vi.mock("@/lib/accounts/format", () => ({
-  formatAccountLabel: vi.fn((a: { name: string; currency: string }) => `${a.name} (${a.currency})`),
-}));
-
 vi.mock("@/lib/money", () => ({
-  toCop: vi.fn((cents: bigint, _currency: string, _rate: number) => cents),
+  formatMoney: vi.fn((cents: bigint, currency: string) => `${currency} ${cents}`),
 }));
 
-vi.mock("@/lib/widgets/handlers/_shared", () => ({
-  nowInBogota: vi.fn(() => ({ year: 2026, month: 5, day: 1 })),
-  roundUtilizationPct: vi.fn((used: bigint, limit: bigint) => {
-    if (limit === BigInt(0)) return 0;
-    return Math.round((Number(used) / Number(limit)) * 100);
-  }),
-}));
-
-vi.mock("@/lib/widgets/handlers/tc-focus", () => ({
-  computeNextCutoff: vi.fn(
-    (_cutoffDay: number, today: { day: number; month: number; year: number }) => {
-      // Simple mock: cutoff is cutoffDay - today.day days away
-      const daysTo = _cutoffDay - today.day;
-      return { next: `2026-05-${String(_cutoffDay).padStart(2, "0")}`, daysTo };
-    },
-  ),
-}));
-
-// aliasedTable stub
-vi.mock("drizzle-orm", async (importOriginal) => {
-  const original = await importOriginal<typeof import("drizzle-orm")>();
-  return {
-    ...original,
-    sql: vi.fn(() => "sql()"),
-    isNull: vi.fn(() => "isNull()"),
-    eq: vi.fn(() => "eq()"),
-    and: vi.fn(() => "and()"),
-  };
-});
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
 
 import type { Job } from "bullmq";
 import {
@@ -157,6 +72,7 @@ import {
   getCurrentYearMonth,
   type TcHealthCheckJobData,
 } from "./tc-health-check";
+import type { TcCardSnapshot } from "@/lib/insights/tc-health";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -171,23 +87,36 @@ function makeJob(data: TcHealthCheckJobData = {}): Job<TcHealthCheckJobData> {
   } as unknown as Job<TcHealthCheckJobData>;
 }
 
-/** Reset and re-wire mock chains after vi.resetAllMocks. */
-function rewireDbMock() {
-  const groupByFn = mocks.dbMultiGroupBy;
-  const multiWhereFn = mocks.dbMultiWhere.mockReturnValue({ groupBy: groupByFn });
-  const leftJoinFn = mocks.dbMultiLeftJoin.mockReturnValue({ where: multiWhereFn });
-  const fromMultiFn = mocks.dbMultiFrom.mockReturnValue({ leftJoin: leftJoinFn });
+/** A minimal TcCardSnapshot for a multi-currency card at high utilization. */
+function makeMultiSnap(overrides: Partial<TcCardSnapshot> = {}): TcCardSnapshot {
+  return {
+    cardId: "pc-uuid-card-1",
+    kind: "physical",
+    label: "Visa Premium",
+    cutoffDay: null,
+    currency: "COP",
+    creditLimitCents: BigInt(10_000_000),
+    usedCents: BigInt(9_500_000),
+    utilizationPct: 95,
+    daysToCutoff: null,
+    ...overrides,
+  };
+}
 
-  const whereFn = mocks.dbSingleWhere;
-  const fromSingleFn = mocks.dbSingleFrom.mockReturnValue({ where: whereFn });
-
-  mocks.dbSelect.mockImplementation(() => {
-    const callCount = mocks.dbSelect.mock.calls.length;
-    if (callCount === 1) {
-      return { from: fromMultiFn };
-    }
-    return { from: fromSingleFn };
-  });
+/** A minimal TcCardSnapshot for a single-currency card with a statement approaching. */
+function makeSingleSnap(overrides: Partial<TcCardSnapshot> = {}): TcCardSnapshot {
+  return {
+    cardId: "acc-42",
+    kind: "account",
+    label: "MasterCard (COP)",
+    cutoffDay: 3,
+    currency: "COP",
+    creditLimitCents: BigInt(5_000_000),
+    usedCents: BigInt(0),
+    utilizationPct: 0,
+    daysToCutoff: 2,
+    ...overrides,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -208,7 +137,6 @@ describe("getCurrentYearMonth", () => {
 describe("tcHealthCheckProcessor", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    rewireDbMock();
     // Default FX rate — not used unless USD involved
     mocks.getCurrentFxRate.mockResolvedValue({ rate: 4000, source: "db", fetchedAt: new Date() });
   });
@@ -221,8 +149,8 @@ describe("tcHealthCheckProcessor", () => {
   // Test 1: No cards — completes cleanly without emit
   // -------------------------------------------------------------------------
   it("completes without error or emit when no cards exist", async () => {
-    mocks.dbMultiGroupBy.mockResolvedValueOnce([]);
-    mocks.dbSingleWhere.mockResolvedValueOnce([]);
+    mocks.fetchMultiCurrencyCards.mockResolvedValueOnce([]);
+    mocks.fetchSingleCurrencyCards.mockResolvedValueOnce([]);
 
     await expect(tcHealthCheckProcessor(makeJob())).resolves.toBeUndefined();
     expect(mocks.emitNotification).not.toHaveBeenCalled();
@@ -232,24 +160,23 @@ describe("tcHealthCheckProcessor", () => {
   // Test 2: Multi-currency card with high utilization → emit util-95
   // -------------------------------------------------------------------------
   it("emits util-95 notification for a multi-currency card at 95% utilization", async () => {
-    // creditLimit = 10_000_000, cop debt = 9_500_000 → used=9_500_000 → 95%
-    const limit = BigInt(10_000_000);
-    const debt = BigInt(-9_500_000); // balances are negative = debt
-    mocks.dbMultiGroupBy.mockResolvedValueOnce([
+    const snap = makeMultiSnap(); // 95%, no cutoff
+    mocks.fetchMultiCurrencyCards.mockResolvedValueOnce([
       {
         id: "uuid-card-1",
         name: "Visa Premium",
         institution: "Bancolombia",
         network: "visa",
         last4: "1234",
-        creditLimitCents: limit,
-        statementCutoffDay: null, // no cutoff
+        creditLimitCents: BigInt(10_000_000),
+        statementCutoffDay: null,
         userId: 1,
-        copDebtCents: debt.toString(),
-        usdDebtCents: "0",
+        copDebtCents: BigInt(-9_500_000),
+        usdDebtCents: BigInt(0),
       },
     ]);
-    mocks.dbSingleWhere.mockResolvedValueOnce([]);
+    mocks.fetchSingleCurrencyCards.mockResolvedValueOnce([]);
+    mocks.buildMultiSnapshot.mockReturnValue(snap);
     mocks.emitNotification.mockResolvedValue({ id: 10 });
 
     await tcHealthCheckProcessor(makeJob());
@@ -270,21 +197,20 @@ describe("tcHealthCheckProcessor", () => {
   // Test 3: Single-currency card with statement approaching → emit statement
   // -------------------------------------------------------------------------
   it("emits statement notification for a single-currency card with cutoff in 2 days", async () => {
-    mocks.dbMultiGroupBy.mockResolvedValueOnce([]);
-    mocks.dbSingleWhere.mockResolvedValueOnce([
+    const snap = makeSingleSnap(); // daysToCutoff=2, util=0
+    mocks.fetchMultiCurrencyCards.mockResolvedValueOnce([]);
+    mocks.fetchSingleCurrencyCards.mockResolvedValueOnce([
       {
         id: 42,
         name: "MasterCard",
         institution: "Davivienda",
         currency: "COP",
-        metadata: {
-          creditLimitCents: 5_000_000,
-          cutoffDay: 3, // mocked today.day = 1 → daysTo = 2
-        },
+        metadata: { creditLimitCents: 5_000_000, cutoffDay: 3 },
         userId: 2,
-        balanceCents: "0", // no debt
+        balanceCents: BigInt(0),
       },
     ]);
+    mocks.buildSingleSnapshot.mockReturnValue(snap);
     mocks.emitNotification.mockResolvedValue({ id: 20 });
 
     await tcHealthCheckProcessor(makeJob());
@@ -303,18 +229,20 @@ describe("tcHealthCheckProcessor", () => {
   // Test 4: Dedup — emitNotification returns null, no error
   // -------------------------------------------------------------------------
   it("handles dedup gracefully when emitNotification returns null", async () => {
-    mocks.dbMultiGroupBy.mockResolvedValueOnce([]);
-    mocks.dbSingleWhere.mockResolvedValueOnce([
+    const snap = makeSingleSnap({ cardId: "acc-7", daysToCutoff: 1 });
+    mocks.fetchMultiCurrencyCards.mockResolvedValueOnce([]);
+    mocks.fetchSingleCurrencyCards.mockResolvedValueOnce([
       {
         id: 7,
         name: "Card",
         institution: "Nequi",
         currency: "COP",
-        metadata: { creditLimitCents: 2_000_000, cutoffDay: 2 }, // daysTo = 1
+        metadata: { creditLimitCents: 2_000_000, cutoffDay: 2 },
         userId: 3,
-        balanceCents: "0",
+        balanceCents: BigInt(0),
       },
     ]);
+    mocks.buildSingleSnapshot.mockReturnValue(snap);
     mocks.emitNotification.mockResolvedValue(null); // deduped
 
     await expect(tcHealthCheckProcessor(makeJob())).resolves.toBeUndefined();
@@ -325,28 +253,32 @@ describe("tcHealthCheckProcessor", () => {
   // Test 5: Per-card emit failure is contained — other cards still process
   // -------------------------------------------------------------------------
   it("logs error and continues when one emit fails — other cards still fire", async () => {
-    mocks.dbMultiGroupBy.mockResolvedValueOnce([]);
-    mocks.dbSingleWhere.mockResolvedValueOnce([
+    const snapA = makeSingleSnap({ cardId: "acc-1", cutoffDay: 2, daysToCutoff: 1 });
+    const snapB = makeSingleSnap({ cardId: "acc-2", cutoffDay: 3, daysToCutoff: 2 });
+
+    // Two different users — each has one card
+    mocks.fetchMultiCurrencyCards.mockResolvedValueOnce([]);
+    mocks.fetchSingleCurrencyCards.mockResolvedValueOnce([
       {
         id: 1,
         name: "Card A",
         institution: "Banco A",
         currency: "COP",
-        metadata: { creditLimitCents: 1_000_000, cutoffDay: 2 }, // daysTo = 1 → statement
+        metadata: { creditLimitCents: 1_000_000, cutoffDay: 2 },
         userId: 1,
-        balanceCents: "0",
+        balanceCents: BigInt(0),
       },
       {
         id: 2,
         name: "Card B",
         institution: "Banco B",
         currency: "COP",
-        metadata: { creditLimitCents: 1_000_000, cutoffDay: 3 }, // daysTo = 2 → statement
+        metadata: { creditLimitCents: 1_000_000, cutoffDay: 3 },
         userId: 2,
-        balanceCents: "0",
+        balanceCents: BigInt(0),
       },
     ]);
-
+    mocks.buildSingleSnapshot.mockReturnValueOnce(snapA).mockReturnValueOnce(snapB);
     mocks.emitNotification
       .mockRejectedValueOnce(new Error("db timeout"))
       .mockResolvedValueOnce({ id: 99 });
@@ -360,7 +292,7 @@ describe("tcHealthCheckProcessor", () => {
   // Test 6: Skip cards with no cutoff AND zero limit
   // -------------------------------------------------------------------------
   it("skips multi-currency cards with null cutoffDay AND zero creditLimit", async () => {
-    mocks.dbMultiGroupBy.mockResolvedValueOnce([
+    mocks.fetchMultiCurrencyCards.mockResolvedValueOnce([
       {
         id: "uuid-skip",
         name: null,
@@ -370,21 +302,23 @@ describe("tcHealthCheckProcessor", () => {
         creditLimitCents: BigInt(0), // no cupo
         statementCutoffDay: null,
         userId: 1,
-        copDebtCents: "0",
-        usdDebtCents: "0",
+        copDebtCents: BigInt(0),
+        usdDebtCents: BigInt(0),
       },
     ]);
-    mocks.dbSingleWhere.mockResolvedValueOnce([]);
+    mocks.fetchSingleCurrencyCards.mockResolvedValueOnce([]);
 
     await tcHealthCheckProcessor(makeJob());
     expect(mocks.emitNotification).not.toHaveBeenCalled();
+    // buildMultiSnapshot should never be called for a skipped card
+    expect(mocks.buildMultiSnapshot).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------
   // Test 7: DB failure propagates for BullMQ retry
   // -------------------------------------------------------------------------
   it("propagates DB errors for BullMQ retry", async () => {
-    mocks.dbMultiGroupBy.mockRejectedValueOnce(new Error("connection refused"));
+    mocks.fetchMultiCurrencyCards.mockRejectedValueOnce(new Error("connection refused"));
 
     await expect(tcHealthCheckProcessor(makeJob())).rejects.toThrow();
   });
@@ -393,8 +327,8 @@ describe("tcHealthCheckProcessor", () => {
   // Test 8: updateProgress called at start and done
   // -------------------------------------------------------------------------
   it("calls updateProgress at start and done", async () => {
-    mocks.dbMultiGroupBy.mockResolvedValueOnce([]);
-    mocks.dbSingleWhere.mockResolvedValueOnce([]);
+    mocks.fetchMultiCurrencyCards.mockResolvedValueOnce([]);
+    mocks.fetchSingleCurrencyCards.mockResolvedValueOnce([]);
 
     const job = makeJob();
     await tcHealthCheckProcessor(job);
@@ -402,5 +336,149 @@ describe("tcHealthCheckProcessor", () => {
     expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ phase: "fetching" }));
     expect(job.updateProgress).toHaveBeenCalledWith(expect.objectContaining({ done: true }));
     expect(job.log).toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 9 (NEW — reviewer gap): Combined triggers on one card → exactly 2
+  // emitNotification calls with distinct entityIds (-statement and -util-90)
+  //
+  // Locks in the orchestrator-decided additive/distinct-entityId behavior.
+  // A future refactor collapsing to a "both" trigger would break this test.
+  // -------------------------------------------------------------------------
+  it("emits exactly 2 notifications for a card that fires both util-90 and statement", async () => {
+    // Card: 92% utilization AND cutoff in 2 days → util-90 + statement
+    const snap = makeMultiSnap({
+      cardId: "pc-combo",
+      utilizationPct: 92,
+      usedCents: BigInt(9_200_000),
+      creditLimitCents: BigInt(10_000_000),
+      daysToCutoff: 2,
+      cutoffDay: 3,
+      currency: "COP",
+    });
+
+    mocks.fetchMultiCurrencyCards.mockResolvedValueOnce([
+      {
+        id: "combo",
+        name: "Combo Card",
+        institution: "Bancolombia",
+        network: "visa",
+        last4: "9999",
+        creditLimitCents: BigInt(10_000_000),
+        statementCutoffDay: 3,
+        userId: 5,
+        copDebtCents: BigInt(-9_200_000),
+        usdDebtCents: BigInt(0),
+      },
+    ]);
+    mocks.fetchSingleCurrencyCards.mockResolvedValueOnce([]);
+    mocks.buildMultiSnapshot.mockReturnValue(snap);
+    mocks.emitNotification.mockResolvedValue({ id: 100 });
+
+    await tcHealthCheckProcessor(makeJob());
+
+    // Must have exactly 2 calls for the same card
+    expect(mocks.emitNotification).toHaveBeenCalledTimes(2);
+
+    const entityIds = (mocks.emitNotification.mock.calls as [number, { entityId: string }][]).map(
+      ([_uid, input]) => input.entityId,
+    );
+
+    // One ends in -util-90, the other in -statement
+    expect(entityIds.some((id: string) => id.endsWith("-util-90"))).toBe(true);
+    expect(entityIds.some((id: string) => id.endsWith("-statement"))).toBe(true);
+
+    // Both are for the same card
+    expect(entityIds.every((id: string) => id.includes("pc-combo"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildNotificationText — payment suggestion (W2)
+//
+// Tested indirectly via tcHealthCheckProcessor by inspecting the `body`
+// passed to emitNotification.
+// ---------------------------------------------------------------------------
+
+describe("buildNotificationText — util body", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.getCurrentFxRate.mockResolvedValue({ rate: 4000, source: "db", fetchedAt: new Date() });
+  });
+
+  it("body includes payment suggestion when paymentNeeded > 0", async () => {
+    // 92% of 10_000_000 = 9_200_000 used
+    // targetCents = 70% of 10_000_000 = 7_000_000
+    // paymentNeeded = 9_200_000 - 7_000_000 = 2_200_000
+    const snap = makeMultiSnap({
+      cardId: "pc-pay-test",
+      utilizationPct: 92,
+      usedCents: BigInt(9_200_000),
+      creditLimitCents: BigInt(10_000_000),
+      daysToCutoff: null,
+      currency: "COP",
+    });
+
+    mocks.fetchMultiCurrencyCards.mockResolvedValueOnce([
+      {
+        id: "pay-test",
+        name: "Pay Card",
+        institution: "Banco",
+        network: null,
+        last4: null,
+        creditLimitCents: BigInt(10_000_000),
+        statementCutoffDay: null,
+        userId: 1,
+        copDebtCents: BigInt(-9_200_000),
+        usdDebtCents: BigInt(0),
+      },
+    ]);
+    mocks.fetchSingleCurrencyCards.mockResolvedValueOnce([]);
+    mocks.buildMultiSnapshot.mockReturnValue(snap);
+    mocks.emitNotification.mockResolvedValue({ id: 50 });
+
+    await tcHealthCheckProcessor(makeJob());
+
+    expect(mocks.emitNotification).toHaveBeenCalledOnce();
+    const [, input] = mocks.emitNotification.mock.calls[0] as [number, { body: string }];
+    expect(input.body).toContain("para bajar al 70%");
+  });
+
+  it("body does NOT include payment suggestion when paymentNeeded would be 0 (exactly 70% used)", async () => {
+    // Exactly 70% of 10_000_000 = 7_000_000 used → paymentNeeded = 0
+    // But utilizationPct=80 so it triggers util-80
+    const snap = makeMultiSnap({
+      cardId: "pc-exact-70",
+      utilizationPct: 80,
+      usedCents: BigInt(7_000_000),
+      creditLimitCents: BigInt(10_000_000),
+      daysToCutoff: null,
+      currency: "COP",
+    });
+
+    mocks.fetchMultiCurrencyCards.mockResolvedValueOnce([
+      {
+        id: "exact-70",
+        name: "Exact Card",
+        institution: "Banco",
+        network: null,
+        last4: null,
+        creditLimitCents: BigInt(10_000_000),
+        statementCutoffDay: null,
+        userId: 1,
+        copDebtCents: BigInt(-8_000_000),
+        usdDebtCents: BigInt(0),
+      },
+    ]);
+    mocks.fetchSingleCurrencyCards.mockResolvedValueOnce([]);
+    mocks.buildMultiSnapshot.mockReturnValue(snap);
+    mocks.emitNotification.mockResolvedValue({ id: 51 });
+
+    await tcHealthCheckProcessor(makeJob());
+
+    expect(mocks.emitNotification).toHaveBeenCalledOnce();
+    const [, input] = mocks.emitNotification.mock.calls[0] as [number, { body: string }];
+    // paymentNeeded = 7_000_000 - 7_000_000 = 0, so no suggestion
+    expect(input.body).not.toContain("para bajar al 70%");
   });
 });

--- a/src/lib/queue/workers/tc-health-check.ts
+++ b/src/lib/queue/workers/tc-health-check.ts
@@ -14,24 +14,27 @@
  *
  * The pure alert logic lives in `src/lib/insights/tc-health.ts` and is
  * shared with the `/insights` page real-time card.
+ *
+ * DB helpers and snapshot builders live in
+ * `src/lib/insights/tc-health-queries.ts` so the /insights page can import
+ * them without pulling BullMQ / ioredis into the RSC route module graph.
  */
 
 import type { Job } from "bullmq";
-import { and, eq, isNull, sql } from "drizzle-orm";
 
-import { db } from "@/lib/db";
-import { accounts, physicalCards, type AccountMetadata } from "@/lib/db/schema";
-import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
-import { notDeleted } from "@/lib/db/helpers";
-import { toCop } from "@/lib/money";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { createLogger } from "@/lib/logger";
-import { formatAccountLabel } from "@/lib/accounts/format";
+import { formatMoney } from "@/lib/money";
 import { emitNotification } from "@/lib/notifications/emit";
 import { createWorker } from "@/lib/queue";
-import { nowInBogota, roundUtilizationPct, type BogotaYmd } from "@/lib/widgets/handlers/_shared";
-import { computeNextCutoff } from "@/lib/widgets/handlers/tc-focus";
+import { nowInBogota } from "@/lib/widgets/handlers/_shared";
 import { computeTcAlerts, type TcCardSnapshot } from "@/lib/insights/tc-health";
+import {
+  fetchMultiCurrencyCards,
+  fetchSingleCurrencyCards,
+  buildMultiSnapshot,
+  buildSingleSnapshot,
+} from "@/lib/insights/tc-health-queries";
 
 const log = createLogger({ module: "worker/tc-health-check" });
 
@@ -55,244 +58,6 @@ export function getCurrentYearMonth(): string {
   })
     .format(new Date())
     .slice(0, 7); // "YYYY-MM"
-}
-
-// ---------------------------------------------------------------------------
-// Internal row types
-// ---------------------------------------------------------------------------
-
-type MultiCurrencyRow = {
-  id: string;
-  name: string | null;
-  institution: string;
-  network: string | null;
-  last4: string | null;
-  creditLimitCents: bigint;
-  statementCutoffDay: number | null;
-  userId: number;
-  /** SUM of COP sub-account balances (negative when in debt) */
-  copDebtCents: bigint;
-  /** SUM of USD sub-account balances (negative when in debt), in USD cents */
-  usdDebtCents: bigint;
-};
-
-type SingleCurrencyRow = {
-  id: number;
-  name: string;
-  institution: string;
-  currency: "COP" | "USD";
-  metadata: AccountMetadata;
-  userId: number;
-  balanceCents: bigint;
-};
-
-// ---------------------------------------------------------------------------
-// Queries — two round-trips for the whole tenant roster, not N+1.
-// Mirrors fetchMultiCurrencyCards / fetchSingleCurrencyCards from mis-tcs.ts.
-// ---------------------------------------------------------------------------
-
-async function fetchMultiCurrencyCards(userId?: number): Promise<MultiCurrencyRow[]> {
-  const rows = await db
-    .select({
-      id: physicalCards.id,
-      name: physicalCards.name,
-      institution: physicalCards.institution,
-      network: physicalCards.network,
-      last4: physicalCards.last4,
-      creditLimitCents: physicalCards.creditLimitCents,
-      statementCutoffDay: physicalCards.statementCutoffDay,
-      userId: physicalCards.userId,
-      copDebtCents: sql<string>`
-        COALESCE(SUM(CASE WHEN ${accounts.currency} = 'COP' THEN ${derivedBalanceCentsSql} ELSE 0 END), 0)
-      `,
-      usdDebtCents: sql<string>`
-        COALESCE(SUM(CASE WHEN ${accounts.currency} = 'USD' THEN ${derivedBalanceCentsSql} ELSE 0 END), 0)
-      `,
-    })
-    .from(physicalCards)
-    .leftJoin(
-      accounts,
-      and(
-        eq(accounts.physicalCardId, physicalCards.id),
-        // Tenancy guard: pair user_id in the JOIN ON clause (memory per-user-table-join-tenant-safety)
-        eq(accounts.userId, physicalCards.userId),
-        notDeleted(accounts.deletedAt),
-      ),
-    )
-    .where(userId !== undefined ? eq(physicalCards.userId, userId) : undefined)
-    .groupBy(
-      physicalCards.id,
-      physicalCards.name,
-      physicalCards.institution,
-      physicalCards.network,
-      physicalCards.last4,
-      physicalCards.creditLimitCents,
-      physicalCards.statementCutoffDay,
-      physicalCards.userId,
-    );
-
-  return rows.map((r) => ({
-    id: r.id,
-    name: r.name,
-    institution: r.institution,
-    network: r.network,
-    last4: r.last4,
-    creditLimitCents: r.creditLimitCents,
-    statementCutoffDay: r.statementCutoffDay ?? null,
-    userId: r.userId,
-    copDebtCents: BigInt(r.copDebtCents),
-    usdDebtCents: BigInt(r.usdDebtCents),
-  }));
-}
-
-async function fetchSingleCurrencyCards(userId?: number): Promise<SingleCurrencyRow[]> {
-  const rows = await db
-    .select({
-      id: accounts.id,
-      name: accounts.name,
-      institution: accounts.institution,
-      currency: accounts.currency,
-      metadata: accounts.metadata,
-      userId: accounts.userId,
-      balanceCents: derivedBalanceCentsSql,
-    })
-    .from(accounts)
-    .where(
-      and(
-        userId !== undefined ? eq(accounts.userId, userId) : undefined,
-        eq(accounts.type, "credit_card"),
-        // Absence of physicalCardId distinguishes "plain" TCs from multi-currency sub-accounts
-        isNull(accounts.physicalCardId),
-        notDeleted(accounts.deletedAt),
-      ),
-    );
-
-  return rows.map((r) => ({
-    id: r.id,
-    name: r.name,
-    institution: r.institution,
-    currency: r.currency as "COP" | "USD",
-    metadata: (r.metadata ?? {}) as AccountMetadata,
-    userId: r.userId,
-    balanceCents: BigInt(r.balanceCents),
-  }));
-}
-
-// ---------------------------------------------------------------------------
-// Snapshot builders — bigint math, no float coercions
-// ---------------------------------------------------------------------------
-
-function buildMultiSnapshot(
-  row: MultiCurrencyRow,
-  copPerUsd: number,
-  today: BogotaYmd,
-): TcCardSnapshot {
-  // Mirrors projectMultiCurrency in mis-tcs.ts
-  const usdDebtInCop = toCop(row.usdDebtCents, "USD", copPerUsd);
-  const availableCents = row.creditLimitCents + row.copDebtCents + usdDebtInCop;
-  const usedCents = row.creditLimitCents - availableCents;
-  const usedClamped = usedCents < BI_ZERO ? BI_ZERO : usedCents;
-
-  const utilizationPct = roundUtilizationPct(usedClamped, row.creditLimitCents);
-
-  const label =
-    row.name?.trim() ||
-    [row.institution, row.last4 ? `*${row.last4}` : null].filter(Boolean).join(" ") ||
-    "Tarjeta de crédito";
-
-  const daysToCutoff =
-    row.statementCutoffDay !== null
-      ? computeNextCutoff(row.statementCutoffDay, today).daysTo
-      : null;
-
-  return {
-    cardId: `pc-${row.id}`,
-    kind: "physical",
-    label,
-    cutoffDay: row.statementCutoffDay,
-    creditLimitCents: row.creditLimitCents,
-    usedCents: usedClamped,
-    utilizationPct,
-    daysToCutoff,
-  };
-}
-
-function buildSingleSnapshot(
-  row: SingleCurrencyRow,
-  copPerUsd: number,
-  today: BogotaYmd,
-): TcCardSnapshot {
-  // Mirrors projectSingleCurrency in mis-tcs.ts
-  const limitNativeCents = BigInt(row.metadata.creditLimitCents ?? 0);
-  const usedNativeCents = row.balanceCents < BI_ZERO ? -row.balanceCents : BI_ZERO;
-
-  // Utilization on native cents (ratio is invariant under positive-rate scaling)
-  const utilizationPct = roundUtilizationPct(usedNativeCents, limitNativeCents);
-
-  const cutoffDay = row.metadata.cutoffDay ?? null;
-  const daysToCutoff = cutoffDay !== null ? computeNextCutoff(cutoffDay, today).daysTo : null;
-
-  const label = formatAccountLabel(
-    {
-      name: row.name,
-      currency: row.currency,
-      institution: row.institution,
-      metadata: { last4s: row.metadata.last4s ?? null },
-    },
-    { withInstitution: true },
-  );
-
-  return {
-    cardId: `acc-${row.id}`,
-    kind: "account",
-    label,
-    cutoffDay,
-    creditLimitCents: limitNativeCents,
-    usedCents: usedNativeCents,
-    utilizationPct,
-    daysToCutoff,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Per-user snapshot fetch — used by the /insights page card.
-// Mirrors the cron logic but scoped to a single userId and driven by the
-// caller-supplied fxRate (the page already has it in scope).
-// ---------------------------------------------------------------------------
-
-/**
- * Fetch and build TcCardSnapshot[] for a single user. Used by the /insights
- * page real-time card. Cards with no cupo AND no cutoff are excluded.
- *
- * @param userId   The authenticated user's id.
- * @param fxRate   Current COP/USD FX rate (from `getCurrentFxRate().rate`).
- * @param today    Bogota date (from `nowInBogota(new Date())`).
- */
-export async function fetchUserTcSnapshots(
-  userId: number,
-  fxRate: number,
-  today: BogotaYmd,
-): Promise<TcCardSnapshot[]> {
-  const [multiRows, singleRows] = await Promise.all([
-    fetchMultiCurrencyCards(userId),
-    fetchSingleCurrencyCards(userId),
-  ]);
-
-  const snapshots: TcCardSnapshot[] = [];
-
-  for (const row of multiRows) {
-    if (row.statementCutoffDay === null && row.creditLimitCents === BI_ZERO) continue;
-    snapshots.push(buildMultiSnapshot(row, fxRate, today));
-  }
-
-  for (const row of singleRows) {
-    const limitCents = BigInt(row.metadata.creditLimitCents ?? 0);
-    const cutoffDay = row.metadata.cutoffDay ?? null;
-    if (cutoffDay === null && limitCents === BI_ZERO) continue;
-    snapshots.push(buildSingleSnapshot(row, fxRate, today));
-  }
-
-  return snapshots;
 }
 
 // ---------------------------------------------------------------------------
@@ -461,9 +226,18 @@ function buildNotificationText(
 
   const pct = snap.utilizationPct;
   const tier = trigger === "util-95" ? "95%" : trigger === "util-90" ? "90%" : "80%";
+  let body = `Tenés el ${pct}% del cupo usado — llegaste al umbral del ${tier}.`;
+
+  // Payment suggestion: how much to pay to get back to 70% utilization
+  const targetCents = (snap.creditLimitCents * BigInt(70)) / BigInt(100);
+  const paymentNeeded = snap.usedCents - targetCents;
+  if (paymentNeeded > BI_ZERO) {
+    body += ` Pagá ${formatMoney(paymentNeeded, snap.currency)} para bajar al 70%.`;
+  }
+
   return {
     title: `${snap.label}: cupo al ${pct}%`,
-    body: `Tenés el ${pct}% del cupo usado — llegaste al umbral del ${tier}.`,
+    body,
   };
 }
 

--- a/src/lib/queue/workers/tc-health-check.ts
+++ b/src/lib/queue/workers/tc-health-check.ts
@@ -1,0 +1,492 @@
+/**
+ * TC health-check BullMQ worker.
+ *
+ * Runs daily at 08:00 America/Bogota. For every user, iterates their TCs
+ * (both multi-currency `physical_cards` AND single-currency `accounts` with
+ * `metadata.cutoffDay`) and emits `tc_health_alert` notifications when:
+ *
+ *   - Statement cutoff is ≤ 3 days away
+ *   - Utilization ≥ 80% (highest crossed bucket: 80 / 90 / 95)
+ *
+ * Dedup is handled by `emitNotification`'s partial unique index on
+ * (user_id, type, entity_id) WHERE read_at IS NULL, using the entityId
+ * scheme `tc-alert-{cardId}-{yearMonth}-{trigger}`.
+ *
+ * The pure alert logic lives in `src/lib/insights/tc-health.ts` and is
+ * shared with the `/insights` page real-time card.
+ */
+
+import type { Job } from "bullmq";
+import { and, eq, isNull, sql } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { accounts, physicalCards, type AccountMetadata } from "@/lib/db/schema";
+import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
+import { notDeleted } from "@/lib/db/helpers";
+import { toCop } from "@/lib/money";
+import { getCurrentFxRate } from "@/lib/fx/repo";
+import { createLogger } from "@/lib/logger";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { emitNotification } from "@/lib/notifications/emit";
+import { createWorker } from "@/lib/queue";
+import { nowInBogota, roundUtilizationPct, type BogotaYmd } from "@/lib/widgets/handlers/_shared";
+import { computeNextCutoff } from "@/lib/widgets/handlers/tc-focus";
+import { computeTcAlerts, type TcCardSnapshot } from "@/lib/insights/tc-health";
+
+const log = createLogger({ module: "worker/tc-health-check" });
+
+export type TcHealthCheckJobData = Record<string, never>;
+
+const BI_ZERO = BigInt(0);
+
+// ---------------------------------------------------------------------------
+// yearMonth helper (Bogota-anchored) — mirrors budget-check.ts pattern
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the current yearMonth string in America/Bogota timezone.
+ * Format: "YYYY-MM".
+ */
+export function getCurrentYearMonth(): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Bogota",
+    year: "numeric",
+    month: "2-digit",
+  })
+    .format(new Date())
+    .slice(0, 7); // "YYYY-MM"
+}
+
+// ---------------------------------------------------------------------------
+// Internal row types
+// ---------------------------------------------------------------------------
+
+type MultiCurrencyRow = {
+  id: string;
+  name: string | null;
+  institution: string;
+  network: string | null;
+  last4: string | null;
+  creditLimitCents: bigint;
+  statementCutoffDay: number | null;
+  userId: number;
+  /** SUM of COP sub-account balances (negative when in debt) */
+  copDebtCents: bigint;
+  /** SUM of USD sub-account balances (negative when in debt), in USD cents */
+  usdDebtCents: bigint;
+};
+
+type SingleCurrencyRow = {
+  id: number;
+  name: string;
+  institution: string;
+  currency: "COP" | "USD";
+  metadata: AccountMetadata;
+  userId: number;
+  balanceCents: bigint;
+};
+
+// ---------------------------------------------------------------------------
+// Queries — two round-trips for the whole tenant roster, not N+1.
+// Mirrors fetchMultiCurrencyCards / fetchSingleCurrencyCards from mis-tcs.ts.
+// ---------------------------------------------------------------------------
+
+async function fetchMultiCurrencyCards(userId?: number): Promise<MultiCurrencyRow[]> {
+  const rows = await db
+    .select({
+      id: physicalCards.id,
+      name: physicalCards.name,
+      institution: physicalCards.institution,
+      network: physicalCards.network,
+      last4: physicalCards.last4,
+      creditLimitCents: physicalCards.creditLimitCents,
+      statementCutoffDay: physicalCards.statementCutoffDay,
+      userId: physicalCards.userId,
+      copDebtCents: sql<string>`
+        COALESCE(SUM(CASE WHEN ${accounts.currency} = 'COP' THEN ${derivedBalanceCentsSql} ELSE 0 END), 0)
+      `,
+      usdDebtCents: sql<string>`
+        COALESCE(SUM(CASE WHEN ${accounts.currency} = 'USD' THEN ${derivedBalanceCentsSql} ELSE 0 END), 0)
+      `,
+    })
+    .from(physicalCards)
+    .leftJoin(
+      accounts,
+      and(
+        eq(accounts.physicalCardId, physicalCards.id),
+        // Tenancy guard: pair user_id in the JOIN ON clause (memory per-user-table-join-tenant-safety)
+        eq(accounts.userId, physicalCards.userId),
+        notDeleted(accounts.deletedAt),
+      ),
+    )
+    .where(userId !== undefined ? eq(physicalCards.userId, userId) : undefined)
+    .groupBy(
+      physicalCards.id,
+      physicalCards.name,
+      physicalCards.institution,
+      physicalCards.network,
+      physicalCards.last4,
+      physicalCards.creditLimitCents,
+      physicalCards.statementCutoffDay,
+      physicalCards.userId,
+    );
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    institution: r.institution,
+    network: r.network,
+    last4: r.last4,
+    creditLimitCents: r.creditLimitCents,
+    statementCutoffDay: r.statementCutoffDay ?? null,
+    userId: r.userId,
+    copDebtCents: BigInt(r.copDebtCents),
+    usdDebtCents: BigInt(r.usdDebtCents),
+  }));
+}
+
+async function fetchSingleCurrencyCards(userId?: number): Promise<SingleCurrencyRow[]> {
+  const rows = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      institution: accounts.institution,
+      currency: accounts.currency,
+      metadata: accounts.metadata,
+      userId: accounts.userId,
+      balanceCents: derivedBalanceCentsSql,
+    })
+    .from(accounts)
+    .where(
+      and(
+        userId !== undefined ? eq(accounts.userId, userId) : undefined,
+        eq(accounts.type, "credit_card"),
+        // Absence of physicalCardId distinguishes "plain" TCs from multi-currency sub-accounts
+        isNull(accounts.physicalCardId),
+        notDeleted(accounts.deletedAt),
+      ),
+    );
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    institution: r.institution,
+    currency: r.currency as "COP" | "USD",
+    metadata: (r.metadata ?? {}) as AccountMetadata,
+    userId: r.userId,
+    balanceCents: BigInt(r.balanceCents),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot builders — bigint math, no float coercions
+// ---------------------------------------------------------------------------
+
+function buildMultiSnapshot(
+  row: MultiCurrencyRow,
+  copPerUsd: number,
+  today: BogotaYmd,
+): TcCardSnapshot {
+  // Mirrors projectMultiCurrency in mis-tcs.ts
+  const usdDebtInCop = toCop(row.usdDebtCents, "USD", copPerUsd);
+  const availableCents = row.creditLimitCents + row.copDebtCents + usdDebtInCop;
+  const usedCents = row.creditLimitCents - availableCents;
+  const usedClamped = usedCents < BI_ZERO ? BI_ZERO : usedCents;
+
+  const utilizationPct = roundUtilizationPct(usedClamped, row.creditLimitCents);
+
+  const label =
+    row.name?.trim() ||
+    [row.institution, row.last4 ? `*${row.last4}` : null].filter(Boolean).join(" ") ||
+    "Tarjeta de crédito";
+
+  const daysToCutoff =
+    row.statementCutoffDay !== null
+      ? computeNextCutoff(row.statementCutoffDay, today).daysTo
+      : null;
+
+  return {
+    cardId: `pc-${row.id}`,
+    kind: "physical",
+    label,
+    cutoffDay: row.statementCutoffDay,
+    creditLimitCents: row.creditLimitCents,
+    usedCents: usedClamped,
+    utilizationPct,
+    daysToCutoff,
+  };
+}
+
+function buildSingleSnapshot(
+  row: SingleCurrencyRow,
+  copPerUsd: number,
+  today: BogotaYmd,
+): TcCardSnapshot {
+  // Mirrors projectSingleCurrency in mis-tcs.ts
+  const limitNativeCents = BigInt(row.metadata.creditLimitCents ?? 0);
+  const usedNativeCents = row.balanceCents < BI_ZERO ? -row.balanceCents : BI_ZERO;
+
+  // Utilization on native cents (ratio is invariant under positive-rate scaling)
+  const utilizationPct = roundUtilizationPct(usedNativeCents, limitNativeCents);
+
+  const cutoffDay = row.metadata.cutoffDay ?? null;
+  const daysToCutoff = cutoffDay !== null ? computeNextCutoff(cutoffDay, today).daysTo : null;
+
+  const label = formatAccountLabel(
+    {
+      name: row.name,
+      currency: row.currency,
+      institution: row.institution,
+      metadata: { last4s: row.metadata.last4s ?? null },
+    },
+    { withInstitution: true },
+  );
+
+  return {
+    cardId: `acc-${row.id}`,
+    kind: "account",
+    label,
+    cutoffDay,
+    creditLimitCents: limitNativeCents,
+    usedCents: usedNativeCents,
+    utilizationPct,
+    daysToCutoff,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-user snapshot fetch — used by the /insights page card.
+// Mirrors the cron logic but scoped to a single userId and driven by the
+// caller-supplied fxRate (the page already has it in scope).
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch and build TcCardSnapshot[] for a single user. Used by the /insights
+ * page real-time card. Cards with no cupo AND no cutoff are excluded.
+ *
+ * @param userId   The authenticated user's id.
+ * @param fxRate   Current COP/USD FX rate (from `getCurrentFxRate().rate`).
+ * @param today    Bogota date (from `nowInBogota(new Date())`).
+ */
+export async function fetchUserTcSnapshots(
+  userId: number,
+  fxRate: number,
+  today: BogotaYmd,
+): Promise<TcCardSnapshot[]> {
+  const [multiRows, singleRows] = await Promise.all([
+    fetchMultiCurrencyCards(userId),
+    fetchSingleCurrencyCards(userId),
+  ]);
+
+  const snapshots: TcCardSnapshot[] = [];
+
+  for (const row of multiRows) {
+    if (row.statementCutoffDay === null && row.creditLimitCents === BI_ZERO) continue;
+    snapshots.push(buildMultiSnapshot(row, fxRate, today));
+  }
+
+  for (const row of singleRows) {
+    const limitCents = BigInt(row.metadata.creditLimitCents ?? 0);
+    const cutoffDay = row.metadata.cutoffDay ?? null;
+    if (cutoffDay === null && limitCents === BI_ZERO) continue;
+    snapshots.push(buildSingleSnapshot(row, fxRate, today));
+  }
+
+  return snapshots;
+}
+
+// ---------------------------------------------------------------------------
+// Core processor — exported for testability
+// ---------------------------------------------------------------------------
+
+export async function tcHealthCheckProcessor(job: Job<TcHealthCheckJobData>): Promise<void> {
+  const yearMonth = getCurrentYearMonth();
+  const now = new Date();
+  const today = nowInBogota(now);
+
+  log.info({ event: "tc_health_check_start", jobId: job.id, yearMonth }, "tc-health-check started");
+
+  await job.updateProgress({ phase: "fetching", yearMonth });
+  await job.log(`start: tc-health-check for ${yearMonth}`);
+
+  const [multiRows, singleRows] = await Promise.all([
+    fetchMultiCurrencyCards(),
+    fetchSingleCurrencyCards(),
+  ]);
+
+  // Only fetch FX when needed (multi-currency cards with USD exposure)
+  const needsFx =
+    multiRows.some((r) => r.usdDebtCents !== BI_ZERO) ||
+    singleRows.some((r) => r.currency === "USD");
+  const fxRate = needsFx ? (await getCurrentFxRate()).rate : 0;
+
+  // Build snapshots and group by userId for logging
+  const snapsByUser = new Map<number, TcCardSnapshot[]>();
+
+  for (const row of multiRows) {
+    // Skip if cutoffDay is null AND creditLimitCents is 0 — nothing to alert on
+    if (row.statementCutoffDay === null && row.creditLimitCents === BI_ZERO) continue;
+    const snap = buildMultiSnapshot(row, fxRate, today);
+    const existing = snapsByUser.get(row.userId) ?? [];
+    existing.push(snap);
+    snapsByUser.set(row.userId, existing);
+  }
+
+  for (const row of singleRows) {
+    const limitCents = BigInt(row.metadata.creditLimitCents ?? 0);
+    const cutoffDay = row.metadata.cutoffDay ?? null;
+    // Skip if cutoffDay is null AND creditLimitCents is 0
+    if (cutoffDay === null && limitCents === BI_ZERO) continue;
+    const snap = buildSingleSnapshot(row, fxRate, today);
+    const existing = snapsByUser.get(row.userId) ?? [];
+    existing.push(snap);
+    snapsByUser.set(row.userId, existing);
+  }
+
+  log.info(
+    {
+      event: "tc_health_check_fetched",
+      userCount: snapsByUser.size,
+      multiCount: multiRows.length,
+      singleCount: singleRows.length,
+      jobId: job.id,
+    },
+    `found ${snapsByUser.size} user(s) with TC(s)`,
+  );
+
+  let totalEmitted = 0;
+  let totalDeduped = 0;
+
+  for (const [userId, snaps] of snapsByUser) {
+    for (const snap of snaps) {
+      const triggers = computeTcAlerts(snap);
+      if (triggers.length === 0) continue;
+
+      for (const trigger of triggers) {
+        const entityId = `tc-alert-${snap.cardId}-${yearMonth}-${trigger}`;
+
+        const { title, body } = buildNotificationText(snap, trigger);
+
+        try {
+          const result = await emitNotification(userId, {
+            type: "tc_health_alert",
+            entityId,
+            priority: "medium",
+            title,
+            body,
+            actionUrl: "/insights",
+            metadata: {
+              cardId: snap.cardId,
+              kind: snap.kind,
+              trigger,
+              yearMonth,
+              utilizationPct: snap.utilizationPct,
+              daysToCutoff: snap.daysToCutoff,
+              creditLimitCents: snap.creditLimitCents.toString(),
+              usedCents: snap.usedCents.toString(),
+            },
+          });
+
+          if (result === null) {
+            totalDeduped++;
+            log.debug(
+              { userId, entityId, event: "tc_health_alert_dedup" },
+              "tc_health_alert deduped",
+            );
+          } else {
+            totalEmitted++;
+            log.info(
+              {
+                userId,
+                cardId: snap.cardId,
+                trigger,
+                yearMonth,
+                entityId,
+                notificationId: result.id,
+                event: "tc_health_alert_emitted",
+              },
+              "tc_health_alert notification emitted",
+            );
+          }
+        } catch (err) {
+          // Per-card failures are logged but never abort the loop — other users
+          // must still get their notifications even if one emit fails.
+          log.error(
+            {
+              err,
+              userId,
+              cardId: snap.cardId,
+              trigger,
+              entityId,
+              event: "tc_health_alert_emit_failed",
+            },
+            "tc_health_alert emit failed",
+          );
+        }
+      }
+    }
+  }
+
+  await job.updateProgress({ done: true, emitted: totalEmitted, deduped: totalDeduped });
+  await job.log(`done: yearMonth=${yearMonth} emitted=${totalEmitted} deduped=${totalDeduped}`);
+
+  log.info(
+    {
+      event: "tc_health_check_done",
+      yearMonth,
+      emitted: totalEmitted,
+      deduped: totalDeduped,
+      jobId: job.id,
+    },
+    "tc-health-check complete",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Notification text builders
+// ---------------------------------------------------------------------------
+
+function buildNotificationText(
+  snap: TcCardSnapshot,
+  trigger: string,
+): { title: string; body: string } {
+  if (trigger === "statement") {
+    const days = snap.daysToCutoff!;
+    const when = days === 0 ? "hoy" : days === 1 ? "mañana" : `en ${days} días`;
+    return {
+      title: `${snap.label}: corte ${when}`,
+      body: `El corte de tu tarjeta cae ${when}. Revisá tu saldo.`,
+    };
+  }
+
+  const pct = snap.utilizationPct;
+  const tier = trigger === "util-95" ? "95%" : trigger === "util-90" ? "90%" : "80%";
+  return {
+    title: `${snap.label}: cupo al ${pct}%`,
+    body: `Tenés el ${pct}% del cupo usado — llegaste al umbral del ${tier}.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Worker factory
+// ---------------------------------------------------------------------------
+
+export function createTcHealthCheckWorker() {
+  return createWorker<TcHealthCheckJobData, void>(
+    "tc-health-check",
+    async (job) => {
+      try {
+        await tcHealthCheckProcessor(job);
+      } catch (err) {
+        log.error(
+          { err, event: "tc_health_check_fanout_failed", jobId: job.id },
+          "tc-health-check processor threw — BullMQ will retry",
+        );
+        throw err;
+      }
+    },
+    {
+      concurrency: 1,
+    },
+  );
+}

--- a/src/lib/widgets/handlers/_shared.ts
+++ b/src/lib/widgets/handlers/_shared.ts
@@ -12,9 +12,33 @@
  *
  * Other handlers (tc-focus, mis-tcs, …) import from here to stay byte-for-byte
  * consistent on these small primitives.
+ *
+ * `nowInBogota` and `BogotaYmd` are also exported here so the TC health-check
+ * worker and insights page card can import the canonical Bogota-clock logic
+ * without pulling in the widget layer.
  */
 
 const BOGOTA_OFFSET_MS = 5 * 60 * 60 * 1000;
+
+/**
+ * A calendar date decomposed into year, month (1..12), and day-of-month in
+ * the America/Bogota timezone (UTC-5, no DST).
+ */
+export type BogotaYmd = { year: number; month: number; day: number };
+
+/**
+ * Decompose `now` into a Bogota-local calendar date. Colombia observes a fixed
+ * UTC-5 offset year-round (no DST), so we shift by 5 h and read the UTC
+ * components of the shifted date.
+ */
+export function nowInBogota(now: Date): BogotaYmd {
+  const shifted = new Date(now.getTime() - BOGOTA_OFFSET_MS);
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1, // 1..12
+    day: shifted.getUTCDate(),
+  };
+}
 
 /**
  * Formats `now` as an ISO-8601 string in Bogota local time with the `-05:00`

--- a/src/lib/widgets/handlers/tc-focus.ts
+++ b/src/lib/widgets/handlers/tc-focus.ts
@@ -35,7 +35,13 @@ import { getCurrentFxRate } from "@/lib/fx/repo";
 import { createLogger } from "@/lib/logger";
 import { formatAccountLabel } from "@/lib/accounts/format";
 import type { WidgetHandler, WidgetHandlerResult } from "@/app/api/widget/v1/[id]/registry";
-import { bogotaIsoNow, centsToCop, roundUtilizationPct } from "./_shared";
+import {
+  bogotaIsoNow,
+  centsToCop,
+  nowInBogota,
+  roundUtilizationPct,
+  type BogotaYmd,
+} from "./_shared";
 
 const log = createLogger({ module: "widget-tc-focus" });
 
@@ -85,25 +91,6 @@ const querySchema = z.object({
 });
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-// ---------------------------------------------------------------------------
-// Bogota-aware date helpers — Colombia has no DST, so a fixed UTC-5 offset is
-// exact. We keep the math in milliseconds to avoid Date#getXxx() surprises at
-// month boundaries.
-// ---------------------------------------------------------------------------
-
-const BOGOTA_OFFSET_MS = 5 * 60 * 60 * 1000;
-
-type BogotaYmd = { year: number; month: number; day: number };
-
-function nowInBogota(now: Date): BogotaYmd {
-  const shifted = new Date(now.getTime() - BOGOTA_OFFSET_MS);
-  return {
-    year: shifted.getUTCFullYear(),
-    month: shifted.getUTCMonth() + 1, // 1..12
-    day: shifted.getUTCDate(),
-  };
-}
 
 function daysInMonth(year: number, month: number): number {
   // month is 1..12; Date(year, month, 0) gives the last day of `month`.


### PR DESCRIPTION
Closes #705

Part of Epic #255 (phases D.1 + C.3).

## Summary

- Adds a daily BullMQ cron job (`tc-health-check`, 08:00 COT) that computes utilization ratio and days-to-cutoff for every credit card linked to a user, then fires `in_app` notifications when either threshold is breached
- Adds the `/insights` "Salud de tarjetas" card that surfaces those alerts in real time via the existing notifications API
- Dual-notification design is intentional: cards with FX exposure generate one notification per entityId (COP card + USD card) rather than a single `both` notification — keeps entity linking unambiguous

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (195 files, 2379 specs)
- [x] E2E `/insights` screenshots captured — all `/insights` captures passed (light + dark, chromium + mobile)
- [ ] manual smoke: verify cron registers at startup, trigger manually via admin queue dashboard, confirm notifications appear on `/insights`

Pre-existing E2E failures (home + counterparty) fail identically on `main` — not caused by this branch.