### PR TITLE
fix(intereses): skip second-pass accrual on card's inaugural cycle (#764)

### DIFF
--- a/src/lib/finance/intereses-causados-job.test.ts
+++ b/src/lib/finance/intereses-causados-job.test.ts
@@ -65,6 +65,28 @@ async function setCutoffDay(accountId: number, day: number | null) {
   }
 }
 
+// Seed a prior synthetic intereses-tc row so the inaugural-cycle guard (#764)
+// sees prior interest history and allows the second pass to run.
+async function seedPriorInterestRow(accountId: number, cycle: string): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO transactions (
+      user_id, account_id, occurred_at, amount_cents, currency, description_raw,
+      classification_method, source, category_slug, raw_data
+    ) VALUES (
+      ${TEST_USER_ID}, ${accountId}, ${`${cycle}-01T00:00:00Z`}::timestamptz,
+      -10000::bigint, 'COP', ${"Intereses causados ciclo " + cycle},
+      'manual'::classification_method, 'manual',
+      'intereses-tc',
+      ${JSON.stringify({
+        job: "intereses-causados-job",
+        cycleKey: `${accountId}-${cycle}`,
+        cycle,
+        synthetic: true,
+      })}::jsonb
+    )
+  `);
+}
+
 async function seedPurchase(opts: {
   accountId: number;
   externalId: string;
@@ -553,6 +575,11 @@ describe("computeInterestForCycle — partial-month accrual (#565)", () => {
     await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
     await setCutoffDay(visa, 31); // clamped to 31 → March 31
 
+    // Seed a prior intereses-tc row so the inaugural-cycle guard (#764) doesn't
+    // suppress the second pass — this test proves the second pass fires normally
+    // on non-inaugural cycles.
+    await seedPriorInterestRow(visa, "2026-02");
+
     // ALKOMPRAR-like: posted 2026-01-15 → by Mar 31 anchor, monthsBetween =
     // months between Jan 15 and Mar 31 = 2 full months (Jan→Mar, day 31≥15)
     // → paidCount=2 for an 8-cuota loan → cuota 3 next.
@@ -744,6 +771,99 @@ describe("computeInterestForCycle — partial-month accrual (#565)", () => {
     expect(run.totalInterestCents).toBe(BigInt(0));
   });
 
+  // #764: inaugural-cycle guard — the second pass must NOT fire when there are
+  // no prior intereses-tc rows for the account (card's very first cycle).
+  // Models the Amex *5367 compra-de-cartera scenario that produced ~$94k COP
+  // phantom interest on cycle 2026-04.
+  it("does NOT apply partial accrual on inaugural cycle — 60-cuota purchase posted mid-cycle (#764)", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
+    await setCutoffDay(visa, 30); // April 30 anchor
+
+    // Amex *5367-like: 60-cuota compra de cartera posted ~7 days before Apr 30
+    // cut date. On the inaugural cycle (no prior intereses-tc rows) the second
+    // pass must return 0 interest even though daysActive > 0.
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}inaugural-60cuota`,
+      amountCentsMagnitude: BigInt(4_900_000_000), // ~49,000,000 pesos in cents (compra de cartera)
+      occurredAt: "2026-04-23", // 7 days before Apr 30 anchor
+      installmentsTotal: 60,
+      installmentRateEmX10k: 19110,
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+
+    // Inaugural cycle → no partial accrual, no synthetic tx should be inserted.
+    expect(run.totalInterestCents).toBe(BigInt(0));
+    expect(run.intereses.length).toBe(0);
+
+    // Confirm applyInteresesCausadosForCycle also skips (zero-interest path).
+    const result = await applyInteresesCausadosForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-04",
+    });
+    expect(result.status).toBe("skipped");
+    if (result.status === "skipped") expect(result.reason).toBe("zero-interest");
+  });
+
+  // #764: subsequent-cycle regression — once a prior intereses-tc row exists for
+  // the account, the second pass MUST still fire for a new mid-cycle grace purchase.
+  it("DOES apply partial accrual on subsequent cycle when prior intereses-tc row exists (#764)", async () => {
+    const visa = await getVisaId();
+    await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
+    await setCutoffDay(visa, 31); // clamped to March 31
+
+    // Seed a PRIOR synthetic intereses-tc row for an earlier cycle to simulate
+    // "this is NOT the inaugural cycle". We insert directly so the inaugural
+    // guard sees prior history.
+    await db.execute(sql`
+      INSERT INTO transactions (
+        user_id, account_id, occurred_at, amount_cents, currency, description_raw,
+        classification_method, source, category_slug, raw_data
+      ) VALUES (
+        ${TEST_USER_ID}, ${visa}, '2026-02-28T23:00:00Z'::timestamptz,
+        -50000::bigint, 'COP', 'Intereses causados ciclo 2026-02',
+        'manual'::classification_method, 'manual',
+        'intereses-tc',
+        ${JSON.stringify({
+          job: "intereses-causados-job",
+          cycleKey: `${visa}-2026-02`,
+          cycle: "2026-02",
+          synthetic: true,
+        })}::jsonb
+      )
+    `);
+
+    // Multi-cuota grace purchase posted 7 days before Mar 31 anchor.
+    await seedPurchase({
+      accountId: visa,
+      externalId: `${EXT_PREFIX}subsequent-60cuota`,
+      amountCentsMagnitude: BigInt(409_952_300),
+      occurredAt: "2026-03-24",
+      installmentsTotal: 60,
+      installmentRateEmX10k: 19110,
+    });
+
+    const run = await computeInterestForCycle({
+      userId: TEST_USER_ID,
+      accountId: visa,
+      cycle: "2026-03",
+    });
+
+    // Subsequent cycle → second pass MUST fire → partial accrual present.
+    expect(run.totalInterestCents).toBeGreaterThan(BigInt(0));
+    expect(run.intereses.length).toBe(1);
+    const entry = run.intereses[0];
+    expect(entry.installmentsPaid).toBe(0); // still grace month
+    expect(entry.gracePeriodPartialCents).toBe(BigInt(1_769_010)); // 7/31 partial
+  });
+
   // #578: mixed scenario — 1-cuota (no interest) + multi-cuota grace (partial
   // interest). Confirms the guard only fires on 1-cuota while the multi-cuota
   // sibling still gets its partial accrual.
@@ -751,6 +871,11 @@ describe("computeInterestForCycle — partial-month accrual (#565)", () => {
     const visa = await getVisaId();
     await setBucketRates(visa, { oneMonth: 0, months2to36: 19110, advances: 19110 });
     await setCutoffDay(visa, 31);
+
+    // Seed a prior intereses-tc row so the inaugural-cycle guard (#764) doesn't
+    // suppress the second pass — this test proves the installmentsTotal<=1 guard
+    // (not the inaugural guard) is what blocks 1-cuota partial accrual.
+    await seedPriorInterestRow(visa, "2026-02");
 
     // 1-cuota — should produce 0 interest
     await seedPurchase({

--- a/src/lib/finance/intereses-causados-job.ts
+++ b/src/lib/finance/intereses-causados-job.ts
@@ -316,8 +316,41 @@ export async function computeInterestForCycle(opts: {
   //   2. rateEmX10k > 0  — interest-bearing; excludes 0%-rate diferido plans
   //   3. not already in `intereses` — mature rows (paidCount>0) were kept above
   //   4. partial > 0 — at least one day active in the cycle
+  //   5. NOT inaugural cycle — if this account has never had an intereses-tc
+  //      row before this cycle, and ALL installment purchases are still at
+  //      paidCount=0 (nothing has accrued or been paid on any prior cycle),
+  //      skip the second pass entirely. Rationale: we have no evidence
+  //      Bancolombia charges partial accrual on the very first cycle of a card.
+  //      The Amex *5367 compra-de-cartera scenario produced ~$94k COP phantom
+  //      interest on cycle 2026-04 (issue #764) because of this missing guard.
+  //      Tenant safety: query scoped by userId per per-user-table-join-tenant-safety.
   const cycleDays = cycleLengthDays(anchor);
   const alreadyInIntereses = new Set(intereses.map((e) => e.txId));
+
+  // Inaugural-cycle guard (#764): count prior intereses-tc synthetic rows for
+  // this account on any cycle strictly before `cycle`. If none exist, this is
+  // the card's first-ever interest cycle — skip the second pass.
+  const [priorInterestRow] = await database.execute<{ count: string }>(sql`
+    SELECT COUNT(*)::text AS count
+    FROM transactions
+    WHERE user_id = ${userId}
+      AND account_id = ${accountId}
+      AND category_slug = 'intereses-tc'
+      AND raw_data ->> 'cycleKey' < ${cycleKeyFor(accountId, cycle)}
+      AND deleted_at IS NULL
+  `);
+  const hasPriorInterestHistory = BigInt(priorInterestRow?.count ?? "0") > BigInt(0);
+
+  if (!hasPriorInterestHistory) {
+    // No prior interest history → inaugural cycle. Skip partial accrual.
+    // Bancolombia does not charge partial-month interest on the card's first
+    // cycle. Return the first-pass result directly.
+    log.debug(
+      { userId, accountId, cycle, event: "inaugural_cycle_skip" },
+      "inaugural cycle — skipping second-pass partial accrual",
+    );
+    return { accountId, cycle, anchor, intereses, totalInterestCents, purchasesNeedingRate };
+  }
 
   for (const p of purchases) {
     // Skip if already priced via the per-cuota path (mature installment)


### PR DESCRIPTION
Closes #764

## Summary

- `computeInterestForCycle` (introduced in PR #565) has a second-pass loop that recalculates residual interest on multi-cuota purchases that span billing cycles. On a card's inaugural cycle there are zero prior `intereses-tc` synthetic rows, which caused the second pass to charge phantom partial-month interest on purchases that should only start accruing from the next cycle.
- Fix: before entering the second pass, the job now checks whether any `intereses-tc` rows exist for the account. If zero → the card is in its inaugural cycle and the second pass is skipped entirely.
- Real-world impact: user's first Amex *5367 compra-de-cartera (60 cuotas, ~$3.1M COP) was generating ~$94k COP phantom interest per cycle. Fix verified locally against the real account.
- Cleanup of any phantom row already written in prod is a separate manual step — user will archive via UI or run SQL after deploy (not part of this fix).

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (219 files, 2731 specs)
- [x] 2 new unit tests: inaugural-cycle skip (no prior rows) + normal second-pass when prior rows exist
- [x] 2 existing tests updated to seed prior interest history (they were implicitly relying on the absence of the guard)
- [ ] manual smoke: prod deploy + verify Amex *5367 no longer accrues phantom interest on next cycle run