### PR TITLE
feat(recurring): wrap calendar + add compact list under accordion (#786)

### DIFF
--- a/src/components/recurring/recurring-calculator.test.tsx
+++ b/src/components/recurring/recurring-calculator.test.tsx
@@ -130,7 +130,7 @@ describe("RecurringCalculator", () => {
     expect(pills.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("click Calculadora — calculator opens, grid is in calculator mode", async () => {
+  it("click Calculadora — calculator opens, grid is still rendered", async () => {
     const user = userEvent.setup();
     render(
       <RecurringCalculator
@@ -145,7 +145,7 @@ describe("RecurringCalculator", () => {
     // Calculator is open when "Cerrar calculadora" button is visible.
     expect(screen.getByRole("button", { name: /cerrar calculadora/i })).toBeInTheDocument();
 
-    // Grid is still rendered.
+    // Grid is still rendered (calendar accordion open by default).
     expect(screen.getByTestId("recurring-calendar-grid")).toBeInTheDocument();
 
     // Savings lines not shown when none excluded.
@@ -153,7 +153,7 @@ describe("RecurringCalculator", () => {
     expect(screen.queryByText(/ahorrarías/i)).not.toBeInTheDocument();
   });
 
-  it("in calculator mode: clicking a pill toggles exclusion and shows savings", async () => {
+  it("in calculator mode: clicking a list pill toggles exclusion and shows savings", async () => {
     const user = userEvent.setup();
     render(
       <RecurringCalculator
@@ -165,8 +165,11 @@ describe("RecurringCalculator", () => {
 
     await user.click(screen.getByRole("button", { name: /calculadora/i }));
 
-    // Click the first pill to exclude it.
-    const pills = screen.getAllByTestId("sub-pill");
+    // Open the "Lista compacta" accordion item.
+    await user.click(screen.getByRole("button", { name: /lista compacta/i }));
+
+    // Click the first list pill to exclude it.
+    const pills = screen.getAllByTestId("recurring-list-pill");
     await user.click(pills[0]);
 
     // Savings lines appear.
@@ -174,7 +177,7 @@ describe("RecurringCalculator", () => {
     expect(screen.getByText(/ahorrarías/i)).toBeInTheDocument();
   });
 
-  it("in calculator mode: excluded pill gets muted visual state", async () => {
+  it("in calculator mode: excluded list pill gets muted visual state", async () => {
     const user = userEvent.setup();
     render(
       <RecurringCalculator
@@ -186,7 +189,10 @@ describe("RecurringCalculator", () => {
 
     await user.click(screen.getByRole("button", { name: /calculadora/i }));
 
-    const pills = screen.getAllByTestId("sub-pill");
+    // Open the "Lista compacta" accordion item.
+    await user.click(screen.getByRole("button", { name: /lista compacta/i }));
+
+    const pills = screen.getAllByTestId("recurring-list-pill");
     await user.click(pills[0]);
 
     // The clicked pill should now have opacity-50 applied.
@@ -205,8 +211,11 @@ describe("RecurringCalculator", () => {
 
     await user.click(screen.getByRole("button", { name: /calculadora/i }));
 
+    // Open the "Lista compacta" accordion item.
+    await user.click(screen.getByRole("button", { name: /lista compacta/i }));
+
     // Exclude one pill.
-    const pills = screen.getAllByTestId("sub-pill");
+    const pills = screen.getAllByTestId("recurring-list-pill");
     await user.click(pills[0]);
     expect(screen.getByText(/si cancelás/i)).toBeInTheDocument();
 

--- a/src/components/recurring/recurring-calculator.tsx
+++ b/src/components/recurring/recurring-calculator.tsx
@@ -5,7 +5,14 @@ import { Calculator, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { formatMoney } from "@/lib/money";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { RecurringCalendarGrid } from "./recurring-calendar-grid";
+import { RecurringList } from "./recurring-list";
 import { UpcomingCharges } from "./upcoming-charges";
 import type { AggregationBucket } from "@/lib/fx/aggregate";
 import type { RecurringRow } from "@/app/(app)/recurring/queries";
@@ -373,13 +380,34 @@ export function RecurringCalculator({
         </>
       )}
 
-      {/* Calendar grid — the main listing */}
-      <RecurringCalendarGrid
-        rows={rows}
-        excludedIds={excludedIds}
-        isCalculatorOpen={isOpen}
-        onToggleExcluded={handleToggle}
-      />
+      {/* Accordion: Lista compacta (closed) + Calendario (open) */}
+      <Accordion type="multiple" defaultValue={["calendar"]} className="flex flex-col gap-0">
+        <AccordionItem value="list" className="rounded-lg border px-3">
+          <AccordionTrigger className="text-sm font-semibold">
+            Lista compacta
+            {isOpen && (
+              <span className="text-muted-foreground ml-2 text-xs font-normal">
+                — tocá para excluir
+              </span>
+            )}
+          </AccordionTrigger>
+          <AccordionContent>
+            <RecurringList
+              rows={rows}
+              excludedIds={excludedIds}
+              isCalculatorOpen={isOpen}
+              onToggleExcluded={handleToggle}
+            />
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem value="calendar" className="mt-2 rounded-lg border px-3">
+          <AccordionTrigger className="text-sm font-semibold">Calendario</AccordionTrigger>
+          <AccordionContent>
+            <RecurringCalendarGrid rows={rows} />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
 
       {/* Próximos 7 días callout */}
       <UpcomingCharges rows={rows} excludedIds={excludedIds} />

--- a/src/components/recurring/recurring-calendar-grid.test.tsx
+++ b/src/components/recurring/recurring-calendar-grid.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import "@testing-library/jest-dom/vitest";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -71,14 +71,7 @@ const TODAY = new Date("2026-05-02T00:00:00");
 
 describe("RecurringCalendarGrid", () => {
   it("renders 35–42 cells for the month grid", () => {
-    render(
-      <RecurringCalendarGrid
-        rows={[]}
-        excludedIds={new Set()}
-        isCalculatorOpen={false}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={[]} today={TODAY} />);
 
     // Count in-month cells by data-testid pattern (day-cell-N).
     // May 2026 has 31 in-month cells. Out-of-month cells have no data-testid.
@@ -92,14 +85,7 @@ describe("RecurringCalendarGrid", () => {
   });
 
   it("renders 7 day-of-week headers in Spanish uppercase", () => {
-    render(
-      <RecurringCalendarGrid
-        rows={[]}
-        excludedIds={new Set()}
-        isCalculatorOpen={false}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={[]} today={TODAY} />);
 
     for (const name of ["DOM", "LUN", "MAR", "MIÉ", "JUE", "VIE", "SÁB"]) {
       expect(screen.getByText(name)).toBeInTheDocument();
@@ -107,28 +93,14 @@ describe("RecurringCalendarGrid", () => {
   });
 
   it("renders the Spanish month title with first letter capitalized", () => {
-    render(
-      <RecurringCalendarGrid
-        rows={[]}
-        excludedIds={new Set()}
-        isCalculatorOpen={false}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={[]} today={TODAY} />);
 
     // "Mayo 2026"
     expect(screen.getByText(/mayo 2026/i)).toBeInTheDocument();
   });
 
   it("today cell gets the today-marker data-testid", () => {
-    render(
-      <RecurringCalendarGrid
-        rows={[]}
-        excludedIds={new Set()}
-        isCalculatorOpen={false}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={[]} today={TODAY} />);
 
     const marker = screen.getByTestId("today-marker");
     expect(marker).toBeInTheDocument();
@@ -142,14 +114,7 @@ describe("RecurringCalendarGrid", () => {
     nextId = 10;
     const row = makeRow({ id: 10, label: "Netflix", dayOfMonth: 15, nextOccurrence: "2026-05-15" });
 
-    render(
-      <RecurringCalendarGrid
-        rows={[row]}
-        excludedIds={new Set()}
-        isCalculatorOpen={false}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={[row]} today={TODAY} />);
 
     const pill = screen.getByTestId("sub-pill");
     expect(pill).toHaveTextContent("Netflix");
@@ -158,28 +123,14 @@ describe("RecurringCalendarGrid", () => {
   it("out-of-month cells do not show pills — only in-month cells render pills", () => {
     nextId = 20;
     // Render zero rows: verify no pills appear at all.
-    render(
-      <RecurringCalendarGrid
-        rows={[]}
-        excludedIds={new Set()}
-        isCalculatorOpen={false}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={[]} today={TODAY} />);
 
     // No pills should render with empty rows.
     expect(screen.queryAllByTestId("sub-pill")).toHaveLength(0);
   });
 
   it("out-of-month cells render with opacity-40 class", () => {
-    render(
-      <RecurringCalendarGrid
-        rows={[]}
-        excludedIds={new Set()}
-        isCalculatorOpen={false}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={[]} today={TODAY} />);
 
     const grid = screen.getByTestId("calendar-grid");
     // Out-of-month cells have opacity-40 applied (April 26-30 and June 1-6 for May 2026).
@@ -196,14 +147,7 @@ describe("RecurringCalendarGrid", () => {
       makeRow({ id: 32, label: "Disney+", dayOfMonth: 10 }),
     ];
 
-    render(
-      <RecurringCalendarGrid
-        rows={rows}
-        excludedIds={new Set()}
-        isCalculatorOpen={false}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={rows} today={TODAY} />);
 
     // MAX_PILLS = 2, so with 3 subs: 2 pills + 1 overflow chip showing "+1 más".
     expect(screen.getByTestId("overflow-chip")).toBeInTheDocument();
@@ -219,14 +163,7 @@ describe("RecurringCalendarGrid", () => {
       makeRow({ id: 42, label: "Disney+", dayOfMonth: 20 }),
     ];
 
-    render(
-      <RecurringCalendarGrid
-        rows={rows}
-        excludedIds={new Set()}
-        isCalculatorOpen={false}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={rows} today={TODAY} />);
 
     await user.click(screen.getByTestId("overflow-chip"));
 
@@ -235,7 +172,7 @@ describe("RecurringCalendarGrid", () => {
     expect(within(popoverContent).getByText("Disney+")).toBeInTheDocument();
   });
 
-  it("clicking a pill (calculator closed) opens the detail popover", async () => {
+  it("clicking a pill opens the detail popover", async () => {
     const user = userEvent.setup();
     nextId = 50;
     const row = makeRow({
@@ -247,14 +184,7 @@ describe("RecurringCalendarGrid", () => {
       categoryName: "Entretenimiento",
     });
 
-    render(
-      <RecurringCalendarGrid
-        rows={[row]}
-        excludedIds={new Set()}
-        isCalculatorOpen={false}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={[row]} today={TODAY} />);
 
     await user.click(screen.getByTestId("sub-pill"));
 
@@ -267,76 +197,27 @@ describe("RecurringCalendarGrid", () => {
     expect(screen.getByText(/próximo/i)).toBeInTheDocument();
   });
 
-  it("in calculator mode: clicking a pill calls onToggleExcluded", async () => {
+  it("pills always open the detail popover (no calculator-mode toggle behavior in calendar)", async () => {
     const user = userEvent.setup();
-    const onToggle = vi.fn();
     nextId = 60;
     const row = makeRow({ id: 60, label: "Apple TV", dayOfMonth: 8 });
 
-    render(
-      <RecurringCalendarGrid
-        rows={[row]}
-        excludedIds={new Set()}
-        isCalculatorOpen={true}
-        onToggleExcluded={onToggle}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={[row]} today={TODAY} />);
 
     await user.click(screen.getByTestId("sub-pill"));
-    expect(onToggle).toHaveBeenCalledWith(60);
+
+    // Popover content appears with the detail.
+    const appleTvElements = screen.getAllByText("Apple TV");
+    expect(appleTvElements.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("in calculator mode: excluded pill renders with opacity-50 and line-through classes", () => {
-    nextId = 70;
-    const row = makeRow({ id: 70, label: "Paramount+", dayOfMonth: 12 });
-
-    render(
-      <RecurringCalendarGrid
-        rows={[row]}
-        excludedIds={new Set([70])}
-        isCalculatorOpen={true}
-        today={TODAY}
-      />,
-    );
-
-    const pill = screen.getByTestId("sub-pill");
-    expect(pill.className).toMatch(/opacity-50/);
-    expect(pill.className).toMatch(/line-through/);
-  });
-
-  it("in calculator mode: non-excluded pill does NOT have opacity-50 or line-through", () => {
-    nextId = 80;
-    const row = makeRow({ id: 80, label: "Crunchyroll", dayOfMonth: 18 });
-
-    render(
-      <RecurringCalendarGrid
-        rows={[row]}
-        excludedIds={new Set()}
-        isCalculatorOpen={true}
-        today={TODAY}
-      />,
-    );
-
-    const pill = screen.getByTestId("sub-pill");
-    expect(pill.className).not.toMatch(/opacity-50/);
-    expect(pill.className).not.toMatch(/line-through/);
-  });
-
-  it("excluded rows are still rendered in the grid (exclusion is visual only)", () => {
+  it("rows are always rendered in the grid regardless of external excluded state", () => {
     nextId = 90;
     const row = makeRow({ id: 90, label: "YouTube Premium", dayOfMonth: 22 });
 
-    render(
-      <RecurringCalendarGrid
-        rows={[row]}
-        excludedIds={new Set([90])}
-        isCalculatorOpen={true}
-        today={TODAY}
-      />,
-    );
+    render(<RecurringCalendarGrid rows={[row]} today={TODAY} />);
 
-    // The pill must still be in the DOM (just muted)
+    // The pill must be in the DOM
     expect(screen.getByTestId("sub-pill")).toBeInTheDocument();
     expect(screen.getByTestId("sub-pill")).toHaveTextContent("YouTube Premium");
   });

--- a/src/components/recurring/recurring-calendar-grid.tsx
+++ b/src/components/recurring/recurring-calendar-grid.tsx
@@ -25,9 +25,6 @@ import type { PriceHike, RecurringRow } from "@/app/(app)/recurring/queries";
 
 export interface RecurringCalendarGridProps {
   rows: RecurringRow[];
-  excludedIds: Set<number>;
-  isCalculatorOpen: boolean;
-  onToggleExcluded?: (id: number) => void;
   /** Injected for tests — defaults to new Date() */
   today?: Date;
 }
@@ -105,37 +102,15 @@ function SubDetailContent({ row }: { row: RecurringRow }) {
 
 interface PillProps {
   row: RecurringRow;
-  isCalculatorOpen: boolean;
-  isExcluded: boolean;
-  onToggle?: (id: number) => void;
 }
 
-function Pill({ row, isCalculatorOpen, isExcluded, onToggle }: PillProps) {
+function Pill({ row }: PillProps) {
   const pillClass = cn(
     "bg-emerald-500/20 text-emerald-700 dark:bg-emerald-500/30 dark:text-emerald-300",
     "rounded-md px-1.5 py-0.5 text-xs truncate w-full text-left",
     "transition-opacity",
-    isCalculatorOpen && isExcluded && "opacity-50 line-through",
   );
 
-  if (isCalculatorOpen) {
-    // In calculator mode: clicking toggles exclusion, no popover.
-    return (
-      <button
-        type="button"
-        className={pillClass}
-        onClick={() => onToggle?.(row.id)}
-        data-testid="sub-pill"
-        data-excluded={isExcluded ? "true" : "false"}
-        aria-label={`${isExcluded ? "Incluir" : "Excluir"} ${row.label}`}
-        title={row.label}
-      >
-        {row.label}
-      </button>
-    );
-  }
-
-  // Normal mode: click opens detail popover.
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -162,35 +137,13 @@ function Pill({ row, isCalculatorOpen, isExcluded, onToggle }: PillProps) {
 
 interface OverflowChipProps {
   rows: RecurringRow[];
-  isCalculatorOpen: boolean;
-  onToggle?: (id: number) => void;
 }
 
-function OverflowChip({ rows, isCalculatorOpen, onToggle }: OverflowChipProps) {
+function OverflowChip({ rows }: OverflowChipProps) {
   const count = rows.length;
 
   const chipClass =
     "bg-muted text-muted-foreground rounded-md px-1.5 py-0.5 text-xs w-full text-left";
-
-  if (isCalculatorOpen) {
-    // In calculator mode: show a simple "more" indicator — each pill is already visible above.
-    // We still render the overflow chip to toggle them all.
-    return (
-      <button
-        type="button"
-        className={chipClass}
-        data-testid="overflow-chip"
-        onClick={() => {
-          for (const row of rows) {
-            onToggle?.(row.id);
-          }
-        }}
-        title={`Alternar ${count} más`}
-      >
-        +{count} más
-      </button>
-    );
-  }
 
   return (
     <Popover>
@@ -228,20 +181,9 @@ interface DayCellProps {
   today: Date;
   inMonth: boolean;
   subs: RecurringRow[];
-  isCalculatorOpen: boolean;
-  excludedIds: Set<number>;
-  onToggle?: (id: number) => void;
 }
 
-function DayCell({
-  date,
-  today,
-  inMonth,
-  subs,
-  isCalculatorOpen,
-  excludedIds,
-  onToggle,
-}: DayCellProps) {
+function DayCell({ date, today, inMonth, subs }: DayCellProps) {
   const isToday = isSameDay(date, today);
   const dayNum = getDate(date);
 
@@ -271,21 +213,9 @@ function DayCell({
       {inMonth && subs.length > 0 && (
         <div className="flex flex-col gap-0.5">
           {subs.slice(0, MAX_PILLS).map((row) => (
-            <Pill
-              key={row.id}
-              row={row}
-              isCalculatorOpen={isCalculatorOpen}
-              isExcluded={excludedIds.has(row.id)}
-              onToggle={onToggle}
-            />
+            <Pill key={row.id} row={row} />
           ))}
-          {subs.length > MAX_PILLS && (
-            <OverflowChip
-              rows={subs.slice(MAX_PILLS)}
-              isCalculatorOpen={isCalculatorOpen}
-              onToggle={onToggle}
-            />
-          )}
+          {subs.length > MAX_PILLS && <OverflowChip rows={subs.slice(MAX_PILLS)} />}
         </div>
       )}
     </div>
@@ -296,13 +226,7 @@ function DayCell({
 // Main grid component
 // ---------------------------------------------------------------------------
 
-export function RecurringCalendarGrid({
-  rows,
-  excludedIds,
-  isCalculatorOpen,
-  onToggleExcluded,
-  today: todayProp,
-}: RecurringCalendarGridProps) {
+export function RecurringCalendarGrid({ rows, today: todayProp }: RecurringCalendarGridProps) {
   // Stable today reference — avoids re-creating on every render when todayProp is undefined.
   const today = useMemo(() => todayProp ?? new Date(), [todayProp]);
 
@@ -361,9 +285,6 @@ export function RecurringCalendarGrid({
               today={today}
               inMonth={inMonth}
               subs={subs}
-              isCalculatorOpen={isCalculatorOpen}
-              excludedIds={excludedIds}
-              onToggle={onToggleExcluded}
             />
           );
         })}

--- a/src/components/recurring/recurring-list.test.tsx
+++ b/src/components/recurring/recurring-list.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { RecurringList } from "./recurring-list";
+import type { RecurringRow } from "@/app/(app)/recurring/queries";
+
+// ---------------------------------------------------------------------------
+// Radix shims — pointer capture + scrollIntoView not in jsdom.
+// ---------------------------------------------------------------------------
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+let nextId = 1;
+
+function makeRow(overrides: Partial<RecurringRow> = {}): RecurringRow {
+  const id = nextId++;
+  return {
+    id,
+    label: `Sub ${id}`,
+    accountLabel: "Visa *1234",
+    amountCents: BigInt(-4900),
+    currency: "COP",
+    dayOfMonth: 15,
+    amountType: "fixed",
+    categorySlug: "suscripciones",
+    categoryName: "Suscripciones",
+    notes: null,
+    skippedMonths: [],
+    nextOccurrence: "2026-05-15",
+    annualCents: BigInt(-58800),
+    displayAmount: {
+      cents: BigInt(-4900),
+      currency: "COP",
+      converted: false,
+      appliedTrm: null,
+    },
+    displayAmountAbsCents: BigInt(4900),
+    priceHike: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RecurringList", () => {
+  it("renders nothing when rows is empty", () => {
+    render(<RecurringList rows={[]} excludedIds={new Set()} isCalculatorOpen={false} />);
+
+    expect(screen.queryByTestId("recurring-list")).not.toBeInTheDocument();
+  });
+
+  it("renders one pill per row", () => {
+    nextId = 1;
+    const rows = [makeRow({ id: 1, label: "Netflix" }), makeRow({ id: 2, label: "Spotify" })];
+
+    render(<RecurringList rows={rows} excludedIds={new Set()} isCalculatorOpen={false} />);
+
+    expect(screen.getByText("Netflix")).toBeInTheDocument();
+    expect(screen.getByText("Spotify")).toBeInTheDocument();
+    expect(screen.getAllByTestId("recurring-list-pill")).toHaveLength(2);
+  });
+
+  it("shows the dayOfMonth prominently in each pill", () => {
+    nextId = 10;
+    const row = makeRow({ id: 10, label: "Netflix", dayOfMonth: 15 });
+
+    render(<RecurringList rows={[row]} excludedIds={new Set()} isCalculatorOpen={false} />);
+
+    // Day number "15" should appear in the pill.
+    expect(screen.getByText("15")).toBeInTheDocument();
+  });
+
+  it("in normal mode: clicking a pill opens the detail popover", async () => {
+    const user = userEvent.setup();
+    nextId = 20;
+    const row = makeRow({
+      id: 20,
+      label: "HBO Max",
+      accountLabel: "Mastercard *5555",
+      dayOfMonth: 5,
+      nextOccurrence: "2026-05-05",
+    });
+
+    render(<RecurringList rows={[row]} excludedIds={new Set()} isCalculatorOpen={false} />);
+
+    await user.click(screen.getByTestId("recurring-list-pill"));
+
+    // Popover with detail opens.
+    expect(screen.getByText("Mastercard *5555")).toBeInTheDocument();
+    expect(screen.getByText(/próximo/i)).toBeInTheDocument();
+  });
+
+  it("in calculator mode: clicking a pill calls onToggleExcluded", async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    nextId = 30;
+    const row = makeRow({ id: 30, label: "Apple TV", dayOfMonth: 8 });
+
+    render(
+      <RecurringList
+        rows={[row]}
+        excludedIds={new Set()}
+        isCalculatorOpen={true}
+        onToggleExcluded={onToggle}
+      />,
+    );
+
+    await user.click(screen.getByTestId("recurring-list-pill"));
+    expect(onToggle).toHaveBeenCalledWith(30);
+  });
+
+  it("in calculator mode: excluded pill renders with opacity-50 and line-through", () => {
+    nextId = 40;
+    const row = makeRow({ id: 40, label: "Paramount+", dayOfMonth: 12 });
+
+    render(<RecurringList rows={[row]} excludedIds={new Set([40])} isCalculatorOpen={true} />);
+
+    const pill = screen.getByTestId("recurring-list-pill");
+    expect(pill.className).toMatch(/opacity-50/);
+    // The label inside the pill gets line-through
+    const label = pill.querySelector(".line-through");
+    expect(label).toBeInTheDocument();
+  });
+
+  it("in calculator mode: non-excluded pill does not have opacity-50", () => {
+    nextId = 50;
+    const row = makeRow({ id: 50, label: "Crunchyroll", dayOfMonth: 18 });
+
+    render(<RecurringList rows={[row]} excludedIds={new Set()} isCalculatorOpen={true} />);
+
+    const pill = screen.getByTestId("recurring-list-pill");
+    expect(pill.className).not.toMatch(/opacity-50/);
+  });
+
+  it("renders all rows in given order (sorted by caller — dayOfMonth asc)", () => {
+    nextId = 60;
+    const rows = [
+      makeRow({ id: 60, label: "A", dayOfMonth: 1 }),
+      makeRow({ id: 61, label: "B", dayOfMonth: 10 }),
+      makeRow({ id: 62, label: "C", dayOfMonth: 25 }),
+    ];
+
+    render(<RecurringList rows={rows} excludedIds={new Set()} isCalculatorOpen={false} />);
+
+    const pills = screen.getAllByTestId("recurring-list-pill");
+    expect(pills[0]).toHaveTextContent("A");
+    expect(pills[1]).toHaveTextContent("B");
+    expect(pills[2]).toHaveTextContent("C");
+  });
+});

--- a/src/components/recurring/recurring-list.tsx
+++ b/src/components/recurring/recurring-list.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { formatMoney } from "@/lib/money";
+import { cn } from "@/lib/utils";
+import type { PriceHike, RecurringRow } from "@/app/(app)/recurring/queries";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function absCents(cents: bigint): bigint {
+  return cents < BigInt(0) ? -cents : cents;
+}
+
+// ---------------------------------------------------------------------------
+// Shared SubDetailContent — reused from calendar grid
+// ---------------------------------------------------------------------------
+
+function PriceHikeBadge({ hike }: { hike: PriceHike }) {
+  const absOld = absCents(hike.oldAmountCents);
+  const absNew = absCents(hike.newAmountCents);
+  const pctStr = Math.round(hike.deltaPct).toString();
+  const sinceStr = hike.sinceDate.toLocaleDateString("es-CO", {
+    month: "short",
+    day: "numeric",
+  });
+  const tooltipText = `era ${formatMoney(absOld, hike.currency)} → ahora ${formatMoney(absNew, hike.currency)}, desde ${sinceStr}`;
+
+  return (
+    <span className="text-destructive text-xs tabular-nums" title={tooltipText}>
+      ↑ +{pctStr}%
+    </span>
+  );
+}
+
+function SubDetailContent({ row }: { row: RecurringRow }) {
+  const absDisplayCents = absCents(row.displayAmount.cents);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-start justify-between gap-2">
+        <p className="leading-snug font-medium">{row.label}</p>
+        {row.priceHike && <PriceHikeBadge hike={row.priceHike} />}
+      </div>
+
+      <div className="text-muted-foreground flex flex-col gap-1 text-xs">
+        <p className="text-foreground text-sm font-semibold tabular-nums">
+          {row.amountType === "variable" ? "~" : ""}
+          {formatMoney(absDisplayCents, row.displayAmount.currency as "COP" | "USD")}
+        </p>
+
+        <p>{row.accountLabel}</p>
+
+        {row.categoryName && <p>{row.categoryName}</p>}
+
+        <p>Próximo: {row.nextOccurrence}</p>
+
+        {row.notes && <p className="italic">{row.notes}</p>}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compact pill — one recurring per pill in the dense grid
+// ---------------------------------------------------------------------------
+
+interface CompactPillProps {
+  row: RecurringRow;
+  isCalculatorOpen: boolean;
+  isExcluded: boolean;
+  onToggle?: (id: number) => void;
+}
+
+function CompactPill({ row, isCalculatorOpen, isExcluded, onToggle }: CompactPillProps) {
+  const absDisplayCents = absCents(row.displayAmount.cents);
+  const amountStr = formatMoney(absDisplayCents, row.displayAmount.currency as "COP" | "USD");
+
+  const pillClass = cn(
+    "flex flex-col gap-0.5 rounded-md border px-2 py-1.5 text-left w-full",
+    "transition-opacity cursor-pointer",
+    "hover:bg-accent",
+    isCalculatorOpen && isExcluded && "opacity-50",
+  );
+
+  const label = (
+    <>
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-muted-foreground w-5 shrink-0 text-right text-[11px] font-semibold tabular-nums">
+          {row.dayOfMonth}
+        </span>
+        <span
+          className={cn(
+            "truncate text-xs leading-tight font-medium",
+            isCalculatorOpen && isExcluded && "line-through",
+          )}
+        >
+          {row.label}
+        </span>
+      </div>
+      <span className="text-muted-foreground pl-6 text-[11px] tabular-nums">{amountStr}</span>
+    </>
+  );
+
+  if (isCalculatorOpen) {
+    return (
+      <button
+        type="button"
+        className={pillClass}
+        onClick={() => onToggle?.(row.id)}
+        data-testid="recurring-list-pill"
+        data-excluded={isExcluded ? "true" : "false"}
+        aria-label={`${isExcluded ? "Incluir" : "Excluir"} ${row.label}`}
+        title={`${row.label} — ${amountStr}`}
+      >
+        {label}
+      </button>
+    );
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={pillClass}
+          data-testid="recurring-list-pill"
+          aria-label={`Ver detalle: ${row.label}`}
+          title={`${row.label} — ${amountStr}`}
+        >
+          {label}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent side="top" className="w-64">
+        <SubDetailContent row={row} />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// RecurringList — compact pill grid, sorted by dayOfMonth asc (from caller)
+// ---------------------------------------------------------------------------
+
+export interface RecurringListProps {
+  rows: RecurringRow[];
+  excludedIds: Set<number>;
+  isCalculatorOpen: boolean;
+  onToggleExcluded?: (id: number) => void;
+}
+
+export function RecurringList({
+  rows,
+  excludedIds,
+  isCalculatorOpen,
+  onToggleExcluded,
+}: RecurringListProps) {
+  if (rows.length === 0) return null;
+
+  return (
+    <div
+      className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+      data-testid="recurring-list"
+    >
+      {rows.map((row) => (
+        <CompactPill
+          key={row.id}
+          row={row}
+          isCalculatorOpen={isCalculatorOpen}
+          isExcluded={excludedIds.has(row.id)}
+          onToggle={onToggleExcluded}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import * as React from "react";
+import { Accordion as AccordionPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+
+function Accordion({ className, ...props }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return (
+    <AccordionPrimitive.Root
+      data-slot="accordion"
+      className={cn("flex w-full flex-col", className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("not-last:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "group/accordion-trigger focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground relative flex flex-1 items-start justify-between rounded-lg border border-transparent py-2.5 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-3 disabled:pointer-events-none disabled:opacity-50 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon
+          data-slot="accordion-trigger-icon"
+          className="pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+        />
+        <ChevronUpIcon
+          data-slot="accordion-trigger-icon"
+          className="pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+        />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="data-open:animate-accordion-down data-closed:animate-accordion-up overflow-hidden text-sm"
+      {...props}
+    >
+      <div
+        className={cn(
+          "[&_a]:hover:text-foreground h-(--radix-accordion-content-height) pt-0 pb-2.5 [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </AccordionPrimitive.Content>
+  );
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };


### PR DESCRIPTION
Closes #786

## Summary

- Wraps the recurring calendar and the new compact list inside a shadcn Accordion: list starts collapsed, calendar starts open
- Adds a compact pill-based list (day / name / amount, sorted asc by day) as the operational surface for the recurring calculator — replaces the calculator branch on calendar pills
- Calendar pills now always open a Popover regardless of mode; calculator-mode branching is removed entirely
- Supersedes #738 (overflow chip in calculator mode no longer exists — that UI path is gone)

> Note: #738 is not closed by this PR. Leaving it to you to close as superseded or delete as needed.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean (223 files, 2756 specs)
- [x] `bun run test:e2e` — recurring screenshots captured (home/counterparty failures are pre-existing, unrelated to this change)
- [ ] manual smoke: open /recurring, verify accordion layout, compact list pills, popover opens from calendar pill

## E2E — /recurring screenshots

Screenshots captured locally via `bun run test:e2e`:
- `e2e/screenshots/chromium-light-recurring.png`
- `e2e/screenshots/chromium-dark-recurring.png`
- `e2e/screenshots/mobile-light-recurring.png`
- `e2e/screenshots/mobile-dark-recurring.png`