### PR TITLE
feat(insights): CDT + FIC savings suggestions + canAccessFeature seam (#721)

### DIFF
--- a/src/app/(app)/insights/page.tsx
+++ b/src/app/(app)/insights/page.tsx
@@ -20,8 +20,11 @@ import { fetchRecentAnomalies } from "@/lib/insights/merchant-anomaly-queries";
 import { fetchCashFlowSummary } from "@/lib/insights/cash-flow-queries";
 import { fetchTemporalSummary } from "@/lib/insights/temporal-queries";
 import { fetchRecentDuplicatePayments } from "@/lib/insights/duplicate-payment-queries";
+import { fetchSavingsSuggestion } from "@/lib/insights/savings-suggestions-queries";
 import { dowNameEs, monthNameEs } from "@/lib/insights/temporal";
 import { SpendingHeatmap } from "@/components/insights/spending-heatmap";
+import { SavingsSuggestionsCard } from "@/components/insights/savings-suggestions-card";
+import { canAccessFeature } from "@/lib/auth/can-access-feature";
 import { InsightsViewer } from "./insights-viewer";
 
 export const dynamic = "force-dynamic";
@@ -169,14 +172,23 @@ export default async function InsightsPage({
   // TC Health card — real-time snapshot of all the user's TCs (#705)
   const nowDate = new Date();
   const today = nowInBogota(nowDate);
-  const [tcSnapshots, recentAnomalies, cashFlowSummary, temporalSummary, recentDuplicatePayments] =
-    await Promise.all([
-      fetchUserTcSnapshots(session.id, fx.rate, today),
-      fetchRecentAnomalies(session.id),
-      fetchCashFlowSummary(session.id, nowDate),
-      fetchTemporalSummary(session.id, nowDate),
-      fetchRecentDuplicatePayments(session.id),
-    ]);
+  const [
+    tcSnapshots,
+    recentAnomalies,
+    cashFlowSummary,
+    temporalSummary,
+    recentDuplicatePayments,
+    savingsSuggestions,
+    canSeeSavings,
+  ] = await Promise.all([
+    fetchUserTcSnapshots(session.id, fx.rate, today),
+    fetchRecentAnomalies(session.id),
+    fetchCashFlowSummary(session.id, nowDate),
+    fetchTemporalSummary(session.id, nowDate),
+    fetchRecentDuplicatePayments(session.id),
+    fetchSavingsSuggestion(session.id),
+    canAccessFeature(session.id, "cdt-suggestion"),
+  ]);
   const tcAlerts: Array<{ snap: TcCardSnapshot; triggers: TcAlertTrigger[] }> = tcSnapshots
     .map((snap) => ({ snap, triggers: computeTcAlerts(snap) }))
     .filter((a) => a.triggers.length > 0);
@@ -388,6 +400,11 @@ export default async function InsightsPage({
           )}
         </CardContent>
       </Card>
+
+      {/* Optimizá tus ahorros — C.1 CDT + C.2 FIC savings suggestions (#721) */}
+      {canSeeSavings && savingsSuggestions.length > 0 && (
+        <SavingsSuggestionsCard rows={savingsSuggestions} />
+      )}
 
       <InsightsViewer
         ym={ym}

--- a/src/components/insights/savings-suggestions-card.tsx
+++ b/src/components/insights/savings-suggestions-card.tsx
@@ -1,0 +1,148 @@
+/**
+ * Savings suggestions card — C.1 CDT + C.2 FIC (Epic I, #721).
+ *
+ * Server component — no client interactivity needed.
+ * Shows a bundled CDT + FIC table per idle savings account.
+ *
+ * Rendered only when idle savings are detected. Empty state: do not render.
+ * Gated by canAccessFeature("cdt-suggestion") in the parent page.
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatCop, formatMoney } from "@/lib/money";
+import type { SavingsSuggestionRow } from "@/lib/insights/savings-suggestions-queries";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Props = {
+  rows: SavingsSuggestionRow[];
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function SavingsSuggestionsCard({ rows }: Props) {
+  if (rows.length === 0) return null;
+
+  return (
+    <Card className="border-emerald-200 bg-emerald-50/40 dark:border-emerald-900 dark:bg-emerald-950/15">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-emerald-900 dark:text-emerald-200">
+          Optimizá tus ahorros
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        {rows.map((row) => (
+          <AccountSuggestionBlock key={row.accountId} row={row} />
+        ))}
+        <p className="text-muted-foreground text-xs">
+          Estimaciones — consultá tu banco para tasas reales y condiciones.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-account block
+// ---------------------------------------------------------------------------
+
+function AccountSuggestionBlock({ row }: { row: SavingsSuggestionRow }) {
+  // Determine display amount (native currency)
+  const balanceDisplay =
+    row.currency === "COP"
+      ? formatCop(row.avgBalanceCents)
+      : formatMoney(row.avgBalanceCents, "USD");
+
+  const suggestedAmountCents = row.cdt?.suggestedAmountCents ?? row.fic?.suggestedAmountCents;
+  const suggestedDisplay = suggestedAmountCents
+    ? row.currency === "COP"
+      ? formatCop(suggestedAmountCents)
+      : formatMoney(suggestedAmountCents, "USD")
+    : null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-0.5">
+        <p className="text-sm font-medium text-emerald-900 dark:text-emerald-200">
+          {row.accountLabel}
+        </p>
+        <p className="text-muted-foreground text-sm">
+          Saldo idle:{" "}
+          <span className="font-medium text-emerald-800 dark:text-emerald-300">
+            {balanceDisplay}
+          </span>
+        </p>
+        {suggestedDisplay !== null && (
+          <p className="text-muted-foreground text-sm">
+            Monto sugerido a invertir:{" "}
+            <span className="font-medium text-emerald-800 dark:text-emerald-300">
+              {suggestedDisplay}
+            </span>
+            <span className="text-xs"> (reservando 1.5 meses de gastos)</span>
+          </p>
+        )}
+      </div>
+
+      {/* Tabla CDT + FIC */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-emerald-200 dark:border-emerald-800">
+              <th className="pr-3 pb-1 text-left text-xs font-medium text-emerald-700 dark:text-emerald-400">
+                Producto
+              </th>
+              <th className="pr-3 pb-1 text-right text-xs font-medium text-emerald-700 dark:text-emerald-400">
+                Tasa anual
+              </th>
+              <th className="pr-3 pb-1 text-left text-xs font-medium text-emerald-700 dark:text-emerald-400">
+                Liquidez
+              </th>
+              <th className="pb-1 text-right text-xs font-medium text-emerald-700 dark:text-emerald-400">
+                Yield estimado
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-emerald-100 dark:divide-emerald-900">
+            {/* CDT terms */}
+            {row.cdt?.terms.map((term) => (
+              <tr key={term.months}>
+                <td className="py-1 pr-3 text-left text-emerald-900 dark:text-emerald-200">
+                  CDT {term.months}M
+                </td>
+                <td className="py-1 pr-3 text-right text-emerald-800 tabular-nums dark:text-emerald-300">
+                  {(term.ratePct * 100).toFixed(1)}%
+                </td>
+                <td className="py-1 pr-3 text-left text-emerald-600 dark:text-emerald-400">
+                  Bloqueado {term.months} meses
+                </td>
+                <td className="py-1 text-right font-medium text-emerald-900 tabular-nums dark:text-emerald-200">
+                  {formatCop(term.estimatedYieldCents)}
+                </td>
+              </tr>
+            ))}
+
+            {/* FIC row */}
+            {row.fic && (
+              <tr>
+                <td className="py-1 pr-3 text-left text-emerald-900 dark:text-emerald-200">FIC</td>
+                <td className="py-1 pr-3 text-right text-emerald-800 tabular-nums dark:text-emerald-300">
+                  {row.fic.ratePct.toFixed(1)}%
+                </td>
+                <td className="py-1 pr-3 text-left text-emerald-600 dark:text-emerald-400">
+                  Inmediata
+                </td>
+                <td className="py-1 text-right font-medium text-emerald-900 tabular-nums dark:text-emerald-200">
+                  {formatCop(row.fic.estimatedYearlyYieldCents)}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/insights/savings-suggestions-card.tsx
+++ b/src/components/insights/savings-suggestions-card.tsx
@@ -114,7 +114,7 @@ function AccountSuggestionBlock({ row }: { row: SavingsSuggestionRow }) {
                   CDT {term.months}M
                 </td>
                 <td className="py-1 pr-3 text-right text-emerald-800 tabular-nums dark:text-emerald-300">
-                  {(term.ratePct * 100).toFixed(1)}%
+                  {term.ratePct.toFixed(1)}%
                 </td>
                 <td className="py-1 pr-3 text-left text-emerald-600 dark:text-emerald-400">
                   Bloqueado {term.months} meses

--- a/src/lib/auth/can-access-feature.test.ts
+++ b/src/lib/auth/can-access-feature.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { canAccessFeature, type PremiumFeature } from "./can-access-feature";
+
+describe("canAccessFeature — v1 always returns true", () => {
+  const features: PremiumFeature[] = [
+    "cdt-suggestion",
+    "fic-suggestion",
+    "monthly-claude-report",
+    "conversational-insights",
+  ];
+
+  for (const feature of features) {
+    it(`returns true for feature "${feature}"`, async () => {
+      const result = await canAccessFeature(1, feature);
+      expect(result).toBe(true);
+    });
+  }
+
+  it("returns true for any userId (stub is user-agnostic)", async () => {
+    expect(await canAccessFeature(0, "cdt-suggestion")).toBe(true);
+    expect(await canAccessFeature(999, "fic-suggestion")).toBe(true);
+  });
+});

--- a/src/lib/auth/can-access-feature.ts
+++ b/src/lib/auth/can-access-feature.ts
@@ -1,0 +1,23 @@
+import { createLogger } from "@/lib/logger";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const log = createLogger({ module: "auth/can-access-feature" });
+
+export type PremiumFeature =
+  | "cdt-suggestion"
+  | "fic-suggestion"
+  | "monthly-claude-report"
+  | "conversational-insights";
+
+/**
+ * Premium feature gating — wired here per Epic #255 plan (FIRST premium-gated sub-issue).
+ *
+ * v1: always returns true (no Premium tier active yet).
+ * Phase 7: replace with query against user_subscriptions table.
+ *
+ * See PLAN.md § Business Model & Pricing (Deferred) and issue #255.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function canAccessFeature(userId: number, feature: PremiumFeature): Promise<boolean> {
+  return true;
+}

--- a/src/lib/insights/cdt-fic-rates.ts
+++ b/src/lib/insights/cdt-fic-rates.ts
@@ -1,0 +1,10 @@
+// Actualizar manualmente cada Q desde Banco República — última actualización: 2026-05
+
+export const CDT_RATES = {
+  months6: 0.11, // 11%
+  months12: 0.125, // 12.5%
+  months24: 0.13, // 13%
+} as const;
+
+export const FIC_YIELD = 0.08; // 8%
+export const SAVINGS_BASELINE_YIELD = 0.06; // 6%

--- a/src/lib/insights/savings-suggestions-detector.test.ts
+++ b/src/lib/insights/savings-suggestions-detector.test.ts
@@ -114,17 +114,29 @@ describe("runSavingsSuggestionForUser — no idle accounts", () => {
 
   afterEach(cleanup);
 
-  it("emits nothing when user has no savings accounts", async () => {
-    // Test user may have savings accounts in seed — override by checking
-    // if they have large enough balances. If existing accounts are below
-    // threshold, this test still passes.
-    // We rely on the fact that test seed accounts don't have 5M COP balance.
+  it("emits nothing when user has a savings account below the 5M COP threshold", async () => {
+    // Seed a savings account with a balance of 2M COP — well below the 5M idle
+    // threshold. detectIdleSavings will skip it, so no CDT/FIC notification
+    // should be emitted.
+    const accountId = await seedSavingsAccount();
+    // 2M COP inflow — below the 5M COP IDLE_BALANCE_THRESHOLD_CENTS
+    await seedTx({
+      accountId,
+      amountCents: BigInt(2_000_000 * 100),
+      daysAgo: 30,
+    });
+
     await runSavingsSuggestionForUser(TEST_USER_ID, db);
 
-    // Might or might not emit depending on seed state. If seed has no large
-    // savings balances, emitNotification won't be called for CDT/FIC.
-    // Since we can't guarantee seed state, this test just verifies no crash.
-    expect(true).toBe(true);
+    const cdtCalls = mocks.emitNotification.mock.calls.filter(
+      ([, input]) => input.type === "cdt_suggestion",
+    );
+    const ficCalls = mocks.emitNotification.mock.calls.filter(
+      ([, input]) => input.type === "fic_suggestion",
+    );
+
+    expect(cdtCalls).toHaveLength(0);
+    expect(ficCalls).toHaveLength(0);
   });
 });
 

--- a/src/lib/insights/savings-suggestions-detector.test.ts
+++ b/src/lib/insights/savings-suggestions-detector.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Integration tests for runSavingsSuggestionForUser (DB-hitting).
+ *
+ * Uses findash_test (forced by vitest.setup.ts).
+ * Cleanup sentinel: description_raw LIKE '__savings_test%'.
+ *
+ * NOTE: BigInt literals (0n) are ES2020+. Use BigInt() constructor throughout.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { runSavingsSuggestionForUser } from "./savings-suggestions";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  emitNotification: vi.fn().mockResolvedValue({ id: 999 }),
+  getCurrentFxRate: vi.fn().mockResolvedValue({ rate: 4000, source: "test" }),
+  canAccessFeature: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/lib/notifications/emit", () => ({
+  emitNotification: mocks.emitNotification,
+}));
+
+vi.mock("@/lib/fx/repo", () => ({
+  getCurrentFxRate: mocks.getCurrentFxRate,
+}));
+
+vi.mock("@/lib/auth/can-access-feature", () => ({
+  canAccessFeature: mocks.canAccessFeature,
+}));
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEST_USER_ID = 1;
+const SENTINEL = "__savings_test";
+
+// ---------------------------------------------------------------------------
+// Cleanup helpers
+// ---------------------------------------------------------------------------
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM transactions WHERE description_raw LIKE '__savings_test%'`);
+  await db.execute(sql`DELETE FROM accounts WHERE name LIKE '__savings_test%'`);
+}
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Seeds a synthetic savings account and returns its id.
+ */
+async function seedSavingsAccount(): Promise<number> {
+  const [row] = await db.execute<{ id: number }>(sql`
+    INSERT INTO accounts (
+      user_id, name, institution, institution_slug, type, currency, active
+    ) VALUES (
+      ${TEST_USER_ID},
+      ${`${SENTINEL}_account_${Date.now()}`},
+      'bancolombia',
+      'bancolombia',
+      'savings',
+      'COP',
+      true
+    )
+    RETURNING id
+  `);
+  return row.id;
+}
+
+async function seedTx(opts: {
+  accountId: number;
+  amountCents: bigint;
+  daysAgo?: number;
+}): Promise<number> {
+  const occurredAt = new Date(Date.now() - (opts.daysAgo ?? 1) * 24 * 60 * 60 * 1000).toISOString();
+  const amountCents = Number(opts.amountCents);
+  const [row] = await db.execute<{ id: number }>(sql`
+    INSERT INTO transactions (
+      user_id, account_id, occurred_at, amount_cents, currency,
+      description_raw, classification_method, source
+    ) VALUES (
+      ${TEST_USER_ID},
+      ${opts.accountId},
+      ${occurredAt}::timestamptz,
+      ${amountCents},
+      'COP',
+      ${`${SENTINEL}_tx_${Date.now()}_${Math.random()}`},
+      'rule'::classification_method,
+      'sms'
+    )
+    RETURNING id
+  `);
+  return row.id;
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe("runSavingsSuggestionForUser — no idle accounts", () => {
+  beforeEach(async () => {
+    await cleanup();
+    mocks.emitNotification.mockClear();
+    mocks.canAccessFeature.mockResolvedValue(true);
+  });
+
+  afterEach(cleanup);
+
+  it("emits nothing when user has no savings accounts", async () => {
+    // Test user may have savings accounts in seed — override by checking
+    // if they have large enough balances. If existing accounts are below
+    // threshold, this test still passes.
+    // We rely on the fact that test seed accounts don't have 5M COP balance.
+    await runSavingsSuggestionForUser(TEST_USER_ID, db);
+
+    // Might or might not emit depending on seed state. If seed has no large
+    // savings balances, emitNotification won't be called for CDT/FIC.
+    // Since we can't guarantee seed state, this test just verifies no crash.
+    expect(true).toBe(true);
+  });
+});
+
+describe("runSavingsSuggestionForUser — emission and dedup", () => {
+  let savingsAccountId: number;
+
+  beforeEach(async () => {
+    await cleanup();
+    mocks.emitNotification.mockClear();
+    mocks.canAccessFeature.mockResolvedValue(true);
+
+    savingsAccountId = await seedSavingsAccount();
+
+    // Seed transactions to make the account eligible:
+    // Balance (sum of txs) must be > 5M COP (IDLE_BALANCE_THRESHOLD_CENTS)
+    // Seed 8M inflow and 1M outflow → balance = 7M COP, net positive
+    await seedTx({
+      accountId: savingsAccountId,
+      amountCents: BigInt(8_000_000 * 100),
+      daysAgo: 60,
+    });
+    // Seed 1M outflow (still net positive)
+    await seedTx({
+      accountId: savingsAccountId,
+      amountCents: BigInt(-1_000_000 * 100),
+      daysAgo: 30,
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("emits CDT and FIC notifications for user with idle savings", async () => {
+    await runSavingsSuggestionForUser(TEST_USER_ID, db);
+
+    // Should have emitted at least CDT + FIC for our synthetic account
+    const cdtCalls = mocks.emitNotification.mock.calls.filter(
+      ([, input]) => input.type === "cdt_suggestion",
+    );
+    const ficCalls = mocks.emitNotification.mock.calls.filter(
+      ([, input]) => input.type === "fic_suggestion",
+    );
+
+    expect(cdtCalls.length).toBeGreaterThanOrEqual(1);
+    expect(ficCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("entityId contains Q-YYYY format for quarterly dedup", async () => {
+    await runSavingsSuggestionForUser(TEST_USER_ID, db);
+
+    const cdtCalls = mocks.emitNotification.mock.calls.filter(
+      ([, input]) => input.type === "cdt_suggestion",
+    );
+
+    expect(cdtCalls.length).toBeGreaterThan(0);
+    const entityId: string = cdtCalls[0]![1].entityId;
+    expect(entityId).toMatch(/cdt-suggestion:\d+:Q[1-4]-\d{4}/);
+  });
+
+  it("second run in same quarter produces same entityId (dedup)", async () => {
+    await runSavingsSuggestionForUser(TEST_USER_ID, db);
+
+    const firstRunCdtCalls = mocks.emitNotification.mock.calls
+      .filter(([, input]) => input.type === "cdt_suggestion")
+      .map(([, input]) => input.entityId);
+
+    mocks.emitNotification.mockClear();
+    await runSavingsSuggestionForUser(TEST_USER_ID, db);
+
+    const secondRunCdtCalls = mocks.emitNotification.mock.calls
+      .filter(([, input]) => input.type === "cdt_suggestion")
+      .map(([, input]) => input.entityId);
+
+    // Same entityId — emitNotification dedup handles idempotency at DB level
+    expect(secondRunCdtCalls[0]).toBe(firstRunCdtCalls[0]);
+  });
+
+  it("does not emit CDT when canAccessFeature returns false for cdt-suggestion", async () => {
+    mocks.canAccessFeature.mockImplementation((_userId: number, feature: string) =>
+      Promise.resolve(feature !== "cdt-suggestion"),
+    );
+
+    await runSavingsSuggestionForUser(TEST_USER_ID, db);
+
+    const cdtCalls = mocks.emitNotification.mock.calls.filter(
+      ([, input]) => input.type === "cdt_suggestion",
+    );
+    expect(cdtCalls).toHaveLength(0);
+  });
+
+  it("does not emit FIC when canAccessFeature returns false for fic-suggestion", async () => {
+    mocks.canAccessFeature.mockImplementation((_userId: number, feature: string) =>
+      Promise.resolve(feature !== "fic-suggestion"),
+    );
+
+    await runSavingsSuggestionForUser(TEST_USER_ID, db);
+
+    const ficCalls = mocks.emitNotification.mock.calls.filter(
+      ([, input]) => input.type === "fic_suggestion",
+    );
+    expect(ficCalls).toHaveLength(0);
+  });
+});

--- a/src/lib/insights/savings-suggestions-queries.ts
+++ b/src/lib/insights/savings-suggestions-queries.ts
@@ -1,0 +1,127 @@
+/**
+ * Savings suggestions queries for the /insights page card.
+ *
+ * Server-side only — no BullMQ / ioredis transitively pulled in.
+ * Queries are called in real-time by the /insights RSC.
+ *
+ * Uses derivedBalanceCentsSql (snapshot-anchored) for accurate balance.
+ */
+
+import { and, eq, gte } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { getCurrentFxRate } from "@/lib/fx/repo";
+import {
+  detectIdleSavings,
+  computeCdtSuggestion,
+  computeFicSuggestion,
+  SAVINGS_WINDOW_DAYS,
+} from "./savings-suggestions";
+import { CDT_RATES, FIC_YIELD } from "./cdt-fic-rates";
+import type { Currency } from "@/lib/types";
+import type { CdtSuggestion, FicSuggestion } from "./savings-suggestions";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SavingsSuggestionRow = {
+  accountId: number;
+  accountLabel: string;
+  avgBalanceCents: bigint;
+  currency: Currency;
+  cdt: CdtSuggestion | null;
+  fic: FicSuggestion | null;
+};
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch CDT + FIC savings suggestions for the /insights card.
+ *
+ * Returns an array of per-account rows. Empty array means no idle savings
+ * detected — the card should not be rendered.
+ *
+ * @param userId  Authenticated user id.
+ */
+export async function fetchSavingsSuggestion(userId: number): Promise<SavingsSuggestionRow[]> {
+  const fx = await getCurrentFxRate();
+  const fxRate = fx.rate;
+
+  // Fetch savings accounts with derived balance
+  const accountRows = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      currency: accounts.currency,
+      institution: accounts.institution,
+      metadata: accounts.metadata,
+      type: accounts.type,
+      balanceCents: derivedBalanceCentsSql,
+    })
+    .from(accounts)
+    .where(
+      and(eq(accounts.userId, userId), eq(accounts.active, true), notDeleted(accounts.deletedAt)),
+    );
+
+  if (accountRows.length === 0) return [];
+
+  // Fetch last 90d transactions
+  const ninetyDaysAgo = new Date(Date.now() - SAVINGS_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const txRows = await db
+    .select({
+      accountId: transactions.accountId,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        notDeleted(transactions.deletedAt),
+        gte(transactions.occurredAt, ninetyDaysAgo),
+      ),
+    );
+
+  const accountsForDetection = accountRows.map((row) => ({
+    id: row.id,
+    type: row.type,
+    currency: row.currency as Currency,
+    balanceCents: BigInt(row.balanceCents),
+  }));
+
+  const txsForDetection = txRows.map((row) => ({
+    accountId: row.accountId,
+    amountCents: row.amountCents,
+    currency: row.currency as Currency,
+  }));
+
+  const idleAccounts = detectIdleSavings({
+    accounts: accountsForDetection,
+    txsLast90d: txsForDetection,
+    fxRate,
+  });
+
+  if (idleAccounts.length === 0) return [];
+
+  const accountMap = new Map(accountRows.map((a) => [a.id, a]));
+
+  return idleAccounts.map((idleAccount) => {
+    const accountRow = accountMap.get(idleAccount.accountId)!;
+    const accountLabel = formatAccountLabel(accountRow);
+
+    return {
+      accountId: idleAccount.accountId,
+      accountLabel,
+      avgBalanceCents: idleAccount.avgBalanceCents,
+      currency: idleAccount.currency,
+      cdt: computeCdtSuggestion(idleAccount, CDT_RATES),
+      fic: computeFicSuggestion(idleAccount, FIC_YIELD),
+    };
+  });
+}

--- a/src/lib/insights/savings-suggestions-queries.ts
+++ b/src/lib/insights/savings-suggestions-queries.ts
@@ -111,17 +111,29 @@ export async function fetchSavingsSuggestion(userId: number): Promise<SavingsSug
 
   const accountMap = new Map(accountRows.map((a) => [a.id, a]));
 
-  return idleAccounts.map((idleAccount) => {
+  const rows: SavingsSuggestionRow[] = [];
+
+  for (const idleAccount of idleAccounts) {
+    const cdt = computeCdtSuggestion(idleAccount, CDT_RATES);
+    const fic = computeFicSuggestion(idleAccount, FIC_YIELD);
+
+    // Spec decision #4 + #8: if both suggestions compute to null (e.g. monthly
+    // burn so high that suggestedAmount < 1M COP), skip the row entirely.
+    // The card already guards on rows.length === 0 and renders nothing.
+    if (cdt === null && fic === null) continue;
+
     const accountRow = accountMap.get(idleAccount.accountId)!;
     const accountLabel = formatAccountLabel(accountRow);
 
-    return {
+    rows.push({
       accountId: idleAccount.accountId,
       accountLabel,
       avgBalanceCents: idleAccount.avgBalanceCents,
       currency: idleAccount.currency,
-      cdt: computeCdtSuggestion(idleAccount, CDT_RATES),
-      fic: computeFicSuggestion(idleAccount, FIC_YIELD),
-    };
-  });
+      cdt,
+      fic,
+    });
+  }
+
+  return rows;
 }

--- a/src/lib/insights/savings-suggestions.test.ts
+++ b/src/lib/insights/savings-suggestions.test.ts
@@ -1,0 +1,473 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectIdleSavings,
+  computeCdtSuggestion,
+  computeFicSuggestion,
+  quarterLabel,
+  IDLE_BALANCE_THRESHOLD_CENTS,
+  type IdleSavingsAccount,
+} from "./savings-suggestions";
+import { CDT_RATES, FIC_YIELD, SAVINGS_BASELINE_YIELD } from "./cdt-fic-rates";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FX_RATE = 4000; // COP per USD
+
+function makeIdleAccount(overrides: Partial<IdleSavingsAccount> = {}): IdleSavingsAccount {
+  return {
+    accountId: 1,
+    avgBalanceCents: BigInt(10_000_000 * 100), // 10M COP
+    currency: "COP",
+    monthlyBurnCents: BigInt(500_000 * 100), // 500K COP/month burn
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// quarterLabel
+// ---------------------------------------------------------------------------
+
+describe("quarterLabel", () => {
+  it("returns Q1 for January (month 0)", () => {
+    expect(quarterLabel(new Date(2026, 0, 15))).toBe("Q1-2026");
+  });
+
+  it("returns Q1 for March (month 2)", () => {
+    expect(quarterLabel(new Date(2026, 2, 31))).toBe("Q1-2026");
+  });
+
+  it("returns Q2 for April (month 3)", () => {
+    expect(quarterLabel(new Date(2026, 3, 1))).toBe("Q2-2026");
+  });
+
+  it("returns Q2 for May (month 4)", () => {
+    expect(quarterLabel(new Date(2026, 4, 2))).toBe("Q2-2026");
+  });
+
+  it("returns Q3 for July (month 6)", () => {
+    expect(quarterLabel(new Date(2026, 6, 1))).toBe("Q3-2026");
+  });
+
+  it("returns Q4 for December (month 11)", () => {
+    expect(quarterLabel(new Date(2026, 11, 31))).toBe("Q4-2026");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectIdleSavings — eligibility
+// ---------------------------------------------------------------------------
+
+describe("detectIdleSavings — eligibility", () => {
+  it("skips non-savings accounts (credit_card, loan)", () => {
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "credit_card",
+          currency: "COP",
+          balanceCents: BigInt(20_000_000 * 100),
+        },
+        {
+          id: 2,
+          type: "loan",
+          currency: "COP",
+          balanceCents: BigInt(20_000_000 * 100),
+        },
+      ],
+      txsLast90d: [],
+      fxRate: FX_RATE,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips savings account below 5M COP threshold", () => {
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "savings",
+          currency: "COP",
+          balanceCents: IDLE_BALANCE_THRESHOLD_CENTS - BigInt(1),
+        },
+      ],
+      txsLast90d: [],
+      fxRate: FX_RATE,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("includes savings account just above 5M COP threshold with net positive flow", () => {
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "savings",
+          currency: "COP",
+          balanceCents: IDLE_BALANCE_THRESHOLD_CENTS + BigInt(1),
+        },
+      ],
+      txsLast90d: [
+        // Must have inflow > outflow to pass drain check
+        { accountId: 1, amountCents: BigInt(1_000_000 * 100), currency: "COP" },
+      ],
+      fxRate: FX_RATE,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.accountId).toBe(1);
+  });
+
+  it("skips account being drained (outflow > inflow)", () => {
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "savings",
+          currency: "COP",
+          balanceCents: BigInt(10_000_000 * 100),
+        },
+      ],
+      txsLast90d: [
+        // inflow: 1M
+        { accountId: 1, amountCents: BigInt(1_000_000 * 100), currency: "COP" },
+        // outflow: 3M (being drained)
+        { accountId: 1, amountCents: BigInt(-3_000_000 * 100), currency: "COP" },
+      ],
+      fxRate: FX_RATE,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips account where inflow == outflow (not net positive)", () => {
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "savings",
+          currency: "COP",
+          balanceCents: BigInt(10_000_000 * 100),
+        },
+      ],
+      txsLast90d: [
+        { accountId: 1, amountCents: BigInt(2_000_000 * 100), currency: "COP" },
+        { accountId: 1, amountCents: BigInt(-2_000_000 * 100), currency: "COP" },
+      ],
+      fxRate: FX_RATE,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("includes account with more inflow than outflow", () => {
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "savings",
+          currency: "COP",
+          balanceCents: BigInt(10_000_000 * 100),
+        },
+      ],
+      txsLast90d: [
+        { accountId: 1, amountCents: BigInt(5_000_000 * 100), currency: "COP" },
+        { accountId: 1, amountCents: BigInt(-2_000_000 * 100), currency: "COP" },
+      ],
+      fxRate: FX_RATE,
+    });
+
+    expect(result).toHaveLength(1);
+  });
+
+  it("computes monthlyBurnCents as abs(outflow_90d) / 3", () => {
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "savings",
+          currency: "COP",
+          balanceCents: BigInt(10_000_000 * 100),
+        },
+      ],
+      txsLast90d: [
+        { accountId: 1, amountCents: BigInt(5_000_000 * 100), currency: "COP" },
+        // total outflow = 3M over 90d
+        { accountId: 1, amountCents: BigInt(-1_500_000 * 100), currency: "COP" },
+        { accountId: 1, amountCents: BigInt(-1_500_000 * 100), currency: "COP" },
+      ],
+      fxRate: FX_RATE,
+    });
+
+    expect(result).toHaveLength(1);
+    // 3M / 3 = 1M per month
+    expect(result[0]!.monthlyBurnCents).toBe(BigInt(1_000_000 * 100));
+  });
+
+  it("handles multiple accounts independently", () => {
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "savings",
+          currency: "COP",
+          balanceCents: BigInt(10_000_000 * 100),
+        },
+        {
+          id: 2,
+          type: "savings",
+          currency: "COP",
+          balanceCents: BigInt(2_000_000 * 100), // below threshold
+        },
+      ],
+      txsLast90d: [
+        // account 1 is net positive
+        { accountId: 1, amountCents: BigInt(5_000_000 * 100), currency: "COP" },
+        { accountId: 1, amountCents: BigInt(-1_000_000 * 100), currency: "COP" },
+      ],
+      fxRate: FX_RATE,
+    });
+
+    // Only account 1 qualifies
+    expect(result).toHaveLength(1);
+    expect(result[0]!.accountId).toBe(1);
+  });
+
+  it("converts USD account balance to COP for threshold check", () => {
+    // 1500 USD × 4000 = 6M COP — above 5M threshold
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "savings",
+          currency: "USD",
+          balanceCents: BigInt(1_500 * 100), // 1500 USD
+        },
+      ],
+      txsLast90d: [
+        // inflow
+        { accountId: 1, amountCents: BigInt(500 * 100), currency: "USD" },
+        // outflow
+        { accountId: 1, amountCents: BigInt(-100 * 100), currency: "USD" },
+      ],
+      fxRate: FX_RATE, // 4000
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.currency).toBe("USD");
+    // avgBalanceCents stored in native USD
+    expect(result[0]!.avgBalanceCents).toBe(BigInt(1_500 * 100));
+  });
+
+  it("skips USD account below threshold after FX conversion", () => {
+    // 500 USD × 4000 = 2M COP — below 5M threshold
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "savings",
+          currency: "USD",
+          balanceCents: BigInt(500 * 100), // 500 USD
+        },
+      ],
+      txsLast90d: [{ accountId: 1, amountCents: BigInt(100 * 100), currency: "USD" }],
+      fxRate: FX_RATE,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("ignores transactions from other accounts", () => {
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "savings",
+          currency: "COP",
+          balanceCents: BigInt(10_000_000 * 100),
+        },
+      ],
+      txsLast90d: [
+        // These belong to account 2, not account 1
+        { accountId: 2, amountCents: BigInt(-5_000_000 * 100), currency: "COP" },
+        { accountId: 2, amountCents: BigInt(-5_000_000 * 100), currency: "COP" },
+      ],
+      fxRate: FX_RATE,
+    });
+
+    // Account 1 has zero outflows so inflow (0) === outflow (0) — NOT net positive
+    // Actually no txs at all = inflow=0, outflow=0 — 0 <= 0 fails the check
+    expect(result).toHaveLength(0);
+  });
+
+  it("includes account with zero outflows (purely inbound savings)", () => {
+    const result = detectIdleSavings({
+      accounts: [
+        {
+          id: 1,
+          type: "savings",
+          currency: "COP",
+          balanceCents: BigInt(10_000_000 * 100),
+        },
+      ],
+      txsLast90d: [
+        // Only inflows, no outflows
+        { accountId: 1, amountCents: BigInt(1_000_000 * 100), currency: "COP" },
+        { accountId: 1, amountCents: BigInt(2_000_000 * 100), currency: "COP" },
+      ],
+      fxRate: FX_RATE,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.monthlyBurnCents).toBe(BigInt(0));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCdtSuggestion
+// ---------------------------------------------------------------------------
+
+describe("computeCdtSuggestion", () => {
+  it("returns null when suggested amount is below 1M COP minimum", () => {
+    // balance 5.5M, burn 2M/month → buffer = 3M, suggested = 2.5M > 1M — should pass
+    // To get below 1M: small balance with large burn
+    const account = makeIdleAccount({
+      avgBalanceCents: BigInt(3_000_000 * 100), // 3M
+      monthlyBurnCents: BigInt(1_500_000 * 100), // 1.5M/month → buffer = 2.25M
+      // suggested = 3M - 2.25M = 0.75M < 1M → null
+    });
+
+    const result = computeCdtSuggestion(account, CDT_RATES);
+    expect(result).toBeNull();
+  });
+
+  it("returns suggestion when amount meets minimum", () => {
+    const account = makeIdleAccount({
+      avgBalanceCents: BigInt(10_000_000 * 100),
+      monthlyBurnCents: BigInt(500_000 * 100), // buffer = 750K
+      // suggested = 10M - 750K = 9.25M > 1M → valid
+    });
+
+    const result = computeCdtSuggestion(account, CDT_RATES);
+    expect(result).not.toBeNull();
+    expect(result!.accountId).toBe(1);
+    expect(result!.suggestedAmountCents).toBe(
+      BigInt(10_000_000 * 100) - (BigInt(15) * BigInt(500_000 * 100)) / BigInt(10),
+    );
+  });
+
+  it("generates 3 terms: 6M, 12M, 24M", () => {
+    const account = makeIdleAccount();
+    const result = computeCdtSuggestion(account, CDT_RATES);
+
+    expect(result).not.toBeNull();
+    expect(result!.terms).toHaveLength(3);
+    expect(result!.terms.map((t) => t.months)).toEqual([6, 12, 24]);
+  });
+
+  it("computes correct yield for CDT 12M at 12.5%", () => {
+    const account = makeIdleAccount({
+      avgBalanceCents: BigInt(10_000_000 * 100), // 10M
+      monthlyBurnCents: BigInt(0), // no burn
+    });
+
+    const result = computeCdtSuggestion(account, CDT_RATES);
+    expect(result).not.toBeNull();
+
+    const term12 = result!.terms.find((t) => t.months === 12)!;
+    // 10M × 0.125 × 12/12 = 10M × 0.125 = 1.25M COP
+    // BigInt: suggestedAmount × 125 × 12 / 12_000 = suggestedAmount × 125 / 1000
+    const expected = (BigInt(10_000_000 * 100) * BigInt(125)) / BigInt(1_000);
+    expect(term12.estimatedYieldCents).toBe(expected);
+  });
+
+  it("computes correct yield for CDT 6M at 11%", () => {
+    const account = makeIdleAccount({
+      avgBalanceCents: BigInt(10_000_000 * 100),
+      monthlyBurnCents: BigInt(0),
+    });
+
+    const result = computeCdtSuggestion(account, CDT_RATES);
+    const term6 = result!.terms.find((t) => t.months === 6)!;
+    // 10M × 0.11 × 6/12 = 10M × 0.055 = 550K
+    // BigInt: 10M × 110 × 6 / 12_000 = 10M × 660 / 12_000 = 10M × 11/200 = 550K
+    const expected = (BigInt(10_000_000 * 100) * BigInt(110) * BigInt(6)) / BigInt(12_000);
+    expect(term6.estimatedYieldCents).toBe(expected);
+  });
+
+  it("applies 1.5× monthly burn buffer correctly", () => {
+    const account = makeIdleAccount({
+      avgBalanceCents: BigInt(10_000_000 * 100),
+      monthlyBurnCents: BigInt(2_000_000 * 100), // 2M/month
+    });
+
+    const result = computeCdtSuggestion(account, CDT_RATES);
+    // buffer = 1.5 × 2M = 3M → suggested = 10M - 3M = 7M
+    expect(result!.suggestedAmountCents).toBe(BigInt(7_000_000 * 100));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeFicSuggestion
+// ---------------------------------------------------------------------------
+
+describe("computeFicSuggestion", () => {
+  it("returns null when suggested amount is below 1M COP minimum", () => {
+    const account = makeIdleAccount({
+      avgBalanceCents: BigInt(3_000_000 * 100),
+      monthlyBurnCents: BigInt(1_500_000 * 100),
+    });
+
+    const result = computeFicSuggestion(account, FIC_YIELD);
+    expect(result).toBeNull();
+  });
+
+  it("returns FIC suggestion with annual yield", () => {
+    const account = makeIdleAccount({
+      avgBalanceCents: BigInt(10_000_000 * 100),
+      monthlyBurnCents: BigInt(0),
+    });
+
+    const result = computeFicSuggestion(account, FIC_YIELD);
+    expect(result).not.toBeNull();
+    expect(result!.accountId).toBe(1);
+    expect(result!.ratePct).toBe(8); // 0.08 × 100
+  });
+
+  it("computes correct annual yield at 8%", () => {
+    const account = makeIdleAccount({
+      avgBalanceCents: BigInt(10_000_000 * 100), // 10M COP
+      monthlyBurnCents: BigInt(0),
+    });
+
+    const result = computeFicSuggestion(account, FIC_YIELD);
+    // 10M × 0.08 = 800K
+    // BigInt: 10M × 80 / 1_000 = 10M × 8/100 = 800K
+    const expected = (BigInt(10_000_000 * 100) * BigInt(80)) / BigInt(1_000);
+    expect(result!.estimatedYearlyYieldCents).toBe(expected);
+  });
+
+  it("FIC yield > savings baseline (8% > 6%) differential is positive", () => {
+    const principal = BigInt(10_000_000 * 100);
+    const ficYield = (principal * BigInt(Math.round(FIC_YIELD * 1000))) / BigInt(1_000);
+    const baselineYield =
+      (principal * BigInt(Math.round(SAVINGS_BASELINE_YIELD * 1000))) / BigInt(1_000);
+
+    expect(ficYield).toBeGreaterThan(baselineYield);
+  });
+
+  it("uses same buffer logic as CDT", () => {
+    const account = makeIdleAccount({
+      avgBalanceCents: BigInt(10_000_000 * 100),
+      monthlyBurnCents: BigInt(2_000_000 * 100),
+    });
+
+    const fic = computeFicSuggestion(account, FIC_YIELD);
+    const cdt = computeCdtSuggestion(account, CDT_RATES);
+
+    expect(fic!.suggestedAmountCents).toBe(cdt!.suggestedAmountCents);
+  });
+});

--- a/src/lib/insights/savings-suggestions.ts
+++ b/src/lib/insights/savings-suggestions.ts
@@ -23,6 +23,7 @@ import { formatCop } from "@/lib/money";
 import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
 import { emitNotification } from "@/lib/notifications/emit";
 import { canAccessFeature } from "@/lib/auth/can-access-feature";
+import { getCurrentFxRate } from "@/lib/fx/repo";
 import { CDT_RATES, FIC_YIELD } from "./cdt-fic-rates";
 import { createLogger } from "@/lib/logger";
 import type { Currency } from "@/lib/types";
@@ -206,10 +207,12 @@ export function computeCdtSuggestion(
   ];
 
   const terms: CdtTerm[] = termEntries.map(([months, ratePct]) => {
+    // Yield computation uses the raw fraction from CDT_RATES directly.
     const rateScaled = BigInt(Math.round(ratePct * 1000));
     const estimatedYieldCents =
       (suggestedAmountCents * rateScaled * BigInt(months)) / BigInt(12_000);
-    return { months, ratePct, estimatedYieldCents };
+    // ratePct stored in 0..100 form to match FicSuggestion.ratePct domain.
+    return { months, ratePct: ratePct * 100, estimatedYieldCents };
   });
 
   return {
@@ -270,14 +273,16 @@ export function computeFicSuggestion(
 export async function runSavingsSuggestionForUser(
   userId: number,
   database: DB = defaultDb,
+  /** Pre-fetched FX rate from the calling worker. When omitted, fetched here. */
+  cachedFxRate?: number,
 ): Promise<void> {
   const ninetyDaysAgo = new Date(Date.now() - SAVINGS_WINDOW_DAYS * 24 * 60 * 60 * 1000);
   const now = new Date();
 
-  // Fetch FX rate
-  const { getCurrentFxRate } = await import("@/lib/fx/repo");
-  const fx = await getCurrentFxRate(database);
-  const fxRate = fx.rate;
+  // Use caller-provided FX rate when available to avoid a redundant DB query
+  // per-user (the cash-flow-daily worker already fetches it once for all users).
+  const fxRate =
+    cachedFxRate !== undefined ? cachedFxRate : (await getCurrentFxRate(database)).rate;
 
   // Fetch savings accounts with snapshot-anchored derived balance
   const accountRows = await database

--- a/src/lib/insights/savings-suggestions.ts
+++ b/src/lib/insights/savings-suggestions.ts
@@ -1,0 +1,407 @@
+/**
+ * Savings suggestions — C.1 CDT + C.2 FIC (Epic I, #721).
+ *
+ * Idle-savings detector:
+ *   Identifies savings accounts with large idle balances that are NOT being
+ *   drained (inflows > outflows over 90d). For qualifying accounts, computes
+ *   CDT and FIC suggestions with estimated yields.
+ *
+ * Quarterly dedup:
+ *   entityId = "{cdt|fic}-suggestion:{userId}:Q{1..4}-{YYYY}"
+ *   One notification per type per quarter per user.
+ *
+ * Pure functions exported for unit tests (no DB, no side-effects).
+ * `runSavingsSuggestionForUser` is the DB-driven entry point.
+ */
+
+import { and, eq, gte } from "drizzle-orm";
+import { db as defaultDb, type DB } from "@/lib/db";
+import { accounts, transactions } from "@/lib/db/schema";
+import { notDeleted } from "@/lib/db/helpers";
+import { toCop } from "@/lib/money";
+import { formatCop } from "@/lib/money";
+import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
+import { emitNotification } from "@/lib/notifications/emit";
+import { canAccessFeature } from "@/lib/auth/can-access-feature";
+import { CDT_RATES, FIC_YIELD } from "./cdt-fic-rates";
+import { createLogger } from "@/lib/logger";
+import type { Currency } from "@/lib/types";
+
+const log = createLogger({ module: "insights/savings-suggestions" });
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Minimum average balance (COP) to consider an account idle — 5M COP. */
+export const IDLE_BALANCE_THRESHOLD_CENTS = BigInt(5_000_000 * 100);
+
+/** Minimum CDT amount (COP) to be worth suggesting — 1M COP. */
+export const MIN_CDT_AMOUNT_CENTS = BigInt(1_000_000 * 100);
+
+/** Number of days in the look-back window. */
+export const SAVINGS_WINDOW_DAYS = 90;
+
+// ---------------------------------------------------------------------------
+// Pure types
+// ---------------------------------------------------------------------------
+
+export type IdleSavingsAccount = {
+  accountId: number;
+  /** Latest balance (cents in account currency) — used as avgBalanceCents. */
+  avgBalanceCents: bigint;
+  currency: Currency;
+  /** abs(sum(outflow_90d)) / 3 — monthly burn estimate. */
+  monthlyBurnCents: bigint;
+};
+
+export type CdtTerm = {
+  months: 6 | 12 | 24;
+  ratePct: number;
+  estimatedYieldCents: bigint;
+};
+
+export type CdtSuggestion = {
+  accountId: number;
+  suggestedAmountCents: bigint;
+  terms: CdtTerm[];
+};
+
+export type FicSuggestion = {
+  accountId: number;
+  suggestedAmountCents: bigint;
+  ratePct: number;
+  estimatedYearlyYieldCents: bigint;
+};
+
+// ---------------------------------------------------------------------------
+// Pure — quarterly entityId
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the quarter string for a given date, e.g. "Q2-2026".
+ * month is 0-indexed (JS Date.getMonth()).
+ */
+export function quarterLabel(date: Date): string {
+  const q = Math.floor(date.getMonth() / 3) + 1;
+  return `Q${q}-${date.getFullYear()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Pure — idle savings detection
+// ---------------------------------------------------------------------------
+
+type AccountRow = {
+  id: number;
+  type: string;
+  currency: Currency;
+  balanceCents: bigint;
+};
+
+type TxRow = {
+  accountId: number;
+  amountCents: bigint;
+  currency: Currency;
+};
+
+/**
+ * Detects idle savings accounts from the provided account list and 90-day
+ * transaction history.
+ *
+ * NOTE: `avgBalanceCents` is the account's latest balance (from DB derivation),
+ * not a true daily mean. The spec allows this simplification — it's documented
+ * in the function signature and good enough for the quarterly cadence of this
+ * signal.
+ *
+ * FX conversion: amounts in non-COP currency are converted to COP for the
+ * threshold check. The returned `avgBalanceCents` is in the account's NATIVE
+ * currency so the card can render the correct value.
+ *
+ * @param accounts  All accounts for the user.
+ * @param txsLast90d  All transactions from the last 90 days for the user.
+ * @param fxRate  Current COP/USD rate (from getCurrentFxRate().rate).
+ */
+export function detectIdleSavings({
+  accounts,
+  txsLast90d,
+  fxRate,
+}: {
+  accounts: AccountRow[];
+  txsLast90d: TxRow[];
+  fxRate: number;
+}): IdleSavingsAccount[] {
+  const savingsAccounts = accounts.filter((a) => a.type === "savings");
+  if (savingsAccounts.length === 0) return [];
+
+  const result: IdleSavingsAccount[] = [];
+
+  for (const account of savingsAccounts) {
+    const avgBalanceCents = account.balanceCents;
+
+    // Convert to COP for threshold check
+    const balanceCop = toCop(avgBalanceCents, account.currency, fxRate);
+    if (balanceCop <= IDLE_BALANCE_THRESHOLD_CENTS) continue;
+
+    // Sum inflows and outflows for this account over 90d
+    let inflowCents = BigInt(0);
+    let outflowCents = BigInt(0);
+
+    for (const tx of txsLast90d) {
+      if (tx.accountId !== account.id) continue;
+      const amountCop = toCop(tx.amountCents, tx.currency, fxRate);
+      if (amountCop > BigInt(0)) {
+        inflowCents += amountCop;
+      } else {
+        outflowCents += amountCop; // negative
+      }
+    }
+
+    // Account must NOT be drained — inflows must exceed outflows
+    if (inflowCents <= -outflowCents) continue;
+
+    // monthlyBurn = abs(sum(outflow_90d)) / 3
+    const absOutflow = -outflowCents; // positive
+    const monthlyBurnCents = absOutflow / BigInt(3);
+
+    result.push({
+      accountId: account.id,
+      avgBalanceCents,
+      currency: account.currency,
+      monthlyBurnCents,
+    });
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Pure — CDT suggestion
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes a CDT suggestion for an idle savings account.
+ *
+ * suggestedAmount = avgBalance - 1.5 × monthlyBurn (keep buffer)
+ * Returns null if suggestedAmount < MIN_CDT_AMOUNT_CENTS (not worth suggesting).
+ *
+ * Yield formula (BigInt-only):
+ *   estimatedYieldCents = suggestedAmount × round(ratePct × 1000) × months / 12_000
+ *
+ * The ×1000 / ÷12_000 trick scales the fraction so we stay in BigInt domain.
+ * For a 12.5% rate: round(0.125 × 1000) = 125; yield = principal × 125 × 12 / 12_000.
+ */
+export function computeCdtSuggestion(
+  idleAccount: IdleSavingsAccount,
+  rates: typeof CDT_RATES,
+): CdtSuggestion | null {
+  const buffer = (BigInt(15) * idleAccount.monthlyBurnCents) / BigInt(10); // 1.5 × monthly
+  const suggestedAmountCents = idleAccount.avgBalanceCents - buffer;
+
+  if (suggestedAmountCents < MIN_CDT_AMOUNT_CENTS) return null;
+
+  const termEntries: Array<[6 | 12 | 24, number]> = [
+    [6, rates.months6],
+    [12, rates.months12],
+    [24, rates.months24],
+  ];
+
+  const terms: CdtTerm[] = termEntries.map(([months, ratePct]) => {
+    const rateScaled = BigInt(Math.round(ratePct * 1000));
+    const estimatedYieldCents =
+      (suggestedAmountCents * rateScaled * BigInt(months)) / BigInt(12_000);
+    return { months, ratePct, estimatedYieldCents };
+  });
+
+  return {
+    accountId: idleAccount.accountId,
+    suggestedAmountCents,
+    terms,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure — FIC suggestion
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes a FIC suggestion for an idle savings account.
+ *
+ * Same buffer logic as CDT — same suggested amount.
+ * FIC is liquid so yield is annual (no lock-in period).
+ *
+ * Yield formula:
+ *   estimatedYearlyYieldCents = suggestedAmount × round(FIC_YIELD × 1000) / 1_000
+ */
+export function computeFicSuggestion(
+  idleAccount: IdleSavingsAccount,
+  ficYield: number,
+): FicSuggestion | null {
+  const buffer = (BigInt(15) * idleAccount.monthlyBurnCents) / BigInt(10);
+  const suggestedAmountCents = idleAccount.avgBalanceCents - buffer;
+
+  if (suggestedAmountCents < MIN_CDT_AMOUNT_CENTS) return null;
+
+  const yieldScaled = BigInt(Math.round(ficYield * 1000));
+  const estimatedYearlyYieldCents = (suggestedAmountCents * yieldScaled) / BigInt(1_000);
+
+  return {
+    accountId: idleAccount.accountId,
+    suggestedAmountCents,
+    ratePct: ficYield * 100, // e.g. 0.08 → 8
+    estimatedYearlyYieldCents,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DB-driven entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Run CDT + FIC savings suggestion checks for one user.
+ *
+ * - Fetches current balances (latest balance from accounts.balance_cents field)
+ *   and the last 90 days of transactions.
+ * - Applies detectIdleSavings, computeCdtSuggestion, computeFicSuggestion.
+ * - Emits quarterly-deduped notifications (one CDT + one FIC per quarter).
+ * - Gated by canAccessFeature independently for CDT and FIC.
+ *
+ * Called fire-and-forget from cash-flow-daily worker.
+ */
+export async function runSavingsSuggestionForUser(
+  userId: number,
+  database: DB = defaultDb,
+): Promise<void> {
+  const ninetyDaysAgo = new Date(Date.now() - SAVINGS_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const now = new Date();
+
+  // Fetch FX rate
+  const { getCurrentFxRate } = await import("@/lib/fx/repo");
+  const fx = await getCurrentFxRate(database);
+  const fxRate = fx.rate;
+
+  // Fetch savings accounts with snapshot-anchored derived balance
+  const accountRows = await database
+    .select({
+      id: accounts.id,
+      type: accounts.type,
+      currency: accounts.currency,
+      balanceCents: derivedBalanceCentsSql,
+    })
+    .from(accounts)
+    .where(
+      and(eq(accounts.userId, userId), notDeleted(accounts.deletedAt), eq(accounts.active, true)),
+    );
+
+  const accountsForDetection: AccountRow[] = accountRows.map((row) => ({
+    id: row.id,
+    type: row.type,
+    currency: row.currency as Currency,
+    balanceCents: BigInt(row.balanceCents),
+  }));
+
+  // Fetch last 90d transactions
+  const txRows = await database
+    .select({
+      accountId: transactions.accountId,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        notDeleted(transactions.deletedAt),
+        gte(transactions.occurredAt, ninetyDaysAgo),
+      ),
+    );
+
+  const txsForDetection: TxRow[] = txRows.map((row) => ({
+    accountId: row.accountId,
+    amountCents: row.amountCents,
+    currency: row.currency as Currency,
+  }));
+
+  const idleAccounts = detectIdleSavings({
+    accounts: accountsForDetection,
+    txsLast90d: txsForDetection,
+    fxRate,
+  });
+
+  if (idleAccounts.length === 0) {
+    log.debug({ userId, event: "savings_suggestion_no_idle" }, "no idle savings accounts found");
+    return;
+  }
+
+  const qLabel = quarterLabel(now);
+
+  const [canCdt, canFic] = await Promise.all([
+    canAccessFeature(userId, "cdt-suggestion"),
+    canAccessFeature(userId, "fic-suggestion"),
+  ]);
+
+  for (const idleAccount of idleAccounts) {
+    if (canCdt) {
+      const cdtSuggestion = computeCdtSuggestion(idleAccount, CDT_RATES);
+      if (cdtSuggestion) {
+        // Use the 12M term for the notification body (most common reference)
+        const term12 = cdtSuggestion.terms.find((t) => t.months === 12);
+        const yieldStr = term12 ? formatCop(term12.estimatedYieldCents) : "";
+        const amountStr = formatCop(cdtSuggestion.suggestedAmountCents);
+
+        emitNotification(userId, {
+          type: "cdt_suggestion",
+          entityId: `cdt-suggestion:${userId}:${qLabel}`,
+          title: "Ahorros sin trabajar",
+          body: `Tenés ${amountStr} idle. CDT 12M te rendiría ~${yieldStr} extra al año. Ojo: estimación, consultá tu banco.`,
+          priority: "low",
+          metadata: {
+            accountId: idleAccount.accountId,
+            suggestedAmountCents: String(cdtSuggestion.suggestedAmountCents),
+            quarterLabel: qLabel,
+          },
+        }).catch((err: unknown) => {
+          log.error(
+            { err, userId, event: "cdt_suggestion_emit_failed" },
+            "failed to emit cdt_suggestion notification",
+          );
+        });
+
+        log.info(
+          { userId, accountId: idleAccount.accountId, qLabel, event: "cdt_suggestion_emitted" },
+          "CDT suggestion emitted",
+        );
+      }
+    }
+
+    if (canFic) {
+      const ficSuggestion = computeFicSuggestion(idleAccount, FIC_YIELD);
+      if (ficSuggestion) {
+        const yieldStr = formatCop(ficSuggestion.estimatedYearlyYieldCents);
+        const amountStr = formatCop(ficSuggestion.suggestedAmountCents);
+
+        emitNotification(userId, {
+          type: "fic_suggestion",
+          entityId: `fic-suggestion:${userId}:${qLabel}`,
+          title: "FIC: rendimiento con liquidez inmediata",
+          body: `Tenés ${amountStr} idle. FIC te rendiría ~${yieldStr} al año con liquidez inmediata. Ojo: estimación, consultá tu banco.`,
+          priority: "low",
+          metadata: {
+            accountId: idleAccount.accountId,
+            suggestedAmountCents: String(ficSuggestion.suggestedAmountCents),
+            quarterLabel: qLabel,
+          },
+        }).catch((err: unknown) => {
+          log.error(
+            { err, userId, event: "fic_suggestion_emit_failed" },
+            "failed to emit fic_suggestion notification",
+          );
+        });
+
+        log.info(
+          { userId, accountId: idleAccount.accountId, qLabel, event: "fic_suggestion_emitted" },
+          "FIC suggestion emitted",
+        );
+      }
+    }
+  }
+}

--- a/src/lib/notifications/emit.ts
+++ b/src/lib/notifications/emit.ts
@@ -40,7 +40,10 @@ export type NotificationType =
   // #719 (Epic I B.3+B.4+C.4): velocity cluster, category anomaly, duplicate payment.
   | "velocity_cluster"
   | "category_anomaly"
-  | "duplicate_payment";
+  | "duplicate_payment"
+  // #721 (Epic I C.1+C.2): CDT and FIC savings suggestions (quarterly, premium-gated).
+  | "cdt_suggestion"
+  | "fic_suggestion";
 
 export type NotificationAudience = "user" | "admin";
 export type NotificationPriority = "high" | "medium" | "low";

--- a/src/lib/queue/workers/cash-flow-daily.test.ts
+++ b/src/lib/queue/workers/cash-flow-daily.test.ts
@@ -11,6 +11,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   runSalaryGapForUser: vi.fn(),
   runCashFlowForecastForUser: vi.fn(),
+  runSavingsSuggestionForUser: vi.fn(),
   getCurrentFxRate: vi.fn(),
   dbExecute: vi.fn(),
 }));
@@ -18,6 +19,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/lib/insights/cash-flow", () => ({
   runSalaryGapForUser: mocks.runSalaryGapForUser,
   runCashFlowForecastForUser: mocks.runCashFlowForecastForUser,
+}));
+
+vi.mock("@/lib/insights/savings-suggestions", () => ({
+  runSavingsSuggestionForUser: mocks.runSavingsSuggestionForUser,
 }));
 
 vi.mock("@/lib/fx/repo", () => ({
@@ -64,6 +69,7 @@ describe("cashFlowDailyProcessor", () => {
       },
       shortfallChanged: false,
     });
+    mocks.runSavingsSuggestionForUser.mockResolvedValue(undefined);
     // Default: two users
     mocks.dbExecute.mockResolvedValue([{ id: 1 }, { id: 2 }]);
   });
@@ -147,5 +153,27 @@ describe("cashFlowDailyProcessor", () => {
     expect(job.updateProgress).toHaveBeenCalledWith(
       expect.objectContaining({ gapsTotal: 3, done: true }),
     );
+  });
+
+  it("fires runSavingsSuggestionForUser for each user (fire-and-forget hook)", async () => {
+    mocks.dbExecute.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+
+    await cashFlowDailyProcessor(makeJob());
+
+    // Hook is fire-and-forget so we wait a tick for the promise to resolve
+    await Promise.resolve();
+
+    expect(mocks.runSavingsSuggestionForUser).toHaveBeenCalledTimes(2);
+    expect(mocks.runSavingsSuggestionForUser).toHaveBeenCalledWith(1, expect.anything());
+    expect(mocks.runSavingsSuggestionForUser).toHaveBeenCalledWith(2, expect.anything());
+  });
+
+  it("does not throw when runSavingsSuggestionForUser rejects (fire-and-forget)", async () => {
+    mocks.dbExecute.mockResolvedValue([{ id: 1 }]);
+    mocks.runSavingsSuggestionForUser.mockRejectedValueOnce(new Error("savings check failed"));
+
+    const job = makeJob();
+    // The rejection is caught internally — processor must NOT throw
+    await expect(cashFlowDailyProcessor(job)).resolves.toBeUndefined();
   });
 });

--- a/src/lib/queue/workers/cash-flow-daily.test.ts
+++ b/src/lib/queue/workers/cash-flow-daily.test.ts
@@ -164,8 +164,8 @@ describe("cashFlowDailyProcessor", () => {
     await Promise.resolve();
 
     expect(mocks.runSavingsSuggestionForUser).toHaveBeenCalledTimes(2);
-    expect(mocks.runSavingsSuggestionForUser).toHaveBeenCalledWith(1, expect.anything());
-    expect(mocks.runSavingsSuggestionForUser).toHaveBeenCalledWith(2, expect.anything());
+    expect(mocks.runSavingsSuggestionForUser).toHaveBeenCalledWith(1, expect.anything(), 4000);
+    expect(mocks.runSavingsSuggestionForUser).toHaveBeenCalledWith(2, expect.anything(), 4000);
   });
 
   it("does not throw when runSavingsSuggestionForUser rejects (fire-and-forget)", async () => {

--- a/src/lib/queue/workers/cash-flow-daily.ts
+++ b/src/lib/queue/workers/cash-flow-daily.ts
@@ -59,7 +59,8 @@ export async function cashFlowDailyProcessor(job: Job<CashFlowDailyJobData>): Pr
       forecastsRun++;
 
       // C.1+C.2 — savings suggestions (fire-and-forget, quarterly dedup in emitNotification)
-      runSavingsSuggestionForUser(userId, db).catch((err: unknown) => {
+      // Pass the already-fetched FX rate so each user iteration avoids a redundant DB query.
+      runSavingsSuggestionForUser(userId, db, fx.rate).catch((err: unknown) => {
         log.error({ err, userId, event: "savings_suggestion_failed" }, "savings suggestion failed");
       });
 

--- a/src/lib/queue/workers/cash-flow-daily.ts
+++ b/src/lib/queue/workers/cash-flow-daily.ts
@@ -11,6 +11,7 @@ import type { Job } from "bullmq";
 import { createLogger } from "@/lib/logger";
 import { createWorker } from "@/lib/queue";
 import { runCashFlowForecastForUser, runSalaryGapForUser } from "@/lib/insights/cash-flow";
+import { runSavingsSuggestionForUser } from "@/lib/insights/savings-suggestions";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { db } from "@/lib/db";
 import { sql } from "drizzle-orm";
@@ -56,6 +57,11 @@ export async function cashFlowDailyProcessor(job: Job<CashFlowDailyJobData>): Pr
       // D.4 — 30d forecast
       await runCashFlowForecastForUser(userId, fx.rate, db, today);
       forecastsRun++;
+
+      // C.1+C.2 — savings suggestions (fire-and-forget, quarterly dedup in emitNotification)
+      runSavingsSuggestionForUser(userId, db).catch((err: unknown) => {
+        log.error({ err, userId, event: "savings_suggestion_failed" }, "savings suggestion failed");
+      });
 
       log.debug(
         { userId, gapsEmitted, event: "cash_flow_daily_user_ok" },


### PR DESCRIPTION
## Summary

Closes #721 — Epic I sub-tasks C.1 + C.2 + introduces the `canAccessFeature` premium-tier gating seam. **Final batch of the Epic I closeout sprint.**

- **canAccessFeature seam** (`src/lib/auth/can-access-feature.ts`) — first premium-gated feature lands here per Epic #255 plan. v1 returns true; Phase 7 swaps to a query against user_subscriptions. PremiumFeature union: cdt-suggestion, fic-suggestion, monthly-claude-report, conversational-insights.
- **Idle-savings detection** — pure function over savings accounts: avgBalance > 5M COP threshold (toCop converts USD), inflow > outflow over 90d (not draining), monthlyBurn = abs(outflow_90d) / 3.
- **C.1 CDT suggestion** — amount = avgBalance - 1.5×monthlyBurn; below 1M COP returns null. Plazos 6M/12M/24M with rates from `cdt-fic-rates.ts` (hardcoded, dated comment for manual quarterly refresh).
- **C.2 FIC suggestion** — same eligibility, single annual yield, "Liquidez: Inmediata" tag.
- **/insights "Optimizá tus ahorros" emerald card** — bundled CDT+FIC table per account with disclaimer. Placement after duplicate-payment violet card, before InsightsViewer. Gated by canAccessFeature; renders nothing when no idle savings or all suggestions filter to null.
- **Worker hook** — `runSavingsSuggestionForUser` fire-and-forget after existing salary-gap + forecast checks in `cash-flow-daily`. Pre-fetched FX rate passed through (no per-user re-query).
- **Notifications** — `cdt_suggestion` + `fic_suggestion` types, quarterly entityIds (`cdt-suggestion:{userId}:Q{N}-{YYYY}`).

Reviewer flagged 2 CRITICAL (vacuous integration test — same anti-pattern as #719; empty card body when both CDT+FIC null) + 2 WARNINGs (ratePct domain mismatch; dynamic FX import per user). All 4 fixed in `4ac5d2f`.

## Test plan

- [x] Lint, typecheck, full vitest (2645 passed, 1 skipped) — green
- [x] 5 canAccessFeature unit tests
- [x] 29 savings-suggestions pure unit tests (idle thresholds, CDT/FIC math, quarter labels, multi-account, BigInt purity)
- [x] 6 DB integration tests (worker emit, dedup across runs, below-threshold no-emit unconditional assertion)
- [x] 2 new cash-flow-daily worker tests (savings hook fires + FX rate passed through)
- [x] No \`expect(true).toBe(true)\` survivors