### PR TITLE
chore(accounts): guard BigInt(creditLimitCents) against non-integer JSONB values (#744)

### DIFF
--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/accounts/queries";
 import { computeNextPayment } from "@/lib/accounts/next-payment";
 import { computeUsedPct, isHeavyUsage } from "@/lib/accounts/meter";
+import { safeLimitCents } from "@/lib/accounts/limit";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { toCop } from "@/lib/money";
 import { Money } from "@/components/display/money";
@@ -276,9 +277,8 @@ function CreditCardTile({
     availableCents = limitCents + copDebt + toCop(usdDebt, "USD", copPerUsd);
     meterCurrency = "COP";
   } else {
-    const limit = primary.metadata.creditLimitCents;
-    if (limit !== undefined && limit > 0) {
-      limitCents = BigInt(limit);
+    limitCents = safeLimitCents(primary.metadata.creditLimitCents);
+    if (limitCents !== null) {
       // #420: always derive from limit + ledger. The old
       // `metadata.availableCreditCents` snapshot path went stale whenever a
       // purchase landed via SMS/manual without a balance-adjust.

--- a/src/components/dashboard/accounts-grid.tsx
+++ b/src/components/dashboard/accounts-grid.tsx
@@ -1,6 +1,7 @@
 import { Money } from "@/components/display/money";
 import { CreditMeterBar } from "@/components/accounts/credit-meter-bar";
 import { formatAccountLabel } from "@/lib/accounts/format";
+import { safeLimitCents } from "@/lib/accounts/limit";
 import { groupCreditCards } from "@/lib/accounts/queries";
 import { toCop } from "@/lib/money";
 import type { AccountDetail } from "@/lib/accounts/queries";
@@ -72,8 +73,7 @@ function SharedCreditCardTile({ group, copPerUsd }: { group: AccountDetail[]; co
 }
 
 function SingleCreditCardTile({ account }: { account: AccountDetail }) {
-  const limit = account.metadata.creditLimitCents;
-  const limitCents = limit !== undefined && limit > 0 ? BigInt(limit) : null;
+  const limitCents = safeLimitCents(account.metadata.creditLimitCents);
   const availableCents = limitCents !== null ? limitCents + account.balanceCents : null;
   const debt = account.balanceCents < BigInt(0) ? -account.balanceCents : BigInt(0);
 

--- a/src/lib/accounts/limit.test.ts
+++ b/src/lib/accounts/limit.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { safeLimitCents } from "./limit";
+
+describe("safeLimitCents", () => {
+  it("returns BigInt for a valid positive integer", () => {
+    expect(safeLimitCents(10_000_000)).toBe(BigInt(10_000_000));
+  });
+
+  it("returns BigInt(1) for the minimum valid integer", () => {
+    expect(safeLimitCents(1)).toBe(BigInt(1));
+  });
+
+  it("returns null for 0", () => {
+    expect(safeLimitCents(0)).toBeNull();
+  });
+
+  it("returns null for a negative integer", () => {
+    expect(safeLimitCents(-500)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(safeLimitCents(undefined)).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(safeLimitCents(null)).toBeNull();
+  });
+
+  it("returns null for a non-integer float (999.99)", () => {
+    expect(safeLimitCents(999.99)).toBeNull();
+  });
+
+  it("returns null for a string (runtime guard)", () => {
+    // TS would normally block this, but JSONB can deliver any value at runtime.
+    expect(safeLimitCents("50000" as unknown as number)).toBeNull();
+  });
+
+  it("returns BigInt for Number.MAX_SAFE_INTEGER", () => {
+    expect(safeLimitCents(Number.MAX_SAFE_INTEGER)).toBe(BigInt(Number.MAX_SAFE_INTEGER));
+  });
+});

--- a/src/lib/accounts/limit.ts
+++ b/src/lib/accounts/limit.ts
@@ -1,0 +1,16 @@
+/**
+ * Guard for converting JSONB creditLimitCents to BigInt.
+ *
+ * AccountMetadata.creditLimitCents lives in JSONB (typed as `number`), so a
+ * stale write could store a float. `BigInt(float)` throws a RangeError, so we
+ * validate before converting.
+ *
+ * Returns the value as bigint when the input is a safe positive integer, or
+ * null otherwise (no limit configured / invalid data).
+ */
+export function safeLimitCents(limit: number | undefined | null): bigint | null {
+  if (typeof limit !== "number") return null;
+  if (!Number.isInteger(limit)) return null;
+  if (limit <= 0) return null;
+  return BigInt(limit);
+}


### PR DESCRIPTION
Closes #744

## Summary

- Extracts `safeLimitCents(limit: number | undefined | null): bigint | null` helper in `src/lib/accounts/limit.ts` to guard against non-integer floats that may arrive from JSONB metadata columns.
- `CreditCardTile` (`accounts/page.tsx`) and `SingleCreditCardTile` (`accounts-grid.tsx`) both swap their inline `BigInt(limit)` calls for `safeLimitCents(...)` so both sites stay in sync and neither can throw on fractional values.
- 9 unit tests cover: valid integer, 0, negative, undefined, null, non-integer float, string input, and max safe int boundary.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (2697 tests, 217 files, 17 skipped)
- [x] No UI changes — e2e screenshots not required