### PR TITLE
fix(finance): remove double-charge of deferred interest on graceMonth mes-2 (#777)

### DIFF
--- a/src/lib/finance/installment-schedule.test.ts
+++ b/src/lib/finance/installment-schedule.test.ts
@@ -261,8 +261,7 @@ describe("installmentSchedule — regression #777 (OEM SAS, tx 1019)", () => {
     // Analytically: periodInterestCents(350_000_000, 19110) = 6_688_500 cents exactly.
     // Tolerance ±5 cents covers any platform-level bigint rounding edge.
     const expected = BigInt(6_688_500);
-    expect(m2.interestCents - expected <= BigInt(5)).toBe(true);
-    expect(expected - m2.interestCents <= BigInt(5)).toBe(true);
+    expect(absDiff(m2.interestCents, expected)).toBeLessThanOrEqual(BigInt(5));
   });
 
   it("Σ(capitalCents) === amountCents (no residue for 36 even divisor)", () => {

--- a/src/lib/finance/installment-schedule.test.ts
+++ b/src/lib/finance/installment-schedule.test.ts
@@ -160,11 +160,12 @@ describe("installmentSchedule — F3 (compra de cartera 29M @ 1.39% EM × 60, gr
     expect(m1.cuotaCents).toBe(m1.capitalCents);
   });
 
-  it("month 2 under grace absorbs the deferred month-1 interest", () => {
+  it("month 2 under grace pays single-rate own interest only — no deferral (#777)", () => {
+    // Validated against real abr-2026 extractos: Bancolombia does NOT double-
+    // charge mes-2. Month 2 gets exactly one period's interest on the balance
+    // entering that month; deferredInterestCents is permanently 0.
     const m2 = result.rows[1];
-    // deferred = month-1 interest on the full amount
-    expect(m2.deferredInterestCents).toBe(periodInterestCents(input.amountCents, 13900));
-    // own interest computed on balance-entering-month-2 = amount - capital_m1
+    expect(m2.deferredInterestCents).toBe(BigInt(0));
     const balanceM2Start = input.amountCents - result.rows[0].capitalCents;
     expect(m2.interestCents).toBe(periodInterestCents(balanceM2Start, 13900));
   });
@@ -192,9 +193,11 @@ describe("installmentSchedule — F3 (compra de cartera 29M @ 1.39% EM × 60, gr
     // normal month), month 60 (residue absorbed).
     const expectedPesos: Record<number, { capital: number; interest: number; cuota: number }> = {
       1: { capital: 483_333, interest: 0, cuota: 483_333 },
-      // Month 2: markdown lumps `interest + deferred = 799_482` into one
-      // column; we split them apart, so we check the sum instead.
-      2: { capital: 483_333, interest: 799_482, cuota: 1_282_815 },
+      // Month 2 (#777 fix): single-rate own interest only on balance after month-1
+      // capital. balance = 2_900_000_000 - 48_333_300 = 2_851_666_700 cents;
+      // periodInterestCents(2_851_666_700, 13900) = 39_638_167 cents ≈ 396_382 pesos.
+      // Old value was 799_482 (doubled — deferred + own); that was wrong.
+      2: { capital: 483_333, interest: 396_382, cuota: 879_715 },
       3: { capital: 483_333, interest: 389_663, cuota: 872_996 },
       60: { capital: 483_353, interest: 6_719, cuota: 490_072 },
     };
@@ -225,6 +228,46 @@ describe("installmentSchedule — F3 (compra de cartera 29M @ 1.39% EM × 60, gr
   it("paid / pending split reflects the today anchor", () => {
     expect(result.paidCount).toBe(0);
     expect(result.pendingCount).toBe(60);
+  });
+});
+
+describe("installmentSchedule — regression #777 (OEM SAS, tx 1019)", () => {
+  // Real production tx: OEM SAS 3,600,000 pesos / 36 cuotas / 1.9110% EM / graceMonth.
+  // This purchase had n_paid=1 (mes 2) and was over-charged by ~2× before #777.
+  // Computed analytically:
+  //   capitalPerPeriod = floor(360_000_000 / 36 / 100) * 100 = 10_000_000 cents (exact, no residue)
+  //   balance after month 1 = 360_000_000 - 10_000_000 = 350_000_000 cents
+  //   month-2 interest = periodInterestCents(350_000_000, 19110)
+  //                    = roundHalfUp(350_000_000 × 19110, 1_000_000)
+  //                    = roundHalfUp(6_688_500_000_000, 1_000_000) = 6_688_500 cents
+  const input = {
+    amountCents: BigInt(360_000_000), // 3_600_000 pesos in cents
+    rateEmX10k: 19110, // 1.9110% EM
+    installments: 36,
+    graceMonth: true,
+    purchaseDate: new Date("2026-01-15"), // arbitrary; paidCount drives selection
+    today: new Date("2026-03-15"), // 2 months later → paidCount=2
+  };
+  const result = installmentSchedule(input);
+
+  it("month 1: interestCents=0 and deferredInterestCents=0 (grace)", () => {
+    expect(result.rows[0].interestCents).toBe(BigInt(0));
+    expect(result.rows[0].deferredInterestCents).toBe(BigInt(0));
+  });
+
+  it("month 2: single-rate interest ≈ 6_688_500 cents and deferredInterestCents=0", () => {
+    const m2 = result.rows[1];
+    expect(m2.deferredInterestCents).toBe(BigInt(0));
+    // Analytically: periodInterestCents(350_000_000, 19110) = 6_688_500 cents exactly.
+    // Tolerance ±5 cents covers any platform-level bigint rounding edge.
+    const expected = BigInt(6_688_500);
+    expect(m2.interestCents - expected <= BigInt(5)).toBe(true);
+    expect(expected - m2.interestCents <= BigInt(5)).toBe(true);
+  });
+
+  it("Σ(capitalCents) === amountCents (no residue for 36 even divisor)", () => {
+    const total = result.rows.reduce((a, r) => a + r.capitalCents, BigInt(0));
+    expect(total).toBe(input.amountCents);
   });
 });
 

--- a/src/lib/finance/installment-schedule.ts
+++ b/src/lib/finance/installment-schedule.ts
@@ -5,9 +5,11 @@
 // Rules, per parent #345 + scoped validations against real Bancolombia
 // extracts (ver memoria `tc-installments-interest-model`):
 //
-//   - regla 4: when `graceMonth=true`, month 1 pays ONLY capital (interest
-//     is deferred). Month 2 pays its own interest PLUS the deferred month-1
-//     interest. "Francés puro" does NOT apply here.
+//   - regla 4 (validated against real abr-2026 statements, #777): when
+//     `graceMonth=true`, month 1 pays ONLY capital — no interest at all.
+//     Month 2+ each pay their own single-rate interest on the current
+//     outstanding balance. The earlier "defer-to-month-2" interpretation
+//     caused a 2× overcharge; extractos confirmed NO doubling occurs.
 //   - regla 5: capital per period is `amountCents / N`, fixed, with the
 //     final period absorbing the rounding residue. Interest is a separate
 //     line per period, never bundled into capital.
@@ -37,7 +39,7 @@ export type InstallmentScheduleRow = {
   month: number; // 1..N
   capitalCents: bigint;
   interestCents: bigint; // 0 for month 1 when graceMonth=true
-  deferredInterestCents: bigint; // 0 except for month 2 when graceMonth=true
+  deferredInterestCents: bigint; // always 0; kept for schema/consumer compat (#777)
   cuotaCents: bigint; // capital + interest + deferred
   balanceAfterCents: bigint; // never negative, hits 0 at month N
 };
@@ -104,16 +106,10 @@ export function installmentSchedule(input: InstallmentScheduleInput): Installmen
     let interestThis: bigint;
     let deferredThis: bigint;
     if (graceMonth && month === 1) {
-      // Month 1: interest is computed but deferred to month 2.
+      // Month 1: no interest. Validated against extractos abr-2026 — month-1
+      // deferral does NOT result in a doubled mes-2 charge (#777).
       interestThis = BigInt(0);
       deferredThis = BigInt(0);
-    } else if (graceMonth && month === 2) {
-      // Month 2: own interest + the deferred month-1 interest (based on the
-      // original amount, since month 1 paid no capital either — the balance
-      // entering month 2 is `amountCents - capital_month_1`).
-      const deferredBase = amountCents; // month-1 starts with full amount
-      deferredThis = periodInterestCents(deferredBase, rateEmX10k);
-      interestThis = periodInterestCents(balance, rateEmX10k);
     } else {
       interestThis = periodInterestCents(balance, rateEmX10k);
       deferredThis = BigInt(0);

--- a/src/lib/finance/installment-schedule.ts
+++ b/src/lib/finance/installment-schedule.ts
@@ -30,7 +30,7 @@ export type InstallmentScheduleInput = {
   amountCents: bigint; // original purchase amount (positive magnitude)
   rateEmX10k: number; // EM rate stored as percent × 10000 (0 = 0%, 19110 = 1.9110% EM)
   installments: number; // total cuotas, N >= 1
-  graceMonth: boolean; // true = month-1 interest deferred to month 2
+  graceMonth: boolean; // true = mes 1 sin interés (gracia); mes 2+ pagan single-rate own interest
   purchaseDate: Date; // anchor for month counting
   today: Date; // drives paid vs pending split
 };


### PR DESCRIPTION
Closes #777

## Summary

- In `installment-schedule.ts` mes-2 of a grace-month purchase, `deferredInterestCents` was computed on the original purchase amount and then summed with `interestCents` (rate × outstanding) in the job — producing ~2× the correct interest charge for every `n_paid = 1` row.
- Fix: removed the `deferredInterestCents` accumulation for mes-2; grace month means "mes 1 sin cobro", not "defer to mes-2 with double charge". `deferredInterestCents` is left as 0 (schema unchanged).
- Regression test added for tx 1019 (OEM SAS, $3.6 M / 36 cuotas, n_paid=1, rate 1.911% E.M.) asserting interest ≈ $66 885, not $135 681.

## Before / After (ratio evidence from apr-2026 breakdown)

| purchase_tx | n_paid | outstanding_before | our_interest (before) | expected (single rate) | ratio before | ratio after |
|------------:|-------:|-------------------:|----------------------:|-----------------------:|:------------:|:-----------:|
| 1019        | 1      | $3 500 000        | $135 681             | $66 885               | **2.03**     | 1.00        |
| 1739        | 1      | $4 031 198        | $155 378             | $77 036               | **2.02**     | 1.00        |
| 1726        | 5      | $374 645          | $7 020               | $7 020                | 1.00         | 1.00        |
| 1224        | 2      | $66 062           | $1 248               | $1 248                | 1.00         | 1.00        |

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test src/lib/finance/installment-schedule.test.ts src/lib/finance/intereses-causados-job.test.ts` — 70 specs pass
- [ ] manual smoke: re-run intereses-causados job against a prod copy and verify tx 1019 interest ≈ $66 885