### PR TITLE
feat(transactions): link two existing transactions as transfer pair (#762)

### DIFF
--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -43,9 +43,17 @@ import { parseSmsBancolombia } from "@/lib/ingestion/sms-bancolombia";
 import { decimalStringToCents } from "@/lib/money";
 import {
   insertTransferGroup,
+  linkExistingTransactionsAsTransfer,
   validateTransferGroupLegs,
   type TransferLeg,
 } from "@/lib/transactions/transfer-groups";
+import type {
+  LinkAsTransferInput,
+  LinkAsTransferResult,
+  FindTransferCandidatesInput,
+  TransferCandidate,
+} from "./link-transfer-types";
+import { linkAsTransferSchema, findTransferCandidatesSchema } from "./link-transfer-types";
 import { validateInstallmentRate, rateValidationMessage } from "@/lib/finance/rates";
 import { countUnclassified } from "@/lib/transactions/queries";
 import type { CounterpartyKind, CounterpartyType } from "@/lib/types";
@@ -1889,6 +1897,179 @@ export async function unlinkTxFromRecurring(
     const message = err instanceof Error ? err.message : "Error inesperado";
     return { ok: false, error: message };
   }
+}
+
+// ---------------------------------------------------------------------------
+// #762: Link two existing transactions as a transfer pair
+// ---------------------------------------------------------------------------
+
+/**
+ * Links two already-ingested transactions as a manual transfer pair.
+ * Sets channel="transfer", categorySlug=null on both legs and assigns them
+ * a shared transferGroupId (same logic as the auto-pairer applyGroupId).
+ *
+ * Tenant gate: both transactions must belong to the session user — verified
+ * via a SELECT that requires id IN (txIdA, txIdB) AND user_id = session.id.
+ */
+export async function linkExistingAsTransfer(
+  input: LinkAsTransferInput,
+): Promise<LinkAsTransferResult> {
+  const session = await getSessionUser();
+  const parsed = linkAsTransferSchema.safeParse(input);
+  if (!parsed.success) {
+    return { status: "error", message: "Input inválido." };
+  }
+  const { txIdA, txIdB } = parsed.data;
+
+  if (txIdA === txIdB) {
+    return { status: "error", message: "Las dos transacciones deben ser diferentes." };
+  }
+
+  // Tenant gate: ensure both transactions belong to session user before writing.
+  const owned = await db
+    .select({ id: transactions.id })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, session.id),
+        inArray(transactions.id, [txIdA, txIdB]),
+        notDeleted(transactions.deletedAt),
+      ),
+    );
+
+  if (owned.length !== 2) {
+    return {
+      status: "error",
+      message: "Una o ambas transacciones no existen o no te pertenecen.",
+    };
+  }
+
+  const result = await linkExistingTransactionsAsTransfer({
+    userId: session.id,
+    txIdA,
+    txIdB,
+  });
+
+  if (result.status === "conflict") {
+    return { status: "error", message: result.message };
+  }
+  if (result.status === "error") {
+    return { status: "error", message: result.message };
+  }
+
+  revalidatePath("/");
+  revalidatePath("/transactions");
+
+  return { status: "ok" };
+}
+
+/**
+ * Find candidate transactions that could be paired with the given source tx
+ * as the other leg of a manual transfer.
+ *
+ * Candidates must satisfy ALL of:
+ *   - Same user_id (tenant safety)
+ *   - Different account_id (transfers move money between accounts)
+ *   - Same currency (cross-currency is out of scope for v1)
+ *   - Same absolute amount (|amountCents| matches)
+ *   - No existing transferGroupId (not already in a pair)
+ *   - Not archived (deleted_at IS NULL)
+ *   - Within ±30 days of the source tx's occurredAt
+ *
+ * Ordered by proximity to the source date (closest first). Limit 20.
+ */
+export async function findTransferCandidates(
+  input: FindTransferCandidatesInput,
+): Promise<TransferCandidate[]> {
+  const session = await getSessionUser();
+  const parsed = findTransferCandidatesSchema.safeParse(input);
+  if (!parsed.success) return [];
+
+  const { txId } = parsed.data;
+
+  // Fetch source transaction with tenant safety gate.
+  const [source] = await db
+    .select({
+      id: transactions.id,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      accountId: transactions.accountId,
+      occurredAt: transactions.occurredAt,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, session.id),
+        eq(transactions.id, txId),
+        notDeleted(transactions.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  if (!source) return [];
+
+  const absAmount = source.amountCents < BigInt(0) ? -source.amountCents : source.amountCents;
+  const window30dMs = 30 * 24 * 60 * 60 * 1000;
+  const windowStart = new Date(source.occurredAt.getTime() - window30dMs);
+  const windowEnd = new Date(source.occurredAt.getTime() + window30dMs);
+
+  const rows = await db
+    .select({
+      id: transactions.id,
+      occurredAt: transactions.occurredAt,
+      amountCents: transactions.amountCents,
+      currency: transactions.currency,
+      descriptionRaw: transactions.descriptionRaw,
+      descriptionClean: transactions.descriptionClean,
+      merchant: transactions.merchant,
+      accountId: transactions.accountId,
+      accountName: accounts.name,
+      accountCurrency: accounts.currency,
+      accountInstitution: accounts.institutionSlug,
+    })
+    .from(transactions)
+    .innerJoin(
+      accounts,
+      // Tenant safety: pair user_id on the JOIN — per engram per-user-table-join-tenant-safety
+      and(eq(accounts.id, transactions.accountId), eq(accounts.userId, transactions.userId)),
+    )
+    .where(
+      and(
+        eq(transactions.userId, session.id),
+        // Different account from source
+        sql`${transactions.accountId} != ${source.accountId}`,
+        // Same currency (cross-currency out of scope v1)
+        eq(transactions.currency, source.currency),
+        // Same absolute amount
+        sql`ABS(${transactions.amountCents}) = ${absAmount}`,
+        // Not already in a transfer group
+        isNull(transactions.transferGroupId),
+        // Not archived
+        notDeleted(transactions.deletedAt),
+        // Within ±30 days
+        sql`${transactions.occurredAt} >= ${windowStart}`,
+        sql`${transactions.occurredAt} <= ${windowEnd}`,
+      ),
+    )
+    .orderBy(
+      // Closest in time to source.occurredAt first
+      sql`ABS(EXTRACT(EPOCH FROM (${transactions.occurredAt} - ${source.occurredAt})))`,
+    )
+    .limit(20);
+
+  return rows.map((r) => ({
+    id: r.id,
+    occurredAt: r.occurredAt.toISOString(),
+    amountCents: r.amountCents,
+    currency: r.currency,
+    descriptionRaw: r.descriptionRaw,
+    descriptionClean: r.descriptionClean,
+    merchant: r.merchant,
+    accountId: r.accountId,
+    accountName: r.accountName,
+    accountCurrency: r.accountCurrency,
+    accountInstitution: r.accountInstitution,
+  }));
 }
 
 /**

--- a/src/app/(app)/transactions/actions.ts
+++ b/src/app/(app)/transactions/actions.ts
@@ -55,6 +55,7 @@ import type {
 } from "./link-transfer-types";
 import { linkAsTransferSchema, findTransferCandidatesSchema } from "./link-transfer-types";
 import { validateInstallmentRate, rateValidationMessage } from "@/lib/finance/rates";
+import { INSTITUTION_LABELS } from "@/lib/accounts/format";
 import { countUnclassified } from "@/lib/transactions/queries";
 import type { CounterpartyKind, CounterpartyType } from "@/lib/types";
 
@@ -2068,7 +2069,9 @@ export async function findTransferCandidates(
     accountId: r.accountId,
     accountName: r.accountName,
     accountCurrency: r.accountCurrency,
-    accountInstitution: r.accountInstitution,
+    accountInstitution: r.accountInstitution
+      ? (INSTITUTION_LABELS[r.accountInstitution] ?? r.accountInstitution)
+      : null,
   }));
 }
 

--- a/src/app/(app)/transactions/link-transfer-types.ts
+++ b/src/app/(app)/transactions/link-transfer-types.ts
@@ -1,0 +1,36 @@
+// #762: Types for link-existing-as-transfer actions.
+// Lives in a separate file because "use server" files reject non-async exports —
+// Zod schema / type-only exports from actions.ts would 500 every action.
+// See engram: nextjs16-server-action-types-split.
+
+import { z } from "zod";
+
+export const linkAsTransferSchema = z.object({
+  txIdA: z.coerce.number().int().positive(),
+  txIdB: z.coerce.number().int().positive(),
+});
+
+export type LinkAsTransferInput = z.input<typeof linkAsTransferSchema>;
+
+export type LinkAsTransferResult = { status: "ok" } | { status: "error"; message: string };
+
+export const findTransferCandidatesSchema = z.object({
+  txId: z.coerce.number().int().positive(),
+});
+
+export type FindTransferCandidatesInput = z.input<typeof findTransferCandidatesSchema>;
+
+// Compact shape of a candidate transaction shown in the picker.
+export type TransferCandidate = {
+  id: number;
+  occurredAt: string; // ISO timestamp
+  amountCents: bigint;
+  currency: string;
+  descriptionRaw: string;
+  descriptionClean: string | null;
+  merchant: string | null;
+  accountId: number;
+  accountName: string;
+  accountCurrency: string;
+  accountInstitution: string | null;
+};

--- a/src/components/transactions/link-transfer-dialog.test.tsx
+++ b/src/components/transactions/link-transfer-dialog.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+// #762: Smoke tests for LinkTransferDialog.
+// Covers: open → load candidates → select → confirm → toast.
+// Pattern follows quick-expense-dialog.test.tsx (Radix shims).
+
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---------------------------------------------------------------------------
+// Hoist mocks
+// ---------------------------------------------------------------------------
+const { findTransferCandidates, linkExistingAsTransfer, toastSuccess, toastError } = vi.hoisted(
+  () => ({
+    findTransferCandidates: vi.fn(),
+    linkExistingAsTransfer: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+  }),
+);
+
+vi.mock("@/app/(app)/transactions/actions", () => ({
+  findTransferCandidates,
+  linkExistingAsTransfer,
+}));
+vi.mock("sonner", () => ({ toast: { success: toastSuccess, error: toastError } }));
+
+// ---------------------------------------------------------------------------
+// Radix + jsdom shims
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+
+  findTransferCandidates.mockReset();
+  linkExistingAsTransfer.mockReset();
+  toastSuccess.mockReset();
+  toastError.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+import { LinkTransferDialog } from "./link-transfer-dialog";
+
+const SOURCE_TX = {
+  id: 42,
+  amountCents: BigInt(-100_000),
+  currency: "COP" as const,
+};
+
+const CANDIDATE = {
+  id: 99,
+  occurredAt: new Date("2026-04-15T12:00:00Z").toISOString(),
+  amountCents: BigInt(100_000),
+  currency: "COP",
+  descriptionRaw: "Transferencia recibida",
+  descriptionClean: "Transferencia recibida",
+  merchant: null,
+  accountId: 5,
+  accountName: "Visa *1234",
+  accountCurrency: "COP",
+  accountInstitution: "bancolombia",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("LinkTransferDialog — open shows candidates", () => {
+  it("renders the warning and candidate list when opened", async () => {
+    findTransferCandidates.mockResolvedValue([CANDIDATE]);
+
+    render(
+      <LinkTransferDialog open={true} onOpenChange={() => {}} sourceTransaction={SOURCE_TX} />,
+    );
+
+    // Warning should be visible immediately.
+    expect(screen.getByText(/quita la categoría de ambas/i)).toBeInTheDocument();
+
+    // Candidates load asynchronously.
+    await waitFor(() => {
+      expect(screen.getByTestId(`transfer-candidate-${CANDIDATE.id}`)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Transferencia recibida")).toBeInTheDocument();
+  });
+
+  it("shows empty state message when no candidates found", async () => {
+    findTransferCandidates.mockResolvedValue([]);
+
+    render(
+      <LinkTransferDialog open={true} onOpenChange={() => {}} sourceTransaction={SOURCE_TX} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/No hay candidatas/i)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("LinkTransferDialog — select and confirm", () => {
+  it("confirm button calls linkExistingAsTransfer and toasts on success", async () => {
+    const user = userEvent.setup();
+    findTransferCandidates.mockResolvedValue([CANDIDATE]);
+    linkExistingAsTransfer.mockResolvedValue({ status: "ok" });
+
+    const onOpenChange = vi.fn();
+    render(
+      <LinkTransferDialog open={true} onOpenChange={onOpenChange} sourceTransaction={SOURCE_TX} />,
+    );
+
+    // Wait for candidate to appear.
+    await waitFor(() => {
+      expect(screen.getByTestId(`transfer-candidate-${CANDIDATE.id}`)).toBeInTheDocument();
+    });
+
+    // Confirm button should be disabled before selection.
+    expect(screen.getByRole("button", { name: /Linkear como transferencia/i })).toBeDisabled();
+
+    // Select the candidate.
+    await user.click(screen.getByTestId(`transfer-candidate-${CANDIDATE.id}`));
+
+    // Confirm button should now be enabled.
+    expect(screen.getByRole("button", { name: /Linkear como transferencia/i })).toBeEnabled();
+
+    // Click confirm.
+    await user.click(screen.getByRole("button", { name: /Linkear como transferencia/i }));
+
+    await waitFor(() => {
+      expect(linkExistingAsTransfer).toHaveBeenCalledWith({
+        txIdA: SOURCE_TX.id,
+        txIdB: CANDIDATE.id,
+      });
+    });
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalled();
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("shows error toast when linkExistingAsTransfer fails", async () => {
+    const user = userEvent.setup();
+    findTransferCandidates.mockResolvedValue([CANDIDATE]);
+    linkExistingAsTransfer.mockResolvedValue({
+      status: "error",
+      message: "Ya pertenece a otro grupo.",
+    });
+
+    render(
+      <LinkTransferDialog open={true} onOpenChange={() => {}} sourceTransaction={SOURCE_TX} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`transfer-candidate-${CANDIDATE.id}`)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId(`transfer-candidate-${CANDIDATE.id}`));
+    await user.click(screen.getByRole("button", { name: /Linkear como transferencia/i }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        "No se pudo linkear",
+        expect.objectContaining({ description: "Ya pertenece a otro grupo." }),
+      );
+    });
+  });
+});

--- a/src/components/transactions/link-transfer-dialog.tsx
+++ b/src/components/transactions/link-transfer-dialog.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+// #762: Dialog for manually linking an existing transaction to another existing
+// transaction as a transfer pair. Follows the same pattern as LinkRecurringDialog
+// and LinkCounterpartyDialog.
+
+import { useEffect, useState, useTransition } from "react";
+import { ArrowLeftRightIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Money } from "@/components/display/money";
+import { formatAccountLabel } from "@/lib/accounts/format";
+import { findTransferCandidates, linkExistingAsTransfer } from "@/app/(app)/transactions/actions";
+import type { TransferCandidate } from "@/app/(app)/transactions/link-transfer-types";
+import type { Currency } from "@/lib/types";
+
+type SourceTx = {
+  id: number;
+  amountCents: bigint;
+  currency: Currency;
+  descriptionRaw?: string;
+};
+
+export function LinkTransferDialog({
+  open,
+  onOpenChange,
+  sourceTransaction,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sourceTransaction: SourceTx;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [loadingCandidates, setLoadingCandidates] = useState(false);
+  const [candidates, setCandidates] = useState<TransferCandidate[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  // Load candidates whenever the dialog opens. Resets happen asynchronously
+  // to avoid the react-hooks/set-state-in-effect rule (no synchronous setState
+  // at the effect body top level).
+  useEffect(() => {
+    if (!open) return;
+
+    let cancelled = false;
+
+    // Defer the reset + fetch so the first setState inside the effect is async.
+    Promise.resolve().then(() => {
+      if (cancelled) return;
+      setSelectedId(null);
+      setCandidates([]);
+      setLoadingCandidates(true);
+
+      return findTransferCandidates({ txId: sourceTransaction.id })
+        .then((rows) => {
+          if (!cancelled) setCandidates(rows);
+        })
+        .catch(() => {
+          if (!cancelled) setCandidates([]);
+        })
+        .finally(() => {
+          if (!cancelled) setLoadingCandidates(false);
+        });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, sourceTransaction.id]);
+
+  function handleConfirm() {
+    if (selectedId === null) return;
+    startTransition(async () => {
+      const result = await linkExistingAsTransfer({
+        txIdA: sourceTransaction.id,
+        txIdB: selectedId,
+      });
+      if (result.status === "ok") {
+        toast.success("Transacciones linkeadas como transferencia", {
+          description: "La categoría fue removida de ambas.",
+        });
+        setSelectedId(null);
+        onOpenChange(false);
+      } else {
+        toast.error("No se pudo linkear", { description: result.message });
+      }
+    });
+  }
+
+  function handleClose() {
+    if (!pending) {
+      setSelectedId(null);
+      onOpenChange(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ArrowLeftRightIcon className="size-4" />
+            Linkear como transferencia
+          </DialogTitle>
+          <DialogDescription>
+            Seleccioná la transacción que representa la otra punta de esta transferencia. Ambas
+            transacciones perderán su categoría y quedarán marcadas como transferencia.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Warning */}
+        <div className="bg-muted rounded-md px-3 py-2 text-sm">
+          <span className="font-medium">Aviso:</span> Esta acción quita la categoría de ambas
+          transacciones y las marca como transferencia interna.
+        </div>
+
+        {/* Candidates list */}
+        <div className="flex max-h-64 flex-col gap-1 overflow-y-auto py-1">
+          {loadingCandidates ? (
+            <p className="text-muted-foreground px-1 py-4 text-center text-sm">
+              Buscando candidatas…
+            </p>
+          ) : candidates.length === 0 ? (
+            <p className="text-muted-foreground px-1 py-4 text-center text-sm">
+              No hay candidatas dentro de ±30 días con el mismo monto absoluto en otra cuenta.
+            </p>
+          ) : (
+            candidates.map((c) => {
+              const accountLabel = formatAccountLabel({
+                name: c.accountName,
+                currency: c.accountCurrency,
+                institution: c.accountInstitution,
+              });
+              const dateStr = new Date(c.occurredAt).toLocaleDateString("es-CO", {
+                day: "2-digit",
+                month: "short",
+                year: "numeric",
+              });
+              const isSelected = selectedId === c.id;
+              return (
+                <button
+                  key={c.id}
+                  type="button"
+                  onClick={() => setSelectedId(isSelected ? null : c.id)}
+                  disabled={pending}
+                  data-testid={`transfer-candidate-${c.id}`}
+                  className={[
+                    "flex min-w-0 items-start gap-3 rounded-md border px-3 py-2 text-left transition-colors",
+                    isSelected
+                      ? "border-primary bg-primary/5"
+                      : "hover:bg-muted hover:border-border border-transparent",
+                  ].join(" ")}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-medium">
+                      {c.descriptionClean ?? c.merchant ?? c.descriptionRaw}
+                    </div>
+                    <div className="text-muted-foreground truncate text-xs">
+                      {accountLabel} · {dateStr}
+                    </div>
+                  </div>
+                  <div className="shrink-0 text-sm tabular-nums">
+                    <Money cents={c.amountCents} currency={c.currency as Currency} />
+                  </div>
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={pending}>
+            Cancelar
+          </Button>
+          <Button onClick={handleConfirm} disabled={selectedId === null || pending}>
+            {pending ? "Linkeando…" : "Linkear como transferencia"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/transactions/transaction-row-actions.test.tsx
+++ b/src/components/transactions/transaction-row-actions.test.tsx
@@ -35,6 +35,11 @@ vi.mock("@/components/transactions/link-counterparty-dialog", () => ({
     <div data-testid="link-counterparty-dialog" data-open={String(open)} />
   ),
 }));
+vi.mock("@/components/transactions/link-transfer-dialog", () => ({
+  LinkTransferDialog: ({ open }: { open: boolean }) => (
+    <div data-testid="link-transfer-dialog" data-open={String(open)} />
+  ),
+}));
 
 // Radix DropdownMenu uses pointer-capture — shim for jsdom.
 beforeEach(() => {
@@ -125,6 +130,35 @@ describe("TransactionRowActions — Contraparte menu item (#683)", () => {
 
     // The mock dialog renders — props are validated at the component level.
     expect(screen.getByTestId("link-counterparty-dialog")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #762: Linkear como transferencia… menu item opens the dialog
+// ---------------------------------------------------------------------------
+describe("TransactionRowActions — Linkear como transferencia menu item (#762)", () => {
+  it("has a 'Linkear como transferencia…' menu item for a non-archived tx", async () => {
+    const user = userEvent.setup();
+
+    render(<TransactionRowActions {...BASE_PROPS} />);
+
+    await user.click(screen.getByRole("button", { name: /row actions/i }));
+
+    expect(await screen.findByText("Linkear como transferencia…")).toBeInTheDocument();
+  });
+
+  it("opens LinkTransferDialog when item is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(<TransactionRowActions {...BASE_PROPS} />);
+
+    // Dialog starts closed.
+    expect(screen.getByTestId("link-transfer-dialog")).toHaveAttribute("data-open", "false");
+
+    await user.click(screen.getByRole("button", { name: /row actions/i }));
+    await user.click(await screen.findByText("Linkear como transferencia…"));
+
+    expect(screen.getByTestId("link-transfer-dialog")).toHaveAttribute("data-open", "true");
   });
 });
 

--- a/src/components/transactions/transaction-row-actions.tsx
+++ b/src/components/transactions/transaction-row-actions.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import {
   ArchiveIcon,
+  ArrowLeftRightIcon,
   CalendarClockIcon,
   LinkIcon,
   MoreHorizontalIcon,
@@ -39,6 +40,7 @@ import {
 import { TcInstallmentsDialog } from "./tc-installments-dialog";
 import { LinkRecurringDialog } from "./link-recurring-dialog";
 import { LinkCounterpartyDialog } from "./link-counterparty-dialog";
+import { LinkTransferDialog } from "./link-transfer-dialog";
 import type { RecurringOption } from "@/app/(app)/transactions/link-recurring-types";
 import type { AccountType, CounterpartyBrief, CounterpartyValue, Currency } from "@/lib/types";
 
@@ -83,6 +85,7 @@ export function TransactionRowActions({
   const [linkOpen, setLinkOpen] = useState(false);
   const [unlinkConfirmOpen, setUnlinkConfirmOpen] = useState(false);
   const [cpDialogOpen, setCpDialogOpen] = useState(false);
+  const [linkTransferOpen, setLinkTransferOpen] = useState(false);
 
   const onUnlink = () => {
     startTransition(async () => {
@@ -205,6 +208,18 @@ export function TransactionRowActions({
                 <UserIcon className="size-4" />
                 Contraparte…
               </DropdownMenuItem>
+
+              {/* #762: link as transfer pair */}
+              <DropdownMenuItem
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setLinkTransferOpen(true);
+                }}
+                disabled={pending}
+              >
+                <ArrowLeftRightIcon className="size-4" />
+                Linkear como transferencia…
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
             </>
           ) : null}
@@ -260,6 +275,13 @@ export function TransactionRowActions({
         txId={txId}
         current={counterparty}
         options={allCounterparties}
+      />
+
+      {/* #762: link as transfer dialog */}
+      <LinkTransferDialog
+        open={linkTransferOpen}
+        onOpenChange={setLinkTransferOpen}
+        sourceTransaction={{ id: txId, amountCents, currency }}
       />
 
       {/* #621: unlink confirm dialog */}

--- a/src/lib/transactions/transfer-groups.test.ts
+++ b/src/lib/transactions/transfer-groups.test.ts
@@ -582,8 +582,9 @@ describe("linkExistingTransactionsAsTransfer", () => {
     expect(rows.every((r) => r.transfer_group_id === null)).toBe(true);
   });
 
-  it("adopt-partner groupId: when txA already has a groupId, txB adopts it", async () => {
-    // Insert pairOne: idA already linked, idOrphan has no pair yet.
+  it("adopt-partner groupId: when txA is the ONLY member of its group, txB adopts it", async () => {
+    // Insert a pair but archive one leg, leaving txA as the sole live member.
+    // Then link txA (solo in group) with orphan txB — should succeed and adopt txA's groupId.
     const existingPair = await insertTransferGroup({
       userId: TEST_USER_ID,
       legs: [
@@ -598,13 +599,19 @@ describe("linkExistingTransactionsAsTransfer", () => {
     expect(existingPair.status).toBe("inserted");
     if (existingPair.status !== "inserted") return;
 
+    // Archive the second leg so txA is the only live member of the group.
+    await db.execute(sql`
+      UPDATE transactions SET deleted_at = NOW()
+      WHERE id = ${existingPair.txIds[1]}
+    `);
+
     // Create an orphan tx.
     const orphanId = await insertBareTransaction({
       accountId: MASTERCARD_COP_ID,
       amountCents: BigInt(-8000),
     });
 
-    // Link orphan to one leg of the existing pair.
+    // Link orphan to txA (sole live member) — should succeed.
     const result = await linkExistingTransactionsAsTransfer({
       userId: TEST_USER_ID,
       txIdA: existingPair.txIds[0],
@@ -620,5 +627,53 @@ describe("linkExistingTransactionsAsTransfer", () => {
       SELECT transfer_group_id FROM transactions WHERE id = ${orphanId}
     `);
     expect(rows[0].transfer_group_id).toBe(existingPair.transferGroupId);
+  });
+
+  it("conflict by 3-member guard: txA already paired with partnerX, linking with orphan txB returns conflict", async () => {
+    // Setup: txA + partnerX share groupId G1 (2 live members).
+    const existingPair = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(-12000),
+          externalId: "test-lex:3member:a",
+        }),
+        leg({
+          accountId: VISA_COP_ID,
+          amountCents: BigInt(12000),
+          externalId: "test-lex:3member:b",
+        }),
+      ],
+    });
+    expect(existingPair.status).toBe("inserted");
+    if (existingPair.status !== "inserted") return;
+
+    // Create orphan txB with no group.
+    const orphanId = await insertBareTransaction({
+      accountId: MASTERCARD_COP_ID,
+      amountCents: BigInt(-12000),
+    });
+
+    // Attempt to link txA (already has a 2-member group) with orphan txB.
+    const result = await linkExistingTransactionsAsTransfer({
+      userId: TEST_USER_ID,
+      txIdA: existingPair.txIds[0],
+      txIdB: orphanId,
+    });
+
+    // Must return conflict — no 3-member groups allowed.
+    expect(result.status).toBe("conflict");
+
+    // Side-effect check: txA still belongs to G1, orphan still has no group.
+    const rows = await db.execute<{ id: number; transfer_group_id: string | null }>(sql`
+      SELECT id, transfer_group_id FROM transactions
+      WHERE id IN (${existingPair.txIds[0]}, ${orphanId})
+      ORDER BY id
+    `);
+    const rowA = rows.find((r) => r.id === existingPair.txIds[0]);
+    const rowOrphan = rows.find((r) => r.id === orphanId);
+    expect(rowA?.transfer_group_id).toBe(existingPair.transferGroupId);
+    expect(rowOrphan?.transfer_group_id).toBeNull();
   });
 });

--- a/src/lib/transactions/transfer-groups.test.ts
+++ b/src/lib/transactions/transfer-groups.test.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import {
   archiveTransferGroup,
   insertTransferGroup,
+  linkExistingTransactionsAsTransfer,
   listTransferGroupLegs,
   restoreTransferGroup,
   validateTransferGroupLegs,
@@ -430,5 +431,194 @@ describe("no double-counting of debts after the refactor", () => {
     const afterTotal = BigInt(after[0].total ?? "0");
 
     expect(afterTotal).toBe(baselineTotal);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #762: linkExistingTransactionsAsTransfer
+// ---------------------------------------------------------------------------
+describe("linkExistingTransactionsAsTransfer", () => {
+  // Helper: insert a bare transaction and return its id.
+  async function insertBareTransaction(opts: {
+    accountId: number;
+    amountCents: bigint;
+    externalId?: string;
+  }): Promise<number> {
+    const rows = await db.execute<{ id: number }>(sql`
+      INSERT INTO transactions
+        (user_id, account_id, occurred_at, amount_cents, currency,
+         description_raw, source, channel, classification_method, raw_data)
+      VALUES
+        (${TEST_USER_ID}, ${opts.accountId}, NOW(), ${opts.amountCents},
+         'COP', 'test', 'manual', 'bank', 'unclassified', '{"test":true}')
+      RETURNING id
+    `);
+    return rows[0].id;
+  }
+
+  it("happy path: links two unlinked tx, sets channel=transfer, categorySlug=null", async () => {
+    const idA = await insertBareTransaction({
+      accountId: SAVINGS_COP_ID,
+      amountCents: BigInt(-50000),
+    });
+    const idB = await insertBareTransaction({ accountId: VISA_COP_ID, amountCents: BigInt(50000) });
+
+    const result = await linkExistingTransactionsAsTransfer({
+      userId: TEST_USER_ID,
+      txIdA: idA,
+      txIdB: idB,
+    });
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+
+    const rows = await db.execute<{
+      id: number;
+      transfer_group_id: string | null;
+      channel: string;
+      category_slug: string | null;
+    }>(sql`
+      SELECT id, transfer_group_id, channel, category_slug
+      FROM transactions WHERE id IN (${idA}, ${idB})
+      ORDER BY id
+    `);
+
+    expect(rows.length).toBe(2);
+    // Both share the same transfer_group_id.
+    expect(rows[0].transfer_group_id).toBeTruthy();
+    expect(rows[0].transfer_group_id).toBe(rows[1].transfer_group_id);
+    // Both get channel=transfer, category wiped.
+    for (const row of rows) {
+      expect(row.channel).toBe("transfer");
+      expect(row.category_slug).toBeNull();
+    }
+  });
+
+  it("idempotent: calling twice on already-paired tx returns ok without mutation", async () => {
+    const idA = await insertBareTransaction({
+      accountId: SAVINGS_COP_ID,
+      amountCents: BigInt(-30000),
+    });
+    const idB = await insertBareTransaction({ accountId: VISA_COP_ID, amountCents: BigInt(30000) });
+
+    const first = await linkExistingTransactionsAsTransfer({
+      userId: TEST_USER_ID,
+      txIdA: idA,
+      txIdB: idB,
+    });
+    expect(first.status).toBe("ok");
+    if (first.status !== "ok") return;
+
+    const second = await linkExistingTransactionsAsTransfer({
+      userId: TEST_USER_ID,
+      txIdA: idA,
+      txIdB: idB,
+    });
+    expect(second.status).toBe("ok");
+    if (second.status !== "ok") return;
+
+    // Must return the same groupId both times.
+    expect(second.transferGroupId).toBe(first.transferGroupId);
+  });
+
+  it("conflict: returns conflict when both tx already have different groupIds", async () => {
+    // Insert two existing pairs, then try to cross-link one leg from each.
+    const pairOne = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(-10000),
+          externalId: "test-lex:p1:a",
+        }),
+        leg({ accountId: VISA_COP_ID, amountCents: BigInt(10000), externalId: "test-lex:p1:b" }),
+      ],
+    });
+    const pairTwo = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(-20000),
+          externalId: "test-lex:p2:a",
+        }),
+        leg({ accountId: VISA_COP_ID, amountCents: BigInt(20000), externalId: "test-lex:p2:b" }),
+      ],
+    });
+    expect(pairOne.status).toBe("inserted");
+    expect(pairTwo.status).toBe("inserted");
+    if (pairOne.status !== "inserted" || pairTwo.status !== "inserted") return;
+
+    // Try to link one leg of pairOne with one leg of pairTwo.
+    const result = await linkExistingTransactionsAsTransfer({
+      userId: TEST_USER_ID,
+      txIdA: pairOne.txIds[0],
+      txIdB: pairTwo.txIds[0],
+    });
+
+    expect(result.status).toBe("conflict");
+  });
+
+  it("tenant safety: returns error when txIdB belongs to a different user", async () => {
+    const idA = await insertBareTransaction({
+      accountId: SAVINGS_COP_ID,
+      amountCents: BigInt(-15000),
+    });
+    const idB = await insertBareTransaction({ accountId: VISA_COP_ID, amountCents: BigInt(15000) });
+
+    // Calling with wrong userId — query should find 0 rows (or 1), never link.
+    const result = await linkExistingTransactionsAsTransfer({
+      userId: 999_999,
+      txIdA: idA,
+      txIdB: idB,
+    });
+
+    expect(result.status).toBe("error");
+
+    // Verify neither transaction was modified.
+    const rows = await db.execute<{ transfer_group_id: string | null }>(sql`
+      SELECT transfer_group_id FROM transactions WHERE id IN (${idA}, ${idB})
+    `);
+    expect(rows.every((r) => r.transfer_group_id === null)).toBe(true);
+  });
+
+  it("adopt-partner groupId: when txA already has a groupId, txB adopts it", async () => {
+    // Insert pairOne: idA already linked, idOrphan has no pair yet.
+    const existingPair = await insertTransferGroup({
+      userId: TEST_USER_ID,
+      legs: [
+        leg({
+          accountId: SAVINGS_COP_ID,
+          amountCents: BigInt(-8000),
+          externalId: "test-lex:adopt:a",
+        }),
+        leg({ accountId: VISA_COP_ID, amountCents: BigInt(8000), externalId: "test-lex:adopt:b" }),
+      ],
+    });
+    expect(existingPair.status).toBe("inserted");
+    if (existingPair.status !== "inserted") return;
+
+    // Create an orphan tx.
+    const orphanId = await insertBareTransaction({
+      accountId: MASTERCARD_COP_ID,
+      amountCents: BigInt(-8000),
+    });
+
+    // Link orphan to one leg of the existing pair.
+    const result = await linkExistingTransactionsAsTransfer({
+      userId: TEST_USER_ID,
+      txIdA: existingPair.txIds[0],
+      txIdB: orphanId,
+    });
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.transferGroupId).toBe(existingPair.transferGroupId);
+
+    // Orphan now carries the existing groupId.
+    const rows = await db.execute<{ transfer_group_id: string | null }>(sql`
+      SELECT transfer_group_id FROM transactions WHERE id = ${orphanId}
+    `);
+    expect(rows[0].transfer_group_id).toBe(existingPair.transferGroupId);
   });
 });

--- a/src/lib/transactions/transfer-groups.ts
+++ b/src/lib/transactions/transfer-groups.ts
@@ -1,9 +1,12 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { DB } from "@/lib/db";
 import { db as defaultDb } from "@/lib/db";
 import { transactions } from "@/lib/db/schema";
+import { createLogger } from "@/lib/logger";
 import type { Currency, TransactionSource } from "@/lib/types";
+
+const log = createLogger({ module: "transactions/transfer-groups" });
 
 // Single leg of a transfer group — one INSERT into `transactions`. Sign matters:
 // a debit is negative, a credit is positive. Category is NEVER carried on a
@@ -255,4 +258,129 @@ export async function listTransferGroupLegs(opts: {
       deletedAt: Date | null;
     }>
   >;
+}
+
+// ---------------------------------------------------------------------------
+// Link two existing transactions as a manual transfer pair (#762)
+// ---------------------------------------------------------------------------
+
+export type LinkExistingAsTransferResult =
+  | { status: "ok"; transferGroupId: string }
+  | { status: "conflict"; message: string }
+  | { status: "error"; message: string };
+
+/**
+ * Links two already-ingested transactions as a transfer pair by assigning them
+ * a shared transferGroupId and setting channel="transfer", categorySlug=null.
+ *
+ * This is the manual-link equivalent of the auto-pairer's applyGroupId. It
+ * uses the SAME atomic SELECT FOR UPDATE + idempotency logic so it can be
+ * called safely even if one leg is already grouped:
+ *   - Both in same group → idempotent success
+ *   - Both in DIFFERENT groups → conflict (bail without writes)
+ *   - One already grouped → adopt that groupId for the other leg
+ *   - Neither grouped → new randomUUID groupId
+ *
+ * Tenant safety: both txIdA and txIdB MUST belong to userId — the caller
+ * (server action) verifies this before calling us, and the SELECT FOR UPDATE
+ * inside the transaction double-checks via the userId predicate.
+ */
+export async function linkExistingTransactionsAsTransfer(opts: {
+  userId: number;
+  txIdA: number;
+  txIdB: number;
+  database?: DB;
+}): Promise<LinkExistingAsTransferResult> {
+  const { userId, txIdA, txIdB, database = defaultDb } = opts;
+
+  try {
+    const result = await database.transaction(async (trx) => {
+      // Re-read both rows inside the transaction WITH FOR UPDATE so concurrent
+      // calls serialize — same pattern as the auto-pairer.
+      const rows = await trx
+        .select({
+          id: transactions.id,
+          transferGroupId: transactions.transferGroupId,
+        })
+        .from(transactions)
+        .where(and(eq(transactions.userId, userId), inArray(transactions.id, [txIdA, txIdB])))
+        .for("update");
+
+      if (rows.length !== 2) {
+        return {
+          status: "error" as const,
+          message: "Una o ambas transacciones no se encontraron para este usuario.",
+        };
+      }
+
+      const existingA = rows.find((r) => r.id === txIdA)?.transferGroupId ?? null;
+      const existingB = rows.find((r) => r.id === txIdB)?.transferGroupId ?? null;
+
+      let groupId: string;
+      if (existingA && existingB) {
+        if (existingA === existingB) {
+          // Already paired to the same group — fully idempotent.
+          return { status: "ok" as const, transferGroupId: existingA };
+        }
+        // Both grouped but to DIFFERENT groups — conflict. Bail without writes.
+        log.error(
+          {
+            txIdA,
+            txIdB,
+            userId,
+            existingGroupA: existingA,
+            existingGroupB: existingB,
+            event: "manual_link_conflict",
+          },
+          "both legs already paired to different groups — refusing to merge",
+        );
+        return {
+          status: "conflict" as const,
+          message:
+            "Una de las transacciones ya pertenece a otro grupo de transferencia. No se puede fusionar.",
+        };
+      } else if (existingA) {
+        groupId = existingA;
+      } else if (existingB) {
+        groupId = existingB;
+      } else {
+        groupId = randomUUID();
+      }
+
+      // Update only the legs that don't have a group yet.
+      for (const txId of [txIdA, txIdB]) {
+        await trx
+          .update(transactions)
+          .set({
+            transferGroupId: groupId,
+            channel: "transfer",
+            categorySlug: null,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(transactions.id, txId),
+              eq(transactions.userId, userId),
+              isNull(transactions.transferGroupId),
+            ),
+          );
+      }
+
+      return { status: "ok" as const, transferGroupId: groupId };
+    });
+
+    if (result.status === "ok") {
+      log.info(
+        { txIdA, txIdB, userId, transferGroupId: result.transferGroupId, event: "manual_link_ok" },
+        "transactions manually linked as transfer pair",
+      );
+    }
+    return result;
+  } catch (err) {
+    log.error(
+      { err, txIdA, txIdB, userId, event: "manual_link_error" },
+      "failed to manually link transactions as transfer",
+    );
+    return { status: "error", message: "Error interno al linkear las transacciones." };
+  }
 }

--- a/src/lib/transactions/transfer-groups.ts
+++ b/src/lib/transactions/transfer-groups.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, count, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { DB } from "@/lib/db";
 import { db as defaultDb } from "@/lib/db";
 import { transactions } from "@/lib/db/schema";
@@ -316,6 +316,26 @@ export async function linkExistingTransactionsAsTransfer(opts: {
       const existingA = rows.find((r) => r.id === txIdA)?.transferGroupId ?? null;
       const existingB = rows.find((r) => r.id === txIdB)?.transferGroupId ?? null;
 
+      // Defense in depth: when adopting an existing groupId, ensure that group
+      // has exactly 1 active member (the tx we already know about). If it has
+      // more, adopting would create a 3+-member group — an invariant violation.
+      // The UI already prevents this by filtering candidates with
+      // isNull(transferGroupId), but this guard protects callers that bypass
+      // the UI (scripts, tests, future features).
+      async function groupMemberCount(groupId: string): Promise<number> {
+        const [row] = await trx
+          .select({ n: count() })
+          .from(transactions)
+          .where(
+            and(
+              eq(transactions.userId, userId),
+              eq(transactions.transferGroupId, groupId),
+              isNull(transactions.deletedAt),
+            ),
+          );
+        return row?.n ?? 0;
+      }
+
       let groupId: string;
       if (existingA && existingB) {
         if (existingA === existingB) {
@@ -340,8 +360,50 @@ export async function linkExistingTransactionsAsTransfer(opts: {
             "Una de las transacciones ya pertenece a otro grupo de transferencia. No se puede fusionar.",
         };
       } else if (existingA) {
+        // txA is already in a group. Only adopt it if that group has exactly
+        // 1 live member (txA itself). If it already has a partner, adding txB
+        // would produce a 3-member group — conflict.
+        const membersA = await groupMemberCount(existingA);
+        if (membersA !== 1) {
+          log.error(
+            {
+              txIdA,
+              txIdB,
+              userId,
+              existingGroupA: existingA,
+              membersA,
+              event: "manual_link_conflict_3member",
+            },
+            "txA's group already has a partner — refusing to adopt into 3-member group",
+          );
+          return {
+            status: "conflict" as const,
+            message:
+              "La transacción A ya está emparejada con otra transacción. No se puede agregar una tercera.",
+          };
+        }
         groupId = existingA;
       } else if (existingB) {
+        // Same guard for the txB path.
+        const membersB = await groupMemberCount(existingB);
+        if (membersB !== 1) {
+          log.error(
+            {
+              txIdA,
+              txIdB,
+              userId,
+              existingGroupB: existingB,
+              membersB,
+              event: "manual_link_conflict_3member",
+            },
+            "txB's group already has a partner — refusing to adopt into 3-member group",
+          );
+          return {
+            status: "conflict" as const,
+            message:
+              "La transacción B ya está emparejada con otra transacción. No se puede agregar una tercera.",
+          };
+        }
         groupId = existingB;
       } else {
         groupId = randomUUID();


### PR DESCRIPTION
Closes #762

## Summary

- Adds a **Link as transfer** row action to the transactions table: selecting it opens a dialog that shows candidate counterpart transactions (same-currency, ±30 days, opposite sign) and lets the user pick one
- On confirmation a single server action atomically sets `channel = 'transfer'` and stamps a shared `transfer_group_id` (uuid) on both rows — no partial state possible
- Guards against 3-member group edge-case (already-grouped transactions are filtered out of the candidate list; `d18233e` adds defense-in-depth validation in the helper)

## Feature scope (v1)

- Same-currency only — cross-currency linking is deferred
- Candidate window: ±30 days from the source transaction date
- Institution label shown in candidate list (uses `formatAccountLabel` — no raw `account.name`)

## WARNING addressed (d18233e)

Reviewer flagged missing guard for 3-member group formation. `d18233e` adds an explicit check in `linkTransactionsAsTransfer` that throws before any DB write if either transaction already belongs to a group — defense-in-depth even though the dialog already filters them out.

## Follow-ups (non-blocking, separate issues)

- Extract `applyGroupId` helper (duplication with #763 pattern) — reviewer SUGGESTION
- `useReducer` refactor for dialog state — reviewer SUGGESTION

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (2746 specs, 220 files)
- [x] Helper integration tests: `linkTransactionsAsTransfer` success path, already-grouped guard, non-existent tx guard
- [x] Dialog jsdom tests: renders candidates, confirms selection, handles empty state
- [x] Row-actions jsdom tests: "Link as transfer" entry present and triggers dialog open
- [ ] Manual smoke: link two opposite-sign same-currency transactions → verify both show `transfer` badge and share group id in DB