### PR TITLE
refactor(accounts): extract type exports from settings/accounts/actions.ts to sibling file (#756)

### DIFF
--- a/src/app/(app)/settings/accounts/actions-types.ts
+++ b/src/app/(app)/settings/accounts/actions-types.ts
@@ -1,0 +1,112 @@
+// Sibling types file — no "use server" directive.
+// All types that were previously exported from actions.ts live here.
+// actions.ts imports them with `import type` and re-exports where needed.
+// See AGENTS.md and engram nextjs16-server-action-types-split for the pattern.
+
+// ---------------------------------------------------------------------------
+// AccountUpsertInput
+// ---------------------------------------------------------------------------
+
+type MetadataSide = {
+  last4s?: string[];
+  network?: "visa" | "mastercard" | "amex";
+  creditLimitCents?: number;
+  cutoffDay?: number;
+  interestRateMonthly?: number;
+  termMonths?: number;
+  loanOriginalCents?: number;
+  loanRemainingCents?: number;
+  monthlyPaymentCents?: number;
+  creditRateBuckets?: {
+    oneMonth: number;
+    months2to36: number;
+    advances: number;
+  };
+};
+
+type AccountSide = {
+  currency: "COP" | "USD";
+  balance: number | string;
+  metadata?: MetadataSide;
+};
+
+type PhysicalCardInput = {
+  name?: string;
+  creditLimitCents?: number;
+  cutoffDay?: number;
+  last4?: string;
+  network?: "visa" | "mastercard" | "amex";
+};
+
+export type AccountUpsertInput = {
+  id?: number | string;
+  name: string;
+  institutionSlug: string;
+  institution?: string;
+  type: "savings" | "credit_card" | "loan";
+  active?: boolean | string;
+  primary: AccountSide;
+  secondary?: AccountSide;
+  physicalCard?: PhysicalCardInput;
+};
+
+// ---------------------------------------------------------------------------
+// UpsertAccountResult
+// ---------------------------------------------------------------------------
+
+export type UpsertAccountResult =
+  | { ok: true; propagatedToSiblings: number }
+  | { ok: false; message: string };
+
+// ---------------------------------------------------------------------------
+// UpdatePhysicalCardInput
+// ---------------------------------------------------------------------------
+
+export type UpdatePhysicalCardInput = {
+  id: string;
+  name?: string | null;
+  creditLimitCents?: number | string;
+  statementCutoffDay?: number | string | null;
+  last4?: string | null;
+  network?: "visa" | "mastercard" | "amex" | null;
+};
+
+// ---------------------------------------------------------------------------
+// AdjustBalanceInput
+// ---------------------------------------------------------------------------
+
+type DeclaredBalance =
+  | { kind: "balance"; balanceCents: number | string }
+  | { kind: "availableCredit"; availableCreditCents: number | string }
+  | { kind: "sharedAvailableCop"; availableCopCents: number | string }
+  | {
+      kind: "perCurrencyDualDebt";
+      debtCopCents?: number | string;
+      debtUsdCents?: number | string;
+    };
+
+export type AdjustBalanceInput = {
+  accountId: number | string;
+  declared: DeclaredBalance;
+  reason?: string;
+};
+
+// ---------------------------------------------------------------------------
+// AdjustBalanceResult
+// ---------------------------------------------------------------------------
+
+export type AdjustBalanceResult =
+  | { status: "ok"; diffCents: string; txId: number }
+  // #447 — dual-debt commit returns one entry per sub-account (ordered
+  // primary-then-sibling) so the UI can surface both diffs in a single toast.
+  | {
+      status: "ok_dual";
+      results: Array<{
+        accountId: number;
+        currency: "COP" | "USD";
+        diffCents: string;
+        txId: number;
+      }>;
+    }
+  | { status: "noop" }
+  | { status: "error"; message: string };

--- a/src/app/(app)/settings/accounts/actions.ts
+++ b/src/app/(app)/settings/accounts/actions.ts
@@ -19,6 +19,20 @@ import { derivedBalanceCentsSql } from "@/lib/accounts/queries";
 import { getSessionUser } from "@/lib/auth/session";
 import { getCurrentFxRate } from "@/lib/fx/repo";
 import { convertCents } from "@/lib/money";
+import type {
+  AccountUpsertInput,
+  AdjustBalanceInput,
+  AdjustBalanceResult,
+  UpdatePhysicalCardInput,
+  UpsertAccountResult,
+} from "./actions-types";
+export type {
+  AccountUpsertInput,
+  AdjustBalanceInput,
+  AdjustBalanceResult,
+  UpdatePhysicalCardInput,
+  UpsertAccountResult,
+} from "./actions-types";
 
 const ADJUSTMENT_CATEGORY_SLUG = "adjustments";
 
@@ -134,8 +148,6 @@ const upsertSchema = z
     path: ["physicalCard"],
   });
 
-export type AccountUpsertInput = z.input<typeof upsertSchema>;
-
 function revalidate() {
   revalidatePath("/");
   revalidatePath("/accounts");
@@ -206,10 +218,6 @@ async function ensureAdjustmentsCategory(
     .set({ deletedAt: null, updatedAt: new Date() })
     .where(and(eq(categories.userId, userId), eq(categories.slug, ADJUSTMENT_CATEGORY_SLUG)));
 }
-
-export type UpsertAccountResult =
-  | { ok: true; propagatedToSiblings: number }
-  | { ok: false; message: string };
 
 export async function upsertAccount(input: AccountUpsertInput): Promise<UpsertAccountResult> {
   const session = await getSessionUser();
@@ -406,8 +414,6 @@ const updatePhysicalCardSchema = z
   })
   .strict();
 
-export type UpdatePhysicalCardInput = z.input<typeof updatePhysicalCardSchema>;
-
 /**
  * Partially updates a physical card's shared attributes (#346, #362). Scoped by
  * `user_id = session.id`. Field semantics:
@@ -506,24 +512,6 @@ const adjustSchema = z.object({
   declared: declaredSchema,
   reason: z.string().max(500).optional(),
 });
-
-export type AdjustBalanceInput = z.input<typeof adjustSchema>;
-
-export type AdjustBalanceResult =
-  | { status: "ok"; diffCents: string; txId: number }
-  // #447 — dual-debt commit returns one entry per sub-account (ordered
-  // primary-then-sibling) so the UI can surface both diffs in a single toast.
-  | {
-      status: "ok_dual";
-      results: Array<{
-        accountId: number;
-        currency: "COP" | "USD";
-        diffCents: string;
-        txId: number;
-      }>;
-    }
-  | { status: "noop" }
-  | { status: "error"; message: string };
 
 /**
  * Reconciliation balance adjustment (YNAB pattern). Inserts a transaction for


### PR DESCRIPTION
Closes #756

## Summary

- Pure refactor — zero behavior change. Moves 5 type exports out of a `"use server"` file to a sibling file (no directive), per the engram-documented pattern (`nextjs16-server-action-types-split`).
- Re-export bridge in `actions.ts` keeps the single external caller (`balance-adjust-dialog.tsx`) untouched.
- Implementation note: the types were `z.input<typeof schema>` aliases of private schemas; rewritten as explicit TypeScript types matching the zod input shapes (TypeScript confirms structural compatibility). Future schema changes need to propagate to the explicit types — known trade-off documented here.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (2711 passed / 17 skipped, 218 test files)
- [x] No UI changes — e2e screenshots skipped per agent rules