### PR TITLE
feat(imports): force re-import for already-consolidated cycles (#760)

### DIFF
--- a/src/app/(app)/imports/_dispatch-ui-types.test.ts
+++ b/src/app/(app)/imports/_dispatch-ui-types.test.ts
@@ -1,0 +1,41 @@
+// Unit tests for hintSchema — validates query-string parsing including the
+// #760 force flag. No DB or server action involved.
+
+import { describe, expect, it } from "vitest";
+import { hintSchema } from "./_dispatch-ui-types";
+
+describe("hintSchema — force param (#760)", () => {
+  it('force="1" parses to true', () => {
+    const result = hintSchema.safeParse({
+      hint_account_id: "42",
+      hint_cycle: "2026-04",
+      force: "1",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.force).toBe(true);
+  });
+
+  it('force="0" parses to false', () => {
+    const result = hintSchema.safeParse({ force: "0" });
+    expect(result.success).toBe(true);
+    expect(result.data?.force).toBe(false);
+  });
+
+  it("force absent parses to false", () => {
+    const result = hintSchema.safeParse({ hint_account_id: "5" });
+    expect(result.success).toBe(true);
+    expect(result.data?.force).toBe(false);
+  });
+
+  it("force=undefined parses to false", () => {
+    const result = hintSchema.safeParse({ force: undefined });
+    expect(result.success).toBe(true);
+    expect(result.data?.force).toBe(false);
+  });
+
+  it("force with any other value parses to false", () => {
+    const result = hintSchema.safeParse({ force: "yes" });
+    expect(result.success).toBe(true);
+    expect(result.data?.force).toBe(false);
+  });
+});

--- a/src/app/(app)/imports/_dispatch-ui-types.ts
+++ b/src/app/(app)/imports/_dispatch-ui-types.ts
@@ -20,6 +20,11 @@ export const hintSchema = z.object({
     .string()
     .regex(/^\d{4}-\d{2}$/)
     .optional(),
+  // #760 — when "1", bypass the already-consolidated guard in the commit step.
+  force: z
+    .string()
+    .optional()
+    .transform((v) => v === "1"),
 });
 
 export type HintParams = z.infer<typeof hintSchema>;

--- a/src/app/(app)/imports/actions.ts
+++ b/src/app/(app)/imports/actions.ts
@@ -53,7 +53,7 @@ import {
   consolidateCycleFromStatement,
   hashStatementBuffer,
 } from "@/lib/ingestion/bancolombia-statement/consolidate";
-import { hintSchema } from "./_dispatch-ui-types";
+import { hintSchema, type HintParams } from "./_dispatch-ui-types";
 
 import type { IngestionKind, ReconciliationParsedStatement } from "@/lib/ingestion/dispatch-types";
 import type { ExistingTxnForMatch, MatchingPlan } from "@/lib/reconciliation/engine/types";
@@ -232,7 +232,7 @@ export async function previewIngestion(formData: FormData): Promise<ImportPrevie
     hint_account_id: rawHintAccountId ?? undefined,
     hint_cycle: rawHintCycle ?? undefined,
   });
-  const hints = hintParse.success ? hintParse.data : {};
+  const hints: HintParams = hintParse.success ? hintParse.data : { force: false };
 
   // --- Validate hint_account_id ownership before use (AC-19) ---
   let validatedHintAccountId: number | null = null;
@@ -681,7 +681,7 @@ export async function previewIngestion(formData: FormData): Promise<ImportPrevie
 
 export async function commitIngestion(
   token: string,
-  overrides?: { accountId?: number },
+  overrides?: { accountId?: number; force?: boolean },
 ): Promise<UnifiedCommitResult> {
   const session = await getSessionUser();
   const userId = session.id;
@@ -765,7 +765,7 @@ export async function commitIngestion(
   }
 
   if (v2.kind === "bancolombia-tc-detallado" && v2.tcDetalladoData) {
-    return _commitTcDetallado(v2, effectiveAccountId!, userId);
+    return _commitTcDetallado(v2, effectiveAccountId!, userId, overrides?.force);
   }
 
   log.error(
@@ -913,6 +913,7 @@ async function _commitTcDetallado(
   entry: CacheEntryV2,
   accountId: number,
   userId: number,
+  force?: boolean,
 ): Promise<UnifiedCommitResult> {
   const { parsedSheets, cycle, siblingAccountId, fileHash } = entry.tcDetalladoData!;
 
@@ -982,6 +983,7 @@ async function _commitTcDetallado(
       parsed: sheet,
       fileHash,
       dryRun: false,
+      force,
     });
 
     allInsertedTxIds.push(...(r.insertedTxIds ?? []));

--- a/src/app/(app)/imports/page.tsx
+++ b/src/app/(app)/imports/page.tsx
@@ -15,7 +15,7 @@ import { accounts } from "@/lib/db/schema";
 import { notDeleted } from "@/lib/db/helpers";
 import { getSessionUser } from "@/lib/auth/session";
 import { createLogger } from "@/lib/logger";
-import { hintSchema } from "./_dispatch-ui-types";
+import { hintSchema, type HintParams } from "./_dispatch-ui-types";
 import { StatementUploader } from "@/components/imports/statement-uploader";
 
 const log = createLogger({ module: "imports-page" });
@@ -43,8 +43,9 @@ export default async function ImportsPage({
   const hintParse = hintSchema.safeParse({
     hint_account_id: flatParams.hint_account_id,
     hint_cycle: flatParams.hint_cycle,
+    force: flatParams.force,
   });
-  const hints = hintParse.success ? hintParse.data : {};
+  const hints: HintParams = hintParse.success ? hintParse.data : { force: false };
 
   // Validate hint_account_id ownership server-side before pre-filling (AC-19)
   let validatedHintAccountId: number | undefined;
@@ -111,6 +112,7 @@ export default async function ImportsPage({
         initialHint={{
           accountId: validatedHintAccountId,
           cycle: hints.hint_cycle,
+          force: hints.force,
         }}
       />
     </main>

--- a/src/app/(app)/settings/accounts/tc-consolidation-status.tsx
+++ b/src/app/(app)/settings/accounts/tc-consolidation-status.tsx
@@ -193,12 +193,20 @@ export async function TcConsolidationStatus({ userId }: { userId: number }) {
                           <UnskipCycleLink accountId={group.primaryAccountId} cycle={cycle.cycle} />
                         ) : null}
                         {cycle.status === "consolidated" ? (
-                          <Link
-                            href={`/settings/accounts/${group.primaryAccountId}/consolidate/${cycle.cycle}`}
-                            className="text-muted-foreground text-xs underline"
-                          >
-                            Ver run
-                          </Link>
+                          <>
+                            <Link
+                              href={`/settings/accounts/${group.primaryAccountId}/consolidate/${cycle.cycle}`}
+                              className="text-muted-foreground text-xs underline"
+                            >
+                              Ver run
+                            </Link>
+                            <Link
+                              href={`/imports?hint_account_id=${group.primaryAccountId}&hint_cycle=${cycle.cycle}&force=1`}
+                              className="text-muted-foreground text-xs underline"
+                            >
+                              Re-importar
+                            </Link>
+                          </>
                         ) : null}
                       </div>
                       {group.isMultiCurrency ? (

--- a/src/components/imports/statement-uploader.tsx
+++ b/src/components/imports/statement-uploader.tsx
@@ -51,6 +51,9 @@ type UploaderProps = {
   initialHint?: {
     accountId?: number;
     cycle?: string;
+    // #760 — when true, the commit step will bypass the already-consolidated
+    // guard and upsert the existing statement_imports row.
+    force?: boolean;
   };
 };
 
@@ -527,6 +530,10 @@ export function StatementUploader({ accounts, initialHint }: UploaderProps) {
     initialHint?.accountId ?? null,
   );
   const [cycleInput, setCycleInput] = useState<string>(initialHint?.cycle ?? "");
+  // #760 — force flag comes from hint (URL query param ?force=1). Stable for
+  // the lifetime of the component — the page is server-rendered so the prop
+  // never changes after initial mount.
+  const [force] = useState<boolean>(initialHint?.force ?? false);
   const [manualKind, setManualKind] = useState<IngestionKind | null>(null);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [_isPending, startTransition] = useTransition();
@@ -589,10 +596,10 @@ export function StatementUploader({ accounts, initialHint }: UploaderProps) {
 
     startTransition(async () => {
       try {
-        const result = await commitIngestion(
-          token,
-          selectedAccountId ? { accountId: selectedAccountId } : undefined,
-        );
+        const result = await commitIngestion(token, {
+          ...(selectedAccountId ? { accountId: selectedAccountId } : {}),
+          ...(force ? { force: true } : {}),
+        });
 
         if (result.status === "committed") {
           setPhase({ kind: "done", result });
@@ -624,7 +631,7 @@ export function StatementUploader({ accounts, initialHint }: UploaderProps) {
         setPhase({ kind: "error", message });
       }
     });
-  }, [phase, selectedAccountId]);
+  }, [phase, selectedAccountId, force]);
 
   const handleCancel = useCallback(() => {
     setPhase({ kind: "idle" });

--- a/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.test.ts
@@ -1373,3 +1373,109 @@ describe("consolidateCycleFromStatement — balance_at_end_cents persistence (#5
     expect(imp.balanceAtEndCents).toBe(CURRENT_BALANCE);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Force re-import (#760)
+// ---------------------------------------------------------------------------
+// When force=true the already-consolidated guard is bypassed and the existing
+// statement_imports row is upserted in place. Transaction dedup (externalId)
+// handles the rest naturally — result is "0 insertadas, N matched".
+describe("consolidateCycleFromStatement — force re-import (#760)", () => {
+  const TAG_FORCE = "STMT_FORCE_TEST";
+  const FORCE_CYCLE = "2026-06";
+  let userId!: number;
+  let accountId!: number;
+
+  beforeAll(async () => {
+    userId = await createUser(`${TAG_FORCE.toLowerCase()}.${Date.now()}@test.local`);
+    accountId = await createTCAccount(userId);
+  });
+
+  afterAll(async () => {
+    await cleanupUser(userId);
+  });
+
+  function buildSimpleStatement(): ParsedStatement {
+    return buildParsed(
+      [
+        row({
+          authorizationNumber: "FORCE01",
+          merchant: "TIENDA FORCE",
+          occurredAt: utcDate(2026, 6, 15),
+          amountCents: BigInt(500000),
+        }),
+      ],
+      {
+        period: {
+          startDate: utcDate(2026, 5, 31),
+          endDate: utcDate(2026, 6, 30),
+          dueDate: utcDate(2026, 7, 16),
+        },
+      },
+    );
+  }
+
+  it("without force, second call short-circuits to already-consolidated (existing behavior preserved)", async () => {
+    // First consolidation
+    const r1 = await consolidateCycleFromStatement({
+      userId,
+      accountId,
+      cycle: FORCE_CYCLE,
+      parsed: buildSimpleStatement(),
+      fileHash: "force01a".repeat(8),
+      dryRun: false,
+    });
+    expect(r1.status).toBe("consolidated");
+
+    // Second call — no force flag
+    const r2 = await consolidateCycleFromStatement({
+      userId,
+      accountId,
+      cycle: FORCE_CYCLE,
+      parsed: buildSimpleStatement(),
+      fileHash: "force01b".repeat(8),
+      dryRun: false,
+    });
+    expect(r2.status).toBe("already-consolidated");
+    expect(r2.statementImportId).toBe(r1.statementImportId);
+  });
+
+  it("with force=true, second consolidation succeeds and does not throw", async () => {
+    const r3 = await consolidateCycleFromStatement({
+      userId,
+      accountId,
+      cycle: FORCE_CYCLE,
+      parsed: buildSimpleStatement(),
+      fileHash: "force01c".repeat(8),
+      dryRun: false,
+      force: true,
+    });
+    expect(r3.status).toBe("consolidated");
+    // statementImportId must still be present
+    expect(r3.statementImportId).not.toBeNull();
+  });
+
+  it("with force=true, statement_imports has exactly ONE row for the cycle (upsert, not insert)", async () => {
+    const allImports = await db
+      .select({ id: statementImports.id })
+      .from(statementImports)
+      .where(
+        and(
+          eq(statementImports.userId, userId),
+          eq(statementImports.accountId, accountId),
+          eq(statementImports.cycle, FORCE_CYCLE),
+        ),
+      );
+    expect(allImports).toHaveLength(1);
+  });
+
+  it("transactions inserted by the original import are unchanged after force re-import", async () => {
+    const txs = await db
+      .select({ id: transactions.id, merchant: transactions.merchant })
+      .from(transactions)
+      .where(and(eq(transactions.userId, userId), eq(transactions.accountId, accountId)));
+    // The TIENDA FORCE purchase should appear exactly once (externalId dedup)
+    const tiendaTxs = txs.filter((t) => t.merchant === "TIENDA FORCE");
+    expect(tiendaTxs).toHaveLength(1);
+  });
+});

--- a/src/lib/ingestion/bancolombia-statement/consolidate.ts
+++ b/src/lib/ingestion/bancolombia-statement/consolidate.ts
@@ -181,6 +181,10 @@ export type ConsolidateOptions = {
   // balance_adjustment tx post-intereses so the final ledger SUM matches
   // this value exactly.
   saldoRealLedgerCents?: bigint | null;
+  // #760 — when true, bypass the already-consolidated guard and upsert the
+  // existing statement_imports row instead of inserting a new one. Useful
+  // when the user wants to re-import a corrected extracto.
+  force?: boolean;
 };
 
 export function hashStatementBuffer(buffer: Buffer): string {
@@ -814,6 +818,7 @@ export async function consolidateCycleFromStatement(
 
   // Short-circuit if this cycle is already consolidated. Return the persisted
   // report so callers can display past runs without re-work.
+  // #760: when force=true, skip this guard and proceed to upsert the row.
   const [existing] = await database
     .select({
       id: statementImports.id,
@@ -830,7 +835,7 @@ export async function consolidateCycleFromStatement(
       ),
     )
     .limit(1);
-  if (existing) {
+  if (existing && !opts.force) {
     const persistedReport = (existing.report ?? {}) as Partial<ConsolidationReport>;
     return {
       ...(persistedReport as ConsolidationReport),
@@ -922,24 +927,45 @@ export async function consolidateCycleFromStatement(
     insertedBeforePeriodCount,
     crossTwinReassignedIds,
   } = await database.transaction(async (txDb) => {
-    const [imp] = await txDb
-      .insert(statementImports)
-      .values({
-        userId: opts.userId,
-        accountId: opts.accountId,
-        fileHash: opts.fileHash,
-        periodStart: toIsoDate(opts.parsed.period.startDate),
-        periodEnd: toIsoDate(opts.parsed.period.endDate),
-        txnCount: 0,
-        kind: "extracto_detallado",
-        cycle: opts.cycle,
-        // #563 — persist the cycle-end balance from the extracto summary so
-        // the snapshot backfill (#562) can use it as an opening-balance anchor.
-        // currentBalanceCents = "Pago total" = what the bank says you owe.
-        balanceAtEndCents: opts.parsed.summary.currentBalanceCents,
-        report: null,
-      })
-      .returning({ id: statementImports.id });
+    // #760 — when force=true and a previous row already exists, UPDATE it in
+    // place (upsert) so we never accumulate duplicate rows per (user, account,
+    // cycle). The unique constraint is on (userId, accountId, kind, cycle).
+    let imp: { id: number };
+    if (opts.force && existing) {
+      await txDb
+        .update(statementImports)
+        .set({
+          fileHash: opts.fileHash,
+          periodStart: toIsoDate(opts.parsed.period.startDate),
+          periodEnd: toIsoDate(opts.parsed.period.endDate),
+          txnCount: 0, // will be updated at end of tx
+          balanceAtEndCents: opts.parsed.summary.currentBalanceCents,
+          report: null,
+          importedAt: new Date(),
+        })
+        .where(eq(statementImports.id, existing.id));
+      imp = { id: existing.id };
+    } else {
+      const [inserted] = await txDb
+        .insert(statementImports)
+        .values({
+          userId: opts.userId,
+          accountId: opts.accountId,
+          fileHash: opts.fileHash,
+          periodStart: toIsoDate(opts.parsed.period.startDate),
+          periodEnd: toIsoDate(opts.parsed.period.endDate),
+          txnCount: 0,
+          kind: "extracto_detallado",
+          cycle: opts.cycle,
+          // #563 — persist the cycle-end balance from the extracto summary so
+          // the snapshot backfill (#562) can use it as an opening-balance anchor.
+          // currentBalanceCents = "Pago total" = what the bank says you owe.
+          balanceAtEndCents: opts.parsed.summary.currentBalanceCents,
+          report: null,
+        })
+        .returning({ id: statementImports.id });
+      imp = inserted;
+    }
 
     const matchedIdsToUpdate: number[] = [];
     for (const m of match.matched) {


### PR DESCRIPTION
Closes #760

## Summary
- Adds a `force` flag to the consolidation flow that bypasses the "already consolidated" guard. The existing `statement_imports` row is UPDATED (not duplicated); transactions dedup naturally — output is typically "0 inserted, N matched".
- `commitIngestion` in the imports server action accepts and threads the `force` param through to `consolidate()`.
- UI: "Re-importar" link added in `/settings/accounts` next to "Ver run" on already-consolidated cycle rows; clicking it redirects to `/imports?...&force=1`.

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (2729 specs, 17 skipped)
- [x] 4 new consolidate-action tests covering force-bypass path
- [x] 5 new dispatch-ui type tests covering force field in hintSchema
- [x] No DB migration — bypass is application-level only
- [ ] Manual smoke: Re-importar link visible on consolidated cycle rows in /settings/accounts; import with force=1 updates existing row, dedup runs cleanly

## Screenshots (e2e)

### settings-accounts (light / dark)
`chromium-light-settings-accounts.png` | `chromium-dark-settings-accounts.png`

### settings-consolidate-2026-03 (light / dark)
`chromium-light-settings-consolidate-2026-03.png` | `chromium-dark-settings-consolidate-2026-03.png`

### imports page (light / dark)
`chromium-light-imports.png` | `chromium-dark-imports.png`