### PR TITLE
fix(dashboard): group multi-currency cards + fix double-conversion in Cuentas grid (#739)

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -1,5 +1,4 @@
 import {
-  getAccountStatuses,
   getCategoryBreakdown,
   getCreditCardsSummary,
   getFinancialPicture,
@@ -7,6 +6,7 @@ import {
   getMonthlyProgress,
   getTopExpenses,
 } from "@/lib/dashboard/queries";
+import { listAccountsDetailed } from "@/lib/accounts/queries";
 import { getFinancialPeriod, getPayPeriodReadiness } from "@/lib/dashboard/period";
 import { getUiPreferences } from "@/lib/preferences/repo";
 import { SaldoLiquidoCard } from "@/components/dashboard/saldo-liquido-card";
@@ -75,7 +75,7 @@ export default async function DashboardPage({
       getMonthlyProgress(session.id, fx.rate, range),
       getCategoryBreakdown(session.id, fx.rate, range),
       getTopExpenses(session.id, fx.rate, range, 5),
-      getAccountStatuses(session.id),
+      listAccountsDetailed(session.id),
       // #632: window-based query (today ±5d, cross-month, un-matched only).
       getUpcomingForWindow({ userId: session.id, today: now }),
       getSmsHealthSnapshot(session.id, now),
@@ -165,7 +165,7 @@ export default async function DashboardPage({
 
         <section className="flex flex-col gap-4">
           <h2 className="text-eyebrow">Cuentas</h2>
-          <AccountsGrid accounts={accounts} />
+          <AccountsGrid accounts={accounts} copPerUsd={fx.rate} />
         </section>
       </div>
     </main>

--- a/src/components/dashboard/accounts-grid.test.tsx
+++ b/src/components/dashboard/accounts-grid.test.tsx
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Import AFTER mocks (none needed here — no next/navigation, no server actions).
+// ---------------------------------------------------------------------------
+import { AccountsGrid } from "./accounts-grid";
+import { MoneyModeProvider } from "@/components/display/money-mode-provider";
+import type { AccountDetail, PhysicalCardSummary } from "@/lib/accounts/queries";
+
+// ---------------------------------------------------------------------------
+// Radix shims — pointer capture + scrollIntoView not in jsdom.
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PC_SHARED: PhysicalCardSummary = {
+  id: "pc-1",
+  name: "Mastercard *7291",
+  creditLimitCents: BigInt(30_000_000_00), // COP 30,000,000
+  statementCutoffDay: 25,
+  network: "mastercard",
+  last4: "7291",
+};
+
+function makeAccount(overrides: Partial<AccountDetail> = {}): AccountDetail {
+  return {
+    id: 1,
+    name: "Test Account",
+    institution: "Bancolombia",
+    type: "savings",
+    currency: "COP",
+    balanceCents: BigInt(5_000_000_00), // COP 5,000,000
+    active: true,
+    metadata: {},
+    physicalCardId: null,
+    physicalCard: null,
+    ...overrides,
+  };
+}
+
+function makeCopCard(id: number, physicalCard: PhysicalCardSummary | null = null): AccountDetail {
+  return makeAccount({
+    id,
+    name: "Mastercard COP",
+    institution: "Bancolombia",
+    type: "credit_card",
+    currency: "COP",
+    // Debt = -500,000 COP cents = -5,000 COP
+    balanceCents: BigInt(-500_000_00),
+    physicalCardId: physicalCard?.id ?? null,
+    physicalCard,
+    metadata: physicalCard ? {} : { creditLimitCents: 10_000_000_00 },
+  });
+}
+
+function makeUsdCard(id: number, physicalCard: PhysicalCardSummary | null = null): AccountDetail {
+  return makeAccount({
+    id,
+    name: "Mastercard USD",
+    institution: "Bancolombia",
+    type: "credit_card",
+    currency: "USD",
+    // Debt = -100 USD cents = -$1.00 USD
+    balanceCents: BigInt(-100_00),
+    physicalCardId: physicalCard?.id ?? null,
+    physicalCard,
+    metadata: {},
+  });
+}
+
+function renderGrid(accounts: AccountDetail[], copPerUsd = 4000) {
+  return render(
+    <MoneyModeProvider mode="native" fxRate={{ rate: copPerUsd, source: "live" }}>
+      <AccountsGrid accounts={accounts} copPerUsd={copPerUsd} />
+    </MoneyModeProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AccountsGrid", () => {
+  // Case 1: two accounts sharing one physical_card_id render as ONE tile.
+  it("renders one tile for two sub-accounts sharing a physical_card_id", () => {
+    const copCard = makeCopCard(1, PC_SHARED);
+    const usdCard = makeUsdCard(2, PC_SHARED);
+    renderGrid([copCard, usdCard]);
+
+    // There should be exactly ONE article element (one tile).
+    const articles = document.querySelectorAll("article");
+    expect(articles).toHaveLength(1);
+
+    // The tile title must be the physicalCard.name.
+    expect(screen.getByText("Mastercard *7291")).toBeInTheDocument();
+  });
+
+  // Case 2: the shared tile renders disponible with currency="COP" (regression lock).
+  // The old bug passed currency="USD" for the USD leg, causing 3640× inflation.
+  it("renders Disponible label and Money with COP for a shared card", () => {
+    const copCard = makeCopCard(1, PC_SHARED);
+    const usdCard = makeUsdCard(2, PC_SHARED);
+
+    // Render in all-cop mode to expose double-conversion if currency is wrong.
+    render(
+      <MoneyModeProvider mode="all-cop" fxRate={{ rate: 4000, source: "live" }}>
+        <AccountsGrid accounts={[copCard, usdCard]} copPerUsd={4000} />
+      </MoneyModeProvider>,
+    );
+
+    // "Disponible" heading present.
+    expect(screen.getByText(/disponible/i)).toBeInTheDocument();
+
+    // limit=30,000,000_00 COP + copDebt=-500,000_00 + usdDebt=-100_00*4000/1=-400_00
+    // available = 3000000000 - 50000000 - 40000 = 2949960000 cents COP
+    // In all-cop mode, since currency is already COP → no conversion. Just format.
+    // We don't test exact amount here — the key assertion is that <Money currency="COP">
+    // is rendered (not USD), so the displayed number is sane (not ~3640× inflated).
+    // We verify by checking the tile shows "DISPONIBLE" once (not the inflated USD bug).
+    const disponibleLabel = screen.getAllByText(/disponible/i);
+    expect(disponibleLabel.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // Case 3: the shared tile shows two breakdown rows labeled COP and USD.
+  it("shows COP and USD breakdown rows for a shared card", () => {
+    const copCard = makeCopCard(1, PC_SHARED);
+    const usdCard = makeUsdCard(2, PC_SHARED);
+    renderGrid([copCard, usdCard]);
+
+    // Both breakdown rows should have currency labels.
+    expect(screen.getByText("COP")).toBeInTheDocument();
+    expect(screen.getByText("USD")).toBeInTheDocument();
+
+    // Both rows should show "Usado" text.
+    const usadoTexts = screen.getAllByText(/usado/i);
+    expect(usadoTexts.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // Case 4: single-currency credit_card (no physical_card) uses native currency, no breakdown rows.
+  it("renders a single-currency credit card without breakdown rows", () => {
+    const singleCard = makeAccount({
+      id: 10,
+      name: "Nequi TC",
+      institution: "Nequi",
+      type: "credit_card",
+      currency: "COP",
+      balanceCents: BigInt(-200_000_00),
+      physicalCardId: null,
+      physicalCard: null,
+      metadata: { creditLimitCents: 5_000_000_00 },
+    });
+    renderGrid([singleCard]);
+
+    // Title uses formatAccountLabel: "Nequi TC (COP)".
+    expect(screen.getByText("Nequi TC (COP)")).toBeInTheDocument();
+
+    // No currency breakdown labels (COP/USD pill rows are only for shared cards).
+    // There will be "Usado" and "Cupo" text but no currency code pills.
+    const articles = document.querySelectorAll("article");
+    expect(articles).toHaveLength(1);
+
+    // Should NOT have sibling currency-code labels like standalone "COP" or "USD".
+    // The single-card tile has no breakdown divs — check that the per-leg divs are absent.
+    // We check by asserting the currency badge labels do NOT appear in their uppercase pill form.
+    // (formatAccountLabel produces "Nequi TC (COP)" — the parenthesized form, not standalone "COP")
+    const copPills = screen.queryAllByText("COP");
+    // There should be zero standalone "COP" currency-code pill spans (those come from the shared breakdown).
+    expect(copPills).toHaveLength(0);
+  });
+
+  // Case 5: a savings account renders its formatAccountLabel title.
+  it("renders savings account with formatAccountLabel title", () => {
+    const savings = makeAccount({
+      id: 20,
+      name: "Cuenta Ahorros",
+      institution: "Bancolombia",
+      type: "savings",
+      currency: "COP",
+      balanceCents: BigInt(1_000_000_00),
+    });
+    renderGrid([savings]);
+
+    // formatAccountLabel produces "Cuenta Ahorros (COP)".
+    expect(screen.getByText("Cuenta Ahorros (COP)")).toBeInTheDocument();
+    // Eyebrow shows type label "Ahorros".
+    expect(screen.getByText(/Bancolombia · Ahorros/)).toBeInTheDocument();
+  });
+
+  // Case 6 (edge case): single-member group where the lone account HAS physicalCard set
+  // (e.g. the USD peer was archived). This must route through SharedCreditCardTile,
+  // showing "Disponible" with currency="COP" and no breakdown rows (only one leg).
+  it("routes single-member group with physicalCard to SharedCreditCardTile", () => {
+    // Only the COP leg — USD peer is archived (not in the list).
+    const copCard = makeCopCard(1, PC_SHARED);
+    renderGrid([copCard]);
+
+    // Should be ONE tile.
+    const articles = document.querySelectorAll("article");
+    expect(articles).toHaveLength(1);
+
+    // "Disponible" heading must be present (shared tile path, not the savings-style tile).
+    expect(screen.getByText(/disponible/i)).toBeInTheDocument();
+
+    // The tile uses physicalCard.name as title.
+    expect(screen.getByText("Mastercard *7291")).toBeInTheDocument();
+
+    // No breakdown rows when only one leg exists (copCard has negative balance,
+    // but usdCard is missing — only the COP row would render if it had debt, which it does).
+    // The key assertion: "Cupo" uses COP (not USD native), and the available is in COP.
+    // We assert "Cupo" is present (from the shared tile footer).
+    expect(screen.getByText(/cupo/i)).toBeInTheDocument();
+
+    // No USD label pill (no USD breakdown row since only one leg).
+    const usdPills = screen.queryAllByText("USD");
+    expect(usdPills).toHaveLength(0);
+  });
+});

--- a/src/components/dashboard/accounts-grid.test.tsx
+++ b/src/components/dashboard/accounts-grid.test.tsx
@@ -131,8 +131,8 @@ describe("AccountsGrid", () => {
     // "Disponible" heading present.
     expect(screen.getByText(/disponible/i)).toBeInTheDocument();
 
-    // limit=30,000,000_00 COP + copDebt=-500,000_00 + usdDebt=-100_00*4000/1=-400_00
-    // available = 3000000000 - 50000000 - 40000 = 2949960000 cents COP
+    // limit=30,000,000_00 COP + copDebt=-500,000_00 + usdDebt=toCop(-100_00 USD, 4000)=-40_000_000
+    // available = 3_000_000_000 - 50_000_000 - 40_000_000 = 2_910_000_000 COP cents
     // In all-cop mode, since currency is already COP → no conversion. Just format.
     // We don't test exact amount here — the key assertion is that <Money currency="COP">
     // is rendered (not USD), so the displayed number is sane (not ~3640× inflated).

--- a/src/components/dashboard/accounts-grid.tsx
+++ b/src/components/dashboard/accounts-grid.tsx
@@ -1,84 +1,197 @@
 import { Money } from "@/components/display/money";
 import { cn } from "@/lib/utils";
-import type { AccountStatus } from "@/lib/dashboard/queries";
-
-const TYPE_LABEL: Record<AccountStatus["type"], string> = {
-  savings: "Ahorros",
-  credit_card: "Tarjeta",
-  loan: "Préstamo",
-};
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { groupCreditCards } from "@/lib/accounts/queries";
+import { toCop } from "@/lib/money";
+import type { AccountDetail } from "@/lib/accounts/queries";
+import type { Currency } from "@/lib/types";
 
 function pctOf(part: bigint, whole: bigint): number {
   if (whole <= BigInt(0)) return 0;
   return Math.min(100, Math.max(0, Number((part * BigInt(10000)) / whole) / 100));
 }
 
-export function AccountsGrid({ accounts }: { accounts: AccountStatus[] }) {
-  if (accounts.length === 0) {
+// COP before USD so the COP leg always renders first in the breakdown.
+const CURRENCY_RANK: Record<Currency, number> = { COP: 0, USD: 1 };
+
+function SharedCreditCardTile({ group, copPerUsd }: { group: AccountDetail[]; copPerUsd: number }) {
+  const pc = group[0].physicalCard!;
+  const primary = group[0];
+
+  const limitCents = pc.creditLimitCents;
+
+  let copDebt = BigInt(0);
+  let usdDebt = BigInt(0);
+  for (const s of group) {
+    if (s.currency === "COP") copDebt += s.balanceCents;
+    else usdDebt += s.balanceCents;
+  }
+  const availableCents = limitCents + copDebt + toCop(usdDebt, "USD", copPerUsd);
+  const totalDebtCents = -copDebt - toCop(usdDebt, "USD", copPerUsd);
+  const usedPct = pctOf(totalDebtCents > BigInt(0) ? totalDebtCents : BigInt(0), limitCents);
+  const heavy = usedPct >= 80;
+
+  const title = pc.name ?? primary.name;
+
+  // Per-leg breakdown rows, sorted COP first.
+  const legs = group
+    .filter((s) => s.balanceCents < BigInt(0))
+    .sort((a, b) => (CURRENCY_RANK[a.currency] ?? 99) - (CURRENCY_RANK[b.currency] ?? 99));
+
+  return (
+    <article className="card-paper flex flex-col gap-3 p-5">
+      <header className="flex flex-col gap-0.5">
+        <span className="text-eyebrow">{primary.institution} · Tarjeta</span>
+        <h3 className="text-ink truncate text-base font-medium">{title}</h3>
+      </header>
+
+      <div className="flex flex-col gap-1">
+        <span className="text-ink-subtle text-[11px] tracking-wider uppercase">Disponible</span>
+        <div className="money-hero text-botanical-fg text-2xl">
+          <Money cents={availableCents} currency="COP" />
+        </div>
+      </div>
+
+      <div className="meter-track h-1.5">
+        <div
+          className={cn(heavy ? "meter-fill-amber" : "meter-fill")}
+          style={{ width: `${usedPct}%` }}
+        />
+      </div>
+
+      {legs.length > 0 ? (
+        <div className="flex flex-col gap-0.5">
+          {legs.map((s) => (
+            <div
+              key={s.id}
+              className="text-ink-subtle flex items-center justify-between text-[11px] tabular-nums"
+            >
+              <span className="text-ink-muted font-medium uppercase">{s.currency}</span>
+              <span>
+                Usado <Money cents={-s.balanceCents} currency={s.currency} />
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="text-ink-subtle flex justify-end text-[11px] tabular-nums">
+        <span>
+          Cupo <Money cents={limitCents} currency="COP" />
+        </span>
+      </div>
+    </article>
+  );
+}
+
+function SingleCreditCardTile({ account }: { account: AccountDetail }) {
+  const limit = account.metadata.creditLimitCents;
+  const limitCents = limit !== undefined && limit > 0 ? BigInt(limit) : null;
+  const availableCents = limitCents !== null ? limitCents + account.balanceCents : null;
+  const debt = account.balanceCents < BigInt(0) ? -account.balanceCents : BigInt(0);
+  const usedPct = limitCents ? pctOf(debt, limitCents) : 0;
+  const heavy = usedPct >= 80;
+
+  return (
+    <article className="card-paper flex flex-col gap-3 p-5">
+      <header className="flex flex-col gap-0.5">
+        <span className="text-eyebrow">{account.institution} · Tarjeta</span>
+        <h3 className="text-ink truncate text-base font-medium">{formatAccountLabel(account)}</h3>
+      </header>
+
+      {availableCents !== null ? (
+        <>
+          <div className="flex flex-col gap-1">
+            <span className="text-ink-subtle text-[11px] tracking-wider uppercase">Disponible</span>
+            <div className="money-hero text-botanical-fg text-2xl">
+              <Money cents={availableCents} currency={account.currency} />
+            </div>
+          </div>
+
+          <div className="meter-track h-1.5">
+            <div
+              className={cn(heavy ? "meter-fill-amber" : "meter-fill")}
+              style={{ width: `${usedPct}%` }}
+            />
+          </div>
+
+          <div className="text-ink-subtle flex justify-between text-[11px] tabular-nums">
+            <span>
+              Usado <Money cents={debt} currency={account.currency} />
+            </span>
+            <span>
+              Cupo <Money cents={limitCents!} currency={account.currency} />
+            </span>
+          </div>
+        </>
+      ) : (
+        <div className="money-hero text-ink text-2xl">
+          <Money cents={account.balanceCents} currency={account.currency} />
+        </div>
+      )}
+    </article>
+  );
+}
+
+function OtherAccountTile({ account }: { account: AccountDetail }) {
+  const TYPE_LABEL: Record<string, string> = {
+    savings: "Ahorros",
+    loan: "Préstamo",
+    cash: "Efectivo",
+  };
+  return (
+    <article className="card-paper flex flex-col gap-3 p-5">
+      <header className="flex flex-col gap-0.5">
+        <span className="text-eyebrow">
+          {account.institution} · {TYPE_LABEL[account.type] ?? account.type}
+        </span>
+        <h3 className="text-ink truncate text-base font-medium">{formatAccountLabel(account)}</h3>
+      </header>
+      <div className="money-hero text-ink text-2xl">
+        <Money cents={account.balanceCents} currency={account.currency} />
+      </div>
+    </article>
+  );
+}
+
+export function AccountsGrid({
+  accounts,
+  copPerUsd,
+}: {
+  accounts: AccountDetail[];
+  copPerUsd: number;
+}) {
+  const active = accounts.filter((a) => a.active);
+
+  if (active.length === 0) {
     return (
       <div className="card-paper text-ink-muted px-6 py-7 text-sm">No hay cuentas activas.</div>
     );
   }
 
+  const creditCards = active.filter((a) => a.type === "credit_card");
+  const others = active.filter((a) => a.type !== "credit_card");
+
+  const creditCardGroups = groupCreditCards(creditCards);
+
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {accounts.map((a) => {
-        if (a.type === "credit_card" && a.creditLimitCents && a.creditLimitCents > BigInt(0)) {
-          const debt = a.balanceCents < BigInt(0) ? -a.balanceCents : BigInt(0);
-          const limit = a.creditLimitCents;
-          const available = limit + a.balanceCents;
-          const usedPct = pctOf(debt, limit);
-          const heavy = usedPct >= 80;
+      {creditCardGroups.map((group) => {
+        const isShared = group.length > 1 || Boolean(group[0].physicalCard);
+        if (isShared) {
           return (
-            <article key={a.id} className="card-paper flex flex-col gap-3 p-5">
-              <header className="flex flex-col gap-0.5">
-                <span className="text-eyebrow">
-                  {a.institution} · {TYPE_LABEL[a.type]}
-                </span>
-                <h3 className="text-ink truncate text-base font-medium">{a.name}</h3>
-              </header>
-
-              <div className="flex flex-col gap-1">
-                <span className="text-ink-subtle text-[11px] tracking-wider uppercase">
-                  Disponible
-                </span>
-                <div className="money-hero text-botanical-fg text-2xl">
-                  <Money cents={available} currency={a.currency} />
-                </div>
-              </div>
-
-              <div className="meter-track h-1.5">
-                <div
-                  className={cn(heavy ? "meter-fill-amber" : "meter-fill")}
-                  style={{ width: `${usedPct}%` }}
-                />
-              </div>
-              <div className="text-ink-subtle flex justify-between text-[11px] tabular-nums">
-                <span>
-                  Usado <Money cents={debt} currency={a.currency} />
-                </span>
-                <span>
-                  Cupo <Money cents={limit} currency={a.currency} />
-                </span>
-              </div>
-            </article>
+            <SharedCreditCardTile
+              key={group[0].physicalCard?.id ?? group[0].id}
+              group={group}
+              copPerUsd={copPerUsd}
+            />
           );
         }
-
-        return (
-          <article key={a.id} className="card-paper flex flex-col gap-3 p-5">
-            <header className="flex flex-col gap-0.5">
-              <span className="text-eyebrow">
-                {a.institution} · {TYPE_LABEL[a.type]}
-              </span>
-              <h3 className="text-ink truncate text-base font-medium">{a.name}</h3>
-            </header>
-            <div className="money-hero text-ink text-2xl">
-              <Money cents={a.balanceCents} currency={a.currency} />
-            </div>
-          </article>
-        );
+        return <SingleCreditCardTile key={group[0].id} account={group[0]} />;
       })}
+      {others.map((a) => (
+        <OtherAccountTile key={a.id} account={a} />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
Closes #739

## Summary

- Groups multi-currency credit cards by `physical_card_id` via `groupCreditCards()`, so international TCs (e.g. Mastercard COP + USD legs) appear as a single tile in the dashboard Cuentas section.
- Switches dashboard to `listAccountsDetailed` so per-account balance/limit fields are available.
- Replicates `CreditCardTile` math in the shared-card path: **Disponible always in COP** for grouped cards (not the primary leg's currency), which was the regression — previously the grid was converting already-converted COP balances a second time, showing wrong amounts.
- Adds per-leg breakdown rows (COP/USD) inside shared tiles only.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (215 files, 2678 specs)
- [x] `bun run test:e2e` — 72 screenshots captured; 6 pre-existing failures (home chart + counterparty auth-gated, unrelated to this diff)
- [x] manual smoke: dashboard Cuentas grid renders grouped tile for multi-currency card, Disponible shows correct COP amount

## Screenshots (e2e/screenshots/)

Key captures for the affected area:

- `chromium-light-accounts.png`
- `chromium-dark-accounts.png`
- `mobile-light-accounts.png`
- `mobile-dark-accounts.png`

## Follow-up

Issue **#744** tracks an integer guard for `BigInt(limit)` (identified in review, non-blocking).