### PR TITLE
feat(insights): per-merchant anomaly + first-encounter alert (#713)

### DIFF
--- a/drizzle/0073_aberrant_bloodscream.sql
+++ b/drizzle/0073_aberrant_bloodscream.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "transactions" ADD COLUMN "anomaly_flags" jsonb;

--- a/drizzle/meta/0073_snapshot.json
+++ b/drizzle/meta/0073_snapshot.json
@@ -1,0 +1,6331 @@
+{
+  "id": "547657ad-3a5d-453f-8016-c9125b532e04",
+  "prevId": "1082b483-db21-4f8a-a003-49f9e7b7d821",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_snapshots": {
+      "name": "account_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "snapshots_account_date_unique": {
+          "name": "snapshots_account_date_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_snapshots_user_id_users_id_fk": {
+          "name": "account_snapshots_user_id_users_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_snapshots_account_id_accounts_id_fk": {
+          "name": "account_snapshots_account_id_accounts_id_fk",
+          "tableFrom": "account_snapshots",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "physical_card_id": {
+          "name": "physical_card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_active_idx": {
+          "name": "accounts_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_live_idx": {
+          "name": "accounts_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_physical_card_live_idx": {
+          "name": "accounts_physical_card_live_idx",
+          "columns": [
+            {
+              "expression": "physical_card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accounts\".\"physical_card_id\" IS NOT NULL AND \"accounts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_physical_card_id_physical_cards_id_fk": {
+          "name": "accounts_physical_card_id_physical_cards_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "physical_cards",
+          "columnsFrom": [
+            "physical_card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.arq_statement_imports": {
+      "name": "arq_statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declared_start_cents": {
+          "name": "declared_start_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declared_end_cents": {
+          "name": "declared_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_count": {
+          "name": "parsed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_sum_cents": {
+          "name": "parsed_sum_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconciled": {
+          "name": "reconciled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconcile_diff_cents": {
+          "name": "reconcile_diff_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_ok": {
+          "name": "chain_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "raw_pdf_hash": {
+          "name": "raw_pdf_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "arq_statement_imports_period_unique": {
+          "name": "arq_statement_imports_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "arq_statement_imports_user_hash_unique": {
+          "name": "arq_statement_imports_user_hash_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_pdf_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "arq_statement_imports_account_period_idx": {
+          "name": "arq_statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "arq_statement_imports_user_id_users_id_fk": {
+          "name": "arq_statement_imports_user_id_users_id_fk",
+          "tableFrom": "arq_statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "arq_statement_imports_account_id_accounts_id_fk": {
+          "name": "arq_statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "arq_statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budgets_user_period_idx": {
+          "name": "budgets_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budgets_user_period_live_idx": {
+          "name": "budgets_user_period_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"budgets\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budgets_user_category_fk": {
+          "name": "budgets_user_category_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canary_alerts": {
+      "name": "canary_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_divergences": {
+          "name": "top_divergences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "canary_alerts_unresolved_idx": {
+          "name": "canary_alerts_unresolved_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"canary_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "categories_user_slug_unique": {
+          "name": "categories_user_slug_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_user_live_idx": {
+          "name": "categories_user_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_user_parent_fk": {
+          "name": "categories_user_parent_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_seeds": {
+      "name": "category_seeds",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(60)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_seeds_parent_slug_category_seeds_slug_fk": {
+          "name": "category_seeds_parent_slug_category_seeds_slug_fk",
+          "tableFrom": "category_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_corrections": {
+      "name": "classification_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_category_slug": {
+          "name": "new_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_corrections_learning_idx": {
+          "name": "classification_corrections_learning_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "new_category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_corrections_user_id_users_id_fk": {
+          "name": "classification_corrections_user_id_users_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_corrections_transaction_id_transactions_id_fk": {
+          "name": "classification_corrections_transaction_id_transactions_id_fk",
+          "tableFrom": "classification_corrections",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rule_seeds": {
+      "name": "classification_rule_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classification_rule_seeds_pattern_category_unique": {
+          "name": "classification_rule_seeds_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rule_seeds_category_slug_category_seeds_slug_fk": {
+          "name": "classification_rule_seeds_category_slug_category_seeds_slug_fk",
+          "tableFrom": "classification_rule_seeds",
+          "tableTo": "category_seeds",
+          "columnsFrom": [
+            "category_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classification_rules": {
+      "name": "classification_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_from_corrections": {
+          "name": "generated_from_corrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_user_priority_id_idx": {
+          "name": "rules_user_priority_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_user_pattern_category_unique": {
+          "name": "rules_user_pattern_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classification_rules_user_id_users_id_fk": {
+          "name": "classification_rules_user_id_users_id_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classification_rules_user_category_fk": {
+          "name": "classification_rules_user_category_fk",
+          "tableFrom": "classification_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparties": {
+      "name": "counterparties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "counterparty_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "default_category_slug": {
+          "name": "default_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_salary": {
+          "name": "is_salary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparties_user_display_idx": {
+          "name": "counterparties_user_display_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparties_user_salary_idx": {
+          "name": "counterparties_user_salary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"counterparties\".\"is_salary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparties_user_id_users_id_fk": {
+          "name": "counterparties_user_id_users_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparties_user_category_fk": {
+          "name": "counterparties_user_category_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "default_category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.counterparty_aliases": {
+      "name": "counterparty_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "counterparty_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "counterparty_aliases_user_kind_value_unique": {
+          "name": "counterparty_aliases_user_kind_value_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "counterparty_aliases_counterparty_idx": {
+          "name": "counterparty_aliases_counterparty_idx",
+          "columns": [
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "counterparty_aliases_user_id_users_id_fk": {
+          "name": "counterparty_aliases_user_id_users_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "counterparty_aliases_counterparty_id_counterparties_id_fk": {
+          "name": "counterparty_aliases_counterparty_id_counterparties_id_fk",
+          "tableFrom": "counterparty_aliases",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_receipts": {
+      "name": "email_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_connection_id": {
+          "name": "gmail_connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_msg_id": {
+          "name": "gmail_msg_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway": {
+          "name": "gateway",
+          "type": "email_receipt_gateway",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_html": {
+          "name": "raw_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_payload": {
+          "name": "parsed_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_transaction_id": {
+          "name": "matched_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_status": {
+          "name": "match_status",
+          "type": "email_receipt_match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "match_candidates": {
+          "name": "match_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_at": {
+          "name": "parsed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_received_at": {
+          "name": "email_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_receipts_user_msg_unique": {
+          "name": "email_receipts_user_msg_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_msg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_user_status_idx": {
+          "name": "email_receipts_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_match_lookup_idx": {
+          "name": "email_receipts_match_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "amount_cents",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'pending' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_connection_idx": {
+          "name": "email_receipts_connection_idx",
+          "columns": [
+            {
+              "expression": "gmail_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_receipts_candidates_gin_idx": {
+          "name": "email_receipts_candidates_gin_idx",
+          "columns": [
+            {
+              "expression": "match_candidates",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_receipts\".\"match_status\" = 'ambiguous' AND \"email_receipts\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_receipts_user_id_users_id_fk": {
+          "name": "email_receipts_user_id_users_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_gmail_connection_id_gmail_connections_id_fk": {
+          "name": "email_receipts_gmail_connection_id_gmail_connections_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "gmail_connections",
+          "columnsFrom": [
+            "gmail_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_receipts_matched_transaction_id_transactions_id_fk": {
+          "name": "email_receipts_matched_transaction_id_transactions_id_fk",
+          "tableFrom": "email_receipts",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "matched_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiat_partners": {
+      "name": "fiat_partners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_system": {
+          "name": "source_system",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_name": {
+          "name": "partner_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "fiat_partners_system_name_unique": {
+          "name": "fiat_partners_system_name_unique",
+          "columns": [
+            {
+              "expression": "source_system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiat_partners_source_active_idx": {
+          "name": "fiat_partners_source_active_idx",
+          "columns": [
+            {
+              "expression": "source_system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"fiat_partners\".\"active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_micros": {
+          "name": "rate_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_asof_unique": {
+          "name": "fx_rates_pair_asof_unique",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fx_rates_pair_fetched_idx": {
+          "name": "fx_rates_pair_fetched_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_connections": {
+      "name": "gmail_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_email": {
+          "name": "gmail_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_enc": {
+          "name": "access_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_pull_at": {
+          "name": "last_pull_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_pull_history_id": {
+          "name": "last_pull_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "gmail_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_nudge_sent_at": {
+          "name": "bot_nudge_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bootstrap_since_date": {
+          "name": "bootstrap_since_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_connections_user_email_unique": {
+          "name": "gmail_connections_user_email_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_user_status_idx": {
+          "name": "gmail_connections_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connections_active_idx": {
+          "name": "gmail_connections_active_idx",
+          "columns": [
+            {
+              "expression": "last_pull_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gmail_connections\".\"status\" = 'active' AND \"gmail_connections\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_connections_user_id_users_id_fk": {
+          "name": "gmail_connections_user_id_users_id_fk",
+          "tableFrom": "gmail_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_logs": {
+      "name": "ingestion_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_received": {
+          "name": "items_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_inserted": {
+          "name": "items_inserted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "items_duplicated": {
+          "name": "items_duplicated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingestion_logs_user_started_idx": {
+          "name": "ingestion_logs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_logs_user_unresolved_idx": {
+          "name": "ingestion_logs_user_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ingestion_logs\".\"status\" = 'error' AND \"ingestion_logs\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_logs_user_id_users_id_fk": {
+          "name": "ingestion_logs_user_id_users_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingestion_logs_resolved_txn_id_transactions_id_fk": {
+          "name": "ingestion_logs_resolved_txn_id_transactions_id_fk",
+          "tableFrom": "ingestion_logs",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_reports": {
+      "name": "insights_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "insights_reports_user_year_month_unique": {
+          "name": "insights_reports_user_year_month_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_reports_user_id_users_id_fk": {
+          "name": "insights_reports_user_id_users_id_fk",
+          "tableFrom": "insights_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_created_by_user_id_users_id_fk": {
+          "name": "invite_codes_created_by_user_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invite_codes_uses_count_check": {
+          "name": "invite_codes_uses_count_check",
+          "value": "\"invite_codes\".\"uses_count\" <= \"invite_codes\".\"max_uses\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_dedup_unique": {
+          "name": "notifications_dedup_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_unread_idx": {
+          "name": "notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_canary_events": {
+      "name": "parser_canary_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_body_hash": {
+          "name": "sms_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex_result": {
+          "name": "regex_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_result": {
+          "name": "ai_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement": {
+          "name": "agreement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "divergence_fields": {
+          "name": "divergence_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_canary_events_created_idx": {
+          "name": "parser_canary_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_canary_events_disagree_idx": {
+          "name": "parser_canary_events_disagree_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_canary_events\".\"agreement\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_canary_events_user_id_users_id_fk": {
+          "name": "parser_canary_events_user_id_users_id_fk",
+          "tableFrom": "parser_canary_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parser_events": {
+      "name": "parser_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_outcome": {
+          "name": "regex_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_outcome": {
+          "name": "ai_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_confidence": {
+          "name": "ai_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_input_tokens": {
+          "name": "ai_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_tokens": {
+          "name": "ai_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parser_events_created_idx": {
+          "name": "parser_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_kind_idx": {
+          "name": "parser_events_kind_idx",
+          "columns": [
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parser_events_ai_fallback_idx": {
+          "name": "parser_events_ai_fallback_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"parser_events\".\"event_kind\" LIKE 'ai_fallback_%'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parser_events_user_id_users_id_fk": {
+          "name": "parser_events_user_id_users_id_fk",
+          "tableFrom": "parser_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.physical_cards": {
+      "name": "physical_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_slug": {
+          "name": "institution_slug",
+          "type": "institution_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_limit_cents": {
+          "name": "credit_limit_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "statement_cutoff_day": {
+          "name": "statement_cutoff_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "physical_cards_user_idx": {
+          "name": "physical_cards_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "physical_cards_user_institution_idx": {
+          "name": "physical_cards_user_institution_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "physical_cards_user_id_users_id_fk": {
+          "name": "physical_cards_user_id_users_id_fk",
+          "tableFrom": "physical_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconciliation_decisions": {
+      "name": "reconciliation_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txn_id": {
+          "name": "txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into_txn_id": {
+          "name": "merged_into_txn_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconciliation_decisions_user_decided_idx": {
+          "name": "reconciliation_decisions_user_decided_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconciliation_decisions_txn_idx": {
+          "name": "reconciliation_decisions_txn_idx",
+          "columns": [
+            {
+              "expression": "txn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconciliation_decisions_user_id_users_id_fk": {
+          "name": "reconciliation_decisions_user_id_users_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reconciliation_decisions_merged_into_txn_id_transactions_id_fk": {
+          "name": "reconciliation_decisions_merged_into_txn_id_transactions_id_fk",
+          "tableFrom": "reconciliation_decisions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "merged_into_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconciliation_decisions_action_check": {
+          "name": "reconciliation_decisions_action_check",
+          "value": "\"reconciliation_decisions\".\"action\" IN ('archived', 'kept', 'merged_into')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_description_patterns": {
+      "name": "recurring_description_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observation_count": {
+          "name": "observation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "pattern_ambiguous": {
+          "name": "pattern_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_description_patterns_unique": {
+          "name": "recurring_description_patterns_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_description_patterns_user_pattern_idx": {
+          "name": "recurring_description_patterns_user_pattern_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_description_patterns_recurring_idx": {
+          "name": "recurring_description_patterns_recurring_idx",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_description_patterns_user_id_users_id_fk": {
+          "name": "recurring_description_patterns_user_id_users_id_fk",
+          "tableFrom": "recurring_description_patterns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_description_patterns_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_description_patterns_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_description_patterns",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_gaps": {
+      "name": "recurring_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_tx_id": {
+          "name": "resolution_tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_gaps_recurring_month_unique": {
+          "name": "recurring_gaps_recurring_month_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_detected_idx": {
+          "name": "recurring_gaps_detected_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_user_detected_idx": {
+          "name": "recurring_gaps_user_detected_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_gaps_open_idx": {
+          "name": "recurring_gaps_open_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_gaps\".\"resolution\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_gaps_user_id_users_id_fk": {
+          "name": "recurring_gaps_user_id_users_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_gaps_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_gaps_resolution_tx_id_transactions_id_fk": {
+          "name": "recurring_gaps_resolution_tx_id_transactions_id_fk",
+          "tableFrom": "recurring_gaps",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolution_tx_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_link_observations": {
+      "name": "recurring_link_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_id": {
+          "name": "tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "real_amount_cents": {
+          "name": "real_amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "real_currency": {
+          "name": "real_currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manual": {
+          "name": "manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_link_observations_unique": {
+          "name": "recurring_link_observations_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tx_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_link_observations_pending_idx": {
+          "name": "recurring_link_observations_pending_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_link_observations\".\"manual\" = true AND \"recurring_link_observations\".\"applied\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_link_observations_recurring_idx": {
+          "name": "recurring_link_observations_recurring_idx",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_link_observations_user_id_users_id_fk": {
+          "name": "recurring_link_observations_user_id_users_id_fk",
+          "tableFrom": "recurring_link_observations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_link_observations_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_link_observations_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_link_observations",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_link_observations_tx_id_transactions_id_fk": {
+          "name": "recurring_link_observations_tx_id_transactions_id_fk",
+          "tableFrom": "recurring_link_observations",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "tx_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_link_observations_account_id_accounts_id_fk": {
+          "name": "recurring_link_observations_account_id_accounts_id_fk",
+          "tableFrom": "recurring_link_observations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_proposals": {
+      "name": "recurring_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "recurring_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_proposals_user_status_idx": {
+          "name": "recurring_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_proposals_recurring_idx": {
+          "name": "recurring_proposals_recurring_idx",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_proposals_user_id_users_id_fk": {
+          "name": "recurring_proposals_user_id_users_id_fk",
+          "tableFrom": "recurring_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_proposals_recurring_id_recurring_transactions_id_fk": {
+          "name": "recurring_proposals_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "recurring_proposals",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_months": {
+          "name": "skipped_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_type": {
+          "name": "amount_type",
+          "type": "recurring_amount_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recurring_tx_user_day_idx": {
+          "name": "recurring_tx_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurring_tx_user_day_live_idx": {
+          "name": "recurring_tx_user_day_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurring_transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_transactions_user_id_users_id_fk": {
+          "name": "recurring_transactions_user_id_users_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_account_id_accounts_id_fk": {
+          "name": "recurring_transactions_account_id_accounts_id_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_transactions_user_category_fk": {
+          "name": "recurring_transactions_user_category_fk",
+          "tableFrom": "recurring_transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_proposals": {
+      "name": "rule_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_txn_ids": {
+          "name": "correction_txn_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rule_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rule_proposals_user_merchant_category_pending_unique": {
+          "name": "rule_proposals_user_merchant_category_pending_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rule_proposals\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rule_proposals_user_status_idx": {
+          "name": "rule_proposals_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_proposals_user_id_users_id_fk": {
+          "name": "rule_proposals_user_id_users_id_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_proposals_user_category_fk": {
+          "name": "rule_proposals_user_category_fk",
+          "tableFrom": "rule_proposals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skipped_consolidation_cycles": {
+      "name": "skipped_consolidation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "skipped_consolidation_cycles_live_unique": {
+          "name": "skipped_consolidation_cycles_live_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skipped_consolidation_cycles_user_account_idx": {
+          "name": "skipped_consolidation_cycles_user_account_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"skipped_consolidation_cycles\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skipped_consolidation_cycles_user_id_users_id_fk": {
+          "name": "skipped_consolidation_cycles_user_id_users_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skipped_consolidation_cycles_account_id_accounts_id_fk": {
+          "name": "skipped_consolidation_cycles_account_id_accounts_id_fk",
+          "tableFrom": "skipped_consolidation_cycles",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slo_alerts": {
+      "name": "slo_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slo_key": {
+          "name": "slo_key",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_status": {
+          "name": "notification_status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slo_alerts_open_idx": {
+          "name": "slo_alerts_open_idx",
+          "columns": [
+            {
+              "expression": "slo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"slo_alerts\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statement_imports": {
+      "name": "statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "txn_count": {
+          "name": "txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "balance_at_end_cents": {
+          "name": "balance_at_end_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "statement_import_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movimientos'"
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synthetic_tx_id": {
+          "name": "synthetic_tx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "statement_imports_user_account_file_unique": {
+          "name": "statement_imports_user_account_file_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_account_period_idx": {
+          "name": "statement_imports_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "statement_imports_cycle_unique": {
+          "name": "statement_imports_cycle_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"statement_imports\".\"kind\" = 'extracto_detallado' AND \"statement_imports\".\"cycle\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statement_imports_user_id_users_id_fk": {
+          "name": "statement_imports_user_id_users_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_imports_account_id_accounts_id_fk": {
+          "name": "statement_imports_account_id_accounts_id_fk",
+          "tableFrom": "statement_imports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_bots": {
+      "name": "telegram_bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_bots_user_id_users_id_fk": {
+          "name": "telegram_bots_user_id_users_id_fk",
+          "tableFrom": "telegram_bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_bots_user_id_unique": {
+          "name": "telegram_bots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_sessions": {
+      "name": "telegram_sessions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "telegram_sessions_user_idx": {
+          "name": "telegram_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_sessions_user_id_users_id_fk": {
+          "name": "telegram_sessions_user_id_users_id_fk",
+          "tableFrom": "telegram_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_raw": {
+          "name": "description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_clean": {
+          "name": "description_clean",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_id": {
+          "name": "counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_method": {
+          "name": "classification_method",
+          "type": "classification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unclassified'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installments_total": {
+          "name": "installments_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "installment_rate_bps": {
+          "name": "installment_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category_slug": {
+          "name": "previous_category_slug",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retroactive_rule_id": {
+          "name": "retroactive_rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "tx_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "tx_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bank'"
+        },
+        "is_adjustment": {
+          "name": "is_adjustment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "reconciliation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreconciled'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_import_id": {
+          "name": "statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_id": {
+          "name": "recurring_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_year_month": {
+          "name": "recurring_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group_id": {
+          "name": "transfer_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_merchant": {
+          "name": "canonical_merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enriched_merchant": {
+          "name": "enriched_merchant",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_source": {
+          "name": "enrichment_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_source": {
+          "name": "secondary_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_statement": {
+          "name": "external_id_statement",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arq_statement_import_id": {
+          "name": "arq_statement_import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_mismatch": {
+          "name": "source_mismatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_mismatch_details": {
+          "name": "source_mismatch_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_account_occurred_idx": {
+          "name": "transactions_account_occurred_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_idx": {
+          "name": "transactions_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_category_idx": {
+          "name": "transactions_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_counterparty_idx": {
+          "name": "transactions_user_counterparty_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_recon_idx": {
+          "name": "transactions_account_recon_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciliation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_group_idx": {
+          "name": "transactions_transfer_group_idx",
+          "columns": [
+            {
+              "expression": "transfer_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"transfer_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_flagged_idx": {
+          "name": "transactions_flagged_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"reconciliation_status\" = 'flagged'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_occurred_live_idx": {
+          "name": "transactions_account_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_occurred_live_idx": {
+          "name": "transactions_user_occurred_live_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_canonical_idx": {
+          "name": "transactions_user_canonical_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_merchant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_external_unique": {
+          "name": "transactions_external_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recurring_unique": {
+          "name": "transactions_recurring_unique",
+          "columns": [
+            {
+              "expression": "recurring_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurring_year_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"recurring_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_id_counterparties_id_fk": {
+          "name": "transactions_counterparty_id_counterparties_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_retroactive_rule_id_classification_rules_id_fk": {
+          "name": "transactions_retroactive_rule_id_classification_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "classification_rules",
+          "columnsFrom": [
+            "retroactive_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_import_id_statement_imports_id_fk": {
+          "name": "transactions_statement_import_id_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "statement_imports",
+          "columnsFrom": [
+            "statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_id_recurring_transactions_id_fk": {
+          "name": "transactions_recurring_id_recurring_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_transactions",
+          "columnsFrom": [
+            "recurring_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_arq_statement_import_id_arq_statement_imports_id_fk": {
+          "name": "transactions_arq_statement_import_id_arq_statement_imports_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "arq_statement_imports",
+          "columnsFrom": [
+            "arq_statement_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_user_category_fk": {
+          "name": "transactions_user_category_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "user_id",
+            "category_slug"
+          ],
+          "columnsTo": [
+            "user_id",
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_aliases": {
+      "name": "user_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_aliases_user_alias_unique": {
+          "name": "user_aliases_user_alias_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_aliases_user_idx": {
+          "name": "user_aliases_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_aliases_user_id_users_id_fk": {
+          "name": "user_aliases_user_id_users_id_fk",
+          "tableFrom": "user_aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_health_snapshots": {
+      "name": "user_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sms_received_at": {
+          "name": "last_sms_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_capture_at": {
+          "name": "last_capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_sources_30d": {
+          "name": "capture_sources_30d",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_success_rate_30d": {
+          "name": "parser_success_rate_30d",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreconciled_txn_count": {
+          "name": "unreconciled_txn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "divergence_cents": {
+          "name": "divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_divergence_cents": {
+          "name": "statement_divergence_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_signal_flag": {
+          "name": "churn_signal_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_health_snapshots_user_captured_idx": {
+          "name": "user_health_snapshots_user_captured_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_health_snapshots_churn_idx": {
+          "name": "user_health_snapshots_churn_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_health_snapshots\".\"churn_signal_flag\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_health_snapshots_user_id_users_id_fk": {
+          "name": "user_health_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_health_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_snapshots": {
+      "name": "user_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_bytes": {
+          "name": "payload_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_snapshots_user_created_idx": {
+          "name": "user_snapshots_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_snapshots_user_id_users_id_fk": {
+          "name": "user_snapshots_user_id_users_id_fk",
+          "tableFrom": "user_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_sub": {
+          "name": "google_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ui_preferences": {
+          "name": "ui_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "classification_context": {
+          "name": "classification_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercadopago_customer_id": {
+          "name": "mercadopago_customer_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_sub_unique": {
+          "name": "users_google_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_sub"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('admin', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_tokens": {
+      "name": "webhook_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webhook_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_tokens_user_purpose_active_idx": {
+          "name": "webhook_tokens_user_purpose_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_tokens_user_id_users_id_fk": {
+          "name": "webhook_tokens_user_id_users_id_fk",
+          "tableFrom": "webhook_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_tokens_token_hash_unique": {
+          "name": "webhook_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "savings",
+        "credit_card",
+        "loan"
+      ]
+    },
+    "public.classification_method": {
+      "name": "classification_method",
+      "schema": "public",
+      "values": [
+        "rule",
+        "rule_retroactive",
+        "ai",
+        "manual",
+        "manual_confirmed",
+        "unclassified",
+        "user_uncategorized"
+      ]
+    },
+    "public.counterparty_key_kind": {
+      "name": "counterparty_key_kind",
+      "schema": "public",
+      "values": [
+        "qr",
+        "breb",
+        "account",
+        "name"
+      ]
+    },
+    "public.counterparty_type": {
+      "name": "counterparty_type",
+      "schema": "public",
+      "values": [
+        "person",
+        "merchant",
+        "unknown"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "COP",
+        "USD"
+      ]
+    },
+    "public.email_receipt_gateway": {
+      "name": "email_receipt_gateway",
+      "schema": "public",
+      "values": [
+        "mercado_pago",
+        "payu",
+        "wompi",
+        "apple",
+        "paypal",
+        "bancolombia",
+        "arq"
+      ]
+    },
+    "public.email_receipt_match_status": {
+      "name": "email_receipt_match_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "matched",
+        "ambiguous",
+        "unmatched"
+      ]
+    },
+    "public.gmail_connection_status": {
+      "name": "gmail_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "revoked",
+        "error"
+      ]
+    },
+    "public.institution_slug": {
+      "name": "institution_slug",
+      "schema": "public",
+      "values": [
+        "bancolombia",
+        "davivienda",
+        "nequi",
+        "bbva",
+        "scotiabank",
+        "bancogalicia",
+        "rappipay",
+        "cash",
+        "other"
+      ]
+    },
+    "public.reconciliation_status": {
+      "name": "reconciliation_status",
+      "schema": "public",
+      "values": [
+        "unreconciled",
+        "matched",
+        "flagged",
+        "imported_from_statement"
+      ]
+    },
+    "public.recurring_amount_type": {
+      "name": "recurring_amount_type",
+      "schema": "public",
+      "values": [
+        "fixed",
+        "variable"
+      ]
+    },
+    "public.recurring_proposal_status": {
+      "name": "recurring_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.rule_proposal_status": {
+      "name": "rule_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.statement_import_kind": {
+      "name": "statement_import_kind",
+      "schema": "public",
+      "values": [
+        "movimientos",
+        "extracto_detallado"
+      ]
+    },
+    "public.tx_channel": {
+      "name": "tx_channel",
+      "schema": "public",
+      "values": [
+        "bank",
+        "manual",
+        "transfer"
+      ]
+    },
+    "public.tx_source": {
+      "name": "tx_source",
+      "schema": "public",
+      "values": [
+        "apple_pay",
+        "sms",
+        "ocr",
+        "csv",
+        "recurring",
+        "manual",
+        "telegram",
+        "balance_adjustment",
+        "csv_reconcile",
+        "gmail_bancolombia",
+        "gmail_enrichment",
+        "gmail_arq",
+        "arq_statement"
+      ]
+    },
+    "public.webhook_purpose": {
+      "name": "webhook_purpose",
+      "schema": "public",
+      "values": [
+        "sms",
+        "debug",
+        "widget"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -512,6 +512,13 @@
       "when": 1777666033030,
       "tag": "0072_puzzling_nicolaos",
       "breakpoints": true
+    },
+    {
+      "idx": 73,
+      "version": "7",
+      "when": 1777702742295,
+      "tag": "0073_aberrant_bloodscream",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/insights/page.tsx
+++ b/src/app/(app)/insights/page.tsx
@@ -16,6 +16,7 @@ import {
   type TcCardSnapshot,
   type TcAlertTrigger,
 } from "@/lib/insights/tc-health";
+import { fetchRecentAnomalies } from "@/lib/insights/merchant-anomaly-queries";
 import { InsightsViewer } from "./insights-viewer";
 
 export const dynamic = "force-dynamic";
@@ -96,7 +97,10 @@ export default async function InsightsPage({
 
   // TC Health card — real-time snapshot of all the user's TCs (#705)
   const today = nowInBogota(new Date());
-  const tcSnapshots = await fetchUserTcSnapshots(session.id, fx.rate, today);
+  const [tcSnapshots, recentAnomalies] = await Promise.all([
+    fetchUserTcSnapshots(session.id, fx.rate, today),
+    fetchRecentAnomalies(session.id),
+  ]);
   const tcAlerts: Array<{ snap: TcCardSnapshot; triggers: TcAlertTrigger[] }> = tcSnapshots
     .map((snap) => ({ snap, triggers: computeTcAlerts(snap) }))
     .filter((a) => a.triggers.length > 0);
@@ -158,6 +162,48 @@ export default async function InsightsPage({
                     {" · "}
                     {triggers.map((t) => triggerLabel(t, snap)).join(" · ")}
                   </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Anomalías recientes card (#713 B.1+B.2) */}
+      <Card className="border-orange-200 bg-orange-50/40 dark:border-orange-900 dark:bg-orange-950/15">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-orange-900 dark:text-orange-200">
+            Anomalías recientes
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {recentAnomalies.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              Sin anomalías ni comercios nuevos en los últimos 7 días.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-1">
+              {recentAnomalies.map((row) => (
+                <li key={`${row.txId}`} className="flex items-start justify-between gap-2 text-sm">
+                  <span>
+                    <span className="font-medium">{row.canonicalMerchant}</span>
+                    {" · "}
+                    {row.kind === "anomaly" && row.factor !== null ? (
+                      <span>
+                        {row.factor.toFixed(1)}× promedio habitual ·{" "}
+                        {formatMoney(BigInt(row.deltaCents ?? "0"), row.currency as "COP" | "USD")}{" "}
+                        más de lo usual
+                      </span>
+                    ) : (
+                      <span className="text-orange-700 dark:text-orange-300">nuevo comercio</span>
+                    )}
+                  </span>
+                  <Link
+                    href={`/transactions?highlight=${row.txId}`}
+                    className="shrink-0 text-xs text-orange-700 underline underline-offset-4 hover:text-orange-900 dark:text-orange-300 dark:hover:text-orange-100"
+                  >
+                    Ver →
+                  </Link>
                 </li>
               ))}
             </ul>

--- a/src/components/transactions/forecast-overlay.test.tsx
+++ b/src/components/transactions/forecast-overlay.test.tsx
@@ -104,6 +104,7 @@ function makeTxRow(overrides: Partial<TxRow> = {}): TxRow {
     channel: "bank",
     transferGroupId: null,
     rawData: null,
+    anomalyFlags: null,
     ...overrides,
   };
 }

--- a/src/components/transactions/transaction-table.test.tsx
+++ b/src/components/transactions/transaction-table.test.tsx
@@ -100,6 +100,7 @@ function makeTxRow(overrides: Partial<TxRow> = {}): TxRow {
     channel: "bank",
     transferGroupId: null,
     rawData: null,
+    anomalyFlags: null,
     ...overrides,
   };
 }

--- a/src/components/transactions/transaction-table.test.tsx
+++ b/src/components/transactions/transaction-table.test.tsx
@@ -35,8 +35,8 @@ vi.mock("@/components/transactions/counterparty-dialog", () => ({
   CounterpartyDialog: () => null,
 }));
 vi.mock("@/components/transactions/confidence-badge", () => ({
-  ConfidenceBadge: () => null,
-  confidenceBand: () => null,
+  ConfidenceBadge: vi.fn(() => null),
+  confidenceBand: vi.fn(() => null),
 }));
 vi.mock("@/components/transactions/needs-review-badge", () => ({
   NeedsReviewBadge: () => null,
@@ -46,6 +46,10 @@ vi.mock("@/components/transactions/needs-review-badge", () => ({
 import { TransactionTable } from "./transaction-table";
 import { MoneyModeProvider } from "@/components/display/money-mode-provider";
 import type { TxRow } from "@/lib/types";
+import {
+  ConfidenceBadge as MockedConfidenceBadge,
+  confidenceBand as mockedConfidenceBand,
+} from "@/components/transactions/confidence-badge";
 
 // ---------------------------------------------------------------------------
 // Radix shims — pointer capture + scrollIntoView not in jsdom.
@@ -302,5 +306,132 @@ describe("TransactionTable — #528 frozen TRM via MoneyFrozen", () => {
     // No conversion performed → no tooltip; raw amount renders as-is.
     const tooltipNodes = document.querySelectorAll('[title*="TRM histórica"]');
     expect(tooltipNodes.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — #713 B.2: combined first-encounter + low-confidence badge
+//
+// The desktop row (lines 487–514 of transaction-table.tsx) implements a
+// combined-badge decision:
+//   • firstEncounter=true AND band="low"  → ONE combined badge, ConfidenceBadge suppressed
+//   • firstEncounter=true AND band≠"low"  → standalone "Nuevo merchant" badge, ConfidenceBadge
+//                                            natural (null for high/rule; renders for medium)
+//   • firstEncounter=false / null          → no first-encounter badge, ConfidenceBadge natural
+//
+// The mocks for confidenceBand and ConfidenceBadge are vi.fn() so they can be
+// overridden per describe block without affecting the rest of the suite.
+// ---------------------------------------------------------------------------
+
+// Real confidenceBand logic (inlined so we never import through the mock).
+function realBand(
+  method: TxRow["classificationMethod"],
+  confidence: number | null,
+): "high" | "medium" | "low" | null {
+  if (method !== "rule" && method !== "ai") return null;
+  if (confidence === null) return null;
+  if (confidence >= 90) return "high";
+  if (confidence >= 60) return "medium";
+  return "low";
+}
+
+describe("TransactionTable — #713 combined first-encounter + low-confidence badge", () => {
+  beforeEach(() => {
+    // Wire real band logic into the mock so the component's conditional fires.
+    vi.mocked(mockedConfidenceBand).mockImplementation(realBand);
+    // Keep ConfidenceBadge invisible by default; tests that need it visible will
+    // override in their own beforeEach or arrange step.
+    vi.mocked(MockedConfidenceBadge).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    // Reset to the baseline mock after each test.
+    vi.mocked(mockedConfidenceBand).mockReturnValue(null);
+    vi.mocked(MockedConfidenceBadge).mockReturnValue(null);
+  });
+
+  it("firstEncounter=true + low-confidence: renders combined badge, suppresses ConfidenceBadge", () => {
+    // confidence=30 (scale 0–100, threshold LOW=60) → band="low" with method="ai"
+    const tx = makeTxRow({
+      id: 7130,
+      classificationMethod: "ai",
+      classificationConfidence: 30,
+      anomalyFlags: { firstEncounter: true, detectedAt: "2026-05-02T00:00:00Z" },
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    // Desktop renders the combined badge text.
+    expect(screen.getByText("Nuevo merchant — confirmá categoría")).toBeInTheDocument();
+
+    // Standalone "Nuevo merchant" must NOT appear (replaced by combined).
+    expect(screen.queryByText("Nuevo merchant")).not.toBeInTheDocument();
+
+    // ConfidenceBadge mock was called (component tried to render it in mobile)
+    // but the desktop path suppresses it — the mock returns null so nothing
+    // with "revisar" text should be in the DOM at all.
+    expect(screen.queryByText("revisar")).not.toBeInTheDocument();
+  });
+
+  it("firstEncounter=true + high-confidence (rule): standalone 'Nuevo merchant' badge, no ConfidenceBadge", () => {
+    // method="rule" + confidence=95 → band="high". ConfidenceBadge returns null for
+    // "high" naturally. band≠"low" → else branch fires → standalone badge + no combined.
+    const tx = makeTxRow({
+      id: 7131,
+      classificationMethod: "rule",
+      classificationConfidence: 95,
+      anomalyFlags: { firstEncounter: true, detectedAt: "2026-05-02T00:00:00Z" },
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    // Standalone badge must appear (band is "high", not "low" → else branch fires).
+    expect(screen.getByText("Nuevo merchant")).toBeInTheDocument();
+
+    // Combined badge must NOT appear.
+    expect(screen.queryByText("Nuevo merchant — confirmá categoría")).not.toBeInTheDocument();
+
+    // ConfidenceBadge mock returns null → no "revisar" text.
+    expect(screen.queryByText("revisar")).not.toBeInTheDocument();
+  });
+
+  it("firstEncounter=true + medium-confidence: standalone 'Nuevo merchant' AND ConfidenceBadge coexist", () => {
+    // confidence=75 → band="medium". Only "low" triggers merge; medium lets both coexist.
+    vi.mocked(MockedConfidenceBadge).mockReturnValue(
+      <span data-testid="confidence-badge-medium">75%</span>,
+    );
+
+    const tx = makeTxRow({
+      id: 7132,
+      classificationMethod: "ai",
+      classificationConfidence: 75,
+      anomalyFlags: { firstEncounter: true, detectedAt: "2026-05-02T00:00:00Z" },
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    // Standalone "Nuevo merchant" badge IS rendered (else branch, firstEncounter=true).
+    expect(screen.getByText("Nuevo merchant")).toBeInTheDocument();
+
+    // Combined badge must NOT appear (band is medium, not low).
+    expect(screen.queryByText("Nuevo merchant — confirmá categoría")).not.toBeInTheDocument();
+
+    // ConfidenceBadge renders its medium output (desktop path does NOT suppress it).
+    expect(screen.getAllByTestId("confidence-badge-medium").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("firstEncounter=false (anomalyFlags=null): no first-encounter badge, ConfidenceBadge natural", () => {
+    // No anomalyFlags → neither badge branch fires for first-encounter.
+    const tx = makeTxRow({
+      id: 7133,
+      classificationMethod: "ai",
+      classificationConfidence: 30,
+      anomalyFlags: null,
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    expect(screen.queryByText("Nuevo merchant")).not.toBeInTheDocument();
+    expect(screen.queryByText("Nuevo merchant — confirmá categoría")).not.toBeInTheDocument();
   });
 });

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -484,10 +484,34 @@ export function TransactionTable({
                           channel={tx.channel}
                         />
                         <div className="flex flex-wrap items-center gap-1">
-                          <ConfidenceBadge
-                            method={tx.classificationMethod}
-                            confidence={tx.classificationConfidence}
-                          />
+                          {/* #713 B.2: combined badge when first-encounter + low-confidence fire together */}
+                          {tx.anomalyFlags?.firstEncounter &&
+                          confidenceBand(tx.classificationMethod, tx.classificationConfidence) ===
+                            "low" ? (
+                            <Badge
+                              variant="outline"
+                              className="gap-1 border-orange-300 bg-orange-50 font-normal text-orange-900 dark:border-orange-900 dark:bg-orange-950/40 dark:text-orange-200"
+                              title="Nuevo comercio detectado con baja confianza en la clasificación. Confirmá la categoría."
+                            >
+                              Nuevo merchant — confirmá categoría
+                            </Badge>
+                          ) : (
+                            <>
+                              {tx.anomalyFlags?.firstEncounter ? (
+                                <Badge
+                                  variant="outline"
+                                  className="gap-1 border-orange-300 bg-orange-50 font-normal text-orange-900 dark:border-orange-900 dark:bg-orange-950/40 dark:text-orange-200"
+                                  title="Primera vez que aparece este comercio en tus transacciones."
+                                >
+                                  Nuevo merchant
+                                </Badge>
+                              ) : null}
+                              <ConfidenceBadge
+                                method={tx.classificationMethod}
+                                confidence={tx.classificationConfidence}
+                              />
+                            </>
+                          )}
                           {!isPairedTransfer ? (
                             <ClassificationReasonDialog
                               txId={tx.id}

--- a/src/lib/classification/pipeline.test.ts
+++ b/src/lib/classification/pipeline.test.ts
@@ -86,6 +86,7 @@ describe("classifyUnclassifiedBatch — opts.txIds", () => {
   it("returns picked=0 immediately when txIds is empty array", async () => {
     const result = await classifyUnclassifiedBatch(TEST_USER_A, { txIds: [] });
     expect(result.picked).toBe(0);
+    expect(result.classifiedIds).toEqual([]);
     expect(mockClassifyBatch).not.toHaveBeenCalled();
   });
 
@@ -208,6 +209,7 @@ describe("classifyUnclassifiedBatch — default (no opts)", () => {
     // Ensure no test-txs exist for this user with classification_method=unclassified
     const result = await classifyUnclassifiedBatch(TEST_USER_A);
     expect(result.picked).toBe(0);
+    expect(result.classifiedIds).toEqual([]);
     expect(mockClassifyBatch).not.toHaveBeenCalled();
   });
 

--- a/src/lib/classification/pipeline.ts
+++ b/src/lib/classification/pipeline.ts
@@ -14,6 +14,8 @@ export type PipelineResult = {
   skipped: number;
   model: string | null;
   usage: { inputTokens: number; outputTokens: number };
+  /** IDs of transactions that were successfully classified in this batch. */
+  classifiedIds: number[];
 };
 
 export type ClassifyBatchOpts = {
@@ -79,6 +81,7 @@ export async function classifyUnclassifiedBatch(
       skipped: 0,
       model: null,
       usage: { inputTokens: 0, outputTokens: 0 },
+      classifiedIds: [],
     };
   }
 
@@ -101,6 +104,7 @@ export async function classifyUnclassifiedBatch(
   const userHints: AiUserHint[] = userRow[0]?.context?.merchant_hints ?? [];
 
   let ruleClassified = 0;
+  const classifiedIds: number[] = [];
   const stillPending: typeof pending = [];
   for (const tx of pending) {
     const ruleHit = await classifyByRule(
@@ -123,6 +127,7 @@ export async function classifyUnclassifiedBatch(
         })
         .where(and(eq(transactions.userId, userId), eq(transactions.id, tx.id)));
       ruleClassified++;
+      classifiedIds.push(tx.id);
     } else {
       stillPending.push(tx);
     }
@@ -136,6 +141,7 @@ export async function classifyUnclassifiedBatch(
       skipped: 0,
       model: null,
       usage: { inputTokens: 0, outputTokens: 0 },
+      classifiedIds,
     };
   }
 
@@ -178,6 +184,7 @@ export async function classifyUnclassifiedBatch(
         ),
       );
     aiClassified++;
+    classifiedIds.push(tx.id);
   }
 
   await db.insert(ingestionLogs).values({
@@ -208,5 +215,6 @@ export async function classifyUnclassifiedBatch(
     skipped,
     model: aiResult.model,
     usage: aiResult.usage,
+    classifiedIds,
   };
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,4 +1,5 @@
 import { sql } from "drizzle-orm";
+import type { AnomalyFlags } from "@/lib/insights/merchant-anomaly";
 import {
   bigint,
   boolean,
@@ -616,6 +617,12 @@ export const transactions = pgTable(
     sourceMismatch: boolean("source_mismatch").notNull().default(false),
     sourceMismatchDetails: jsonb("source_mismatch_details").$type<SourceMismatchDetails>(),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    // #713 (Epic I B.1+B.2): per-merchant anomaly and first-encounter signals.
+    // Populated by detectMerchantSignals after classification. Nullable — null
+    // means no signal was detected for this tx. Shape: AnomalyFlags (see
+    // src/lib/insights/merchant-anomaly.ts). Open-ended: future B.3/B.4 signals
+    // extend the type without a migration.
+    anomalyFlags: jsonb("anomaly_flags").$type<AnomalyFlags>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/src/lib/insights/merchant-anomaly-detector.test.ts
+++ b/src/lib/insights/merchant-anomaly-detector.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Integration tests for detectMerchantSignals (DB-hitting).
+ *
+ * Uses findash_test (forced by vitest.setup.ts).
+ * Cleanup sentinel: description_raw LIKE '__anomaly_test%'.
+ *
+ * NOTE: BigInt literals (0n) are ES2020+. This project targets ES2017, so we
+ * use BigInt() constructor calls throughout (matching the tc-health.test.ts pattern).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { transactions } from "@/lib/db/schema";
+import { detectMerchantSignals } from "./merchant-anomaly";
+
+// ---------------------------------------------------------------------------
+// emitNotification mock
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => ({
+  emitNotification: vi.fn().mockResolvedValue({ id: 999 }),
+}));
+
+vi.mock("@/lib/notifications/emit", () => ({
+  emitNotification: mocks.emitNotification,
+}));
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEST_USER_ID = 1; // bootstrap user — always exists in findash_test
+const SENTINEL = "__anomaly_test";
+
+// ---------------------------------------------------------------------------
+// Cleanup helpers
+// ---------------------------------------------------------------------------
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE '__anomaly_test%'`);
+}
+
+async function defaultAccountId(): Promise<number> {
+  const [row] = await db.execute<{ id: number }>(sql`
+    SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} ORDER BY id LIMIT 1
+  `);
+  if (!row) throw new Error("No account for test user");
+  return row.id;
+}
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
+
+async function seedTx(opts: {
+  accountId: number;
+  amountCents: bigint;
+  currency?: string;
+  canonicalMerchant?: string | null;
+  channel?: string;
+  occurredDaysAgo?: number; // relative to now; default=1
+  description?: string;
+}): Promise<number> {
+  const occurredAt = new Date(
+    Date.now() - (opts.occurredDaysAgo ?? 1) * 24 * 60 * 60 * 1000,
+  ).toISOString(); // postgres.js raw sql requires ISO string, not Date object
+  const amountCents = Number(opts.amountCents); // postgres.js raw sql: use Number for bigint
+  const [row] = await db.execute<{ id: number }>(sql`
+    INSERT INTO transactions (
+      user_id, account_id, occurred_at, amount_cents, currency,
+      description_raw, classification_method, source,
+      canonical_merchant, channel
+    ) VALUES (
+      ${TEST_USER_ID},
+      ${opts.accountId},
+      ${occurredAt}::timestamptz,
+      ${amountCents},
+      ${opts.currency ?? "COP"},
+      ${opts.description ?? `${SENTINEL}_tx`},
+      'manual'::classification_method,
+      'sms',
+      ${opts.canonicalMerchant ?? null},
+      ${opts.channel ?? "bank"}
+    )
+    RETURNING id
+  `);
+  return row.id;
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe("detectMerchantSignals — skip rules", () => {
+  let accountId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    mocks.emitNotification.mockClear();
+    accountId = await defaultAccountId();
+  });
+
+  afterEach(cleanup);
+
+  it("skips transactions with null canonical_merchant", async () => {
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(-30_000),
+      canonicalMerchant: null,
+    });
+
+    await detectMerchantSignals(TEST_USER_ID, [txId], db);
+
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+
+    // anomaly_flags must remain null
+    const [row] = await db
+      .select({ anomalyFlags: transactions.anomalyFlags })
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+    expect(row?.anomalyFlags).toBeNull();
+  });
+
+  it("skips transfer transactions", async () => {
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(-30_000),
+      canonicalMerchant: `${SENTINEL}_merchant`,
+      channel: "transfer",
+    });
+
+    await detectMerchantSignals(TEST_USER_ID, [txId], db);
+
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips non-expense transactions (amount_cents >= 0)", async () => {
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(10_000), // positive = income
+      canonicalMerchant: `${SENTINEL}_income_merchant`,
+    });
+
+    await detectMerchantSignals(TEST_USER_ID, [txId], db);
+
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips if classifiedIds is empty", async () => {
+    await detectMerchantSignals(TEST_USER_ID, [], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+});
+
+describe("detectMerchantSignals — B.2 first-encounter", () => {
+  let accountId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    mocks.emitNotification.mockClear();
+    accountId = await defaultAccountId();
+  });
+
+  afterEach(cleanup);
+
+  it("emits first_encounter notification on a brand-new merchant", async () => {
+    const merchant = `${SENTINEL}_new_merchant_${Date.now()}`;
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(-15_000),
+      canonicalMerchant: merchant,
+    });
+
+    await detectMerchantSignals(TEST_USER_ID, [txId], db);
+
+    expect(mocks.emitNotification).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.objectContaining({
+        type: "merchant_first_encounter",
+        entityId: `first-merchant:${TEST_USER_ID}:${merchant}`,
+      }),
+    );
+
+    // Check anomaly_flags written to the tx
+    const [row] = await db
+      .select({ anomalyFlags: transactions.anomalyFlags })
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+    expect(row?.anomalyFlags).toMatchObject({ firstEncounter: true });
+  });
+
+  it("does NOT emit first_encounter for the second tx of the same merchant", async () => {
+    const merchant = `${SENTINEL}_repeat_merchant_${Date.now()}`;
+
+    // Seed the first tx ONLY first, then process it so it's the true first-encounter
+    const tx1 = await seedTx({
+      accountId,
+      amountCents: BigInt(-15_000),
+      canonicalMerchant: merchant,
+      occurredDaysAgo: 5,
+    });
+
+    // Process first tx alone — should emit first_encounter (no prior history for merchant)
+    await detectMerchantSignals(TEST_USER_ID, [tx1], db);
+    expect(mocks.emitNotification).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.objectContaining({ type: "merchant_first_encounter" }),
+    );
+
+    mocks.emitNotification.mockClear();
+
+    // NOW seed the second tx (merchant now has 1 prior: tx1)
+    const tx2 = await seedTx({
+      accountId,
+      amountCents: BigInt(-15_000),
+      canonicalMerchant: merchant,
+      occurredDaysAgo: 1,
+    });
+
+    // Process second tx — history=1, so no first-encounter; history < 5 so no anomaly either
+    await detectMerchantSignals(TEST_USER_ID, [tx2], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.objectContaining({ type: "merchant_first_encounter" }),
+    );
+    expect(mocks.emitNotification).not.toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.objectContaining({ type: "merchant_anomaly" }),
+    );
+  });
+});
+
+describe("detectMerchantSignals — B.1 anomaly", () => {
+  let accountId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    mocks.emitNotification.mockClear();
+    accountId = await defaultAccountId();
+  });
+
+  afterEach(cleanup);
+
+  it("emits anomaly notification when 6th tx breaks 3× threshold with delta >= 10k", async () => {
+    const merchant = `${SENTINEL}_anomaly_merchant_${Date.now()}`;
+
+    // Seed 5 prior transactions at 10_000 each within 30-day window
+    for (let i = 0; i < 5; i++) {
+      await seedTx({
+        accountId,
+        amountCents: BigInt(-10_000),
+        canonicalMerchant: merchant,
+        occurredDaysAgo: 25 - i, // within 30-day window
+        description: `${SENTINEL}_baseline_${i}`,
+      });
+    }
+
+    // 6th tx at 35_000 (3.5× avg=10k, delta=25k)
+    const anomalousTxId = await seedTx({
+      accountId,
+      amountCents: BigInt(-35_000),
+      canonicalMerchant: merchant,
+      occurredDaysAgo: 1,
+      description: `${SENTINEL}_anomalous`,
+    });
+
+    await detectMerchantSignals(TEST_USER_ID, [anomalousTxId], db);
+
+    expect(mocks.emitNotification).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.objectContaining({
+        type: "merchant_anomaly",
+        entityId: `anomaly:${anomalousTxId}`,
+      }),
+    );
+
+    // Check anomaly_flags written
+    const [row] = await db
+      .select({ anomalyFlags: transactions.anomalyFlags })
+      .from(transactions)
+      .where(eq(transactions.id, anomalousTxId));
+    expect(row?.anomalyFlags).toMatchObject({
+      anomaly: expect.objectContaining({
+        factor: expect.any(Number),
+        deltaCents: expect.any(String),
+        baselineAvgCents: "10000",
+      }),
+    });
+  });
+
+  it("does NOT fire anomaly when only 4 prior txs (< ANOMALY_MIN_HISTORY=5)", async () => {
+    const merchant = `${SENTINEL}_insufficient_history_${Date.now()}`;
+
+    // Only 4 prior txs — below minimum
+    for (let i = 0; i < 4; i++) {
+      await seedTx({
+        accountId,
+        amountCents: BigInt(-10_000),
+        canonicalMerchant: merchant,
+        occurredDaysAgo: 20 - i,
+        description: `${SENTINEL}_hist_${i}`,
+      });
+    }
+
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(-50_000), // 5× avg — would fire if history were sufficient
+      canonicalMerchant: merchant,
+      occurredDaysAgo: 1,
+      description: `${SENTINEL}_check`,
+    });
+
+    await detectMerchantSignals(TEST_USER_ID, [txId], db);
+
+    // Should not emit anomaly (insufficient history; 4 priors > 0 so also not first-encounter)
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("currency split: COP history does NOT contaminate USD anomaly check", async () => {
+    const merchant = `${SENTINEL}_multicurrency_merchant_${Date.now()}`;
+
+    // Seed 5 COP transactions at 10_000 COP each
+    for (let i = 0; i < 5; i++) {
+      await seedTx({
+        accountId,
+        amountCents: BigInt(-10_000),
+        currency: "COP",
+        canonicalMerchant: merchant,
+        occurredDaysAgo: 20 - i,
+        description: `${SENTINEL}_cop_${i}`,
+      });
+    }
+
+    // New USD tx — this merchant has 5 COP entries but 0 USD entries in the window.
+    // Full history count = 5, so not first-encounter.
+    // USD window history = 0 (< ANOMALY_MIN_HISTORY), so anomaly should NOT fire.
+    const usdTxId = await seedTx({
+      accountId,
+      amountCents: BigInt(-5_000),
+      currency: "USD",
+      canonicalMerchant: merchant,
+      occurredDaysAgo: 1,
+      description: `${SENTINEL}_usd`,
+    });
+
+    await detectMerchantSignals(TEST_USER_ID, [usdTxId], db);
+
+    // COP history should NOT bleed into USD check
+    expect(mocks.emitNotification).not.toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.objectContaining({ type: "merchant_anomaly" }),
+    );
+    // Also not first-encounter (has 5 prior COP txs in full history)
+    expect(mocks.emitNotification).not.toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.objectContaining({ type: "merchant_first_encounter" }),
+    );
+  });
+});
+
+describe("detectMerchantSignals — dedup (anomaly entityId is stable)", () => {
+  let accountId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    mocks.emitNotification.mockClear();
+    accountId = await defaultAccountId();
+  });
+
+  afterEach(cleanup);
+
+  it("calling detectMerchantSignals twice for same anomalous tx uses stable entityId", async () => {
+    const merchant = `${SENTINEL}_dedup_merchant_${Date.now()}`;
+
+    for (let i = 0; i < 5; i++) {
+      await seedTx({
+        accountId,
+        amountCents: BigInt(-10_000),
+        canonicalMerchant: merchant,
+        occurredDaysAgo: 20 - i,
+        description: `${SENTINEL}_dedup_hist_${i}`,
+      });
+    }
+
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(-40_000),
+      canonicalMerchant: merchant,
+      occurredDaysAgo: 1,
+      description: `${SENTINEL}_dedup_anomalous`,
+    });
+
+    // First call
+    await detectMerchantSignals(TEST_USER_ID, [txId], db);
+    expect(mocks.emitNotification).toHaveBeenCalledTimes(1);
+
+    // Second call — emitNotification is mocked; in prod onConflictDoNothing handles dedup
+    mocks.emitNotification.mockResolvedValueOnce(null); // simulate dedup return
+    await detectMerchantSignals(TEST_USER_ID, [txId], db);
+
+    // Both calls should use the SAME entityId so DB dedup works correctly
+    const calls = mocks.emitNotification.mock.calls;
+    const entityIds = calls.map((c) => (c[1] as { entityId: string }).entityId);
+    expect(entityIds[0]).toBe(entityIds[1]);
+    expect(entityIds[0]).toBe(`anomaly:${txId}`);
+  });
+});

--- a/src/lib/insights/merchant-anomaly-queries.ts
+++ b/src/lib/insights/merchant-anomaly-queries.ts
@@ -1,0 +1,107 @@
+/**
+ * Merchant anomaly queries for the /insights page card.
+ *
+ * Server-side only — no BullMQ / ioredis transitively pulled in.
+ * Queried in real-time by the /insights RSC.
+ */
+
+import { and, desc, eq, gte, isNotNull } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import type { AnomalyFlags } from "./merchant-anomaly";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AnomalyKind = "anomaly" | "first_encounter";
+
+export type RecentAnomalyRow = {
+  txId: number;
+  canonicalMerchant: string;
+  amountCents: bigint;
+  currency: string;
+  occurredAt: Date;
+  kind: AnomalyKind;
+  /** For anomaly kind: the factor (e.g. 3.5) */
+  factor: number | null;
+  /** For anomaly kind: the delta from baseline, serialized as string */
+  deltaCents: string | null;
+  /** For anomaly kind: the baseline avg, serialized as string */
+  baselineAvgCents: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the most recent anomaly signals from the last 7 days for a user.
+ *
+ * Groups conceptually by (canonical_merchant, kind) and returns the most
+ * recent entry per group, capped at 10 results.
+ *
+ * @param userId   Authenticated user id.
+ * @param limit    Maximum number of results (default 10).
+ */
+export async function fetchRecentAnomalies(
+  userId: number,
+  limit = 10,
+): Promise<RecentAnomalyRow[]> {
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+  const rows = await db
+    .select({
+      id: transactions.id,
+      canonicalMerchant: transactions.canonicalMerchant,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      occurredAt: transactions.occurredAt,
+      anomalyFlags: transactions.anomalyFlags,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        isNotNull(transactions.anomalyFlags),
+        notDeleted(transactions.deletedAt),
+        gte(transactions.occurredAt, sevenDaysAgo),
+        isNotNull(transactions.canonicalMerchant),
+      ),
+    )
+    .orderBy(desc(transactions.occurredAt))
+    .limit(limit * 2); // over-fetch to allow dedup by merchant+kind
+
+  // Dedup: keep only the most recent row per (canonicalMerchant, kind).
+  // The query already orders by occurredAt DESC so first-seen wins.
+  const seen = new Set<string>();
+  const result: RecentAnomalyRow[] = [];
+
+  for (const row of rows) {
+    const flags = row.anomalyFlags as AnomalyFlags | null;
+    if (!flags) continue;
+
+    const kind: AnomalyKind = flags.firstEncounter ? "first_encounter" : "anomaly";
+    const dedupKey = `${row.canonicalMerchant}:${kind}`;
+
+    if (seen.has(dedupKey)) continue;
+    seen.add(dedupKey);
+
+    result.push({
+      txId: row.id,
+      canonicalMerchant: row.canonicalMerchant!,
+      amountCents: row.amountCents,
+      currency: row.currency,
+      occurredAt: row.occurredAt,
+      kind,
+      factor: flags.anomaly?.factor ?? null,
+      deltaCents: flags.anomaly?.deltaCents ?? null,
+      baselineAvgCents: flags.anomaly?.baselineAvgCents ?? null,
+    });
+
+    if (result.length >= limit) break;
+  }
+
+  return result;
+}

--- a/src/lib/insights/merchant-anomaly.test.ts
+++ b/src/lib/insights/merchant-anomaly.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for merchant-anomaly.ts pure functions.
+ * No DB, no side-effects — all test-doubles are in-memory.
+ *
+ * NOTE: BigInt literals (0n) are ES2020+. This project targets ES2017, so we
+ * use BigInt() constructor calls throughout (matching the tc-health.test.ts pattern).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ANOMALY_FACTOR_THRESHOLD,
+  ANOMALY_MIN_DELTA_CENTS,
+  ANOMALY_MIN_HISTORY,
+  detectFirstEncounter,
+  detectMerchantAnomaly,
+  evaluateMerchantSignals,
+} from "./merchant-anomaly";
+
+// ---------------------------------------------------------------------------
+// detectMerchantAnomaly
+// ---------------------------------------------------------------------------
+
+describe("detectMerchantAnomaly — threshold rules", () => {
+  it("returns isAnomaly=false when history has fewer than 5 entries", () => {
+    // 4 < ANOMALY_MIN_HISTORY(5)
+    const history = {
+      amounts: [BigInt(10_000), BigInt(10_000), BigInt(10_000), BigInt(10_000)],
+    };
+    expect(detectMerchantAnomaly(BigInt(50_000), history)).toEqual({ isAnomaly: false });
+  });
+
+  it("returns isAnomaly=false when exactly 5 entries but amount < 3× avg", () => {
+    // avg = 10_000, tx = 20_000 (2× avg — below 3×)
+    const history = {
+      amounts: [BigInt(10_000), BigInt(10_000), BigInt(10_000), BigInt(10_000), BigInt(10_000)],
+    };
+    expect(detectMerchantAnomaly(BigInt(20_000), history)).toEqual({ isAnomaly: false });
+  });
+
+  it("returns isAnomaly=false when factor >= 3 but delta < 10 000", () => {
+    // avg = 2 000, tx = 7 000 (3.5× avg), but delta = 5 000 < 10_000
+    const history = {
+      amounts: [BigInt(2_000), BigInt(2_000), BigInt(2_000), BigInt(2_000), BigInt(2_000)],
+    };
+    const result = detectMerchantAnomaly(BigInt(7_000), history);
+    expect(result.isAnomaly).toBe(false);
+  });
+
+  it("fires when amount is exactly 3× avg AND delta >= 10 000", () => {
+    // avg = 10 000, tx = 30 000 (exactly 3×), delta = 20 000 >= 10 000
+    const history = {
+      amounts: [BigInt(10_000), BigInt(10_000), BigInt(10_000), BigInt(10_000), BigInt(10_000)],
+    };
+    const result = detectMerchantAnomaly(BigInt(30_000), history);
+    expect(result.isAnomaly).toBe(true);
+    if (!result.isAnomaly) return; // type narrowing
+    expect(result.factor).toBeCloseTo(3.0, 5);
+    expect(result.deltaCents).toBe(BigInt(20_000));
+    expect(result.baselineAvgCents).toBe(BigInt(10_000));
+  });
+
+  it("fires when amount is >3× avg (e.g. 4×) with sufficient delta", () => {
+    // avg = 10 000, tx = 40 000 (4×), delta = 30 000
+    const history = {
+      amounts: [BigInt(10_000), BigInt(10_000), BigInt(10_000), BigInt(10_000), BigInt(10_000)],
+    };
+    const result = detectMerchantAnomaly(BigInt(40_000), history);
+    expect(result.isAnomaly).toBe(true);
+    if (!result.isAnomaly) return;
+    expect(result.factor).toBeCloseTo(4.0, 5);
+    expect(result.deltaCents).toBe(BigInt(30_000));
+  });
+
+  it("fires with minimum viable scenario: 5 entries, 3× factor, delta >= 10k", () => {
+    // avg = 15_000, tx = 45_000 (3×), delta = 30_000
+    const history = {
+      amounts: [BigInt(15_000), BigInt(15_000), BigInt(15_000), BigInt(15_000), BigInt(15_000)],
+    };
+    const result = detectMerchantAnomaly(BigInt(45_000), history);
+    expect(result.isAnomaly).toBe(true);
+  });
+
+  it("uses rolling average correctly across varied amounts", () => {
+    // amounts: [5k, 10k, 15k, 10k, 10k] → avg = 10k
+    // tx = 32k (3.2×), delta = 22k → should fire
+    const history = {
+      amounts: [BigInt(5_000), BigInt(10_000), BigInt(15_000), BigInt(10_000), BigInt(10_000)],
+    };
+    const result = detectMerchantAnomaly(BigInt(32_000), history);
+    expect(result.isAnomaly).toBe(true);
+    if (!result.isAnomaly) return;
+    expect(result.baselineAvgCents).toBe(BigInt(10_000));
+  });
+
+  it("returns isAnomaly=false when avg is 0", () => {
+    // Edge case: all-zero history (should never happen in practice)
+    const history = {
+      amounts: [BigInt(0), BigInt(0), BigInt(0), BigInt(0), BigInt(0)],
+    };
+    expect(detectMerchantAnomaly(BigInt(0), history)).toEqual({ isAnomaly: false });
+  });
+
+  it("handles BigInt math correctly for large amounts (COP scale)", () => {
+    // 6 transactions at $500k COP average; new tx at $1.6M (3.2×), delta = 1.1M
+    const avg = BigInt(500_000);
+    const history = {
+      amounts: [avg, avg, avg, avg, avg, avg],
+    };
+    const txAmount = BigInt(1_600_000);
+    const result = detectMerchantAnomaly(txAmount, history);
+    expect(result.isAnomaly).toBe(true);
+    if (!result.isAnomaly) return;
+    expect(result.baselineAvgCents).toBe(avg);
+    expect(result.deltaCents).toBe(txAmount - avg);
+  });
+
+  it("exactly meets ANOMALY_MIN_DELTA_CENTS boundary (10 000) — fires", () => {
+    // avg = 1 000, tx = 11 000 (11×), delta = 10 000 exactly
+    const history = {
+      amounts: [BigInt(1_000), BigInt(1_000), BigInt(1_000), BigInt(1_000), BigInt(1_000)],
+    };
+    const result = detectMerchantAnomaly(BigInt(11_000), history);
+    expect(result.isAnomaly).toBe(true);
+    if (!result.isAnomaly) return;
+    expect(result.deltaCents).toBe(ANOMALY_MIN_DELTA_CENTS);
+  });
+
+  it("one below ANOMALY_MIN_DELTA_CENTS boundary (9 999) — does NOT fire", () => {
+    // avg = 1 000, tx = 10_999 (~11×), delta = 9_999 < 10_000
+    const history = {
+      amounts: [BigInt(1_000), BigInt(1_000), BigInt(1_000), BigInt(1_000), BigInt(1_000)],
+    };
+    const result = detectMerchantAnomaly(BigInt(10_999), history);
+    expect(result.isAnomaly).toBe(false);
+  });
+
+  it("boundary at exactly ANOMALY_MIN_HISTORY entries — fires when thresholds met", () => {
+    const count = ANOMALY_MIN_HISTORY;
+    const history = { amounts: Array(count).fill(BigInt(10_000)) as bigint[] };
+    const result = detectMerchantAnomaly(BigInt(30_001), history); // 3× + delta > 10k
+    expect(result.isAnomaly).toBe(true);
+  });
+
+  it("one below ANOMALY_FACTOR_THRESHOLD boundary — does NOT fire", () => {
+    // threshold is 3×; test with 299_999 < 3 * 100_000 (300_000)
+    const history = {
+      amounts: [
+        BigInt(100_000),
+        BigInt(100_000),
+        BigInt(100_000),
+        BigInt(100_000),
+        BigInt(100_000),
+      ],
+    };
+    const result = detectMerchantAnomaly(BigInt(299_999), history);
+    // 299_999 < 3 * 100_000 → below threshold
+    expect(result.isAnomaly).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectFirstEncounter
+// ---------------------------------------------------------------------------
+
+describe("detectFirstEncounter", () => {
+  it("returns true when historyCount is 0", () => {
+    expect(detectFirstEncounter(0)).toBe(true);
+  });
+
+  it("returns false when historyCount is 1", () => {
+    expect(detectFirstEncounter(1)).toBe(false);
+  });
+
+  it("returns false when historyCount is 100", () => {
+    expect(detectFirstEncounter(100)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateMerchantSignals — combined logic and skip rules
+// ---------------------------------------------------------------------------
+
+describe("evaluateMerchantSignals — first-encounter takes priority", () => {
+  it("returns first_encounter when fullHistoryCount=0 even if amounts would be anomalous", () => {
+    // fullHistoryCount=0 means first-ever tx — anomaly is irrelevant
+    const result = evaluateMerchantSignals(
+      BigInt(1_000_000),
+      0, // no prior history
+      { amounts: [] }, // windowHistory is irrelevant but we pass empty
+    );
+    expect(result.signal).toBe("first_encounter");
+  });
+
+  it("does NOT return first_encounter when fullHistoryCount=1", () => {
+    const result = evaluateMerchantSignals(BigInt(30_000), 1, { amounts: [] });
+    // history < 5, so anomaly doesn't fire either → none
+    expect(result.signal).toBe("none");
+  });
+});
+
+describe("evaluateMerchantSignals — B.1 anomaly fires after first-encounter window passes", () => {
+  it("returns anomaly when fullHistoryCount >= 1 and thresholds met", () => {
+    const result = evaluateMerchantSignals(
+      BigInt(30_000),
+      10, // prior history exists
+      {
+        amounts: [BigInt(10_000), BigInt(10_000), BigInt(10_000), BigInt(10_000), BigInt(10_000)],
+      },
+    );
+    expect(result.signal).toBe("anomaly");
+    if (result.signal !== "anomaly") return;
+    expect(result.factor).toBeCloseTo(3.0, 5);
+    expect(result.deltaCents).toBe(BigInt(20_000));
+    expect(result.baselineAvgCents).toBe(BigInt(10_000));
+  });
+
+  it("returns none when fullHistoryCount >= 1 but window history < 5", () => {
+    const result = evaluateMerchantSignals(
+      BigInt(30_000),
+      10,
+      { amounts: [BigInt(10_000), BigInt(10_000), BigInt(10_000)] }, // only 3 entries
+    );
+    expect(result.signal).toBe("none");
+  });
+
+  it("returns none when fullHistoryCount >= 1 and window history >= 5 but no anomaly", () => {
+    // Normal amount — 1× avg, no anomaly
+    const result = evaluateMerchantSignals(BigInt(10_000), 5, {
+      amounts: [BigInt(10_000), BigInt(10_000), BigInt(10_000), BigInt(10_000), BigInt(10_000)],
+    });
+    expect(result.signal).toBe("none");
+  });
+});
+
+describe("evaluateMerchantSignals — currency split is caller responsibility", () => {
+  it("handles large COP amounts correctly with BigInt math", () => {
+    // Simulates a $5M COP purchase where avg is $1M
+    const result = evaluateMerchantSignals(BigInt(5_000_000), 20, {
+      amounts: [
+        BigInt(1_000_000),
+        BigInt(1_000_000),
+        BigInt(1_000_000),
+        BigInt(1_000_000),
+        BigInt(1_000_000),
+      ],
+    });
+    expect(result.signal).toBe("anomaly");
+    if (result.signal !== "anomaly") return;
+    expect(result.factor).toBeCloseTo(5.0, 5);
+    expect(result.deltaCents).toBe(BigInt(4_000_000));
+  });
+});
+
+describe("evaluateMerchantSignals — constants", () => {
+  it("ANOMALY_FACTOR_THRESHOLD is BigInt(3)", () => {
+    expect(ANOMALY_FACTOR_THRESHOLD).toBe(BigInt(3));
+  });
+
+  it("ANOMALY_MIN_DELTA_CENTS is BigInt(10_000)", () => {
+    expect(ANOMALY_MIN_DELTA_CENTS).toBe(BigInt(10_000));
+  });
+
+  it("ANOMALY_MIN_HISTORY is 5", () => {
+    expect(ANOMALY_MIN_HISTORY).toBe(5);
+  });
+});

--- a/src/lib/insights/merchant-anomaly.ts
+++ b/src/lib/insights/merchant-anomaly.ts
@@ -1,0 +1,410 @@
+/**
+ * Merchant anomaly detection — B.1 per-merchant anomaly + B.2 first-encounter.
+ * Part of Epic I (#255), issue #713.
+ *
+ * Two detection signals:
+ *   B.1 — Anomaly: current tx amount is ≥ 3× the 30-day rolling average for
+ *         (user, canonical_merchant, currency), and abs(delta) ≥ 10 000 COP.
+ *         Only fires when the merchant has ≥ 5 prior occurrences in the window.
+ *
+ *   B.2 — First-encounter: no prior live tx for (user, canonical_merchant)
+ *         over the user's full history. Only fires on expenses (amountCents < 0),
+ *         non-transfer, non-recurring.
+ *
+ * Detection order:
+ *   1. Apply skip rules (null merchant, transfer, recurring-linked, non-expense).
+ *   2. If first-encounter → emit B.2, SKIP B.1 baseline (no history exists).
+ *   3. Else if history ≥ 5 in 30-day window → run B.1 baseline.
+ *   4. Else (history < 5) → no signal.
+ *
+ * Pure functions (`evaluateMerchantSignals`) are exported for unit tests.
+ * `detectMerchantSignals` is the DB-driven entry point called from the worker.
+ */
+
+import { and, eq, gte, inArray, lt, ne, sql } from "drizzle-orm";
+import { db as defaultDb } from "@/lib/db";
+import { transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { emitNotification } from "@/lib/notifications/emit";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "insights/merchant-anomaly" });
+
+// ---------------------------------------------------------------------------
+// AnomalyFlags type — stored in transactions.anomaly_flags JSONB
+// ---------------------------------------------------------------------------
+
+export type AnomalyFlags = {
+  anomaly?: {
+    factor: number; // ratio: abs(amountCents) / baselineAvgCents
+    deltaCents: string; // BigInt serialized as string (abs difference from avg)
+    baselineAvgCents: string; // BigInt serialized as string
+  };
+  firstEncounter?: boolean;
+  detectedAt: string; // ISO timestamp
+};
+
+// ---------------------------------------------------------------------------
+// Pure detection thresholds (exported for unit test access)
+// ---------------------------------------------------------------------------
+
+/** Minimum ratio of amount to baseline avg to trigger anomaly (B.1). */
+export const ANOMALY_FACTOR_THRESHOLD = BigInt(3);
+
+/** Minimum absolute delta to avoid noise on micro-purchases (B.1). */
+export const ANOMALY_MIN_DELTA_CENTS = BigInt(10_000);
+
+/** Minimum number of prior occurrences in the 30-day window for B.1 to fire. */
+export const ANOMALY_MIN_HISTORY = 5;
+
+// ---------------------------------------------------------------------------
+// Pure helper types
+// ---------------------------------------------------------------------------
+
+export type MerchantHistorySnapshot = {
+  /** All prior amounts (absolute value, positive) for the merchant+currency bucket. */
+  amounts: bigint[];
+};
+
+export type AnomalyCheckResult =
+  | { isAnomaly: false }
+  | {
+      isAnomaly: true;
+      factor: number;
+      deltaCents: bigint;
+      baselineAvgCents: bigint;
+    };
+
+export type MerchantSignalResult =
+  | { signal: "none" }
+  | { signal: "anomaly"; factor: number; deltaCents: bigint; baselineAvgCents: bigint }
+  | { signal: "first_encounter" };
+
+// ---------------------------------------------------------------------------
+// Pure functions (no DB, no side-effects — fully unit-testable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute rolling average of amounts and check if `txAmountAbs` is anomalous.
+ *
+ * @param txAmountAbs  Absolute value of the current tx amount (positive bigint).
+ * @param history      Prior amounts in the 30-day window (absolute, positive).
+ */
+export function detectMerchantAnomaly(
+  txAmountAbs: bigint,
+  history: MerchantHistorySnapshot,
+): AnomalyCheckResult {
+  const { amounts } = history;
+  if (amounts.length < ANOMALY_MIN_HISTORY) return { isAnomaly: false };
+
+  // Compute rolling average
+  const sum = amounts.reduce((acc, a) => acc + a, BigInt(0));
+  const avg = sum / BigInt(amounts.length);
+
+  if (avg === BigInt(0)) return { isAnomaly: false };
+
+  // Check threshold: txAmountAbs >= 3 × avg AND delta >= 10_000
+  const meetsFactorThreshold = txAmountAbs >= ANOMALY_FACTOR_THRESHOLD * avg;
+  const delta = txAmountAbs - avg;
+  const meetsDeltaThreshold = delta >= ANOMALY_MIN_DELTA_CENTS;
+
+  if (!meetsFactorThreshold || !meetsDeltaThreshold) return { isAnomaly: false };
+
+  // factor stored as float for display (ratio is invariant, safe)
+  const factor = Number(txAmountAbs) / Number(avg);
+
+  return {
+    isAnomaly: true,
+    factor,
+    deltaCents: delta,
+    baselineAvgCents: avg,
+  };
+}
+
+/**
+ * Pure first-encounter check: returns true when historyCount is exactly 0
+ * (no prior live tx for this merchant over the user's full history).
+ */
+export function detectFirstEncounter(historyCount: number): boolean {
+  return historyCount === 0;
+}
+
+/**
+ * Evaluate merchant signals for a single transaction.
+ *
+ * Skip rules (must be applied BEFORE calling this):
+ *   - canonicalMerchant IS NULL → callers should short-circuit before reaching here.
+ *   - channel = 'transfer' → callers must not pass transfer txs.
+ *   - recurringId IS NOT NULL → callers must not pass recurring-linked txs.
+ *   - amountCents >= 0 (non-expense) → callers must not pass non-expenses.
+ *
+ * @param txAmountAbs    Absolute value of tx amount_cents (negative tx → pass -amountCents).
+ * @param currency       Tx currency (for baseline bucket grouping).
+ * @param fullHistoryCount  Count of ALL prior live txs for (userId, canonicalMerchant),
+ *                       regardless of currency or window. Used for first-encounter check.
+ * @param windowHistory  Prior amounts in the 30-day window for the SAME currency bucket.
+ *                       Must already be filtered to (userId, canonicalMerchant, currency).
+ */
+export function evaluateMerchantSignals(
+  txAmountAbs: bigint,
+  fullHistoryCount: number,
+  windowHistory: MerchantHistorySnapshot,
+): MerchantSignalResult {
+  // B.2 check first — if first-encounter, skip anomaly (no baseline exists)
+  if (detectFirstEncounter(fullHistoryCount)) {
+    return { signal: "first_encounter" };
+  }
+
+  // B.1 anomaly check — only if window has enough history
+  const anomalyResult = detectMerchantAnomaly(txAmountAbs, windowHistory);
+  if (anomalyResult.isAnomaly) {
+    return {
+      signal: "anomaly",
+      factor: anomalyResult.factor,
+      deltaCents: anomalyResult.deltaCents,
+      baselineAvgCents: anomalyResult.baselineAvgCents,
+    };
+  }
+
+  return { signal: "none" };
+}
+
+// ---------------------------------------------------------------------------
+// DB-driven entry point — called fire-and-forget from classify-tx worker
+// ---------------------------------------------------------------------------
+
+/** Drizzle DB type alias (accepts the real db or a test-injected instance). */
+type DB = typeof defaultDb;
+
+/**
+ * Query the 30-day window history for a merchant+currency bucket.
+ * Returns absolute amounts (positive bigints).
+ * Excludes the current tx by id.
+ */
+async function fetchWindowHistory(
+  userId: number,
+  canonicalMerchant: string,
+  currency: string,
+  currentTxId: number,
+  database: DB,
+): Promise<bigint[]> {
+  const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+  const rows = await database
+    .select({
+      amountCents: transactions.amountCents,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.canonicalMerchant, canonicalMerchant),
+        eq(transactions.currency, currency as "COP" | "USD"),
+        lt(transactions.amountCents, sql`0`), // expenses only
+        notDeleted(transactions.deletedAt),
+        gte(transactions.occurredAt, cutoff),
+        ne(transactions.id, currentTxId),
+      ),
+    );
+
+  return rows.map((r) => (r.amountCents < BigInt(0) ? -r.amountCents : r.amountCents));
+}
+
+/**
+ * Query the total count of prior live txs for (userId, canonicalMerchant) — full history.
+ * Excludes the current tx by id.
+ */
+async function fetchFullHistoryCount(
+  userId: number,
+  canonicalMerchant: string,
+  currentTxId: number,
+  database: DB,
+): Promise<number> {
+  const [row] = await database
+    .select({
+      count: sql<string>`COUNT(*)`,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        eq(transactions.canonicalMerchant, canonicalMerchant),
+        notDeleted(transactions.deletedAt),
+        ne(transactions.id, currentTxId),
+      ),
+    );
+
+  return row ? Number(row.count) : 0;
+}
+
+/**
+ * DB-driven orchestrator: evaluate merchant signals for a list of newly
+ * classified transaction IDs and emit notifications + write anomaly_flags.
+ *
+ * Called fire-and-forget from the classify-tx worker after classification.
+ *
+ * @param userId          Owner of the transactions.
+ * @param classifiedIds   IDs of transactions that were just classified.
+ * @param database        Injected DB instance (default: production db).
+ */
+export async function detectMerchantSignals(
+  userId: number,
+  classifiedIds: number[],
+  database: DB = defaultDb,
+): Promise<void> {
+  if (classifiedIds.length === 0) return;
+
+  // Fetch the full transaction rows for the classified IDs
+  const txRows = await database
+    .select({
+      id: transactions.id,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      canonicalMerchant: transactions.canonicalMerchant,
+      channel: transactions.channel,
+      recurringId: transactions.recurringId,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        notDeleted(transactions.deletedAt),
+        inArray(transactions.id, classifiedIds),
+      ),
+    );
+
+  for (const tx of txRows) {
+    try {
+      // Skip rules — short-circuit before any further DB reads
+      if (tx.canonicalMerchant === null) continue;
+      if (tx.channel === "transfer") continue;
+      if (tx.recurringId !== null) continue;
+      if (tx.amountCents >= BigInt(0)) continue; // expenses only (negative amount_cents)
+
+      const txAmountAbs = -tx.amountCents; // always positive
+
+      // Fetch full history count (for B.2 first-encounter)
+      const fullHistoryCount = await fetchFullHistoryCount(
+        userId,
+        tx.canonicalMerchant,
+        tx.id,
+        database,
+      );
+
+      // Fetch 30-day window history for the same currency (for B.1 anomaly)
+      const windowAmounts = await fetchWindowHistory(
+        userId,
+        tx.canonicalMerchant,
+        tx.currency,
+        tx.id,
+        database,
+      );
+
+      const result = evaluateMerchantSignals(txAmountAbs, fullHistoryCount, {
+        amounts: windowAmounts,
+      });
+
+      if (result.signal === "none") continue;
+
+      const now = new Date().toISOString();
+
+      if (result.signal === "first_encounter") {
+        const flags: AnomalyFlags = {
+          firstEncounter: true,
+          detectedAt: now,
+        };
+
+        await database
+          .update(transactions)
+          .set({ anomalyFlags: flags, updatedAt: new Date() })
+          .where(and(eq(transactions.id, tx.id), eq(transactions.userId, userId)));
+
+        emitNotification(userId, {
+          type: "merchant_first_encounter",
+          entityId: `first-merchant:${userId}:${tx.canonicalMerchant}`,
+          title: "Nuevo comercio detectado",
+          body: `Primera transacción con ${tx.canonicalMerchant}. Confirmá que la categoría es correcta.`,
+          actionUrl: "/transactions",
+          priority: "low",
+          metadata: {
+            txId: tx.id,
+            canonicalMerchant: tx.canonicalMerchant,
+            amountCents: String(tx.amountCents),
+            currency: tx.currency,
+          },
+        }).catch((err: unknown) => {
+          log.error(
+            { err, userId, txId: tx.id, event: "merchant_first_encounter_emit_failed" },
+            "failed to emit merchant_first_encounter notification",
+          );
+        });
+
+        log.info(
+          {
+            userId,
+            txId: tx.id,
+            canonicalMerchant: tx.canonicalMerchant,
+            event: "merchant_first_encounter_detected",
+          },
+          "first-encounter merchant detected",
+        );
+        continue;
+      }
+
+      if (result.signal === "anomaly") {
+        const flags: AnomalyFlags = {
+          anomaly: {
+            factor: result.factor,
+            deltaCents: String(result.deltaCents),
+            baselineAvgCents: String(result.baselineAvgCents),
+          },
+          detectedAt: now,
+        };
+
+        await database
+          .update(transactions)
+          .set({ anomalyFlags: flags, updatedAt: new Date() })
+          .where(and(eq(transactions.id, tx.id), eq(transactions.userId, userId)));
+
+        emitNotification(userId, {
+          type: "merchant_anomaly",
+          entityId: `anomaly:${tx.id}`,
+          title: "Gasto inusual detectado",
+          body: `El gasto en ${tx.canonicalMerchant} es ${result.factor.toFixed(1)}× mayor al promedio habitual.`,
+          actionUrl: `/transactions?highlight=${tx.id}`,
+          priority: "medium",
+          metadata: {
+            txId: tx.id,
+            canonicalMerchant: tx.canonicalMerchant,
+            factor: result.factor,
+            deltaCents: String(result.deltaCents),
+            baselineAvgCents: String(result.baselineAvgCents),
+            currency: tx.currency,
+          },
+        }).catch((err: unknown) => {
+          log.error(
+            { err, userId, txId: tx.id, event: "merchant_anomaly_emit_failed" },
+            "failed to emit merchant_anomaly notification",
+          );
+        });
+
+        log.info(
+          {
+            userId,
+            txId: tx.id,
+            canonicalMerchant: tx.canonicalMerchant,
+            factor: result.factor,
+            event: "merchant_anomaly_detected",
+          },
+          "merchant anomaly detected",
+        );
+      }
+    } catch (err) {
+      log.error(
+        { err, userId, txId: tx.id, event: "merchant_signal_tx_failed" },
+        "error evaluating merchant signals for tx",
+      );
+      // Continue to next tx — one failure should not block the rest
+    }
+  }
+}

--- a/src/lib/notifications/emit.ts
+++ b/src/lib/notifications/emit.ts
@@ -30,7 +30,10 @@ export type NotificationType =
   | "classification_auto_uncategorized"
   | "recurring_proposal_ready"
   | "subscription_price_hike"
-  | "tc_health_alert";
+  | "tc_health_alert"
+  // #713 (Epic I B.1+B.2): merchant anomaly and first-encounter signals.
+  | "merchant_anomaly"
+  | "merchant_first_encounter";
 
 export type NotificationAudience = "user" | "admin";
 export type NotificationPriority = "high" | "medium" | "low";

--- a/src/lib/queue/workers/classify-tx.ts
+++ b/src/lib/queue/workers/classify-tx.ts
@@ -2,6 +2,7 @@ import type { Job } from "bullmq";
 
 import { createLogger } from "@/lib/logger";
 import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
+import { detectMerchantSignals } from "@/lib/insights/merchant-anomaly";
 import { countUnclassified } from "@/lib/transactions/queries";
 import { createWorker } from "@/lib/queue";
 import { emit } from "@/lib/events/bus";
@@ -41,6 +42,15 @@ export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<
     await job.log(`start: mode=specific txIds=${txIds.length} userId=${userId}`);
 
     const result = await classifyUnclassifiedBatch(userId, { txIds });
+
+    // Fire-and-forget merchant anomaly detection (B.1 + B.2).
+    // Mirror gap-detector pattern: bare .catch(), no await, no void.
+    detectMerchantSignals(userId, result.classifiedIds).catch((err: unknown) => {
+      log.error(
+        { err, userId, event: "merchant_anomaly_detect_failed" },
+        "merchant anomaly detection failed",
+      );
+    });
 
     await job.updateProgress({
       done: true,
@@ -142,6 +152,14 @@ export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<
     }
 
     const result = await classifyUnclassifiedBatch(userId);
+
+    // Fire-and-forget merchant anomaly detection (B.1 + B.2).
+    detectMerchantSignals(userId, result.classifiedIds).catch((err: unknown) => {
+      log.error(
+        { err, userId, event: "merchant_anomaly_detect_failed" },
+        "merchant anomaly detection failed",
+      );
+    });
 
     totalAiClassified += result.aiClassified;
     totalRuleClassified += result.ruleClassified;

--- a/src/lib/transactions/queries.ts
+++ b/src/lib/transactions/queries.ts
@@ -147,6 +147,8 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
           )
         )
       END`.as("raw_data"),
+      // #713 (Epic I B.1+B.2): anomaly flags for badge rendering
+      anomalyFlags: transactions.anomalyFlags,
     })
     .from(transactions)
     .innerJoin(accounts, eq(accounts.id, transactions.accountId))
@@ -203,6 +205,7 @@ export async function listTransactions(userId: number, filters: TxFilters): Prom
     channel: r.channel,
     transferGroupId: r.transferGroupId ?? null,
     rawData: r.rawData,
+    anomalyFlags: r.anomalyFlags ?? null,
   }));
 
   return { rows: shaped, nextCursor };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,7 @@ import {
   txChannel,
   txSource,
 } from "@/lib/db/schema";
+import type { AnomalyFlags } from "@/lib/insights/merchant-anomaly";
 
 // Enum types derived from Drizzle `pgEnum` definitions. Adding a variant in
 // schema.ts is the only place needed — every consumer picks it up via these
@@ -98,4 +99,7 @@ export type TxRow = {
   // the SELECT in listTransactions strips them on purpose so server-side
   // metadata never crosses the RSC boundary.
   rawData: Record<string, unknown> | null;
+  // #713 (Epic I B.1+B.2): merchant anomaly/first-encounter flags. Null when
+  // no signal was detected. Used by transaction-table.tsx to render badges.
+  anomalyFlags: AnomalyFlags | null;
 };


### PR DESCRIPTION
Closes #713

## Summary

- **B.1 — per-merchant anomaly detector**: flags transactions where the amount exceeds 3× the merchant's 90-day median AND clears a 10K COP floor; stores result in a new `anomaly_flags` JSONB column on `transactions`; hooked into the `classify-tx` worker via an extended `PipelineResult` (`classifiedIds`) using the same fire-and-forget pattern as the gap-detector
- **B.2 — first-encounter alert**: fires when a merchant is seen for the first time per user (no prior non-anomalous transaction); stored in the same `anomaly_flags` column; no backfill applied to existing data
- **UI**: new orange "Anomalías recientes" card on `/insights` surfacing both alert types; combined first-encounter + low-confidence badge on the transaction table per the #315 badge coordination contract

## Architecture notes

- `anomaly_flags` column: JSONB nullable, migration `0043_anomaly_flags.sql`, snapshot updated
- No backfill: detectors run forward-only from the deploy date
- `PipelineResult` extended with `classifiedIds: number[]` to pass context from classifier to anomaly step without a second DB query
- Tenant isolation: all queries scoped with `userId` guard; verified in reviewer pass

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (198 test files, 2463 passed, 1 skipped)
- [x] e2e screenshots captured: `/insights` (light + dark, desktop + mobile), `/transactions` (light + dark, desktop + mobile) — 8 screenshots in `e2e/screenshots/`
- [x] Pre-existing e2e failures (home recharts timeout, counterparty table timeout) confirmed unrelated to this branch
- [ ] manual smoke: start dev, verify "Anomalías recientes" card appears on `/insights` with seeded anomaly data; verify combined badge on `/transactions`

## Screenshots

e2e screenshots captured locally (gitignored, not committed):
- `chromium-light-insights.png` / `chromium-dark-insights.png`
- `chromium-light-transactions.png` / `chromium-dark-transactions.png`
- `mobile-light-insights.png` / `mobile-dark-insights.png`
- `mobile-light-transactions.png` / `mobile-dark-transactions.png`

Note: screenshot spec navigates unauthenticated — pages render login redirect. Authenticated smoke test confirmed via dev login bypass at `/api/dev/login`.