### PR TITLE
feat(insights): velocity + category anomaly + duplicate payment (#719)

### DIFF
--- a/src/app/(app)/insights/page.tsx
+++ b/src/app/(app)/insights/page.tsx
@@ -19,6 +19,7 @@ import {
 import { fetchRecentAnomalies } from "@/lib/insights/merchant-anomaly-queries";
 import { fetchCashFlowSummary } from "@/lib/insights/cash-flow-queries";
 import { fetchTemporalSummary } from "@/lib/insights/temporal-queries";
+import { fetchRecentDuplicatePayments } from "@/lib/insights/duplicate-payment-queries";
 import { dowNameEs, monthNameEs } from "@/lib/insights/temporal";
 import { SpendingHeatmap } from "@/components/insights/spending-heatmap";
 import { InsightsViewer } from "./insights-viewer";
@@ -168,12 +169,14 @@ export default async function InsightsPage({
   // TC Health card — real-time snapshot of all the user's TCs (#705)
   const nowDate = new Date();
   const today = nowInBogota(nowDate);
-  const [tcSnapshots, recentAnomalies, cashFlowSummary, temporalSummary] = await Promise.all([
-    fetchUserTcSnapshots(session.id, fx.rate, today),
-    fetchRecentAnomalies(session.id),
-    fetchCashFlowSummary(session.id, nowDate),
-    fetchTemporalSummary(session.id, nowDate),
-  ]);
+  const [tcSnapshots, recentAnomalies, cashFlowSummary, temporalSummary, recentDuplicatePayments] =
+    await Promise.all([
+      fetchUserTcSnapshots(session.id, fx.rate, today),
+      fetchRecentAnomalies(session.id),
+      fetchCashFlowSummary(session.id, nowDate),
+      fetchTemporalSummary(session.id, nowDate),
+      fetchRecentDuplicatePayments(session.id),
+    ]);
   const tcAlerts: Array<{ snap: TcCardSnapshot; triggers: TcAlertTrigger[] }> = tcSnapshots
     .map((snap) => ({ snap, triggers: computeTcAlerts(snap) }))
     .filter((a) => a.triggers.length > 0);
@@ -340,6 +343,49 @@ export default async function InsightsPage({
                 Sin patrones destacados por el momento.
               </p>
             )}
+        </CardContent>
+      </Card>
+
+      {/* Pagos duplicados detectados card — C.4 (#719) */}
+      <Card className="border-violet-200 bg-violet-50/40 dark:border-violet-900 dark:bg-violet-950/15">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-violet-900 dark:text-violet-200">
+            Pagos duplicados detectados
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {recentDuplicatePayments.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              No hemos detectado pagos duplicados en los últimos 30 días.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-1">
+              {recentDuplicatePayments.map((row) => (
+                <li
+                  key={`${row.newTxId}`}
+                  className="flex items-start justify-between gap-2 text-sm"
+                >
+                  <span>
+                    <span className="font-medium">{row.canonicalMerchant}</span>
+                    {" · "}
+                    <span className="text-violet-800 dark:text-violet-300">
+                      {row.newAccountLabel}
+                    </span>
+                    {" y "}
+                    <span className="text-violet-800 dark:text-violet-300">
+                      {row.otherAccountLabel}
+                    </span>
+                  </span>
+                  <Link
+                    href={`/transactions?highlight=${row.newTxId}`}
+                    className="shrink-0 text-xs text-violet-700 underline underline-offset-4 hover:text-violet-900 dark:text-violet-300 dark:hover:text-violet-100"
+                  >
+                    Ver →
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
         </CardContent>
       </Card>
 

--- a/src/components/transactions/transaction-table.test.tsx
+++ b/src/components/transactions/transaction-table.test.tsx
@@ -435,3 +435,134 @@ describe("TransactionTable — #713 combined first-encounter + low-confidence ba
     expect(screen.queryByText("Nuevo merchant — confirmá categoría")).not.toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests — #719 B.4: categoryAnomaly badge priority chain
+// ---------------------------------------------------------------------------
+
+describe("TransactionTable — #719 categoryAnomaly badge priority", () => {
+  beforeEach(() => {
+    vi.mocked(mockedConfidenceBand).mockImplementation(realBand);
+    vi.mocked(MockedConfidenceBadge).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.mocked(mockedConfidenceBand).mockReturnValue(null);
+    vi.mocked(MockedConfidenceBadge).mockReturnValue(null);
+  });
+
+  it("Priority 1: categoryAnomaly + low-confidence → combined rose badge, suppresses ConfidenceBadge", () => {
+    const tx = makeTxRow({
+      id: 7190,
+      classificationMethod: "ai",
+      classificationConfidence: 30, // low
+      anomalyFlags: {
+        categoryAnomaly: {
+          expectedCategory: "alimentacion",
+          actualCategory: "transporte",
+          modalShare: 0.9,
+        },
+        detectedAt: "2026-05-02T00:00:00Z",
+      },
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    // The combined rose badge text must contain the expected category
+    const badge = screen.getByText(/Categoría inusual — confirmá \(alimentacion\)/);
+    expect(badge).toBeInTheDocument();
+
+    // Standalone "Categoría inusual" badge must NOT appear separately
+    expect(screen.queryByText("Categoría inusual")).not.toBeInTheDocument();
+
+    // ConfidenceBadge mock returns null → no confidence text
+    expect(screen.queryByText("revisar")).not.toBeInTheDocument();
+  });
+
+  it("Priority 2: categoryAnomaly + firstEncounter → combined orange badge, suppresses both", () => {
+    const tx = makeTxRow({
+      id: 7191,
+      classificationMethod: "rule",
+      classificationConfidence: 95, // high
+      anomalyFlags: {
+        categoryAnomaly: {
+          expectedCategory: "alimentacion",
+          actualCategory: "transporte",
+          modalShare: 0.85,
+        },
+        firstEncounter: true,
+        detectedAt: "2026-05-02T00:00:00Z",
+      },
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    expect(screen.getByText("Categoría inusual + nuevo merchant")).toBeInTheDocument();
+
+    // Neither standalone badge nor confidence badge should appear
+    expect(screen.queryByText("Categoría inusual")).not.toBeInTheDocument();
+    expect(screen.queryByText("Nuevo merchant")).not.toBeInTheDocument();
+    expect(screen.queryByText("revisar")).not.toBeInTheDocument();
+  });
+
+  it("Priority 3: categoryAnomaly alone → standalone purple badge, ConfidenceBadge coexists", () => {
+    // Method=ai, confidence=75 → band=medium; category-anomaly alone takes priority 3
+    vi.mocked(MockedConfidenceBadge).mockReturnValue(
+      <span data-testid="confidence-badge-medium">75%</span>,
+    );
+
+    const tx = makeTxRow({
+      id: 7192,
+      classificationMethod: "ai",
+      classificationConfidence: 75, // medium
+      anomalyFlags: {
+        categoryAnomaly: {
+          expectedCategory: "servicios",
+          actualCategory: "entretenimiento",
+          modalShare: 0.9,
+        },
+        detectedAt: "2026-05-02T00:00:00Z",
+      },
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    // Standalone purple badge
+    expect(screen.getByText("Categoría inusual")).toBeInTheDocument();
+
+    // ConfidenceBadge still renders (NOT suppressed in priority 3)
+    expect(screen.getAllByTestId("confidence-badge-medium").length).toBeGreaterThanOrEqual(1);
+
+    // Combined badges must NOT appear
+    expect(screen.queryByText(/confirmá/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Categoría inusual + nuevo merchant")).not.toBeInTheDocument();
+  });
+
+  it("Suppression: categoryAnomaly + low-confidence suppresses standalone Nuevo merchant", () => {
+    // When priority 1 fires (catAnom + low), even if firstEncounter=true,
+    // the combined catAnom+low badge wins and neither firstEncounter badge renders.
+    const tx = makeTxRow({
+      id: 7193,
+      classificationMethod: "ai",
+      classificationConfidence: 30, // low
+      anomalyFlags: {
+        categoryAnomaly: {
+          expectedCategory: "alimentacion",
+          actualCategory: "transporte",
+          modalShare: 0.9,
+        },
+        firstEncounter: true,
+        detectedAt: "2026-05-02T00:00:00Z",
+      },
+    });
+
+    render(<TransactionTable rows={[tx]} {...TABLE_PROPS} />);
+
+    // Priority 1 fires (catAnom+low) — combined rose badge
+    expect(screen.getByText(/Categoría inusual — confirmá/)).toBeInTheDocument();
+
+    // Neither first-encounter badge should appear
+    expect(screen.queryByText("Nuevo merchant")).not.toBeInTheDocument();
+    expect(screen.queryByText("Nuevo merchant — confirmá categoría")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/transactions/transaction-table.tsx
+++ b/src/components/transactions/transaction-table.tsx
@@ -484,34 +484,102 @@ export function TransactionTable({
                           channel={tx.channel}
                         />
                         <div className="flex flex-wrap items-center gap-1">
-                          {/* #713 B.2: combined badge when first-encounter + low-confidence fire together */}
-                          {tx.anomalyFlags?.firstEncounter &&
-                          confidenceBand(tx.classificationMethod, tx.classificationConfidence) ===
-                            "low" ? (
-                            <Badge
-                              variant="outline"
-                              className="gap-1 border-orange-300 bg-orange-50 font-normal text-orange-900 dark:border-orange-900 dark:bg-orange-950/40 dark:text-orange-200"
-                              title="Nuevo comercio detectado con baja confianza en la clasificación. Confirmá la categoría."
-                            >
-                              Nuevo merchant — confirmá categoría
-                            </Badge>
-                          ) : (
-                            <>
-                              {tx.anomalyFlags?.firstEncounter ? (
+                          {/* #719/#713: badge priority chain — first match wins, others suppressed */}
+                          {(() => {
+                            const band = confidenceBand(
+                              tx.classificationMethod,
+                              tx.classificationConfidence,
+                            );
+                            const hasCatAnom = !!tx.anomalyFlags?.categoryAnomaly;
+                            const hasFirstEnc = !!tx.anomalyFlags?.firstEncounter;
+
+                            // Priority 1: categoryAnomaly + low confidence → combined rose badge
+                            if (hasCatAnom && band === "low") {
+                              const expected =
+                                tx.anomalyFlags?.categoryAnomaly?.expectedCategory ?? "";
+                              return (
+                                <Badge
+                                  variant="outline"
+                                  className="gap-1 border-rose-300 bg-rose-50 font-normal text-rose-900 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200"
+                                  title="Categoría inusual con baja confianza. Confirmá la categoría correcta."
+                                >
+                                  {`Categoría inusual — confirmá (${expected})`}
+                                </Badge>
+                              );
+                            }
+
+                            // Priority 2: categoryAnomaly + firstEncounter → combined orange badge
+                            if (hasCatAnom && hasFirstEnc) {
+                              return (
                                 <Badge
                                   variant="outline"
                                   className="gap-1 border-orange-300 bg-orange-50 font-normal text-orange-900 dark:border-orange-900 dark:bg-orange-950/40 dark:text-orange-200"
-                                  title="Primera vez que aparece este comercio en tus transacciones."
+                                  title="Categoría inusual en un comercio nuevo."
                                 >
-                                  Nuevo merchant
+                                  Categoría inusual + nuevo merchant
                                 </Badge>
-                              ) : null}
+                              );
+                            }
+
+                            // Priority 3: categoryAnomaly alone → standalone purple badge + ConfidenceBadge
+                            if (hasCatAnom) {
+                              return (
+                                <>
+                                  <Badge
+                                    variant="outline"
+                                    className="gap-1 border-purple-300 bg-purple-50 font-normal text-purple-900 dark:border-purple-900 dark:bg-purple-950/40 dark:text-purple-200"
+                                    title="La categoría asignada difiere del patrón habitual para este comercio."
+                                  >
+                                    Categoría inusual
+                                  </Badge>
+                                  <ConfidenceBadge
+                                    method={tx.classificationMethod}
+                                    confidence={tx.classificationConfidence}
+                                  />
+                                </>
+                              );
+                            }
+
+                            // Priority 4: firstEncounter + low confidence → combined orange badge (existing #713)
+                            if (hasFirstEnc && band === "low") {
+                              return (
+                                <Badge
+                                  variant="outline"
+                                  className="gap-1 border-orange-300 bg-orange-50 font-normal text-orange-900 dark:border-orange-900 dark:bg-orange-950/40 dark:text-orange-200"
+                                  title="Nuevo comercio detectado con baja confianza en la clasificación. Confirmá la categoría."
+                                >
+                                  Nuevo merchant — confirmá categoría
+                                </Badge>
+                              );
+                            }
+
+                            // Priority 5: firstEncounter alone → standalone orange badge + ConfidenceBadge
+                            if (hasFirstEnc) {
+                              return (
+                                <>
+                                  <Badge
+                                    variant="outline"
+                                    className="gap-1 border-orange-300 bg-orange-50 font-normal text-orange-900 dark:border-orange-900 dark:bg-orange-950/40 dark:text-orange-200"
+                                    title="Primera vez que aparece este comercio en tus transacciones."
+                                  >
+                                    Nuevo merchant
+                                  </Badge>
+                                  <ConfidenceBadge
+                                    method={tx.classificationMethod}
+                                    confidence={tx.classificationConfidence}
+                                  />
+                                </>
+                              );
+                            }
+
+                            // Default: ConfidenceBadge only
+                            return (
                               <ConfidenceBadge
                                 method={tx.classificationMethod}
                                 confidence={tx.classificationConfidence}
                               />
-                            </>
-                          )}
+                            );
+                          })()}
                           {!isPairedTransfer ? (
                             <ClassificationReasonDialog
                               txId={tx.id}

--- a/src/lib/insights/category-anomaly-detector.detector.test.ts
+++ b/src/lib/insights/category-anomaly-detector.detector.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Integration tests for detectCategoryAnomalyForUser (DB-hitting).
+ *
+ * Uses findash_test (forced by vitest.setup.ts).
+ * Cleanup sentinel: description_raw LIKE '__catanom_test%'.
+ *
+ * NOTE: BigInt literals (0n) are ES2020+. This project targets ES2017, so we
+ * use BigInt() constructor calls throughout (matching the anomaly-detector pattern).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { transactions } from "@/lib/db/schema";
+import { detectCategoryAnomalyForUser } from "./category-anomaly-detector";
+
+// ---------------------------------------------------------------------------
+// emitNotification mock
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => ({
+  emitNotification: vi.fn().mockResolvedValue({ id: 999 }),
+}));
+
+vi.mock("@/lib/notifications/emit", () => ({
+  emitNotification: mocks.emitNotification,
+}));
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEST_USER_ID = 1; // bootstrap user — always exists in findash_test
+const SENTINEL = "__catanom_test";
+
+// ---------------------------------------------------------------------------
+// Cleanup helpers
+// ---------------------------------------------------------------------------
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE '__catanom_test%'`);
+}
+
+async function defaultAccountId(): Promise<number> {
+  const [row] = await db.execute<{ id: number }>(sql`
+    SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} ORDER BY id LIMIT 1
+  `);
+  if (!row) throw new Error("No account for test user");
+  return row.id;
+}
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
+
+async function seedTx(opts: {
+  accountId: number;
+  amountCents: bigint;
+  canonicalMerchant?: string | null;
+  categorySlug?: string | null;
+  classificationMethod?: string;
+  channel?: string;
+  recurringId?: number | null;
+  description?: string;
+}): Promise<number> {
+  const occurredAt = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
+  const amountCents = Number(opts.amountCents);
+  const [row] = await db.execute<{ id: number }>(sql`
+    INSERT INTO transactions (
+      user_id, account_id, occurred_at, amount_cents, currency,
+      description_raw, classification_method, source,
+      canonical_merchant, category_slug, channel
+    ) VALUES (
+      ${TEST_USER_ID},
+      ${opts.accountId},
+      ${occurredAt}::timestamptz,
+      ${amountCents},
+      'COP',
+      ${opts.description ?? `${SENTINEL}_tx`},
+      ${opts.classificationMethod ?? "rule"}::classification_method,
+      'sms',
+      ${opts.canonicalMerchant ?? null},
+      ${opts.categorySlug ?? null},
+      ${opts.channel ?? "bank"}
+    )
+    RETURNING id
+  `);
+  return row.id;
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe("detectCategoryAnomalyForUser — skip rules", () => {
+  let accountId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    mocks.emitNotification.mockClear();
+    accountId = await defaultAccountId();
+  });
+
+  afterEach(cleanup);
+
+  it("skips when classifiedIds is empty", async () => {
+    await detectCategoryAnomalyForUser(TEST_USER_ID, [], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips when classification_method is manual", async () => {
+    const merchant = `${SENTINEL}_manual_${Date.now()}`;
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      categorySlug: "transporte",
+      classificationMethod: "manual",
+    });
+
+    await detectCategoryAnomalyForUser(TEST_USER_ID, [txId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips when channel is transfer", async () => {
+    const merchant = `${SENTINEL}_transfer_${Date.now()}`;
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      categorySlug: "transporte",
+      channel: "transfer",
+    });
+
+    await detectCategoryAnomalyForUser(TEST_USER_ID, [txId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips when categorySlug is null", async () => {
+    const merchant = `${SENTINEL}_nocat_${Date.now()}`;
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      categorySlug: null,
+    });
+
+    await detectCategoryAnomalyForUser(TEST_USER_ID, [txId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips when canonical_merchant is null", async () => {
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: null,
+      categorySlug: "transporte",
+    });
+
+    await detectCategoryAnomalyForUser(TEST_USER_ID, [txId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire when prior history is below 10 txs", async () => {
+    const merchant = `${SENTINEL}_low_hist_${Date.now()}`;
+
+    // Seed 9 prior txs in alimentacion
+    for (let i = 0; i < 9; i++) {
+      await seedTx({
+        accountId,
+        amountCents: BigInt(-50_000),
+        canonicalMerchant: merchant,
+        categorySlug: "alimentacion",
+        description: `${SENTINEL}_prior_${i}`,
+      });
+    }
+
+    const newTxId = await seedTx({
+      accountId,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      categorySlug: "transporte",
+      description: `${SENTINEL}_new`,
+    });
+
+    await detectCategoryAnomalyForUser(TEST_USER_ID, [newTxId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+});
+
+describe("detectCategoryAnomalyForUser — detection fires", () => {
+  let accountId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    mocks.emitNotification.mockClear();
+    accountId = await defaultAccountId();
+  });
+
+  afterEach(cleanup);
+
+  it("emits category_anomaly when 10+ prior txs have 80%+ same category and tx diverges", async () => {
+    const merchant = `${SENTINEL}_anomaly_${Date.now()}`;
+
+    // Seed 10 prior txs in alimentacion (100% modal)
+    for (let i = 0; i < 10; i++) {
+      await seedTx({
+        accountId,
+        amountCents: BigInt(-50_000),
+        canonicalMerchant: merchant,
+        categorySlug: "alimentacion",
+        description: `${SENTINEL}_prior_${i}`,
+      });
+    }
+
+    // New tx in transporte — anomalous
+    const newTxId = await seedTx({
+      accountId,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      categorySlug: "transporte",
+      description: `${SENTINEL}_new`,
+    });
+
+    await detectCategoryAnomalyForUser(TEST_USER_ID, [newTxId], db);
+
+    expect(mocks.emitNotification).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.objectContaining({
+        type: "category_anomaly",
+        entityId: `category-anomaly:${newTxId}`,
+      }),
+    );
+
+    // anomaly_flags written with categoryAnomaly
+    const [row] = await db
+      .select({ anomalyFlags: transactions.anomalyFlags })
+      .from(transactions)
+      .where(eq(transactions.id, newTxId));
+
+    expect(row?.anomalyFlags).toMatchObject({
+      categoryAnomaly: {
+        expectedCategory: "alimentacion",
+        actualCategory: "transporte",
+      },
+    });
+  });
+
+  it("merges categoryAnomaly with existing firstEncounter flag without overwriting", async () => {
+    const merchant = `${SENTINEL}_merge_${Date.now()}`;
+
+    // Seed 10 prior txs
+    for (let i = 0; i < 10; i++) {
+      await seedTx({
+        accountId,
+        amountCents: BigInt(-50_000),
+        canonicalMerchant: merchant,
+        categorySlug: "alimentacion",
+        description: `${SENTINEL}_prior_${i}`,
+      });
+    }
+
+    const newTxId = await seedTx({
+      accountId,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      categorySlug: "transporte",
+      description: `${SENTINEL}_new_with_first_enc`,
+    });
+
+    // Pre-seed firstEncounter on the tx (simulating B.2 already ran)
+    await db.execute(sql`
+      UPDATE transactions
+      SET anomaly_flags = '{"firstEncounter": true, "detectedAt": "2026-05-01T00:00:00Z"}'::jsonb
+      WHERE id = ${newTxId}
+    `);
+
+    await detectCategoryAnomalyForUser(TEST_USER_ID, [newTxId], db);
+
+    const [row] = await db
+      .select({ anomalyFlags: transactions.anomalyFlags })
+      .from(transactions)
+      .where(eq(transactions.id, newTxId));
+
+    // Both flags must be present — merge must not overwrite firstEncounter
+    expect(row?.anomalyFlags).toMatchObject({
+      firstEncounter: true,
+      categoryAnomaly: {
+        expectedCategory: "alimentacion",
+        actualCategory: "transporte",
+      },
+    });
+  });
+
+  it("deduplicates notifications — second call with same txId does not double-emit", async () => {
+    // emitNotification uses idempotent insert; the mock just tracks calls
+    const merchant = `${SENTINEL}_dedup_${Date.now()}`;
+
+    for (let i = 0; i < 10; i++) {
+      await seedTx({
+        accountId,
+        amountCents: BigInt(-50_000),
+        canonicalMerchant: merchant,
+        categorySlug: "alimentacion",
+        description: `${SENTINEL}_d_prior_${i}`,
+      });
+    }
+
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      categorySlug: "transporte",
+      description: `${SENTINEL}_d_new`,
+    });
+
+    await detectCategoryAnomalyForUser(TEST_USER_ID, [txId], db);
+    await detectCategoryAnomalyForUser(TEST_USER_ID, [txId], db);
+
+    // Called twice — the DB-level dedup (onConflictDoNothing) handles idempotency
+    // at the notification layer; the detector itself emits once per call.
+    // This test confirms the detector does NOT throw on second call.
+    expect(mocks.emitNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it("tenant safety — does NOT cross to another user's history", async () => {
+    // This is inherently tested by using TEST_USER_ID=1 throughout and relying
+    // on eq(transactions.userId, userId) in every query. The point of this test
+    // is to confirm the detector uses the userId filter consistently.
+    const merchant = `${SENTINEL}_tenant_${Date.now()}`;
+    // Only seed txs for user 1 — if any query forgets userId, it might pick up
+    // data from other users in findash_test and fire incorrectly.
+    const txId = await seedTx({
+      accountId,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      categorySlug: "transporte",
+      description: `${SENTINEL}_tenant_new`,
+    });
+
+    // No prior history for this user/merchant — should NOT fire
+    await detectCategoryAnomalyForUser(TEST_USER_ID, [txId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/insights/category-anomaly-detector.test.ts
+++ b/src/lib/insights/category-anomaly-detector.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateCategoryAnomaly,
+  CATEGORY_ANOMALY_MIN_HISTORY,
+  CATEGORY_ANOMALY_MIN_SHARE,
+  type CategoryHistoryEntry,
+} from "./category-anomaly-detector";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function historyOf(entries: Array<[string, number]>): CategoryHistoryEntry[] {
+  return entries.map(([categorySlug, count]) => ({ categorySlug, count }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests — evaluateCategoryAnomaly (pure)
+// ---------------------------------------------------------------------------
+
+describe("evaluateCategoryAnomaly — skip when insufficient history", () => {
+  it("returns isAnomaly=false when total < 10", () => {
+    // 9 prior txs — below threshold
+    const history = historyOf([["__catanom_test_alimentacion", 9]]);
+    const result = evaluateCategoryAnomaly(history, "__catanom_test_transporte");
+    expect(result.isAnomaly).toBe(false);
+  });
+
+  it("returns isAnomaly=false when history is empty", () => {
+    const result = evaluateCategoryAnomaly([], "__catanom_test_transporte");
+    expect(result.isAnomaly).toBe(false);
+  });
+
+  it("fires at exactly 10 prior txs (boundary)", () => {
+    // 10 txs, 9 in modal category → share = 0.9 ≥ 0.8 → anomaly
+    const history = historyOf([
+      ["__catanom_test_alimentacion", 9],
+      ["__catanom_test_transporte", 1],
+    ]);
+    const result = evaluateCategoryAnomaly(history, "__catanom_test_transporte");
+    // actual = transporte (1/10 = 10%) vs expected = alimentacion (9/10 = 90%)
+    expect(result.isAnomaly).toBe(true);
+  });
+});
+
+describe("evaluateCategoryAnomaly — modal share threshold", () => {
+  it("fires when modal share is exactly 80% (boundary)", () => {
+    // 8 alimentacion + 2 transporte → alimentacion is modal at exactly 0.80
+    const history = historyOf([
+      ["__catanom_test_alimentacion", 8],
+      ["__catanom_test_transporte", 2],
+    ]);
+    const result = evaluateCategoryAnomaly(history, "__catanom_test_transporte");
+    expect(result.isAnomaly).toBe(true);
+    if (result.isAnomaly) {
+      expect(result.modalShare).toBeCloseTo(0.8, 5);
+      expect(result.expectedCategory).toBe("__catanom_test_alimentacion");
+      expect(result.actualCategory).toBe("__catanom_test_transporte");
+    }
+  });
+
+  it("does NOT fire when modal share is below 80%", () => {
+    // 7 alimentacion + 3 transporte → share = 0.7 < 0.8
+    const history = historyOf([
+      ["__catanom_test_alimentacion", 7],
+      ["__catanom_test_transporte", 3],
+    ]);
+    const result = evaluateCategoryAnomaly(history, "__catanom_test_transporte");
+    expect(result.isAnomaly).toBe(false);
+  });
+
+  it("does NOT fire when actual category matches the modal category", () => {
+    // 9 alimentacion + 1 transporte → modal = alimentacion at 90%
+    // but actual = alimentacion → expected === actual → no anomaly
+    const history = historyOf([
+      ["__catanom_test_alimentacion", 9],
+      ["__catanom_test_transporte", 1],
+    ]);
+    const result = evaluateCategoryAnomaly(history, "__catanom_test_alimentacion");
+    expect(result.isAnomaly).toBe(false);
+  });
+});
+
+describe("evaluateCategoryAnomaly — high confidence anomalies", () => {
+  it("fires when modal share is 100% (all prior in same category)", () => {
+    const history = historyOf([["__catanom_test_servicios", 15]]);
+    const result = evaluateCategoryAnomaly(history, "__catanom_test_entretenimiento");
+    expect(result.isAnomaly).toBe(true);
+    if (result.isAnomaly) {
+      expect(result.modalShare).toBeCloseTo(1.0, 5);
+      expect(result.expectedCategory).toBe("__catanom_test_servicios");
+      expect(result.actualCategory).toBe("__catanom_test_entretenimiento");
+    }
+  });
+
+  it("picks the category with the highest count as the modal", () => {
+    // Two categories close in count but one clearly dominant
+    const history = historyOf([
+      ["__catanom_test_cat_a", 3],
+      ["__catanom_test_cat_b", 9],
+      ["__catanom_test_cat_c", 1],
+      ["__catanom_test_cat_d", 1],
+      ["__catanom_test_cat_e", 1],
+    ]);
+    // total=15, cat_b is modal at 9/15 = 60% — below threshold
+    const result = evaluateCategoryAnomaly(history, "__catanom_test_cat_a");
+    expect(result.isAnomaly).toBe(false);
+  });
+
+  it("fires with multi-category history when modal is dominant", () => {
+    const history = historyOf([
+      ["__catanom_test_cat_dominant", 12],
+      ["__catanom_test_cat_other_1", 1],
+      ["__catanom_test_cat_other_2", 1],
+      ["__catanom_test_cat_other_3", 1],
+    ]);
+    // total=15, dominant = 12/15 = 80% → at threshold
+    const result = evaluateCategoryAnomaly(history, "__catanom_test_cat_other_1");
+    expect(result.isAnomaly).toBe(true);
+    if (result.isAnomaly) {
+      expect(result.expectedCategory).toBe("__catanom_test_cat_dominant");
+    }
+  });
+});
+
+describe("evaluateCategoryAnomaly — exported constants match spec", () => {
+  it("CATEGORY_ANOMALY_MIN_HISTORY is 10", () => {
+    expect(CATEGORY_ANOMALY_MIN_HISTORY).toBe(10);
+  });
+  it("CATEGORY_ANOMALY_MIN_SHARE is 0.8", () => {
+    expect(CATEGORY_ANOMALY_MIN_SHARE).toBeCloseTo(0.8);
+  });
+});

--- a/src/lib/insights/category-anomaly-detector.ts
+++ b/src/lib/insights/category-anomaly-detector.ts
@@ -1,0 +1,257 @@
+/**
+ * Category anomaly detector — B.4 (Epic I, #719).
+ *
+ * Fires when a classified tx has category C₂ for a (user, canonical_merchant)
+ * pair that has ≥10 prior transactions, of which ≥80% fell under some other
+ * category C₁.
+ *
+ * Skip conditions:
+ *   - classificationMethod IN ('manual', 'manual_confirmed') — user chose it
+ *   - categorySlug IS NULL — unclassified
+ *   - channel = 'transfer'
+ *   - recurring_id IS NOT NULL
+ *   - canonical_merchant IS NULL
+ *
+ * On trigger:
+ *   - Writes `anomaly_flags.categoryAnomaly` to the tx (merges with existing flags).
+ *   - Emits one notification per tx (`type="category_anomaly"`).
+ *
+ * Pure functions exported for unit tests.
+ * `detectCategoryAnomalyForUser` is the DB-driven entry point.
+ */
+
+import { and, eq, inArray, ne, sql } from "drizzle-orm";
+import { db as defaultDb } from "@/lib/db";
+import { categories, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { emitNotification } from "@/lib/notifications/emit";
+import { mergeAnomalyFlags } from "@/lib/insights/merchant-anomaly";
+import type { AnomalyFlags } from "@/lib/insights/merchant-anomaly";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "insights/category-anomaly-detector" });
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Minimum prior transactions required to check for category anomaly. */
+export const CATEGORY_ANOMALY_MIN_HISTORY = 10;
+
+/** Minimum share of prior txs under the modal category to fire. */
+export const CATEGORY_ANOMALY_MIN_SHARE = 0.8;
+
+// ---------------------------------------------------------------------------
+// Pure types
+// ---------------------------------------------------------------------------
+
+export type CategoryHistoryEntry = {
+  categorySlug: string;
+  count: number;
+};
+
+export type CategoryAnomalyResult =
+  | { isAnomaly: false }
+  | {
+      isAnomaly: true;
+      expectedCategory: string; // modal category slug
+      actualCategory: string;
+      modalShare: number;
+    };
+
+// ---------------------------------------------------------------------------
+// Pure detection function
+// ---------------------------------------------------------------------------
+
+/**
+ * Given a list of prior category counts for a merchant+user pair, and the
+ * current tx's category slug, determine whether a category anomaly has fired.
+ *
+ * @param history       Prior tx counts by category slug (all combined).
+ * @param actualCategory The category assigned to the current tx.
+ */
+export function evaluateCategoryAnomaly(
+  history: CategoryHistoryEntry[],
+  actualCategory: string,
+): CategoryAnomalyResult {
+  const total = history.reduce((sum, h) => sum + h.count, 0);
+  if (total < CATEGORY_ANOMALY_MIN_HISTORY) return { isAnomaly: false };
+
+  // Find modal category
+  let modalEntry: CategoryHistoryEntry | null = null;
+  for (const h of history) {
+    if (modalEntry === null || h.count > modalEntry.count) {
+      modalEntry = h;
+    }
+  }
+
+  if (!modalEntry) return { isAnomaly: false };
+
+  const modalShare = modalEntry.count / total;
+
+  if (modalShare < CATEGORY_ANOMALY_MIN_SHARE) return { isAnomaly: false };
+  if (modalEntry.categorySlug === actualCategory) return { isAnomaly: false };
+
+  return {
+    isAnomaly: true,
+    expectedCategory: modalEntry.categorySlug,
+    actualCategory,
+    modalShare,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DB-driven entry point
+// ---------------------------------------------------------------------------
+
+type DB = typeof defaultDb;
+
+/**
+ * Detect category anomalies for a user's newly-classified transaction IDs.
+ *
+ * For each eligible tx, queries the prior category distribution for the
+ * (user, canonical_merchant) pair and fires when the modal category diverges.
+ *
+ * Called fire-and-forget from classify-tx worker.
+ */
+export async function detectCategoryAnomalyForUser(
+  userId: number,
+  classifiedIds: number[],
+  database: DB = defaultDb,
+): Promise<void> {
+  if (classifiedIds.length === 0) return;
+
+  // Fetch classified txs
+  const txRows = await database
+    .select({
+      id: transactions.id,
+      canonicalMerchant: transactions.canonicalMerchant,
+      categorySlug: transactions.categorySlug,
+      classificationMethod: transactions.classificationMethod,
+      channel: transactions.channel,
+      recurringId: transactions.recurringId,
+      anomalyFlags: transactions.anomalyFlags,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        notDeleted(transactions.deletedAt),
+        inArray(transactions.id, classifiedIds),
+      ),
+    );
+
+  // Fetch category names for notifications (user's own categories)
+  const allCategories = await database
+    .select({ slug: categories.slug, name: categories.name })
+    .from(categories)
+    .where(and(eq(categories.userId, userId), notDeleted(categories.deletedAt)));
+
+  const categoryNameMap = new Map<string, string>();
+  for (const cat of allCategories) {
+    categoryNameMap.set(cat.slug, cat.name);
+  }
+
+  for (const tx of txRows) {
+    try {
+      // Skip rules
+      if (tx.canonicalMerchant === null) continue;
+      if (tx.categorySlug === null) continue;
+      if (tx.channel === "transfer") continue;
+      if (tx.recurringId !== null) continue;
+      if (tx.classificationMethod === "manual" || tx.classificationMethod === "manual_confirmed") {
+        continue;
+      }
+
+      // Query prior category distribution for (user, canonical_merchant),
+      // excluding the current tx
+      const historyRows = await database
+        .select({
+          categorySlug: transactions.categorySlug,
+          count: sql<string>`COUNT(*)`,
+        })
+        .from(transactions)
+        .where(
+          and(
+            eq(transactions.userId, userId),
+            eq(transactions.canonicalMerchant, tx.canonicalMerchant),
+            notDeleted(transactions.deletedAt),
+            ne(transactions.id, tx.id),
+            sql`${transactions.categorySlug} IS NOT NULL`,
+            sql`${transactions.channel} <> 'transfer'`,
+            sql`${transactions.recurringId} IS NULL`,
+          ),
+        )
+        .groupBy(transactions.categorySlug);
+
+      const history: CategoryHistoryEntry[] = historyRows
+        .filter((r) => r.categorySlug !== null)
+        .map((r) => ({
+          categorySlug: r.categorySlug!,
+          count: Number(r.count),
+        }));
+
+      const result = evaluateCategoryAnomaly(history, tx.categorySlug);
+
+      if (!result.isAnomaly) continue;
+
+      const now = new Date().toISOString();
+      const categoryAnomalyFlag: AnomalyFlags["categoryAnomaly"] = {
+        expectedCategory: result.expectedCategory,
+        actualCategory: result.actualCategory,
+        modalShare: result.modalShare,
+      };
+
+      const existing = tx.anomalyFlags as AnomalyFlags | null;
+      const next: AnomalyFlags = { categoryAnomaly: categoryAnomalyFlag, detectedAt: now };
+      const merged = existing ? mergeAnomalyFlags(existing, next) : next;
+
+      await database
+        .update(transactions)
+        .set({ anomalyFlags: merged, updatedAt: new Date() })
+        .where(and(eq(transactions.id, tx.id), eq(transactions.userId, userId)));
+
+      const expectedName = categoryNameMap.get(result.expectedCategory) ?? result.expectedCategory;
+      const actualName = categoryNameMap.get(result.actualCategory) ?? result.actualCategory;
+
+      emitNotification(userId, {
+        type: "category_anomaly",
+        entityId: `category-anomaly:${tx.id}`,
+        title: "Categoría inusual detectada",
+        body: `Categoría inusual — usualmente ${expectedName}, hoy ${actualName}`,
+        actionUrl: `/transactions?highlight=${tx.id}`,
+        priority: "low",
+        metadata: {
+          txId: tx.id,
+          canonicalMerchant: tx.canonicalMerchant,
+          expectedCategory: result.expectedCategory,
+          actualCategory: result.actualCategory,
+          modalShare: result.modalShare,
+        },
+      }).catch((err: unknown) => {
+        log.error(
+          { err, userId, txId: tx.id, event: "category_anomaly_emit_failed" },
+          "failed to emit category_anomaly notification",
+        );
+      });
+
+      log.info(
+        {
+          userId,
+          txId: tx.id,
+          canonicalMerchant: tx.canonicalMerchant,
+          expectedCategory: result.expectedCategory,
+          actualCategory: result.actualCategory,
+          modalShare: result.modalShare,
+          event: "category_anomaly_detected",
+        },
+        "category anomaly detected",
+      );
+    } catch (err) {
+      log.error(
+        { err, userId, txId: tx.id, event: "category_anomaly_tx_failed" },
+        "error evaluating category anomaly for tx",
+      );
+    }
+  }
+}

--- a/src/lib/insights/duplicate-payment-detector.detector.test.ts
+++ b/src/lib/insights/duplicate-payment-detector.detector.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Integration tests for detectDuplicatePaymentForUser (DB-hitting).
+ *
+ * Uses findash_test (forced by vitest.setup.ts).
+ * Cleanup sentinel: description_raw LIKE '__duppay_test%'.
+ *
+ * NOTE: BigInt literals (0n) are ES2020+. Use BigInt() constructor throughout.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { transactions } from "@/lib/db/schema";
+import { detectDuplicatePaymentForUser } from "./duplicate-payment-detector";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => ({
+  emitNotification: vi.fn().mockResolvedValue({ id: 999 }),
+  getCurrentFxRate: vi.fn().mockResolvedValue({ rate: 4000, source: "test" }),
+}));
+
+vi.mock("@/lib/notifications/emit", () => ({
+  emitNotification: mocks.emitNotification,
+}));
+
+vi.mock("@/lib/fx/repo", () => ({
+  getCurrentFxRate: mocks.getCurrentFxRate,
+}));
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEST_USER_ID = 1;
+const SENTINEL = "__duppay_test";
+
+// ---------------------------------------------------------------------------
+// Cleanup helpers
+// ---------------------------------------------------------------------------
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE '__duppay_test%'`);
+}
+
+async function getAccountIds(): Promise<{ accountA: number; accountB: number }> {
+  const rows = await db.execute<{ id: number }>(sql`
+    SELECT id FROM accounts WHERE user_id = ${TEST_USER_ID} ORDER BY id LIMIT 2
+  `);
+  if (rows.length < 2) throw new Error("Need at least 2 accounts for test user");
+  return { accountA: rows[0]!.id, accountB: rows[1]!.id };
+}
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
+
+async function seedTx(opts: {
+  accountId: number;
+  amountCents: bigint;
+  canonicalMerchant?: string | null;
+  channel?: string;
+  recurringId?: number | null;
+  daysAgo?: number;
+  description?: string;
+}): Promise<number> {
+  const occurredAt = new Date(Date.now() - (opts.daysAgo ?? 1) * 24 * 60 * 60 * 1000).toISOString();
+  const amountCents = Number(opts.amountCents);
+  const [row] = await db.execute<{ id: number }>(sql`
+    INSERT INTO transactions (
+      user_id, account_id, occurred_at, amount_cents, currency,
+      description_raw, classification_method, source,
+      canonical_merchant, channel
+    ) VALUES (
+      ${TEST_USER_ID},
+      ${opts.accountId},
+      ${occurredAt}::timestamptz,
+      ${amountCents},
+      'COP',
+      ${opts.description ?? `${SENTINEL}_tx`},
+      'rule'::classification_method,
+      'sms',
+      ${opts.canonicalMerchant ?? null},
+      ${opts.channel ?? "bank"}
+    )
+    RETURNING id
+  `);
+  return row.id;
+}
+
+async function setRecurringId(txId: number, recurringId: number) {
+  await db.execute(sql`
+    UPDATE transactions SET recurring_id = ${recurringId} WHERE id = ${txId}
+  `);
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe("detectDuplicatePaymentForUser — skip rules", () => {
+  let accountA: number;
+  let accountB: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    mocks.emitNotification.mockClear();
+    const ids = await getAccountIds();
+    accountA = ids.accountA;
+    accountB = ids.accountB;
+  });
+
+  afterEach(cleanup);
+
+  it("skips when classifiedIds is empty", async () => {
+    await detectDuplicatePaymentForUser(TEST_USER_ID, [], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips when canonical_merchant is null", async () => {
+    const txId = await seedTx({
+      accountId: accountA,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: null,
+      description: `${SENTINEL}_no_merchant`,
+    });
+
+    await detectDuplicatePaymentForUser(TEST_USER_ID, [txId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips income txs (amount_cents > 0)", async () => {
+    const merchant = `${SENTINEL}_income_${Date.now()}`;
+    const txId = await seedTx({
+      accountId: accountA,
+      amountCents: BigInt(50_000), // positive
+      canonicalMerchant: merchant,
+      description: `${SENTINEL}_income_new`,
+    });
+
+    await detectDuplicatePaymentForUser(TEST_USER_ID, [txId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips transfer channel", async () => {
+    const merchant = `${SENTINEL}_transfer_${Date.now()}`;
+    const txId = await seedTx({
+      accountId: accountA,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      channel: "transfer",
+      description: `${SENTINEL}_transfer_new`,
+    });
+
+    await detectDuplicatePaymentForUser(TEST_USER_ID, [txId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire when NEITHER tx has a recurring_id", async () => {
+    // Both one-off — fails the recurring requirement
+    const merchant = `${SENTINEL}_norecurring_${Date.now()}`;
+
+    const existingId = await seedTx({
+      accountId: accountA,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      daysAgo: 10,
+      description: `${SENTINEL}_norecurring_existing`,
+    });
+    // No recurring_id on either
+
+    const newId = await seedTx({
+      accountId: accountB,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      description: `${SENTINEL}_norecurring_new`,
+    });
+
+    await detectDuplicatePaymentForUser(TEST_USER_ID, [newId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+
+    void existingId; // suppress unused warning
+  });
+});
+
+describe("detectDuplicatePaymentForUser — detection fires", () => {
+  let accountA: number;
+  let accountB: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    mocks.emitNotification.mockClear();
+    const ids = await getAccountIds();
+    accountA = ids.accountA;
+    accountB = ids.accountB;
+  });
+
+  afterEach(cleanup);
+
+  it("fires when new tx matches existing tx on different account with recurring on existing", async () => {
+    const merchant = `${SENTINEL}_fire_existing_rec_${Date.now()}`;
+
+    // Existing tx on accountA with recurring_id (we'll fake it with a real recurring_id if available,
+    // or just seed with known values and update)
+    const existingId = await seedTx({
+      accountId: accountA,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      daysAgo: 15,
+      description: `${SENTINEL}_existing_rec`,
+    });
+
+    // Simulate recurring_id by finding any existing recurring transaction
+    const [anyRecurring] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM recurring_transactions WHERE user_id = ${TEST_USER_ID} LIMIT 1
+    `);
+
+    if (anyRecurring) {
+      await setRecurringId(existingId, anyRecurring.id);
+    } else {
+      // If no recurring exists, skip test gracefully
+      // (findash_test may not have seeded recurring txs)
+      return;
+    }
+
+    const newId = await seedTx({
+      accountId: accountB,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      description: `${SENTINEL}_new_no_rec`,
+    });
+
+    await detectDuplicatePaymentForUser(TEST_USER_ID, [newId], db);
+
+    expect(mocks.emitNotification).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.objectContaining({
+        type: "duplicate_payment",
+        entityId: expect.stringContaining(`dup-payment:${TEST_USER_ID}:${merchant}`),
+      }),
+    );
+
+    // anomaly_flags written on new tx
+    const [row] = await db
+      .select({ anomalyFlags: transactions.anomalyFlags })
+      .from(transactions)
+      .where(eq(transactions.id, newId));
+
+    expect(row?.anomalyFlags).toMatchObject({
+      duplicatePayment: {
+        pairedTxId: existingId,
+        otherAccountId: accountA,
+      },
+    });
+  });
+
+  it("fires when new tx has recurring_id (pair requirement met by new side)", async () => {
+    const merchant = `${SENTINEL}_fire_new_rec_${Date.now()}`;
+
+    const existingId = await seedTx({
+      accountId: accountA,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      daysAgo: 5,
+      description: `${SENTINEL}_existing_no_rec`,
+    });
+
+    const newId = await seedTx({
+      accountId: accountB,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      description: `${SENTINEL}_new_with_rec`,
+    });
+
+    const [anyRecurring] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM recurring_transactions WHERE user_id = ${TEST_USER_ID} LIMIT 1
+    `);
+
+    if (!anyRecurring) return; // skip if no recurring seeded
+
+    await setRecurringId(newId, anyRecurring.id);
+
+    await detectDuplicatePaymentForUser(TEST_USER_ID, [newId], db);
+
+    expect(mocks.emitNotification).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.objectContaining({ type: "duplicate_payment" }),
+    );
+
+    void existingId;
+  });
+
+  it("does NOT fire when amounts differ by more than 5%", async () => {
+    const merchant = `${SENTINEL}_amt_diff_${Date.now()}`;
+
+    const existingId = await seedTx({
+      accountId: accountA,
+      amountCents: BigInt(-100_000),
+      canonicalMerchant: merchant,
+      daysAgo: 5,
+      description: `${SENTINEL}_existing_diff`,
+    });
+
+    const newId = await seedTx({
+      accountId: accountB,
+      amountCents: BigInt(-90_000), // 10% different → outside 5% tolerance
+      canonicalMerchant: merchant,
+      description: `${SENTINEL}_new_diff`,
+    });
+
+    const [anyRecurring] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM recurring_transactions WHERE user_id = ${TEST_USER_ID} LIMIT 1
+    `);
+    if (!anyRecurring) return;
+
+    await setRecurringId(existingId, anyRecurring.id);
+
+    await detectDuplicatePaymentForUser(TEST_USER_ID, [newId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+
+    void existingId;
+  });
+
+  it("does NOT fire when both txs are on the same account", async () => {
+    const merchant = `${SENTINEL}_same_acct_${Date.now()}`;
+
+    const existingId = await seedTx({
+      accountId: accountA,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      daysAgo: 5,
+      description: `${SENTINEL}_existing_same`,
+    });
+
+    const newId = await seedTx({
+      accountId: accountA, // same account
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      description: `${SENTINEL}_new_same`,
+    });
+
+    const [anyRecurring] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM recurring_transactions WHERE user_id = ${TEST_USER_ID} LIMIT 1
+    `);
+    if (!anyRecurring) return;
+
+    await setRecurringId(existingId, anyRecurring.id);
+
+    await detectDuplicatePaymentForUser(TEST_USER_ID, [newId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+
+    void existingId;
+  });
+
+  it("does NOT fire when existing tx is beyond the 35-day window", async () => {
+    const merchant = `${SENTINEL}_window_${Date.now()}`;
+
+    const existingId = await seedTx({
+      accountId: accountA,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      daysAgo: 36, // beyond 35-day window
+      description: `${SENTINEL}_existing_old`,
+    });
+
+    const newId = await seedTx({
+      accountId: accountB,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      description: `${SENTINEL}_new_after_window`,
+    });
+
+    const [anyRecurring] = await db.execute<{ id: number }>(sql`
+      SELECT id FROM recurring_transactions WHERE user_id = ${TEST_USER_ID} LIMIT 1
+    `);
+    if (!anyRecurring) return;
+
+    await setRecurringId(existingId, anyRecurring.id);
+
+    await detectDuplicatePaymentForUser(TEST_USER_ID, [newId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+
+    void existingId;
+  });
+});
+
+describe("detectDuplicatePaymentForUser — tenant safety", () => {
+  let accountA: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    mocks.emitNotification.mockClear();
+    const ids = await getAccountIds();
+    accountA = ids.accountA;
+  });
+
+  afterEach(cleanup);
+
+  it("does not cross-contaminate with data from other users", async () => {
+    // Only one tx for user 1 — no prior history on a DIFFERENT account.
+    // If the query forgot userId, it might find data from other users.
+    const merchant = `${SENTINEL}_tenant_${Date.now()}`;
+    const txId = await seedTx({
+      accountId: accountA,
+      amountCents: BigInt(-50_000),
+      canonicalMerchant: merchant,
+      description: `${SENTINEL}_tenant_only`,
+    });
+
+    await detectDuplicatePaymentForUser(TEST_USER_ID, [txId], db);
+    expect(mocks.emitNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/insights/duplicate-payment-detector.detector.test.ts
+++ b/src/lib/insights/duplicate-payment-detector.detector.test.ts
@@ -42,6 +42,7 @@ const SENTINEL = "__duppay_test";
 
 async function cleanup() {
   await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE '__duppay_test%'`);
+  await db.execute(sql`DELETE FROM recurring_transactions WHERE label LIKE '__duppay_test%'`);
 }
 
 async function getAccountIds(): Promise<{ accountA: number; accountB: number }> {
@@ -93,6 +94,29 @@ async function setRecurringId(txId: number, recurringId: number) {
   await db.execute(sql`
     UPDATE transactions SET recurring_id = ${recurringId} WHERE id = ${txId}
   `);
+}
+
+/**
+ * Seeds a minimal synthetic recurring_transactions row.
+ * Returns its id so tests can link transactions to it.
+ */
+async function seedRecurring(accountId: number): Promise<number> {
+  const [row] = await db.execute<{ id: number }>(sql`
+    INSERT INTO recurring_transactions (
+      user_id, account_id, label, amount_cents, currency, day_of_month, active, amount_type
+    ) VALUES (
+      ${TEST_USER_ID},
+      ${accountId},
+      ${"__duppay_test_recurring"},
+      ${-50000},
+      'COP',
+      1,
+      true,
+      'fixed'
+    )
+    RETURNING id
+  `);
+  return row.id;
 }
 
 // ---------------------------------------------------------------------------
@@ -187,6 +211,7 @@ describe("detectDuplicatePaymentForUser — skip rules", () => {
 describe("detectDuplicatePaymentForUser — detection fires", () => {
   let accountA: number;
   let accountB: number;
+  let recurringId: number;
 
   beforeEach(async () => {
     await cleanup();
@@ -194,6 +219,9 @@ describe("detectDuplicatePaymentForUser — detection fires", () => {
     const ids = await getAccountIds();
     accountA = ids.accountA;
     accountB = ids.accountB;
+    // Seed a synthetic recurring row — guarantees recurring_id IS NOT NULL
+    // prerequisite without depending on findash_test seed state.
+    recurringId = await seedRecurring(accountA);
   });
 
   afterEach(cleanup);
@@ -201,8 +229,6 @@ describe("detectDuplicatePaymentForUser — detection fires", () => {
   it("fires when new tx matches existing tx on different account with recurring on existing", async () => {
     const merchant = `${SENTINEL}_fire_existing_rec_${Date.now()}`;
 
-    // Existing tx on accountA with recurring_id (we'll fake it with a real recurring_id if available,
-    // or just seed with known values and update)
     const existingId = await seedTx({
       accountId: accountA,
       amountCents: BigInt(-50_000),
@@ -211,18 +237,7 @@ describe("detectDuplicatePaymentForUser — detection fires", () => {
       description: `${SENTINEL}_existing_rec`,
     });
 
-    // Simulate recurring_id by finding any existing recurring transaction
-    const [anyRecurring] = await db.execute<{ id: number }>(sql`
-      SELECT id FROM recurring_transactions WHERE user_id = ${TEST_USER_ID} LIMIT 1
-    `);
-
-    if (anyRecurring) {
-      await setRecurringId(existingId, anyRecurring.id);
-    } else {
-      // If no recurring exists, skip test gracefully
-      // (findash_test may not have seeded recurring txs)
-      return;
-    }
+    await setRecurringId(existingId, recurringId);
 
     const newId = await seedTx({
       accountId: accountB,
@@ -273,13 +288,7 @@ describe("detectDuplicatePaymentForUser — detection fires", () => {
       description: `${SENTINEL}_new_with_rec`,
     });
 
-    const [anyRecurring] = await db.execute<{ id: number }>(sql`
-      SELECT id FROM recurring_transactions WHERE user_id = ${TEST_USER_ID} LIMIT 1
-    `);
-
-    if (!anyRecurring) return; // skip if no recurring seeded
-
-    await setRecurringId(newId, anyRecurring.id);
+    await setRecurringId(newId, recurringId);
 
     await detectDuplicatePaymentForUser(TEST_USER_ID, [newId], db);
 
@@ -302,19 +311,14 @@ describe("detectDuplicatePaymentForUser — detection fires", () => {
       description: `${SENTINEL}_existing_diff`,
     });
 
+    await setRecurringId(existingId, recurringId);
+
     const newId = await seedTx({
       accountId: accountB,
       amountCents: BigInt(-90_000), // 10% different → outside 5% tolerance
       canonicalMerchant: merchant,
       description: `${SENTINEL}_new_diff`,
     });
-
-    const [anyRecurring] = await db.execute<{ id: number }>(sql`
-      SELECT id FROM recurring_transactions WHERE user_id = ${TEST_USER_ID} LIMIT 1
-    `);
-    if (!anyRecurring) return;
-
-    await setRecurringId(existingId, anyRecurring.id);
 
     await detectDuplicatePaymentForUser(TEST_USER_ID, [newId], db);
     expect(mocks.emitNotification).not.toHaveBeenCalled();
@@ -333,19 +337,14 @@ describe("detectDuplicatePaymentForUser — detection fires", () => {
       description: `${SENTINEL}_existing_same`,
     });
 
+    await setRecurringId(existingId, recurringId);
+
     const newId = await seedTx({
       accountId: accountA, // same account
       amountCents: BigInt(-50_000),
       canonicalMerchant: merchant,
       description: `${SENTINEL}_new_same`,
     });
-
-    const [anyRecurring] = await db.execute<{ id: number }>(sql`
-      SELECT id FROM recurring_transactions WHERE user_id = ${TEST_USER_ID} LIMIT 1
-    `);
-    if (!anyRecurring) return;
-
-    await setRecurringId(existingId, anyRecurring.id);
 
     await detectDuplicatePaymentForUser(TEST_USER_ID, [newId], db);
     expect(mocks.emitNotification).not.toHaveBeenCalled();
@@ -360,9 +359,11 @@ describe("detectDuplicatePaymentForUser — detection fires", () => {
       accountId: accountA,
       amountCents: BigInt(-50_000),
       canonicalMerchant: merchant,
-      daysAgo: 36, // beyond 35-day window
+      daysAgo: 40, // well beyond 35-day window (new tx is daysAgo:1, so cutoff ≈ now-36d)
       description: `${SENTINEL}_existing_old`,
     });
+
+    await setRecurringId(existingId, recurringId);
 
     const newId = await seedTx({
       accountId: accountB,
@@ -370,13 +371,6 @@ describe("detectDuplicatePaymentForUser — detection fires", () => {
       canonicalMerchant: merchant,
       description: `${SENTINEL}_new_after_window`,
     });
-
-    const [anyRecurring] = await db.execute<{ id: number }>(sql`
-      SELECT id FROM recurring_transactions WHERE user_id = ${TEST_USER_ID} LIMIT 1
-    `);
-    if (!anyRecurring) return;
-
-    await setRecurringId(existingId, anyRecurring.id);
 
     await detectDuplicatePaymentForUser(TEST_USER_ID, [newId], db);
     expect(mocks.emitNotification).not.toHaveBeenCalled();

--- a/src/lib/insights/duplicate-payment-detector.test.ts
+++ b/src/lib/insights/duplicate-payment-detector.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { withinFivePercent, DUPLICATE_PAYMENT_WINDOW_DAYS } from "./duplicate-payment-detector";
+
+// ---------------------------------------------------------------------------
+// Tests — withinFivePercent (pure BigInt tolerance check)
+// ---------------------------------------------------------------------------
+
+describe("withinFivePercent — basic tolerance", () => {
+  it("returns true for identical amounts", () => {
+    expect(withinFivePercent(BigInt(100_000), BigInt(100_000))).toBe(true);
+  });
+
+  it("returns true when diff is exactly 5%", () => {
+    // 100_000 vs 95_000 → diff=5000, larger=100_000, 5000*20=100_000 == 100_000 → true
+    expect(withinFivePercent(BigInt(100_000), BigInt(95_000))).toBe(true);
+  });
+
+  it("returns false when diff is more than 5%", () => {
+    // 100_000 vs 94_999 → diff=5001, larger=100_000, 5001*20=100_020 > 100_000 → false
+    expect(withinFivePercent(BigInt(100_000), BigInt(94_999))).toBe(false);
+  });
+
+  it("returns true when amounts are within 5% on the other side", () => {
+    // 100_000 vs 105_000 → diff=5000, larger=105_000, 5000*20=100_000 < 105_000 → true
+    expect(withinFivePercent(BigInt(100_000), BigInt(105_000))).toBe(true);
+  });
+
+  it("returns false when amounts differ by more than 5.26%", () => {
+    // The formula diff*20 <= larger is equivalent to diff <= larger/20 = 5% of larger.
+    // For base=1_000_000 vs over=X: diff = X - 1_000_000, larger = X.
+    // False when: (X - 1_000_000)*20 > X → 20X - 20_000_000 > X → 19X > 20_000_000
+    // → X > 1_052_631.  So 1_060_000 is clearly outside.
+    const base = BigInt(1_000_000);
+    const over = BigInt(1_060_000); // ~5.66% → outside 5%
+    expect(withinFivePercent(base, over)).toBe(false);
+  });
+
+  it("handles large COP amounts (BigInt-only math)", () => {
+    // 500_000_00 COP (~5M) and 499_000_00 COP — diff 1_000_00 / 500_000_00 = 0.2% → true
+    expect(withinFivePercent(BigInt(500_000_00), BigInt(499_000_00))).toBe(true);
+  });
+
+  it("returns false for zero inputs", () => {
+    expect(withinFivePercent(BigInt(0), BigInt(100_000))).toBe(false);
+    expect(withinFivePercent(BigInt(100_000), BigInt(0))).toBe(false);
+    expect(withinFivePercent(BigInt(0), BigInt(0))).toBe(false);
+  });
+
+  it("is commutative — order of arguments doesn't matter", () => {
+    const a = BigInt(200_000);
+    const b = BigInt(195_000);
+    expect(withinFivePercent(a, b)).toBe(withinFivePercent(b, a));
+  });
+});
+
+describe("withinFivePercent — real-world COP amounts", () => {
+  it("matches two subscription charges of the same plan (same amount)", () => {
+    // Netflix COP 21,900 on two cards
+    const netflix = BigInt(21_900_00);
+    expect(withinFivePercent(netflix, netflix)).toBe(true);
+  });
+
+  it("matches Netflix with 3% price increase (within 5%)", () => {
+    const old = BigInt(21_900_00);
+    const newPrice = BigInt(22_557_00); // ~3% increase
+    expect(withinFivePercent(old, newPrice)).toBe(true);
+  });
+
+  it("does NOT match completely different amounts", () => {
+    // Netflix vs Amazon Prime — different prices
+    const netflix = BigInt(21_900_00);
+    const amazon = BigInt(8_900_00);
+    expect(withinFivePercent(netflix, amazon)).toBe(false);
+  });
+});
+
+describe("DUPLICATE_PAYMENT_WINDOW_DAYS constant", () => {
+  it("is 35 days per spec", () => {
+    expect(DUPLICATE_PAYMENT_WINDOW_DAYS).toBe(35);
+  });
+});

--- a/src/lib/insights/duplicate-payment-detector.ts
+++ b/src/lib/insights/duplicate-payment-detector.ts
@@ -1,0 +1,293 @@
+/**
+ * Duplicate payment detector — C.4 (Epic I, #719).
+ *
+ * Fires when a newly-classified tx matches an existing tx from the prior 35
+ * days under these conditions:
+ *   - Same canonical_merchant
+ *   - DIFFERENT account_id
+ *   - Both are expenses (amount_cents < 0)
+ *   - Amount within 5% tolerance (BigInt-only math, no float drift)
+ *   - At least ONE of the two has recurring_id IS NOT NULL
+ *     (filters out one-off near-duplicate noise)
+ *
+ * Amount tolerance formula (pure BigInt):
+ *   absDiff * 20 <= max(|a|, |b|) — equivalent to absDiff / max <= 5%
+ *   (multiply both sides by 20 to stay in integer domain)
+ *
+ * FX: caller fetches the rate ONCE and passes it in. toCop converts USD to
+ * COP before comparison so cross-currency amounts compare correctly.
+ *
+ * On trigger:
+ *   - Writes `anomaly_flags.duplicatePayment` on the NEW tx (not the old one).
+ *   - Emits one notification per pair (`type="duplicate_payment"`).
+ *
+ * Pure functions exported for unit tests.
+ * `detectDuplicatePaymentForUser` is the DB-driven entry point.
+ */
+
+import { and, eq, gte, inArray, lt, ne, sql } from "drizzle-orm";
+import { db as defaultDb } from "@/lib/db";
+import { accounts, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { emitNotification } from "@/lib/notifications/emit";
+import { mergeAnomalyFlags } from "@/lib/insights/merchant-anomaly";
+import type { AnomalyFlags } from "@/lib/insights/merchant-anomaly";
+import { toCop } from "@/lib/money";
+import { getCurrentFxRate } from "@/lib/fx/repo";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "insights/duplicate-payment-detector" });
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Number of days to look back when searching for duplicate payments. */
+export const DUPLICATE_PAYMENT_WINDOW_DAYS = 35;
+
+// ---------------------------------------------------------------------------
+// Pure types
+// ---------------------------------------------------------------------------
+
+export type DuplicateCandidatePair = {
+  newTxId: number;
+  existingTxId: number;
+  canonicalMerchant: string;
+  newAmountCop: bigint;
+  existingAmountCop: bigint;
+};
+
+// ---------------------------------------------------------------------------
+// Pure amount tolerance check
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when `|a - b| * 20 <= max(|a|, |b|)`.
+ * This is equivalent to `|a - b| / max(|a|, |b|) <= 5%` without any floats.
+ *
+ * Both inputs MUST be positive (caller passes abs values).
+ */
+export function withinFivePercent(a: bigint, b: bigint): boolean {
+  if (a <= BigInt(0) || b <= BigInt(0)) return false;
+  const diff = a > b ? a - b : b - a;
+  const larger = a > b ? a : b;
+  return diff * BigInt(20) <= larger;
+}
+
+// ---------------------------------------------------------------------------
+// DB-driven entry point
+// ---------------------------------------------------------------------------
+
+type DB = typeof defaultDb;
+
+/**
+ * Detect duplicate payments for a user's newly-classified transaction IDs.
+ *
+ * Fetches FX rate ONCE, then for each eligible new tx, checks the prior
+ * 35 days for existing txs on a different account with the same merchant and
+ * within 5% COP-equivalent amount.
+ *
+ * Called fire-and-forget from classify-tx worker.
+ */
+export async function detectDuplicatePaymentForUser(
+  userId: number,
+  classifiedIds: number[],
+  database: DB = defaultDb,
+): Promise<void> {
+  if (classifiedIds.length === 0) return;
+
+  // Fetch FX rate ONCE for the whole run
+  const fx = await getCurrentFxRate(database);
+  const fxRate = fx.rate;
+
+  // Fetch the newly-classified txs
+  const newTxRows = await database
+    .select({
+      id: transactions.id,
+      canonicalMerchant: transactions.canonicalMerchant,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      accountId: transactions.accountId,
+      recurringId: transactions.recurringId,
+      channel: transactions.channel,
+      occurredAt: transactions.occurredAt,
+      anomalyFlags: transactions.anomalyFlags,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        notDeleted(transactions.deletedAt),
+        inArray(transactions.id, classifiedIds),
+      ),
+    );
+
+  // Filter: only expenses, non-transfer, non-null merchant
+  const eligibleNew = newTxRows.filter(
+    (tx) =>
+      tx.amountCents < BigInt(0) && tx.channel !== "transfer" && tx.canonicalMerchant !== null,
+  );
+
+  if (eligibleNew.length === 0) return;
+
+  // Fetch account info for formatting notification bodies
+  const accountIds = [...new Set(eligibleNew.map((tx) => tx.accountId))];
+  const accountRows = await database
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      currency: accounts.currency,
+      metadata: accounts.metadata,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, userId),
+        notDeleted(accounts.deletedAt),
+        inArray(accounts.id, accountIds),
+      ),
+    );
+
+  const accountMap = new Map(accountRows.map((a) => [a.id, a]));
+
+  for (const newTx of eligibleNew) {
+    try {
+      const cutoff = new Date(
+        newTx.occurredAt.getTime() - DUPLICATE_PAYMENT_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+      );
+
+      // Look for existing txs in the prior 35 days:
+      //   - same canonical_merchant
+      //   - different account_id
+      //   - expense (amount < 0)
+      //   - non-transfer
+      //   - has recurring_id (at least one in the pair)
+      const existingRows = await database
+        .select({
+          id: transactions.id,
+          amountCents: transactions.amountCents,
+          currency: transactions.currency,
+          accountId: transactions.accountId,
+          recurringId: transactions.recurringId,
+        })
+        .from(transactions)
+        .where(
+          and(
+            eq(transactions.userId, userId),
+            eq(transactions.canonicalMerchant, newTx.canonicalMerchant!),
+            ne(transactions.accountId, newTx.accountId),
+            ne(transactions.id, newTx.id),
+            lt(transactions.amountCents, sql`0`),
+            notDeleted(transactions.deletedAt),
+            gte(transactions.occurredAt, cutoff),
+            sql`${transactions.channel} <> 'transfer'`,
+          ),
+        )
+        .limit(20); // cap to avoid runaway on high-frequency merchants
+
+      // At least ONE of the pair must have recurring_id set
+      const newHasRecurring = newTx.recurringId !== null;
+
+      const newAmountCop = toCop(-newTx.amountCents, newTx.currency, fxRate);
+
+      let matched: (typeof existingRows)[number] | null = null;
+      for (const existing of existingRows) {
+        const pairHasRecurring = newHasRecurring || existing.recurringId !== null;
+        if (!pairHasRecurring) continue;
+
+        const existingAmountCop = toCop(-existing.amountCents, existing.currency, fxRate);
+        if (!withinFivePercent(newAmountCop, existingAmountCop)) continue;
+
+        matched = existing;
+        break;
+      }
+
+      if (!matched) continue;
+
+      const now = new Date().toISOString();
+      const occurredMonth = newTx.occurredAt.toISOString().slice(0, 7); // YYYY-MM
+
+      // Only write duplicatePayment to new tx anomaly_flags (not the existing one)
+      const existingFlags = newTx.anomalyFlags as AnomalyFlags | null;
+      const nextFlags: AnomalyFlags = {
+        detectedAt: now,
+        duplicatePayment: {
+          pairedTxId: matched.id,
+          otherAccountId: matched.accountId,
+        },
+      };
+      const merged = existingFlags ? mergeAnomalyFlags(existingFlags, nextFlags) : nextFlags;
+
+      await database
+        .update(transactions)
+        .set({ anomalyFlags: merged, updatedAt: new Date() })
+        .where(and(eq(transactions.id, newTx.id), eq(transactions.userId, userId)));
+
+      // Fetch account info for the matched tx if not already loaded
+      let matchedAccount = accountMap.get(matched.accountId);
+      if (!matchedAccount) {
+        const [fetchedAccount] = await database
+          .select({
+            id: accounts.id,
+            name: accounts.name,
+            currency: accounts.currency,
+            metadata: accounts.metadata,
+          })
+          .from(accounts)
+          .where(and(eq(accounts.id, matched.accountId), eq(accounts.userId, userId)))
+          .limit(1);
+        if (fetchedAccount) {
+          matchedAccount = fetchedAccount;
+        }
+      }
+
+      const newAccount = accountMap.get(newTx.accountId);
+      const accountALabel = newAccount
+        ? formatAccountLabel(newAccount)
+        : `cuenta ${newTx.accountId}`;
+      const accountBLabel = matchedAccount
+        ? formatAccountLabel(matchedAccount)
+        : `cuenta ${matched.accountId}`;
+
+      const entityId = `dup-payment:${userId}:${newTx.canonicalMerchant}:${occurredMonth}`;
+
+      emitNotification(userId, {
+        type: "duplicate_payment",
+        entityId,
+        title: "Posible pago duplicado",
+        body: `Posible pago duplicado: ${newTx.canonicalMerchant} en ${accountALabel} y ${accountBLabel}`,
+        actionUrl: `/transactions?highlight=${newTx.id}`,
+        priority: "medium",
+        metadata: {
+          newTxId: newTx.id,
+          pairedTxId: matched.id,
+          canonicalMerchant: newTx.canonicalMerchant,
+          newAccountId: newTx.accountId,
+          otherAccountId: matched.accountId,
+        },
+      }).catch((err: unknown) => {
+        log.error(
+          { err, userId, txId: newTx.id, event: "duplicate_payment_emit_failed" },
+          "failed to emit duplicate_payment notification",
+        );
+      });
+
+      log.info(
+        {
+          userId,
+          newTxId: newTx.id,
+          pairedTxId: matched.id,
+          canonicalMerchant: newTx.canonicalMerchant,
+          event: "duplicate_payment_detected",
+        },
+        "duplicate payment detected",
+      );
+    } catch (err) {
+      log.error(
+        { err, userId, txId: newTx.id, event: "duplicate_payment_tx_failed" },
+        "error evaluating duplicate payment for tx",
+      );
+    }
+  }
+}

--- a/src/lib/insights/duplicate-payment-detector.ts
+++ b/src/lib/insights/duplicate-payment-detector.ts
@@ -235,7 +235,13 @@ export async function detectDuplicatePaymentForUser(
             metadata: accounts.metadata,
           })
           .from(accounts)
-          .where(and(eq(accounts.id, matched.accountId), eq(accounts.userId, userId)))
+          .where(
+            and(
+              eq(accounts.id, matched.accountId),
+              eq(accounts.userId, userId),
+              notDeleted(accounts.deletedAt),
+            ),
+          )
           .limit(1);
         if (fetchedAccount) {
           matchedAccount = fetchedAccount;

--- a/src/lib/insights/duplicate-payment-queries.ts
+++ b/src/lib/insights/duplicate-payment-queries.ts
@@ -1,0 +1,130 @@
+/**
+ * Duplicate payment queries for the /insights page card.
+ *
+ * Server-side only — no BullMQ / ioredis transitively pulled in.
+ * Queried in real-time by the /insights RSC.
+ */
+
+import { and, desc, eq, gte, isNotNull, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import type { AnomalyFlags } from "./merchant-anomaly";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DuplicatePaymentRow = {
+  newTxId: number;
+  canonicalMerchant: string;
+  amountCents: bigint;
+  currency: string;
+  occurredAt: Date;
+  newAccountLabel: string;
+  otherAccountLabel: string;
+  pairedTxId: number;
+};
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch recent duplicate payment detections from the last 30 days for a user.
+ *
+ * Returns up to `limit` unique pairs, ordered by most recent first.
+ * A "pair" is identified by (newTxId, pairedTxId) — only the new tx side is
+ * surfaced since `anomaly_flags.duplicatePayment` is only written on new txs.
+ *
+ * @param userId  Authenticated user id.
+ * @param limit   Maximum number of results (default 10).
+ */
+export async function fetchRecentDuplicatePayments(
+  userId: number,
+  limit = 10,
+): Promise<DuplicatePaymentRow[]> {
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+  const rows = await db
+    .select({
+      id: transactions.id,
+      canonicalMerchant: transactions.canonicalMerchant,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      occurredAt: transactions.occurredAt,
+      accountId: transactions.accountId,
+      anomalyFlags: transactions.anomalyFlags,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        notDeleted(transactions.deletedAt),
+        gte(transactions.occurredAt, thirtyDaysAgo),
+        isNotNull(transactions.canonicalMerchant),
+        sql`${transactions.anomalyFlags} -> 'duplicatePayment' IS NOT NULL`,
+      ),
+    )
+    .orderBy(desc(transactions.occurredAt))
+    .limit(limit * 2); // over-fetch to allow dedup
+
+  if (rows.length === 0) return [];
+
+  // Collect all account IDs referenced (new tx + paired)
+  const accountIdSet = new Set<number>();
+  for (const row of rows) {
+    accountIdSet.add(row.accountId);
+    const flags = row.anomalyFlags as AnomalyFlags | null;
+    if (flags?.duplicatePayment?.otherAccountId) {
+      accountIdSet.add(flags.duplicatePayment.otherAccountId);
+    }
+  }
+
+  const accountRows = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      currency: accounts.currency,
+      metadata: accounts.metadata,
+    })
+    .from(accounts)
+    .where(and(eq(accounts.userId, userId), notDeleted(accounts.deletedAt)));
+
+  const accountMap = new Map(accountRows.map((a) => [a.id, a]));
+
+  const seen = new Set<string>();
+  const result: DuplicatePaymentRow[] = [];
+
+  for (const row of rows) {
+    const flags = row.anomalyFlags as AnomalyFlags | null;
+    if (!flags?.duplicatePayment) continue;
+
+    const { pairedTxId, otherAccountId } = flags.duplicatePayment;
+    // Dedup by canonical_merchant + pairedTxId
+    const dedupKey = `${row.canonicalMerchant}:${pairedTxId}`;
+    if (seen.has(dedupKey)) continue;
+    seen.add(dedupKey);
+
+    const newAccount = accountMap.get(row.accountId);
+    const otherAccount = accountMap.get(otherAccountId);
+
+    result.push({
+      newTxId: row.id,
+      canonicalMerchant: row.canonicalMerchant!,
+      amountCents: row.amountCents,
+      currency: row.currency,
+      occurredAt: row.occurredAt,
+      newAccountLabel: newAccount ? formatAccountLabel(newAccount) : `cuenta ${row.accountId}`,
+      otherAccountLabel: otherAccount
+        ? formatAccountLabel(otherAccount)
+        : `cuenta ${otherAccountId}`,
+      pairedTxId,
+    });
+
+    if (result.length >= limit) break;
+  }
+
+  return result;
+}

--- a/src/lib/insights/merchant-anomaly.ts
+++ b/src/lib/insights/merchant-anomaly.ts
@@ -41,8 +41,48 @@ export type AnomalyFlags = {
     baselineAvgCents: string; // BigInt serialized as string
   };
   firstEncounter?: boolean;
+  // #719 (Epic I B.3): velocity cluster — ≥4 distinct-merchant expenses on the
+  // same card within a 30-min window.
+  velocity?: {
+    clusterSize: number;
+    windowMinutes: number;
+    firstTxId: number;
+    lastTxId: number;
+  };
+  // #719 (Epic I B.4): category anomaly — tx category diverges from the modal
+  // category for (user, canonical_merchant) based on prior history.
+  categoryAnomaly?: {
+    expectedCategory: string; // modal category slug
+    actualCategory: string; // current tx category slug
+    modalShare: number; // ratio 0..1
+  };
+  // #719 (Epic I C.4): duplicate payment — same merchant on different accounts
+  // within 35 days with similar amounts. Written on the NEW tx only.
+  duplicatePayment?: {
+    pairedTxId: number;
+    otherAccountId: number;
+  };
   detectedAt: string; // ISO timestamp
 };
+
+// ---------------------------------------------------------------------------
+// Merge helper — combines two AnomalyFlags objects without overwriting keys
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge `next` into `prev` without overwriting any keys already present in
+ * `prev`. Both `detectedAt` fields are preserved — `prev.detectedAt` wins.
+ *
+ * Usage: always merge when updating anomaly_flags on an existing row so that,
+ * e.g., a `firstEncounter:true` flag set by B.2 is not lost when B.4 adds
+ * `categoryAnomaly` to the same tx.
+ */
+export function mergeAnomalyFlags(prev: AnomalyFlags, next: Partial<AnomalyFlags>): AnomalyFlags {
+  return {
+    ...next,
+    ...prev, // prev wins on every common key
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Pure detection thresholds (exported for unit test access)

--- a/src/lib/insights/velocity-detector.test.ts
+++ b/src/lib/insights/velocity-detector.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVelocityClusters,
+  VELOCITY_MIN_CLUSTER_SIZE,
+  VELOCITY_WINDOW_MINUTES,
+  type VelocityTx,
+} from "./velocity-detector";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeVelocityTx(
+  id: number,
+  offsetMinutes: number,
+  merchant: string,
+  cardKey = "card-A",
+): VelocityTx {
+  const base = new Date("2026-05-01T10:00:00Z");
+  return {
+    id,
+    occurredAt: new Date(base.getTime() + offsetMinutes * 60_000),
+    amountCents: BigInt(-50_000),
+    canonicalMerchant: merchant,
+    cardKey,
+  };
+}
+
+// Sentinel prefix to identify test data in description_raw (not used here but
+// documents the pattern: __velocity_test_ for real integration tests).
+
+// ---------------------------------------------------------------------------
+// Tests — buildVelocityClusters (pure, no DB)
+// ---------------------------------------------------------------------------
+
+describe("buildVelocityClusters — basic triggering", () => {
+  it("returns no cluster when fewer than 4 distinct merchants", () => {
+    const txs: VelocityTx[] = [
+      makeVelocityTx(1, 0, "__velocity_test_McDonalds"),
+      makeVelocityTx(2, 5, "__velocity_test_BurgerKing"),
+      makeVelocityTx(3, 10, "__velocity_test_Subway"),
+    ];
+    expect(buildVelocityClusters(txs)).toHaveLength(0);
+  });
+
+  it("returns a cluster with exactly 4 distinct merchants within 30 min", () => {
+    const txs: VelocityTx[] = [
+      makeVelocityTx(1, 0, "__velocity_test_McDonalds"),
+      makeVelocityTx(2, 5, "__velocity_test_BurgerKing"),
+      makeVelocityTx(3, 10, "__velocity_test_Subway"),
+      makeVelocityTx(4, 15, "__velocity_test_Dominos"),
+    ];
+    const clusters = buildVelocityClusters(txs);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]!.clusterSize).toBe(4);
+    expect(clusters[0]!.txIds).toHaveLength(4);
+    expect(clusters[0]!.cardKey).toBe("card-A");
+  });
+
+  it("does NOT fire when 4 merchants span more than 30 minutes", () => {
+    const txs: VelocityTx[] = [
+      makeVelocityTx(1, 0, "__velocity_test_McDonalds"),
+      makeVelocityTx(2, 10, "__velocity_test_BurgerKing"),
+      makeVelocityTx(3, 20, "__velocity_test_Subway"),
+      makeVelocityTx(4, 35, "__velocity_test_Dominos"), // 35 min > 30
+    ];
+    expect(buildVelocityClusters(txs)).toHaveLength(0);
+  });
+
+  it("counts DISTINCT merchants — 4 txs from same merchant don't trigger", () => {
+    const txs: VelocityTx[] = [
+      makeVelocityTx(1, 0, "__velocity_test_Rappi"),
+      makeVelocityTx(2, 5, "__velocity_test_Rappi"),
+      makeVelocityTx(3, 10, "__velocity_test_Rappi"),
+      makeVelocityTx(4, 15, "__velocity_test_Rappi"),
+    ];
+    // 1 distinct merchant (Rappi) — Rappi multi-order protection
+    expect(buildVelocityClusters(txs)).toHaveLength(0);
+  });
+
+  it("counts DISTINCT merchants — 3 Rappi + 1 other = 2 distinct → no trigger", () => {
+    const txs: VelocityTx[] = [
+      makeVelocityTx(1, 0, "__velocity_test_Rappi"),
+      makeVelocityTx(2, 5, "__velocity_test_Rappi"),
+      makeVelocityTx(3, 10, "__velocity_test_Rappi"),
+      makeVelocityTx(4, 15, "__velocity_test_McDonalds"),
+    ];
+    expect(buildVelocityClusters(txs)).toHaveLength(0);
+  });
+});
+
+describe("buildVelocityClusters — card key isolation", () => {
+  it("does NOT merge txs from different cards into the same cluster", () => {
+    const txs: VelocityTx[] = [
+      makeVelocityTx(1, 0, "__velocity_test_A", "card-A"),
+      makeVelocityTx(2, 5, "__velocity_test_B", "card-A"),
+      makeVelocityTx(3, 10, "__velocity_test_C", "card-B"), // different card
+      makeVelocityTx(4, 15, "__velocity_test_D", "card-B"), // different card
+    ];
+    // card-A has 2 distinct, card-B has 2 distinct → neither reaches threshold 4
+    expect(buildVelocityClusters(txs)).toHaveLength(0);
+  });
+
+  it("detects clusters independently on each card", () => {
+    const card = (k: string) => k;
+    const txsA: VelocityTx[] = [
+      makeVelocityTx(1, 0, "__velocity_test_A1", card("card-A")),
+      makeVelocityTx(2, 5, "__velocity_test_A2", card("card-A")),
+      makeVelocityTx(3, 10, "__velocity_test_A3", card("card-A")),
+      makeVelocityTx(4, 15, "__velocity_test_A4", card("card-A")),
+    ];
+    const txsB: VelocityTx[] = [
+      makeVelocityTx(5, 0, "__velocity_test_B1", card("card-B")),
+      makeVelocityTx(6, 5, "__velocity_test_B2", card("card-B")),
+      makeVelocityTx(7, 10, "__velocity_test_B3", card("card-B")),
+      makeVelocityTx(8, 15, "__velocity_test_B4", card("card-B")),
+    ];
+    const clusters = buildVelocityClusters([...txsA, ...txsB]);
+    expect(clusters).toHaveLength(2);
+    const keys = clusters.map((c) => c.cardKey).sort();
+    expect(keys).toEqual(["card-A", "card-B"]);
+  });
+});
+
+describe("buildVelocityClusters — cluster metadata", () => {
+  it("records correct firstTxId and lastTxId", () => {
+    const txs: VelocityTx[] = [
+      makeVelocityTx(10, 0, "__velocity_test_M1"),
+      makeVelocityTx(20, 8, "__velocity_test_M2"),
+      makeVelocityTx(30, 16, "__velocity_test_M3"),
+      makeVelocityTx(40, 24, "__velocity_test_M4"),
+    ];
+    const [cluster] = buildVelocityClusters(txs);
+    expect(cluster).toBeDefined();
+    expect(cluster!.firstTxId).toBe(10);
+    expect(cluster!.lastTxId).toBe(40);
+  });
+
+  it("includes all 4 txIds in the cluster", () => {
+    const txs: VelocityTx[] = [
+      makeVelocityTx(1, 0, "__velocity_test_M1"),
+      makeVelocityTx(2, 7, "__velocity_test_M2"),
+      makeVelocityTx(3, 14, "__velocity_test_M3"),
+      makeVelocityTx(4, 21, "__velocity_test_M4"),
+    ];
+    const [cluster] = buildVelocityClusters(txs);
+    expect(cluster!.txIds.sort()).toEqual([1, 2, 3, 4]);
+  });
+
+  it("windowMinutes reflects actual elapsed time in the cluster", () => {
+    const txs: VelocityTx[] = [
+      makeVelocityTx(1, 0, "__velocity_test_M1"),
+      makeVelocityTx(2, 5, "__velocity_test_M2"),
+      makeVelocityTx(3, 10, "__velocity_test_M3"),
+      makeVelocityTx(4, 17, "__velocity_test_M4"), // 17 min elapsed
+    ];
+    const [cluster] = buildVelocityClusters(txs);
+    // ceil(17 * 60000 / 60000) = 17
+    expect(cluster!.windowMinutes).toBe(17);
+  });
+});
+
+describe("buildVelocityClusters — boundary conditions", () => {
+  it("triggers at exactly 30 minutes boundary (inclusive window)", () => {
+    const txs: VelocityTx[] = [
+      makeVelocityTx(1, 0, "__velocity_test_M1"),
+      makeVelocityTx(2, 10, "__velocity_test_M2"),
+      makeVelocityTx(3, 20, "__velocity_test_M3"),
+      makeVelocityTx(4, 30, "__velocity_test_M4"), // exactly 30 min
+    ];
+    // window = 30 min exactly = windowMs, so NOT > windowMs
+    const clusters = buildVelocityClusters(txs);
+    expect(clusters).toHaveLength(1);
+  });
+
+  it("does not trigger with 0 txs", () => {
+    expect(buildVelocityClusters([])).toHaveLength(0);
+  });
+
+  it("detects a cluster when 5 distinct merchants appear — reports clusterSize >= 4", () => {
+    // The sliding-window algorithm emits the cluster as soon as threshold is met
+    // (at distinct count=4), then advances left past the cluster. A 5th tx may
+    // or may not extend the same cluster depending on window state. What matters
+    // is that at least one cluster of size >= 4 is found.
+    const txs: VelocityTx[] = [
+      makeVelocityTx(1, 0, "__velocity_test_M1"),
+      makeVelocityTx(2, 5, "__velocity_test_M2"),
+      makeVelocityTx(3, 10, "__velocity_test_M3"),
+      makeVelocityTx(4, 15, "__velocity_test_M4"),
+      makeVelocityTx(5, 20, "__velocity_test_M5"),
+    ];
+    const clusters = buildVelocityClusters(txs);
+    expect(clusters.length).toBeGreaterThanOrEqual(1);
+    expect(clusters[0]!.clusterSize).toBeGreaterThanOrEqual(4);
+  });
+
+  it("exported constants match spec", () => {
+    expect(VELOCITY_MIN_CLUSTER_SIZE).toBe(4);
+    expect(VELOCITY_WINDOW_MINUTES).toBe(30);
+  });
+});

--- a/src/lib/insights/velocity-detector.ts
+++ b/src/lib/insights/velocity-detector.ts
@@ -1,0 +1,384 @@
+/**
+ * Velocity detector — B.3 (Epic I, #719).
+ *
+ * Fires when ≥4 expense transactions with DISTINCT canonical_merchant values
+ * occur on the same physical card (physical_card_id) within any 30-minute
+ * window. Rappi multi-order protection: consecutive purchases from the SAME
+ * canonical_merchant inside the cluster are NOT counted as distinct.
+ *
+ * Skip conditions per tx (applied before cluster formation):
+ *   - channel = 'transfer'
+ *   - recurring_id IS NOT NULL
+ *   - amount_cents >= 0 (non-expense)
+ *   - canonical_merchant IS NULL
+ *
+ * Cluster grouping key:
+ *   - `physical_card_id` when it is NOT NULL on the account.
+ *   - `account_id` as fallback when physical_card_id IS NULL.
+ *
+ * Cluster size: count of DISTINCT canonical_merchant values (not raw tx count).
+ *
+ * On trigger: writes `anomaly_flags.velocity` to ALL txs in the cluster
+ * (single UPDATE IN), emits ONE notification per cluster.
+ *
+ * Pure functions are exported for unit tests.
+ * `detectVelocityForUser` is the DB-driven entry point.
+ */
+
+import { and, eq, gte, inArray, sql } from "drizzle-orm";
+import { db as defaultDb } from "@/lib/db";
+import { accounts, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { emitNotification } from "@/lib/notifications/emit";
+import { mergeAnomalyFlags } from "@/lib/insights/merchant-anomaly";
+import type { AnomalyFlags } from "@/lib/insights/merchant-anomaly";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ module: "insights/velocity-detector" });
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Minimum distinct-merchant count to trigger a velocity alert. */
+export const VELOCITY_MIN_CLUSTER_SIZE = 4;
+
+/** Window in minutes for velocity clustering. */
+export const VELOCITY_WINDOW_MINUTES = 30;
+
+// ---------------------------------------------------------------------------
+// Pure types
+// ---------------------------------------------------------------------------
+
+export type VelocityTx = {
+  id: number;
+  occurredAt: Date;
+  amountCents: bigint;
+  canonicalMerchant: string; // already filtered — non-null
+  cardKey: string; // physical_card_id or account_id (as string)
+};
+
+export type VelocityCluster = {
+  txIds: number[];
+  cardKey: string;
+  clusterSize: number;
+  firstTxId: number;
+  lastTxId: number;
+  windowMinutes: number;
+  earliestOccurredAt: Date;
+};
+
+// ---------------------------------------------------------------------------
+// Pure helper — build clusters from a flat list of eligible txs
+// ---------------------------------------------------------------------------
+
+/**
+ * Group `txs` by `cardKey`, then sweep each group with a 30-minute sliding
+ * window to identify clusters of ≥4 DISTINCT canonical merchants.
+ *
+ * Returns only clusters that meet or exceed VELOCITY_MIN_CLUSTER_SIZE.
+ */
+export function buildVelocityClusters(txs: VelocityTx[]): VelocityCluster[] {
+  // Group by card key
+  const byCard = new Map<string, VelocityTx[]>();
+  for (const tx of txs) {
+    const group = byCard.get(tx.cardKey);
+    if (group) {
+      group.push(tx);
+    } else {
+      byCard.set(tx.cardKey, [tx]);
+    }
+  }
+
+  const clusters: VelocityCluster[] = [];
+  const windowMs = VELOCITY_WINDOW_MINUTES * 60 * 1000;
+
+  for (const [cardKey, group] of byCard) {
+    // Sort ascending by time
+    const sorted = [...group].sort((a, b) => a.occurredAt.getTime() - b.occurredAt.getTime());
+
+    // Sliding window: expand right, shrink left when window exceeds 30 min
+    let left = 0;
+    const merchants = new Set<string>();
+    // Track merchant→txIds map to collect all txIds in the window
+    const windowTxIds = new Set<number>();
+
+    for (let right = 0; right < sorted.length; right++) {
+      const current = sorted[right]!;
+      merchants.add(current.canonicalMerchant);
+      windowTxIds.add(current.id);
+
+      // Shrink left until window fits in VELOCITY_WINDOW_MINUTES
+      while (current.occurredAt.getTime() - sorted[left]!.occurredAt.getTime() > windowMs) {
+        const leftTx = sorted[left]!;
+        windowTxIds.delete(leftTx.id);
+        // Re-compute merchants for the remaining window
+        merchants.clear();
+        left++;
+        for (let k = left; k <= right; k++) {
+          merchants.add(sorted[k]!.canonicalMerchant);
+          windowTxIds.add(sorted[k]!.id);
+        }
+        // Rebuild windowTxIds from scratch since we might have added leftTx to
+        // windowTxIds from a previous loop iteration — cleaner to recompute.
+        windowTxIds.clear();
+        for (let k = left; k <= right; k++) {
+          windowTxIds.add(sorted[k]!.id);
+        }
+      }
+
+      if (merchants.size >= VELOCITY_MIN_CLUSTER_SIZE) {
+        // Collect all txs in window left..right
+        const clusterTxIds = Array.from(windowTxIds);
+        const windowTxArray = sorted.slice(left, right + 1);
+        const firstTx = windowTxArray[0]!;
+        const lastTx = windowTxArray[windowTxArray.length - 1]!;
+        const actualWindowMs = lastTx.occurredAt.getTime() - firstTx.occurredAt.getTime();
+        const actualWindowMinutes = Math.ceil(actualWindowMs / 60_000) || 1;
+
+        clusters.push({
+          txIds: clusterTxIds,
+          cardKey,
+          clusterSize: merchants.size,
+          firstTxId: firstTx.id,
+          lastTxId: lastTx.id,
+          windowMinutes: actualWindowMinutes,
+          earliestOccurredAt: firstTx.occurredAt,
+        });
+
+        // Advance left past the current position to avoid overlapping clusters
+        // for the same card. One cluster per card per window is enough.
+        left = right + 1;
+        merchants.clear();
+        windowTxIds.clear();
+      }
+    }
+  }
+
+  return clusters;
+}
+
+// ---------------------------------------------------------------------------
+// DB-driven entry point
+// ---------------------------------------------------------------------------
+
+type DB = typeof defaultDb;
+
+/**
+ * Detect velocity clusters for a user's newly-classified transaction IDs.
+ *
+ * Fetches the 30-min window of surrounding eligible txs, builds clusters,
+ * writes anomaly_flags.velocity to all txs in each cluster, and emits one
+ * notification per cluster.
+ *
+ * Called fire-and-forget from classify-tx worker.
+ */
+export async function detectVelocityForUser(
+  userId: number,
+  classifiedIds: number[],
+  database: DB = defaultDb,
+): Promise<void> {
+  if (classifiedIds.length === 0) return;
+
+  // Fetch the classified txs first to determine the time range we need
+  const classifiedRows = await database
+    .select({
+      id: transactions.id,
+      occurredAt: transactions.occurredAt,
+      amountCents: transactions.amountCents,
+      canonicalMerchant: transactions.canonicalMerchant,
+      channel: transactions.channel,
+      recurringId: transactions.recurringId,
+      accountId: transactions.accountId,
+      anomalyFlags: transactions.anomalyFlags,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        notDeleted(transactions.deletedAt),
+        inArray(transactions.id, classifiedIds),
+      ),
+    );
+
+  // Filter to eligible txs only
+  const eligible = classifiedRows.filter(
+    (tx) =>
+      tx.amountCents < BigInt(0) &&
+      tx.channel !== "transfer" &&
+      tx.recurringId === null &&
+      tx.canonicalMerchant !== null,
+  );
+
+  if (eligible.length === 0) return;
+
+  // Determine the time window to search for surrounding txs
+  const earliestMs = Math.min(...eligible.map((tx) => tx.occurredAt.getTime()));
+  const latestMs = Math.max(...eligible.map((tx) => tx.occurredAt.getTime()));
+  const windowMs = VELOCITY_WINDOW_MINUTES * 60 * 1000;
+  const searchStart = new Date(earliestMs - windowMs);
+  const searchEnd = new Date(latestMs + windowMs);
+
+  // Fetch account physical_card_id for all involved accounts
+  const accountIds = [...new Set(eligible.map((tx) => tx.accountId))];
+  const accountRows = await database
+    .select({
+      id: accounts.id,
+      physicalCardId: accounts.physicalCardId,
+      name: accounts.name,
+      currency: accounts.currency,
+      metadata: accounts.metadata,
+    })
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.userId, userId),
+        notDeleted(accounts.deletedAt),
+        inArray(accounts.id, accountIds),
+      ),
+    );
+
+  const accountPhysicalCardMap = new Map<number, string | null>();
+  const accountInfoMap = new Map<
+    number,
+    { name: string; currency: string; metadata: { last4s?: string[] | null } | null }
+  >();
+  for (const a of accountRows) {
+    accountPhysicalCardMap.set(a.id, a.physicalCardId ?? null);
+    accountInfoMap.set(a.id, { name: a.name, currency: a.currency, metadata: a.metadata });
+  }
+
+  // Fetch all eligible txs in the surrounding window (not just classified ones)
+  const surroundingRows = await database
+    .select({
+      id: transactions.id,
+      occurredAt: transactions.occurredAt,
+      amountCents: transactions.amountCents,
+      canonicalMerchant: transactions.canonicalMerchant,
+      channel: transactions.channel,
+      recurringId: transactions.recurringId,
+      accountId: transactions.accountId,
+      anomalyFlags: transactions.anomalyFlags,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        notDeleted(transactions.deletedAt),
+        gte(transactions.occurredAt, searchStart),
+        inArray(transactions.accountId, accountIds),
+        sql`${transactions.amountCents} < 0`,
+        sql`${transactions.channel} <> 'transfer'`,
+        sql`${transactions.recurringId} IS NULL`,
+        sql`${transactions.canonicalMerchant} IS NOT NULL`,
+      ),
+    );
+
+  // Build VelocityTx list
+  const velocityTxs: VelocityTx[] = surroundingRows
+    .filter((tx) => tx.occurredAt <= searchEnd)
+    .map((tx) => {
+      const physicalCardId = accountPhysicalCardMap.get(tx.accountId);
+      const cardKey =
+        physicalCardId !== null && physicalCardId !== undefined
+          ? physicalCardId
+          : String(tx.accountId);
+      return {
+        id: tx.id,
+        occurredAt: tx.occurredAt,
+        amountCents: tx.amountCents,
+        canonicalMerchant: tx.canonicalMerchant!,
+        cardKey,
+      };
+    });
+
+  const clusters = buildVelocityClusters(velocityTxs);
+
+  // Only process clusters that contain at least one newly-classified tx
+  const classifiedIdSet = new Set(classifiedIds);
+
+  for (const cluster of clusters) {
+    const hasNewTx = cluster.txIds.some((id) => classifiedIdSet.has(id));
+    if (!hasNewTx) continue;
+
+    try {
+      const now = new Date().toISOString();
+      const velocityFlag: AnomalyFlags["velocity"] = {
+        clusterSize: cluster.clusterSize,
+        windowMinutes: cluster.windowMinutes,
+        firstTxId: cluster.firstTxId,
+        lastTxId: cluster.lastTxId,
+      };
+
+      // Fetch current anomaly_flags for all txs in cluster to merge
+      const clusterRows = await database
+        .select({ id: transactions.id, anomalyFlags: transactions.anomalyFlags })
+        .from(transactions)
+        .where(and(eq(transactions.userId, userId), inArray(transactions.id, cluster.txIds)));
+
+      // Build per-tx merged flags and update each one
+      for (const row of clusterRows) {
+        const existing = row.anomalyFlags as AnomalyFlags | null;
+        const next: AnomalyFlags = { velocity: velocityFlag, detectedAt: now };
+        const merged = existing ? mergeAnomalyFlags(existing, next) : next;
+
+        await database
+          .update(transactions)
+          .set({ anomalyFlags: merged, updatedAt: new Date() })
+          .where(and(eq(transactions.id, row.id), eq(transactions.userId, userId)));
+      }
+
+      // Determine card label for notification body
+      const firstEligible = surroundingRows.find((r) => r.id === cluster.firstTxId);
+      let cardLabel = cluster.cardKey;
+      if (firstEligible) {
+        const accInfo = accountInfoMap.get(firstEligible.accountId);
+        if (accInfo) {
+          const last4 = accInfo.metadata?.last4s?.[0];
+          cardLabel = last4 ? `*${last4}` : accInfo.name;
+        }
+      }
+
+      const entityId = `velocity:${userId}:${cluster.cardKey}:${cluster.firstTxId}`;
+
+      emitNotification(userId, {
+        type: "velocity_cluster",
+        entityId,
+        title: "Posible uso fraudulento de tarjeta",
+        body: `${cluster.clusterSize} compras en ${cluster.windowMinutes} min con TC ${cardLabel} — ¿fuiste vos?`,
+        actionUrl: "/transactions",
+        priority: "high",
+        metadata: {
+          clusterSize: cluster.clusterSize,
+          windowMinutes: cluster.windowMinutes,
+          firstTxId: cluster.firstTxId,
+          lastTxId: cluster.lastTxId,
+          cardKey: cluster.cardKey,
+        },
+      }).catch((err: unknown) => {
+        log.error(
+          { err, userId, entityId, event: "velocity_cluster_emit_failed" },
+          "failed to emit velocity_cluster notification",
+        );
+      });
+
+      log.info(
+        {
+          userId,
+          clusterSize: cluster.clusterSize,
+          windowMinutes: cluster.windowMinutes,
+          firstTxId: cluster.firstTxId,
+          lastTxId: cluster.lastTxId,
+          cardKey: cluster.cardKey,
+          event: "velocity_cluster_detected",
+        },
+        "velocity cluster detected",
+      );
+    } catch (err) {
+      log.error(
+        { err, userId, cluster, event: "velocity_cluster_tx_failed" },
+        "error processing velocity cluster",
+      );
+    }
+  }
+}

--- a/src/lib/insights/velocity-detector.ts
+++ b/src/lib/insights/velocity-detector.ts
@@ -30,7 +30,6 @@ import { db as defaultDb } from "@/lib/db";
 import { accounts, transactions } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { emitNotification } from "@/lib/notifications/emit";
-import { mergeAnomalyFlags } from "@/lib/insights/merchant-anomaly";
 import type { AnomalyFlags } from "@/lib/insights/merchant-anomaly";
 import { createLogger } from "@/lib/logger";
 
@@ -310,23 +309,17 @@ export async function detectVelocityForUser(
         lastTxId: cluster.lastTxId,
       };
 
-      // Fetch current anomaly_flags for all txs in cluster to merge
-      const clusterRows = await database
-        .select({ id: transactions.id, anomalyFlags: transactions.anomalyFlags })
-        .from(transactions)
+      // Single bulk UPDATE — Postgres `||` merges the velocity blob into
+      // existing anomaly_flags atomically (right-side wins on key conflicts,
+      // so existing flags under OTHER keys survive).
+      const velocityBlob = JSON.stringify({ velocity: velocityFlag, detectedAt: now });
+      await database
+        .update(transactions)
+        .set({
+          anomalyFlags: sql`COALESCE(anomaly_flags, '{}'::jsonb) || ${velocityBlob}::jsonb`,
+          updatedAt: new Date(),
+        })
         .where(and(eq(transactions.userId, userId), inArray(transactions.id, cluster.txIds)));
-
-      // Build per-tx merged flags and update each one
-      for (const row of clusterRows) {
-        const existing = row.anomalyFlags as AnomalyFlags | null;
-        const next: AnomalyFlags = { velocity: velocityFlag, detectedAt: now };
-        const merged = existing ? mergeAnomalyFlags(existing, next) : next;
-
-        await database
-          .update(transactions)
-          .set({ anomalyFlags: merged, updatedAt: new Date() })
-          .where(and(eq(transactions.id, row.id), eq(transactions.userId, userId)));
-      }
 
       // Determine card label for notification body
       const firstEligible = surroundingRows.find((r) => r.id === cluster.firstTxId);

--- a/src/lib/notifications/emit.ts
+++ b/src/lib/notifications/emit.ts
@@ -36,7 +36,11 @@ export type NotificationType =
   | "merchant_first_encounter"
   // #715 (Epic I D.3+D.4): salary-gap and cash flow forecast signals.
   | "salary_gap"
-  | "cash_flow_forecast";
+  | "cash_flow_forecast"
+  // #719 (Epic I B.3+B.4+C.4): velocity cluster, category anomaly, duplicate payment.
+  | "velocity_cluster"
+  | "category_anomaly"
+  | "duplicate_payment";
 
 export type NotificationAudience = "user" | "admin";
 export type NotificationPriority = "high" | "medium" | "low";

--- a/src/lib/queue/workers/classify-tx.ts
+++ b/src/lib/queue/workers/classify-tx.ts
@@ -3,6 +3,9 @@ import type { Job } from "bullmq";
 import { createLogger } from "@/lib/logger";
 import { classifyUnclassifiedBatch } from "@/lib/classification/pipeline";
 import { detectMerchantSignals } from "@/lib/insights/merchant-anomaly";
+import { detectVelocityForUser } from "@/lib/insights/velocity-detector";
+import { detectCategoryAnomalyForUser } from "@/lib/insights/category-anomaly-detector";
+import { detectDuplicatePaymentForUser } from "@/lib/insights/duplicate-payment-detector";
 import { countUnclassified } from "@/lib/transactions/queries";
 import { createWorker } from "@/lib/queue";
 import { emit } from "@/lib/events/bus";
@@ -49,6 +52,24 @@ export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<
       log.error(
         { err, userId, event: "merchant_anomaly_detect_failed" },
         "merchant anomaly detection failed",
+      );
+    });
+    // Fire-and-forget velocity cluster detection (B.3).
+    detectVelocityForUser(userId, result.classifiedIds).catch((err: unknown) => {
+      log.error({ err, userId, event: "velocity_detect_failed" }, "velocity detection failed");
+    });
+    // Fire-and-forget category anomaly detection (B.4).
+    detectCategoryAnomalyForUser(userId, result.classifiedIds).catch((err: unknown) => {
+      log.error(
+        { err, userId, event: "category_anomaly_detect_failed" },
+        "category anomaly detection failed",
+      );
+    });
+    // Fire-and-forget duplicate payment detection (C.4).
+    detectDuplicatePaymentForUser(userId, result.classifiedIds).catch((err: unknown) => {
+      log.error(
+        { err, userId, event: "duplicate_payment_detect_failed" },
+        "duplicate payment detection failed",
       );
     });
 
@@ -158,6 +179,24 @@ export async function classifyTxProcessor(job: Job<ClassifyTxJobData>): Promise<
       log.error(
         { err, userId, event: "merchant_anomaly_detect_failed" },
         "merchant anomaly detection failed",
+      );
+    });
+    // Fire-and-forget velocity cluster detection (B.3).
+    detectVelocityForUser(userId, result.classifiedIds).catch((err: unknown) => {
+      log.error({ err, userId, event: "velocity_detect_failed" }, "velocity detection failed");
+    });
+    // Fire-and-forget category anomaly detection (B.4).
+    detectCategoryAnomalyForUser(userId, result.classifiedIds).catch((err: unknown) => {
+      log.error(
+        { err, userId, event: "category_anomaly_detect_failed" },
+        "category anomaly detection failed",
+      );
+    });
+    // Fire-and-forget duplicate payment detection (C.4).
+    detectDuplicatePaymentForUser(userId, result.classifiedIds).catch((err: unknown) => {
+      log.error(
+        { err, userId, event: "duplicate_payment_detect_failed" },
+        "duplicate payment detection failed",
       );
     });
 


### PR DESCRIPTION
## Summary

Closes #719 — Epic I sub-tasks B.3 + B.4 + C.4 bundled.

- **B.3 Velocity** — sliding-window cluster (≥4 expenses in 30 min on same physical_card_id, fallback accounts.id for mono-currency). Skip same-merchant consecutive, transfers, recurring. ONE notif per cluster; ALL cluster txs get anomaly_flags.velocity via single bulk UPDATE with Postgres || JSONB merge.
- **B.4 Category anomaly** — when (userId, canonical_merchant) has ≥10 prior txs AND modal share ≥80% AND new differs. Skip manual classifications, null slug, transfers, recurring. Per-tx notif.
- **C.4 Duplicate payment** — same canonical_merchant, distinct account_id, within 35d, both expenses, ≥1 recurring_id. 5% tolerance pure BigInt (absDiff * BigInt(20) <= largerCop). FX once at top. Monthly dedup. Violet /insights card.
- **AnomalyFlags** type extended (JSONB, no migration) + mergeAnomalyFlags helper.
- **Combined-badge priority** chain extended to 6 branches.
- **NotificationType** +3: velocity_cluster, category_anomaly, duplicate_payment.
- 3 fire-and-forget hooks at both classify-tx.ts seams.

Reviewer flagged 1 CRITICAL (C.4 tests silently bailed when findash_test had no recurring rows) + 2 WARNINGs (B.3 round-trips, C.4 notDeleted). All fixed in c2f75ec.

## Test plan

- [x] Lint, typecheck, full vitest (2603 passed, 1 skipped)
- [x] 14 velocity + 12 cat-anomaly + 12 dup-payment pure tests
- [x] 9 cat-anomaly + 12 dup-payment DB integration (seeded recurring fixture, no silent skips)
- [x] 4 new jsdom transaction-table priority cases
- [x] Engram anti-pattern memory saved