### PR TITLE
fix(imports): group multi-currency cards in account picker (#752)

### DIFF
--- a/src/app/(app)/imports/page.tsx
+++ b/src/app/(app)/imports/page.tsx
@@ -74,7 +74,8 @@ export default async function ImportsPage({
     }
   }
 
-  // Load non-deleted accounts for the dropdown
+  // Load non-deleted accounts for the dropdown.
+  // physicalCardId is required so the client can group multi-currency legs.
   const userAccounts = await db
     .select({
       id: accounts.id,
@@ -82,6 +83,7 @@ export default async function ImportsPage({
       currency: accounts.currency,
       institution: accounts.institution,
       metadata: accounts.metadata,
+      physicalCardId: accounts.physicalCardId,
     })
     .from(accounts)
     .where(and(eq(accounts.userId, session.id), notDeleted(accounts.deletedAt)));

--- a/src/components/imports/statement-uploader.test.tsx
+++ b/src/components/imports/statement-uploader.test.tsx
@@ -440,5 +440,33 @@ describe("StatementUploader", () => {
       const secondCallFormData = mockPreviewIngestion.mock.calls[1][0] as FormData;
       expect(secondCallFormData.get("hint_account_id")).toBe("10");
     });
+
+    it("single-member group (sibling archived) renders as ONE option with no currency suffix", () => {
+      // Only the USD leg exists — the COP sibling was archived. The grouping
+      // path still fires (physicalCardId is set) and should collapse to one entry
+      // with no "(USD)" suffix, because the xlsx covers whatever currency is present.
+      const ORPHAN_LEG: AccountOption[] = [
+        {
+          id: 11,
+          name: "Bancolombia Mastercard *7291",
+          currency: "USD",
+          institution: "Bancolombia",
+          physicalCardId: "pc-7291",
+        },
+      ];
+
+      render(<StatementUploader accounts={ORPHAN_LEG} />);
+
+      const dropdown = screen.getByLabelText(/cuenta/i);
+      const options = Array.from(dropdown.querySelectorAll("option"));
+
+      // Blank + 1 grouped entry = 2 (NOT 3 by treating it as a bare single)
+      expect(options).toHaveLength(2);
+
+      const card = options.find((o) => o.textContent?.includes("*7291"));
+      expect(card).toBeTruthy();
+      // physicalCardId is set → no currency suffix appended
+      expect(card!.textContent).not.toMatch(/\(USD\)|\(COP\)/);
+    });
   });
 });

--- a/src/components/imports/statement-uploader.test.tsx
+++ b/src/components/imports/statement-uploader.test.tsx
@@ -337,4 +337,108 @@ describe("StatementUploader", () => {
       expect(screen.queryByText("Subir")).not.toBeInTheDocument();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // #752 — Picker grouping for multi-currency cards
+  // ---------------------------------------------------------------------------
+
+  describe("account picker grouping (#752)", () => {
+    const MULTI_CURRENCY_ACCOUNTS: AccountOption[] = [
+      // Multi-currency Mastercard: COP leg (primary) + USD leg — same physicalCardId
+      {
+        id: 10,
+        name: "Bancolombia Mastercard *7291",
+        currency: "COP",
+        institution: "Bancolombia",
+        physicalCardId: "pc-7291",
+      },
+      {
+        id: 11,
+        name: "Bancolombia Mastercard *7291",
+        currency: "USD",
+        institution: "Bancolombia",
+        physicalCardId: "pc-7291",
+      },
+      // Single-currency Visa (no physicalCardId) — shows with currency suffix
+      {
+        id: 20,
+        name: "Bancolombia Visa *2575",
+        currency: "COP",
+        institution: "Bancolombia",
+      },
+      // Savings — no physicalCardId
+      {
+        id: 30,
+        name: "Bancolombia Ahorros",
+        currency: "COP",
+        institution: "Bancolombia",
+      },
+    ];
+
+    it("renders ONE option for a multi-currency card instead of two", () => {
+      render(<StatementUploader accounts={MULTI_CURRENCY_ACCOUNTS} />);
+
+      const dropdown = screen.getByLabelText(/cuenta/i);
+      const options = dropdown.querySelectorAll("option");
+
+      // Blank + 1 grouped card + 1 Visa + 1 Ahorros = 4 total (NOT 5)
+      expect(options).toHaveLength(4);
+    });
+
+    it("grouped card option has no currency suffix in its label", () => {
+      render(<StatementUploader accounts={MULTI_CURRENCY_ACCOUNTS} />);
+
+      const dropdown = screen.getByLabelText(/cuenta/i);
+      const options = Array.from(dropdown.querySelectorAll("option"));
+
+      const mastercard = options.find((o) => o.textContent?.includes("*7291"));
+      expect(mastercard).toBeTruthy();
+      // Must NOT contain "(COP)" or "(USD)" suffix
+      expect(mastercard!.textContent).not.toMatch(/\(COP\)|\(USD\)/);
+    });
+
+    it("single-currency card renders with currency suffix via formatAccountLabel", () => {
+      render(<StatementUploader accounts={MULTI_CURRENCY_ACCOUNTS} />);
+
+      const dropdown = screen.getByLabelText(/cuenta/i);
+      const options = Array.from(dropdown.querySelectorAll("option"));
+
+      const visa = options.find((o) => o.textContent?.includes("*2575"));
+      expect(visa).toBeTruthy();
+      expect(visa!.textContent).toContain("(COP)");
+    });
+
+    it("grouped option value is the COP leg account_id", () => {
+      render(<StatementUploader accounts={MULTI_CURRENCY_ACCOUNTS} />);
+
+      const dropdown = screen.getByLabelText(/cuenta/i);
+      const options = Array.from(dropdown.querySelectorAll("option"));
+
+      const mastercard = options.find((o) => o.textContent?.includes("*7291"));
+      expect(mastercard).toBeTruthy();
+      // COP leg is id=10; USD leg is id=11 — value must be the COP leg
+      expect(mastercard!.getAttribute("value")).toBe("10");
+    });
+
+    it("selecting the grouped option calls previewIngestion with the COP leg account_id", async () => {
+      mockPreviewIngestion.mockResolvedValue(makeArqPreviewResult());
+
+      const user = userEvent.setup();
+      render(<StatementUploader accounts={MULTI_CURRENCY_ACCOUNTS} />);
+
+      // Drop a file first so re-preview fires on account change
+      simulateFileSelect(makeFakePdf());
+      await waitFor(() => expect(mockPreviewIngestion).toHaveBeenCalledTimes(1));
+
+      // Select the grouped Mastercard option
+      const dropdown = screen.getByLabelText(/cuenta/i);
+      await user.selectOptions(dropdown, "10");
+
+      await waitFor(() => expect(mockPreviewIngestion).toHaveBeenCalledTimes(2));
+
+      // The second call's FormData should contain hint_account_id = "10"
+      const secondCallFormData = mockPreviewIngestion.mock.calls[1][0] as FormData;
+      expect(secondCallFormData.get("hint_account_id")).toBe("10");
+    });
+  });
 });

--- a/src/components/imports/statement-uploader.tsx
+++ b/src/components/imports/statement-uploader.tsx
@@ -43,6 +43,7 @@ export type AccountOption = {
   currency: string;
   institution?: string | null;
   metadata?: { last4s?: string[] | null } | null;
+  physicalCardId?: string | null;
 };
 
 type UploaderProps = {
@@ -171,6 +172,62 @@ function DropZone({ onFile, disabled }: { onFile: (file: File) => void; disabled
 }
 
 // ---------------------------------------------------------------------------
+// AccountDropdown helpers
+// ---------------------------------------------------------------------------
+
+type AccountDropdownOption =
+  | {
+      kind: "single";
+      account: AccountOption;
+    }
+  | {
+      kind: "group";
+      physicalCardId: string;
+      /** Primary leg (COP when both COP+USD exist, otherwise whichever comes first) */
+      primary: AccountOption;
+      label: string;
+    };
+
+/**
+ * Collapses multi-currency legs (same physical_card_id) into one option.
+ * Single-currency or ungrouped accounts render as-is with formatAccountLabel.
+ *
+ * The primary leg for a group is the COP leg when one exists; otherwise the
+ * first leg in order. The backend already discovers the sibling via
+ * physicalCardId when the primary account_id is submitted — this is path A.
+ */
+function buildDropdownOptions(accounts: AccountOption[]): AccountDropdownOption[] {
+  const options: AccountDropdownOption[] = [];
+  const seen = new Map<string, AccountDropdownOption & { kind: "group" }>();
+
+  for (const a of accounts) {
+    if (a.physicalCardId) {
+      const existing = seen.get(a.physicalCardId);
+      if (existing) {
+        // Prefer COP leg as primary so the backend resolves COP→USD sibling
+        if (existing.primary.currency !== "COP" && a.currency === "COP") {
+          existing.primary = a;
+        }
+        // Label stays as primary.name (no currency suffix — the xlsx covers both)
+      } else {
+        const entry: AccountDropdownOption & { kind: "group" } = {
+          kind: "group",
+          physicalCardId: a.physicalCardId,
+          primary: a,
+          label: a.name,
+        };
+        seen.set(a.physicalCardId, entry);
+        options.push(entry);
+      }
+    } else {
+      options.push({ kind: "single", account: a });
+    }
+  }
+
+  return options;
+}
+
+// ---------------------------------------------------------------------------
 // AccountDropdown
 // ---------------------------------------------------------------------------
 
@@ -185,6 +242,8 @@ function AccountDropdown({
   onChange: (id: number | null) => void;
   disabled: boolean;
 }) {
+  const options = buildDropdownOptions(accounts);
+
   return (
     <div className="flex flex-col gap-1">
       <label htmlFor="uploader-account" className="text-sm font-medium">
@@ -198,11 +257,20 @@ function AccountDropdown({
         className="bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:ring-2 focus:outline-none disabled:opacity-50"
       >
         <option value="">Seleccioná una cuenta...</option>
-        {accounts.map((a) => (
-          <option key={a.id} value={a.id}>
-            {formatAccountLabel(a)}
-          </option>
-        ))}
+        {options.map((opt) => {
+          if (opt.kind === "group") {
+            return (
+              <option key={`pc-${opt.physicalCardId}`} value={opt.primary.id}>
+                {opt.label}
+              </option>
+            );
+          }
+          return (
+            <option key={opt.account.id} value={opt.account.id}>
+              {formatAccountLabel(opt.account)}
+            </option>
+          );
+        })}
       </select>
     </div>
   );

--- a/src/components/imports/statement-uploader.tsx
+++ b/src/components/imports/statement-uploader.tsx
@@ -207,6 +207,7 @@ function buildDropdownOptions(accounts: AccountOption[]): AccountDropdownOption[
         // Prefer COP leg as primary so the backend resolves COP→USD sibling
         if (existing.primary.currency !== "COP" && a.currency === "COP") {
           existing.primary = a;
+          existing.label = a.name;
         }
         // Label stays as primary.name (no currency suffix — the xlsx covers both)
       } else {


### PR DESCRIPTION
Closes #752

Part of #749

## Summary

- Applies the same `groupCreditCards` pattern introduced in #745 (dashboard widget) to the imports account picker — multi-currency cards now appear as ONE grouped option instead of one entry per leg (~5 options instead of ~11).
- Backend already handles multi-leg dispatch via `physical_card_id`; no server-action changes needed.
- 2nd commit (reviewer feedback): tracks the primary leg label defensively so the picker label stays correct if leg names diverge in the future. Covers the single-member group edge case with an added test.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (218 files, 2707 specs)
- [x] e2e imports screenshots captured — `/imports` page renders correctly with grouped picker (12 screenshots: chromium + mobile x light/dark x bare/hint variants)
- [x] manual smoke: dev server loaded `/imports`, account picker shows grouped multi-currency cards

## E2E Screenshots (imports page)

Captured at `e2e/screenshots/`:
- `chromium-light-imports.png`, `chromium-dark-imports.png`
- `mobile-light-imports.png`, `mobile-dark-imports.png`
- Hint variants: `imports-hint-arq`, `imports-hint-bc`, `imports-hint-tc` (light + dark)
- Bare variant: `imports-bare` (light + dark)

Note: `home` and `counterparty` e2e tests are pre-existing flaky failures (recharts chart + table timeout in no-data test env) — unrelated to this change.