### PR TITLE
refactor(accounts): extract CreditMeter into shared lib for dashboard + /accounts reuse (#746)

### DIFF
--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -12,6 +12,7 @@ import {
   type PhysicalCardSummary,
 } from "@/lib/accounts/queries";
 import { computeNextPayment } from "@/lib/accounts/next-payment";
+import { computeUsedPct, isHeavyUsage } from "@/lib/accounts/meter";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { toCop } from "@/lib/money";
 import { Money } from "@/components/display/money";
@@ -386,9 +387,8 @@ function CreditMeter({
       </div>
     );
   }
-  const used = limitCents > availableCents ? limitCents - availableCents : BigInt(0);
-  const pct = Math.min(100, Number((used * BigInt(10000)) / limitCents) / 100);
-  const high = pct >= 80;
+  const pct = computeUsedPct(limitCents, availableCents);
+  const high = isHeavyUsage(pct);
   return (
     <div className="flex flex-col gap-1">
       <div className="bg-muted h-1.5 overflow-hidden rounded-full">

--- a/src/components/accounts/credit-meter-bar.tsx
+++ b/src/components/accounts/credit-meter-bar.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/lib/utils";
+import { computeUsedPct, isHeavyUsage } from "@/lib/accounts/meter";
+
+/**
+ * Renders the visual credit-usage bar using the shared meter-track /
+ * meter-fill / meter-fill-amber CSS classes. Does NOT include any surrounding
+ * chrome (Card, CardHeader, Disponible/Cupo labels) — those live in the
+ * parent because they vary per call-site.
+ */
+export function CreditMeterBar({
+  limitCents,
+  availableCents,
+}: {
+  limitCents: bigint | null;
+  availableCents: bigint | null;
+}) {
+  const pct = computeUsedPct(limitCents, availableCents);
+  const heavy = isHeavyUsage(pct);
+
+  return (
+    <div className="meter-track h-1.5">
+      <div className={cn(heavy ? "meter-fill-amber" : "meter-fill")} style={{ width: `${pct}%` }} />
+    </div>
+  );
+}

--- a/src/components/dashboard/accounts-grid.tsx
+++ b/src/components/dashboard/accounts-grid.tsx
@@ -1,15 +1,10 @@
 import { Money } from "@/components/display/money";
-import { cn } from "@/lib/utils";
+import { CreditMeterBar } from "@/components/accounts/credit-meter-bar";
 import { formatAccountLabel } from "@/lib/accounts/format";
 import { groupCreditCards } from "@/lib/accounts/queries";
 import { toCop } from "@/lib/money";
 import type { AccountDetail } from "@/lib/accounts/queries";
 import type { Currency } from "@/lib/types";
-
-function pctOf(part: bigint, whole: bigint): number {
-  if (whole <= BigInt(0)) return 0;
-  return Math.min(100, Math.max(0, Number((part * BigInt(10000)) / whole) / 100));
-}
 
 // COP before USD so the COP leg always renders first in the breakdown.
 const CURRENCY_RANK: Record<Currency, number> = { COP: 0, USD: 1 };
@@ -27,9 +22,6 @@ function SharedCreditCardTile({ group, copPerUsd }: { group: AccountDetail[]; co
     else usdDebt += s.balanceCents;
   }
   const availableCents = limitCents + copDebt + toCop(usdDebt, "USD", copPerUsd);
-  const totalDebtCents = -copDebt - toCop(usdDebt, "USD", copPerUsd);
-  const usedPct = pctOf(totalDebtCents > BigInt(0) ? totalDebtCents : BigInt(0), limitCents);
-  const heavy = usedPct >= 80;
 
   const title = pc.name ?? primary.name;
 
@@ -52,12 +44,7 @@ function SharedCreditCardTile({ group, copPerUsd }: { group: AccountDetail[]; co
         </div>
       </div>
 
-      <div className="meter-track h-1.5">
-        <div
-          className={cn(heavy ? "meter-fill-amber" : "meter-fill")}
-          style={{ width: `${usedPct}%` }}
-        />
-      </div>
+      <CreditMeterBar limitCents={limitCents} availableCents={availableCents} />
 
       {legs.length > 0 ? (
         <div className="flex flex-col gap-0.5">
@@ -89,8 +76,6 @@ function SingleCreditCardTile({ account }: { account: AccountDetail }) {
   const limitCents = limit !== undefined && limit > 0 ? BigInt(limit) : null;
   const availableCents = limitCents !== null ? limitCents + account.balanceCents : null;
   const debt = account.balanceCents < BigInt(0) ? -account.balanceCents : BigInt(0);
-  const usedPct = limitCents ? pctOf(debt, limitCents) : 0;
-  const heavy = usedPct >= 80;
 
   return (
     <article className="card-paper flex flex-col gap-3 p-5">
@@ -108,12 +93,7 @@ function SingleCreditCardTile({ account }: { account: AccountDetail }) {
             </div>
           </div>
 
-          <div className="meter-track h-1.5">
-            <div
-              className={cn(heavy ? "meter-fill-amber" : "meter-fill")}
-              style={{ width: `${usedPct}%` }}
-            />
-          </div>
+          <CreditMeterBar limitCents={limitCents} availableCents={availableCents} />
 
           <div className="text-ink-subtle flex justify-between text-[11px] tabular-nums">
             <span>

--- a/src/lib/accounts/meter.test.ts
+++ b/src/lib/accounts/meter.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { computeUsedPct, isHeavyUsage } from "./meter";
+
+describe("computeUsedPct", () => {
+  it("returns 80 when 800 of 1000 is used", () => {
+    expect(computeUsedPct(BigInt(1000), BigInt(200))).toBe(80);
+  });
+
+  it("returns 0 when nothing is used (avail equals limit)", () => {
+    expect(computeUsedPct(BigInt(1000), BigInt(1000))).toBe(0);
+  });
+
+  it("returns 100 when fully used (avail is 0)", () => {
+    expect(computeUsedPct(BigInt(1000), BigInt(0))).toBe(100);
+  });
+
+  it("clamps to 0 on overpayment (avail > limit)", () => {
+    expect(computeUsedPct(BigInt(1000), BigInt(1100))).toBe(0);
+  });
+
+  it("returns 0 when limitCents is null", () => {
+    expect(computeUsedPct(null, BigInt(500))).toBe(0);
+  });
+
+  it("returns 0 when availableCents is null", () => {
+    expect(computeUsedPct(BigInt(1000), null)).toBe(0);
+  });
+
+  it("returns 0 when limitCents is zero", () => {
+    expect(computeUsedPct(BigInt(0), BigInt(0))).toBe(0);
+  });
+});
+
+describe("isHeavyUsage", () => {
+  it("returns true at exactly 80", () => {
+    expect(isHeavyUsage(80)).toBe(true);
+  });
+
+  it("returns false at 79", () => {
+    expect(isHeavyUsage(79)).toBe(false);
+  });
+
+  it("returns true at 100", () => {
+    expect(isHeavyUsage(100)).toBe(true);
+  });
+});

--- a/src/lib/accounts/meter.ts
+++ b/src/lib/accounts/meter.ts
@@ -1,0 +1,16 @@
+export const HEAVY_USAGE_THRESHOLD = 80;
+
+/**
+ * Computes the percentage of a credit limit that is used.
+ * Returns 0 when limitCents is null, zero, or negative (no meter applicable).
+ * Clamps to [0, 100].
+ */
+export function computeUsedPct(limitCents: bigint | null, availableCents: bigint | null): number {
+  if (limitCents === null || availableCents === null || limitCents <= BigInt(0)) return 0;
+  const used = limitCents > availableCents ? limitCents - availableCents : BigInt(0);
+  return Math.min(100, Math.max(0, Number((used * BigInt(10000)) / limitCents) / 100));
+}
+
+export function isHeavyUsage(pct: number): boolean {
+  return pct >= HEAVY_USAGE_THRESHOLD;
+}


### PR DESCRIPTION
Closes #746

## Summary

- Pure refactor — zero behavior change visible to users.
- Math extracted to `src/lib/accounts/meter.ts` (`computeUsedPct`, `isHeavyUsage`, `HEAVY_USAGE_THRESHOLD = 80`).
- Dashboard's meter markup extracted to `<CreditMeterBar>` in `src/components/accounts/credit-meter-bar.tsx`; `/accounts` keeps its distinct rose/emerald visual but now uses the shared math helpers.
- 10 new unit tests for the math helpers (`src/lib/accounts/meter.test.ts`).

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (2688 specs, 216 files)
- [x] manual smoke: e2e screenshots captured — `/accounts` (chromium + mobile, light + dark) show identical visuals before/after
- [x] Reviewer approved: 0 CRITICAL, 0 WARNING, 1 cosmetic SUGGESTION (pre-existing `cn()` no-op, intentionally not addressed)

Note: `home` screenshot tests have a pre-existing timing flake on `.recharts-pie-sector` unrelated to this refactor. All other 72 e2e tests pass.