### PR TITLE
feat(recurring): category filter + deep link from /subscriptions (#731)

### DIFF
--- a/src/app/(app)/settings/recurring/page.tsx
+++ b/src/app/(app)/settings/recurring/page.tsx
@@ -7,9 +7,15 @@ import { RecurringManager } from "./recurring-manager";
 
 export const dynamic = "force-dynamic";
 
-export default async function RecurringPage() {
+export default async function RecurringPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ category?: string }>;
+}) {
   const session = await getSessionUser();
-  const [accs, cats, items] = await Promise.all([
+  const { category: rawCategory } = await searchParams;
+
+  const [accs, cats] = await Promise.all([
     db
       .select({
         id: accounts.id,
@@ -34,29 +40,35 @@ export default async function RecurringPage() {
       .from(categories)
       .where(and(eq(categories.userId, session.id), notDeleted(categories.deletedAt)))
       .orderBy(asc(categories.sortOrder), asc(categories.name)),
-    db
-      .select({
-        id: recurringTransactions.id,
-        accountId: recurringTransactions.accountId,
-        accountName: accounts.name,
-        label: recurringTransactions.label,
-        amountCents: recurringTransactions.amountCents,
-        currency: recurringTransactions.currency,
-        categorySlug: recurringTransactions.categorySlug,
-        dayOfMonth: recurringTransactions.dayOfMonth,
-        active: recurringTransactions.active,
-        notes: recurringTransactions.notes,
-      })
-      .from(recurringTransactions)
-      .innerJoin(accounts, eq(accounts.id, recurringTransactions.accountId))
-      .where(
-        and(
-          eq(recurringTransactions.userId, session.id),
-          notDeleted(recurringTransactions.deletedAt),
-        ),
-      )
-      .orderBy(asc(recurringTransactions.dayOfMonth)),
   ]);
+
+  // Validate the category param against the user's own categories (tenant safety).
+  const validSlugs = new Set(cats.map((c) => c.slug));
+  const activeCategory = rawCategory && validSlugs.has(rawCategory) ? rawCategory : null;
+
+  const recurringWhere = and(
+    eq(recurringTransactions.userId, session.id),
+    notDeleted(recurringTransactions.deletedAt),
+    activeCategory ? eq(recurringTransactions.categorySlug, activeCategory) : undefined,
+  );
+
+  const items = await db
+    .select({
+      id: recurringTransactions.id,
+      accountId: recurringTransactions.accountId,
+      accountName: accounts.name,
+      label: recurringTransactions.label,
+      amountCents: recurringTransactions.amountCents,
+      currency: recurringTransactions.currency,
+      categorySlug: recurringTransactions.categorySlug,
+      dayOfMonth: recurringTransactions.dayOfMonth,
+      active: recurringTransactions.active,
+      notes: recurringTransactions.notes,
+    })
+    .from(recurringTransactions)
+    .innerJoin(accounts, eq(accounts.id, recurringTransactions.accountId))
+    .where(recurringWhere)
+    .orderBy(asc(recurringTransactions.dayOfMonth));
 
   const rows = items.map((r) => ({
     ...r,
@@ -73,7 +85,12 @@ export default async function RecurringPage() {
           the real tx lands.
         </p>
       </header>
-      <RecurringManager accounts={accs} categories={cats} items={rows} />
+      <RecurringManager
+        accounts={accs}
+        categories={cats}
+        items={rows}
+        activeCategory={activeCategory}
+      />
     </main>
   );
 }

--- a/src/app/(app)/settings/recurring/recurring-manager.tsx
+++ b/src/app/(app)/settings/recurring/recurring-manager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -48,16 +49,28 @@ export function RecurringManager({
   accounts,
   categories,
   items,
+  activeCategory,
 }: {
   accounts: AccountOption[];
   categories: CategoryOption[];
   items: RecurringRow[];
+  activeCategory: string | null;
 }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [editor, setEditor] = useState<EditorState>({
     open: false,
     editing: null,
   });
   const [pending, startTransition] = useTransition();
+
+  function onCategoryChange(slug: string) {
+    const next = new URLSearchParams(searchParams.toString());
+    if (slug) next.set("category", slug);
+    else next.delete("category");
+    const qs = next.toString();
+    router.push(qs ? `/settings/recurring?${qs}` : "/settings/recurring");
+  }
 
   function openCreate() {
     setEditor({ open: true, editing: null });
@@ -94,7 +107,20 @@ export function RecurringManager({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex justify-end">
+      <div className="flex items-center justify-between gap-3">
+        <select
+          value={activeCategory ?? ""}
+          onChange={(e) => onCategoryChange(e.target.value)}
+          className="bg-background chevron-select h-9 rounded-md border text-sm"
+          aria-label="Filtrar por categoría"
+        >
+          <option value="">Todas las categorías</option>
+          {categories.map((c) => (
+            <option key={c.slug} value={c.slug}>
+              {c.parentSlug ? `↳ ${c.name}` : c.name}
+            </option>
+          ))}
+        </select>
         <Button onClick={openCreate}>
           <PlusIcon className="size-4" />
           New recurring

--- a/src/app/(app)/subscriptions/page.tsx
+++ b/src/app/(app)/subscriptions/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { getSessionUser } from "@/lib/auth/session";
 import { getUiPreferences } from "@/lib/preferences/repo";
 import { getCurrentFxRate } from "@/lib/fx/repo";
@@ -29,6 +30,12 @@ export default async function SubscriptionsPage() {
           </a>
           .
         </p>
+        <Link
+          href="/settings/recurring?category=suscripciones"
+          className="text-muted-foreground hover:text-foreground mt-1 inline-block text-xs underline underline-offset-4"
+        >
+          Gestionar todas las recurrentes →
+        </Link>
       </header>
 
       <SubscriptionsCalculator


### PR DESCRIPTION
## Summary

Closes #731 — UX improvement.

- \`/settings/recurring\` gets a category filter dropdown. URL-driven via \`?category=<slug>\`. Validated against the user's own categories (tenant-safe). \"Todas las categorías\" removes the param.
- \`/subscriptions\` gets a small muted link \"Gestionar todas las recurrentes →\" pointing to \`/settings/recurring?category=suscripciones\` so the deep link lands on the filtered management view.

Mirrors the URL-driven dropdown pattern from #725.

## Test plan

- [x] Lint + typecheck + tests green
- [ ] Manual smoke post-deploy: open /subscriptions → click \"Gestionar todas las recurrentes\" → land on /settings/recurring with the dropdown showing \"suscripciones\"
- [ ] Manual smoke: change dropdown → URL updates, list filters; \"Todas\" removes the param