### PR TITLE
fix(gmail): route Apple non-transactional emails to skipped, not needs_review (#707)

### DIFF
--- a/src/lib/gmail/parsers/apple.test.ts
+++ b/src/lib/gmail/parsers/apple.test.ts
@@ -221,11 +221,78 @@ describe("appleParser — skip conditions", () => {
     if (r.kind === "skipped") expect(r.reason).toBe("developer_agreement");
   });
 
-  it("skips family welcome email (no invoice/billing signals)", () => {
-    const html = `<html><body><p>Te damos la bienvenida a En familia, Alejandro!</p><p>Como persona que organiza la familia, puedes invitar hasta a otros cinco miembros.</p></body></html>`;
+  it("skips iCloud security alert (Spanish login from new device)", () => {
+    // Sanitized from prod email_receipts.id=915.
+    const html = `<html><body><p>Hola, Test User:</p>
+      <p>Tu cuenta de Apple ( test@example.com ) se ha usado para iniciar sesión en iCloud en un navegador web.</p>
+      <p>Fecha y hora: 24 de febrero de 2026, 11:46 PST</p>
+      <p>Sistema operativo: Windows</p>
+      <p>Si la información mencionada más arriba te resulta familiar, puedes ignorar este mensaje.</p>
+      <p>Atentamente, Soporte técnico de Apple</p>
+    </body></html>`;
     const r = appleParser.parse(html);
-    expect(r.kind).toBe("needs_review");
-    if (r.kind === "needs_review") expect(r.reason).toBe("unrecognized_apple_email_type");
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("security_alert");
+  });
+
+  it("skips iCloud security alert (English variant)", () => {
+    const html = `<html><body><p>Hello Test User,</p>
+      <p>Your Apple Account ( test@example.com ) was used to sign in to iCloud via a web browser.</p>
+      <p>If the information above looks familiar, you can ignore this message.</p>
+      <p>Sincerely, Apple Support</p>
+    </body></html>`;
+    const r = appleParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("security_alert");
+  });
+
+  it("skips Billing Problem notification (no charge yet)", () => {
+    // Sanitized from prod email_receipts.id=907.
+    const html = `<html><body><p>Billing Problem</p>
+      <p>Apple TV (1 month) $ 29.900/month</p>
+      <p>Dear Test User, There is a problem with your payment method which may prevent the renewal of this subscription.</p>
+      <p>To avoid losing access to your service, please update your payment information.</p>
+      <p>Update Payment Information</p>
+      <p>Sincerely, Apple</p>
+    </body></html>`;
+    const r = appleParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("billing_problem");
+  });
+
+  it("skips family welcome email (Spanish)", () => {
+    // Sanitized from prod email_receipts.id=897/909.
+    const html = `<html><body><p>¡Te damos la bienvenida a En familia, Test User!</p>
+      <p>Como persona que organiza la familia, puedes invitar hasta a otros cinco miembros de la familia y darles acceso a los servicios que quieres compartir.</p>
+    </body></html>`;
+    const r = appleParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("family_welcome");
+  });
+
+  it("skips family welcome email (English variant)", () => {
+    const html = `<html><body><p>Welcome to Family Sharing, Test User!</p>
+      <p>As the family organizer, you can invite up to five other family members.</p>
+    </body></html>`;
+    const r = appleParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("family_welcome");
+  });
+
+  it("skips iCloud+ storage upgrade Confirmation (no charge until next cycle)", () => {
+    // Sanitized from prod email_receipts.id=927.
+    const html = `<html><body><p>Confirmation iCloud+ 1 month Renews monthly for $ 12.900</p>
+      <p>Dear Test User, This email confirms your storage plan upgrade:</p>
+      <p>App iCloud</p>
+      <p>Plan iCloud+ with 200 GB of storage</p>
+      <p>Date of Upgrade 13 January 2026</p>
+      <p>Renewal Price $ 12.900/month</p>
+      <p>Your subscription automatically renews for $ 12.900/month starting 13 February 2026 until cancelled.</p>
+      <p>Sincerely, Apple</p>
+    </body></html>`;
+    const r = appleParser.parse(html);
+    expect(r.kind).toBe("skipped");
+    if (r.kind === "skipped") expect(r.reason).toBe("icloud_upgrade_confirmation");
   });
 });
 

--- a/src/lib/gmail/parsers/apple.ts
+++ b/src/lib/gmail/parsers/apple.ts
@@ -9,10 +9,15 @@ const log = createLogger({ module: "gmail/parsers/apple" });
 //   INVOICE (parse):   "Invoice" + ("Order ID:" or "ORDER ID") + Order details + Subtotal/TOTAL
 //   RECEIPT (parse):   "Receipt" + "Order ID:" — same parse path as Invoice
 //   RECENT_PURCHASE:   "Recent Purchase" — security alert, skip
-//   SUBSCRIPTION_CONFIRMED: "Subscription Confirmed" — free trial, no charge, skip
+//   SUBSCRIPTION_CONFIRMED: "Subscription Confirmed" — free trial OR duplicate of
+//                           a separate Invoice email for the same charge, skip
 //   SUBSCRIPTION_EXPIRING:  "Subscription Expir" — upcoming expiry, no charge, skip
 //   DEVELOPER_AGREEMENT:    "signed the following agreement" — skip
-//   OTHER (family, etc.):   no billing data, skip
+//   SECURITY_ALERT:         "iniciar sesión" / "sign in to iCloud" login alert, skip
+//   BILLING_PROBLEM:        "Billing Problem" payment-failure notice, skip
+//   FAMILY_WELCOME:         "bienvenida a En familia" / "Welcome to Family Sharing", skip
+//   ICLOUD_UPGRADE_CONFIRMATION: "Date of Upgrade" storage plan upgrade notice
+//                                (no charge — first bill arrives separately as Invoice), skip
 //
 // Amount: Colombian Apple COP format uses period as thousands separator.
 //   "$ 29.900" = 29 900 COP = 2 990 000 cents
@@ -145,6 +150,39 @@ export const appleParser: GatewayParser = {
         /Developer\s+Agreement/i.test(text)
       ) {
         return { kind: "skipped", reason: "developer_agreement" };
+      }
+
+      // iCloud / Apple Account security alert — login from new device.
+      // Spanish prod sample: "se ha usado para iniciar sesión en iCloud".
+      // English variant phrased as "used to sign in to iCloud" / "sign in to your Apple Account".
+      if (
+        /se\s+ha\s+usado\s+para\s+iniciar\s+sesi[oó]n/i.test(text) ||
+        /used\s+to\s+sign\s+in\s+to\s+(?:iCloud|your\s+Apple)/i.test(text)
+      ) {
+        return { kind: "skipped", reason: "security_alert" };
+      }
+
+      // Payment-failure notification — "Billing Problem" / Spanish equivalent.
+      // No charge has happened; user is being asked to update payment info.
+      if (/Billing\s+Problem/i.test(text) || /Problema\s+de\s+facturaci[oó]n/i.test(text)) {
+        return { kind: "skipped", reason: "billing_problem" };
+      }
+
+      // Family Sharing welcome — sent when the family organizer accepts the role.
+      // No billing data.
+      if (
+        /bienvenida\s+a\s+En\s+familia/i.test(text) ||
+        /Welcome\s+to\s+Family\s+Sharing/i.test(text)
+      ) {
+        return { kind: "skipped", reason: "family_welcome" };
+      }
+
+      // iCloud+ storage plan upgrade Confirmation. The user upgraded mid-cycle;
+      // the first actual charge arrives later as a normal Invoice email. The
+      // discriminator "Date of Upgrade" is unique to this email type — it does
+      // not appear in regular Invoices or Receipts.
+      if (/Date\s+of\s+Upgrade/i.test(text)) {
+        return { kind: "skipped", reason: "icloud_upgrade_confirmation" };
       }
 
       // ----- Invoice / Receipt parse -----


### PR DESCRIPTION
## Summary

- Adds 4 new `skipped` branches to `src/lib/gmail/parsers/apple.ts` for known non-transactional Apple email types that previously fell through to `needs_review`: `security_alert`, `billing_problem`, `family_welcome`, `icloud_upgrade_confirmation`.
- 6 prod receipts (ids 897, 907, 909, 915, 917, 927) had been stuck in `match_status='pending'` because the parser returned `needs_review` for these types, causing the matcher to reattempt them on every cron tick. After this change, the parser sets `parsed_at` and `match_status='unmatched'` on first parse, matching the existing skip path for `recent_purchase_alert` / `subscription_confirmed_trial` / `subscription_expiring` / `developer_agreement`.
- 6 new unit tests in `apple.test.ts` (one per branch + English variants for `security_alert` and `family_welcome`); the prior "family welcome → needs_review" assertion was inverted to `skipped`.

## Investigation context

Issue #707 was rewritten on 2026-05-01 after independent diagnosis disproved the original "Epic G gateway parsers broken" framing. Verified locally against a prod copy:

- 21/21 previously-parsed Apple receipts still parse (no regression)
- 19/19 previously-skipped receipts still skip (no false flips)
- 6/6 stuck receipts route to the correct new `skipped` reason — verified by direct parser invocation on real `raw_html`

## Backfill — no script needed

The `gmail-pull` BullMQ cron runs every 5 minutes (`src/instrumentation.node.ts:178`) and re-queries receipts where `match_status IN ('pending', 'unmatched')`. The 6 stuck receipts have `parsed_at IS NULL`, so the next tick after deploy will re-run the new parser, get `kind='skipped'`, and update them.

The diagnostic SQL from the issue body should return 0 rows within ~5 min of deploy:

```sql
SELECT id FROM email_receipts
WHERE deleted_at IS NULL AND gateway = 'apple' AND match_status = 'pending';
```

## Test plan

- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test src/lib/gmail/` — 225/225 pass
- [x] Full suite — 2384 passed, 1 skipped
- [x] End-to-end on prod copy: 6 stuck receipts → `unmatched` with `parsed_at` set after parser run

Closes #707