### PR TITLE
feat(ui): status dots en lista compacta de recurrentes (#790)

### DIFF
--- a/src/components/recurring/recurring-calculator.tsx
+++ b/src/components/recurring/recurring-calculator.tsx
@@ -472,6 +472,7 @@ export function RecurringCalculator({
               rows={rows}
               excludedIds={excludedIds}
               isCalculatorOpen={isOpen}
+              slotStatusById={slotStatusByRecurringId}
               onToggleExcluded={handleToggle}
             />
           </AccordionContent>

--- a/src/components/recurring/recurring-list.test.tsx
+++ b/src/components/recurring/recurring-list.test.tsx
@@ -168,4 +168,48 @@ describe("RecurringList", () => {
     expect(pills[1]).toHaveTextContent("B");
     expect(pills[2]).toHaveTextContent("C");
   });
+
+  // -------------------------------------------------------------------------
+  // #790: status dots threading from slotStatusById prop.
+  // -------------------------------------------------------------------------
+
+  it("renders an emerald dot for matched, sky for upcoming, rose for overdue, none for dismissed", () => {
+    nextId = 70;
+    const rows = [
+      makeRow({ id: 70, label: "Matched" }),
+      makeRow({ id: 71, label: "Upcoming" }),
+      makeRow({ id: 72, label: "Overdue" }),
+      makeRow({ id: 73, label: "Dismissed" }),
+      makeRow({ id: 74, label: "NoStatus" }),
+    ];
+
+    render(
+      <RecurringList
+        rows={rows}
+        excludedIds={new Set()}
+        isCalculatorOpen={false}
+        slotStatusById={{
+          70: "matched",
+          71: "upcoming",
+          72: "overdue",
+          73: "dismissed",
+        }}
+      />,
+    );
+
+    const dots = screen.getAllByTestId("status-dot");
+    expect(dots).toHaveLength(3);
+    expect(dots[0]).toHaveClass("bg-emerald-600");
+    expect(dots[1]).toHaveClass("bg-sky-500");
+    expect(dots[2]).toHaveClass("bg-rose-600");
+  });
+
+  it("renders no dots when slotStatusById is undefined", () => {
+    nextId = 80;
+    const rows = [makeRow({ id: 80, label: "Anything" })];
+
+    render(<RecurringList rows={rows} excludedIds={new Set()} isCalculatorOpen={false} />);
+
+    expect(screen.queryAllByTestId("status-dot")).toHaveLength(0);
+  });
 });

--- a/src/components/recurring/recurring-list.tsx
+++ b/src/components/recurring/recurring-list.tsx
@@ -4,6 +4,14 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import type { PriceHike, RecurringRow } from "@/app/(app)/recurring/queries";
+import type { UpcomingStatus } from "@/lib/recurring/upcoming";
+
+const STATUS_DOT_CLASS: Record<UpcomingStatus, string | null> = {
+  matched: "bg-emerald-600",
+  upcoming: "bg-sky-500",
+  overdue: "bg-rose-600",
+  dismissed: null,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -70,10 +78,11 @@ interface CompactPillProps {
   row: RecurringRow;
   isCalculatorOpen: boolean;
   isExcluded: boolean;
+  status?: UpcomingStatus;
   onToggle?: (id: number) => void;
 }
 
-function CompactPill({ row, isCalculatorOpen, isExcluded, onToggle }: CompactPillProps) {
+function CompactPill({ row, isCalculatorOpen, isExcluded, status, onToggle }: CompactPillProps) {
   const absDisplayCents = absCents(row.displayAmount.cents);
   const amountStr = formatMoney(absDisplayCents, row.displayAmount.currency as "COP" | "USD");
 
@@ -84,15 +93,24 @@ function CompactPill({ row, isCalculatorOpen, isExcluded, onToggle }: CompactPil
     isCalculatorOpen && isExcluded && "opacity-50",
   );
 
+  const dotClass = status ? STATUS_DOT_CLASS[status] : null;
+
   const label = (
     <>
       <div className="flex items-baseline gap-1.5">
         <span className="text-muted-foreground w-5 shrink-0 text-right text-[11px] font-semibold tabular-nums">
           {row.dayOfMonth}
         </span>
+        {dotClass && (
+          <span
+            className={cn("size-2 shrink-0 self-center rounded-full", dotClass)}
+            data-testid="status-dot"
+            aria-hidden="true"
+          />
+        )}
         <span
           className={cn(
-            "truncate text-xs leading-tight font-medium",
+            "min-w-0 truncate text-xs leading-tight font-medium",
             isCalculatorOpen && isExcluded && "line-through",
           )}
         >
@@ -147,6 +165,7 @@ export interface RecurringListProps {
   rows: RecurringRow[];
   excludedIds: Set<number>;
   isCalculatorOpen: boolean;
+  slotStatusById?: Record<number, UpcomingStatus>;
   onToggleExcluded?: (id: number) => void;
 }
 
@@ -154,6 +173,7 @@ export function RecurringList({
   rows,
   excludedIds,
   isCalculatorOpen,
+  slotStatusById,
   onToggleExcluded,
 }: RecurringListProps) {
   if (rows.length === 0) return null;
@@ -169,6 +189,7 @@ export function RecurringList({
           row={row}
           isCalculatorOpen={isCalculatorOpen}
           isExcluded={excludedIds.has(row.id)}
+          status={slotStatusById?.[row.id]}
           onToggle={onToggleExcluded}
         />
       ))}


### PR DESCRIPTION
## Summary

Follow-up de #788. La lista compacta del accordion (`CompactPill` dentro de `RecurringList`) no recibía el `slotStatusById`, así que los iconos de estado solo aparecían en el calendario y en el legend del header. Esto thread el prop y mete el dot 8px con la misma paleta.

## Changes

- `RecurringList`: nuevo prop `slotStatusById?: Record<number, UpcomingStatus>` (mismo shape que ya pasa el calculator al grid).
- `CompactPill`: dot 8px (`size-2 rounded-full`) entre el `dayOfMonth` y el label — emerald=matched, sky=upcoming, rose=overdue, sin dot para dismissed/undefined.
- `recurring-calculator.tsx`: pasa el mapa que ya tenía en scope.

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (recurring-list + recurring-calculator) — 25 tests pass
- [x] Test nuevo cubre los 3 colores + dismissed/undefined sin dot

Closes #790